### PR TITLE
fix(cdc): align flush marking with snapshot

### DIFF
--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -330,21 +330,30 @@ func executeFlush(
 				return
 			}
 			flushedAt := time.Now().UnixMilli()
-			rowsUpdated, err := MarkFlushedIDs(ctx, db, tableName, schemaID, sub, flushedAt)
+			updatedIDs, err := MarkFlushedIDsAtSnapshot(ctx, db, tableName, schemaID, sub, snapshot, flushedAt)
 			if err != nil {
 				logger.Sugar().Errorw("mark flushed failed", "err", err)
 				return
 			}
 
+			if len(updatedIDs) == 0 {
+				logger.Sugar().Infow("flush chunk marked zero rows; possible concurrent updates", "schema_id", schemaID, "chunk_size", len(sub))
+				continue
+			}
+
 			// Update manifest if configured
 			if manifestStore != nil {
-				if err := updateManifest(ctx, manifestStore, manifestResolver, schemaID, chunkFinalKey, "delta", sub, flushedAt, logger); err != nil {
+				if err := updateManifest(ctx, manifestStore, manifestResolver, schemaID, chunkFinalKey, "delta", updatedIDs, flushedAt, logger); err != nil {
 					logger.Sugar().Errorw("manifest update failed", "err", err)
 					// Don't return - the flush succeeded, manifest is non-critical
 				}
 			}
 
-			logger.Sugar().Infow("flush chunk completed", "schema_id", schemaID, "rows_flushed", rowsUpdated, "chunk_size", len(sub))
+			if len(updatedIDs) < len(sub) {
+				logger.Sugar().Infow("flush chunk marked fewer rows than batch; possible concurrent updates", "schema_id", schemaID, "rows_flushed", len(updatedIDs), "chunk_size", len(sub))
+			}
+
+			logger.Sugar().Infow("flush chunk completed", "schema_id", schemaID, "rows_flushed", len(updatedIDs), "chunk_size", len(sub))
 		}
 		return
 	}
@@ -367,21 +376,30 @@ func executeFlush(
 	}
 
 	flushedAt := time.Now().UnixMilli()
-	rowsUpdated, err := MarkFlushedIDs(ctx, db, tableName, schemaID, batchIDs, flushedAt)
+	updatedIDs, err := MarkFlushedIDsAtSnapshot(ctx, db, tableName, schemaID, batchIDs, snapshot, flushedAt)
 	if err != nil {
 		logger.Sugar().Errorw("mark flushed failed", "err", err)
 		return
 	}
 
+	if len(updatedIDs) == 0 {
+		logger.Sugar().Infow("flush marked zero rows; possible concurrent updates", "schema_id", schemaID, "batch_size", len(batchIDs))
+		return
+	}
+
 	// Update manifest if configured
 	if manifestStore != nil {
-		if err := updateManifest(ctx, manifestStore, manifestResolver, schemaID, finalKey, "delta", batchIDs, flushedAt, logger); err != nil {
+		if err := updateManifest(ctx, manifestStore, manifestResolver, schemaID, finalKey, "delta", updatedIDs, flushedAt, logger); err != nil {
 			logger.Sugar().Errorw("manifest update failed", "err", err)
 			// Don't return - the flush succeeded, manifest is non-critical
 		}
 	}
 
-	logger.Sugar().Infow("flush completed", "schema_id", schemaID, "rows_flushed", rowsUpdated, "final_key", finalKey)
+	if len(updatedIDs) < len(batchIDs) {
+		logger.Sugar().Infow("flush marked fewer rows than batch; possible concurrent updates", "schema_id", schemaID, "rows_flushed", len(updatedIDs), "batch_size", len(batchIDs))
+	}
+
+	logger.Sugar().Infow("flush completed", "schema_id", schemaID, "rows_flushed", len(updatedIDs), "final_key", finalKey)
 
 	// Suppress unused variable warning
 	_ = ids
@@ -419,8 +437,9 @@ func updateManifest(
 
 	// Set row ID bounds if available
 	if len(rowIDs) > 0 {
-		entry.RowIDMin = rowIDs[0].String()
-		entry.RowIDMax = rowIDs[len(rowIDs)-1].String()
+		rowIDMin, rowIDMax := minMaxRowID(rowIDs)
+		entry.RowIDMin = rowIDMin
+		entry.RowIDMax = rowIDMax
 	}
 
 	if err := manifest.AppendFile(ctx, store, manifestPath, schemaID, entry); err != nil {
@@ -429,4 +448,22 @@ func updateManifest(
 
 	logger.Sugar().Infow("manifest updated", "schema_id", schemaID, "manifest_path", manifestPath, "file_path", filePath, "tier", tier)
 	return nil
+}
+
+func minMaxRowID(rowIDs []uuid.UUID) (string, string) {
+	if len(rowIDs) == 0 {
+		return "", ""
+	}
+	minID := rowIDs[0].String()
+	maxID := minID
+	for _, id := range rowIDs[1:] {
+		s := id.String()
+		if s < minID {
+			minID = s
+		}
+		if s > maxID {
+			maxID = s
+		}
+	}
+	return minID, maxID
 }

--- a/internal/cdc/flusher_snapshot_test.go
+++ b/internal/cdc/flusher_snapshot_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+// +build integration
+
+package cdc
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma/internal/e2e_harness"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkFlushedIDsAtSnapshot_SkipsUpdatedRows(t *testing.T) {
+	ctx := context.Background()
+	h := &e2e_harness.TestHarness{}
+	_, err := h.StartPostgres(ctx)
+	require.NoError(t, err)
+	defer func() { _ = h.StopPostgres(ctx) }()
+
+	db := h.PGDB
+	require.NoError(t, createChangeLogTable(ctx, db))
+
+	rowID := uuid.New()
+	snapshot1 := dbNowMs(t, db)
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO change_log (schema_id, row_id, flushed_at, changed_at, deleted_at)
+		VALUES ($1, $2, 0, $3, NULL)
+	`, int16(1), rowID, snapshot1)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `
+		UPDATE change_log SET changed_at = $1
+		WHERE schema_id = $2 AND row_id = $3 AND flushed_at = 0
+	`, snapshot1+1000, int16(1), rowID)
+	require.NoError(t, err)
+
+	updated, err := MarkFlushedIDsAtSnapshot(ctx, db, "change_log", 1, []uuid.UUID{rowID}, snapshot1, snapshot1+2000)
+	require.NoError(t, err)
+	require.Len(t, updated, 0)
+
+	var changedAt, flushedAt int64
+	err = db.QueryRowContext(ctx, `
+		SELECT changed_at, flushed_at
+		FROM change_log
+		WHERE schema_id = $1 AND row_id = $2 AND flushed_at = 0
+	`, int16(1), rowID).Scan(&changedAt, &flushedAt)
+	require.NoError(t, err)
+	require.Greater(t, changedAt, snapshot1)
+	require.Equal(t, int64(0), flushedAt)
+
+	snapshot2 := snapshot1 + 2000
+	updated, err = MarkFlushedIDsAtSnapshot(ctx, db, "change_log", 1, []uuid.UUID{rowID}, snapshot2, snapshot2+1000)
+	require.NoError(t, err)
+	require.Len(t, updated, 1)
+	require.Equal(t, rowID, updated[0])
+
+	err = db.QueryRowContext(ctx, `
+		SELECT flushed_at
+		FROM change_log
+		WHERE schema_id = $1 AND row_id = $2
+	`, int16(1), rowID).Scan(&flushedAt)
+	require.NoError(t, err)
+	require.Greater(t, flushedAt, int64(0))
+}
+
+func createChangeLogTable(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS change_log (
+			schema_id  SMALLINT NOT NULL,
+			row_id     UUID     NOT NULL,
+			flushed_at BIGINT   NOT NULL DEFAULT 0,
+			changed_at BIGINT   NOT NULL,
+			deleted_at BIGINT,
+			PRIMARY KEY (schema_id, row_id, flushed_at)
+		)
+	`)
+	return err
+}
+
+func dbNowMs(t *testing.T, db *sql.DB) int64 {
+	var ts int64
+	err := db.QueryRow("SELECT (extract(epoch from clock_timestamp())*1000)::bigint").Scan(&ts)
+	require.NoError(t, err)
+	return ts
+}

--- a/internal/cdc/helpers.go
+++ b/internal/cdc/helpers.go
@@ -94,31 +94,45 @@ func MarkFlushed(ctx context.Context, db *sql.DB, table string, schemaID int16, 
 	return affected, nil
 }
 
-// MarkFlushedIDs updates flushed_at for specific row_ids. Use when batching by IDs rather than snapshot cutoff.
-func MarkFlushedIDs(ctx context.Context, db *sql.DB, table string, schemaID int16, rowIDs []uuid.UUID, flushedAt int64) (int64, error) {
+// MarkFlushedIDsAtSnapshot updates flushed_at for specific row_ids only if their changed_at
+// is at or before the snapshot. It returns the row_ids actually marked flushed.
+func MarkFlushedIDsAtSnapshot(ctx context.Context, db *sql.DB, table string, schemaID int16, rowIDs []uuid.UUID, snapshot int64, flushedAt int64) ([]uuid.UUID, error) {
 	if table == "" {
 		table = "change_log"
 	}
 	if len(rowIDs) == 0 {
-		return 0, nil
+		return nil, nil
 	}
 	placeholders := make([]string, 0, len(rowIDs))
-	args := make([]any, 0, len(rowIDs)+2)
-	args = append(args, flushedAt, schemaID)
+	args := make([]any, 0, len(rowIDs)+3)
+	args = append(args, flushedAt, schemaID, snapshot)
 	for i, id := range rowIDs {
-		placeholders = append(placeholders, fmt.Sprintf("$%d", i+3))
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+4))
 		args = append(args, id)
 	}
-	query := fmt.Sprintf("UPDATE %s SET flushed_at = $1 WHERE schema_id = $2 AND flushed_at = 0 AND row_id IN (%s)", sanitizeIdentifier(table), strings.Join(placeholders, ","))
-	res, err := db.ExecContext(ctx, query, args...)
+	query := fmt.Sprintf(
+		"UPDATE %s SET flushed_at = $1 WHERE schema_id = $2 AND flushed_at = 0 AND changed_at <= $3 AND row_id IN (%s) RETURNING row_id",
+		sanitizeIdentifier(table),
+		strings.Join(placeholders, ","),
+	)
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return 0, fmt.Errorf("mark flushed by ids: %w", err)
+		return nil, fmt.Errorf("mark flushed by ids with snapshot: %w", err)
 	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("rows affected: %w", err)
+	defer rows.Close()
+
+	var updated []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan flushed row id: %w", err)
+		}
+		updated = append(updated, id)
 	}
-	return affected, nil
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate flushed row ids: %w", err)
+	}
+	return updated, nil
 }
 
 // CopyTmpToFinal copies a parquet file from tmp key to final key and deletes tmp.


### PR DESCRIPTION
## Problem
 CDC flush used to mark change_log.flushed_at only by row_id, without enforcing changed_at <= snapshot.
If the same row_id was updated during the export, the new change could be incorrectly marked as flushed, causing it to be skipped by subsequent CDC runs (data loss).

## Fix
 - Gate marking by the snapshot boundary (changed_at <= snapshot) so only the exported window is marked
 - Update the manifest with the actually-flushed row_ids to avoid count drift
 - Add an integration test for the concurrent update scenario