### PR TITLE
fix(query): enhance anchor filter semantics in change log query

### DIFF
--- a/internal/advanced_query_template.go
+++ b/internal/advanced_query_template.go
@@ -19,21 +19,27 @@ var optimizedQuerySQLTemplate = template.Must(template.New("optimizedQuery").Fun
 	            UNION
 	            -- Include real-time buffer rows from change_log (flushed_at = 0)
 	            -- while preserving the same anchor filter semantics.
-	            {{- if .UseMainTableAsAnchor }}
 	            SELECT cl.row_id
 	            FROM {{.ChangeLogTable}} cl
-	            INNER JOIN {{.MainTable}} m
-	                ON m.ltbase_schema_id = {{.SchemaID}}
-	                AND m.ltbase_row_id = cl.row_id
-	            WHERE cl.schema_id = {{.SchemaID}} AND cl.flushed_at = 0 AND {{.Anchor.Condition}}
-	            {{- else }}
-	            SELECT DISTINCT cl.row_id
-	            FROM {{.ChangeLogTable}} cl
-	            INNER JOIN {{.EAVTable}} t
-	                ON t.schema_id = {{.SchemaID}}
-	                AND t.row_id = cl.row_id
-	            WHERE cl.schema_id = {{.SchemaID}} AND cl.flushed_at = 0 AND {{.Anchor.Condition}}
-	            {{- end }}
+	            WHERE cl.schema_id = {{.SchemaID}}
+	                AND cl.flushed_at = 0
+	                {{- if .UseMainTableAsAnchor }}
+	                AND EXISTS (
+	                    SELECT 1
+	                    FROM {{.MainTable}} m
+	                    WHERE m.ltbase_schema_id = {{.SchemaID}}
+	                        AND m.ltbase_row_id = cl.row_id
+	                        AND {{.Anchor.Condition}}
+	                )
+	                {{- else }}
+	                AND EXISTS (
+	                    SELECT 1
+	                    FROM {{.EAVTable}} t
+	                    WHERE t.schema_id = {{.SchemaID}}
+	                        AND t.row_id = cl.row_id
+	                        AND {{.Anchor.Condition}}
+	                )
+	                {{- end }}
 	            {{- end }}
 	        ),
         keys AS (

--- a/internal/advanced_query_template.go
+++ b/internal/advanced_query_template.go
@@ -5,24 +5,37 @@ import "text/template"
 var optimizedQuerySQLTemplate = template.Must(template.New("optimizedQuery").Funcs(template.FuncMap{
 	"add": func(a, b int) int { return a + b },
 }).Parse(`
-        WITH anchor AS (
-            {{- if .UseMainTableAsAnchor }}
-            SELECT m.ltbase_row_id AS row_id
-            FROM {{.MainTable}} m
-            WHERE m.ltbase_schema_id = {{.SchemaID}} AND {{.Anchor.Condition}}
-            {{- else }}
-            SELECT DISTINCT t.row_id
-            FROM {{.EAVTable}} t
-            WHERE t.schema_id = {{.SchemaID}} AND {{.Anchor.Condition}}
-            {{- end }}
-            {{- if .ChangeLogTable }}
-            UNION
-            -- Include real-time buffer rows from change_log (flushed_at = 0)
-            SELECT cl.row_id
-            FROM {{.ChangeLogTable}} cl
-            WHERE cl.schema_id = {{.SchemaID}} AND cl.flushed_at = 0
-            {{- end }}
-        ),
+	        WITH anchor AS (
+	            {{- if .UseMainTableAsAnchor }}
+	            SELECT m.ltbase_row_id AS row_id
+	            FROM {{.MainTable}} m
+	            WHERE m.ltbase_schema_id = {{.SchemaID}} AND {{.Anchor.Condition}}
+	            {{- else }}
+	            SELECT DISTINCT t.row_id
+	            FROM {{.EAVTable}} t
+	            WHERE t.schema_id = {{.SchemaID}} AND {{.Anchor.Condition}}
+	            {{- end }}
+	            {{- if .ChangeLogTable }}
+	            UNION
+	            -- Include real-time buffer rows from change_log (flushed_at = 0)
+	            -- while preserving the same anchor filter semantics.
+	            {{- if .UseMainTableAsAnchor }}
+	            SELECT cl.row_id
+	            FROM {{.ChangeLogTable}} cl
+	            INNER JOIN {{.MainTable}} m
+	                ON m.ltbase_schema_id = {{.SchemaID}}
+	                AND m.ltbase_row_id = cl.row_id
+	            WHERE cl.schema_id = {{.SchemaID}} AND cl.flushed_at = 0 AND {{.Anchor.Condition}}
+	            {{- else }}
+	            SELECT DISTINCT cl.row_id
+	            FROM {{.ChangeLogTable}} cl
+	            INNER JOIN {{.EAVTable}} t
+	                ON t.schema_id = {{.SchemaID}}
+	                AND t.row_id = cl.row_id
+	            WHERE cl.schema_id = {{.SchemaID}} AND cl.flushed_at = 0 AND {{.Anchor.Condition}}
+	            {{- end }}
+	            {{- end }}
+	        ),
         keys AS (
             SELECT
                 a.row_id

--- a/internal/advanced_query_template_test.go
+++ b/internal/advanced_query_template_test.go
@@ -1,0 +1,96 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func anchorCTESegment(t *testing.T, sql string) string {
+	t.Helper()
+
+	start := strings.Index(sql, "WITH anchor AS (")
+	require.NotEqual(t, -1, start)
+
+	end := strings.Index(sql, "),\n        keys AS (")
+	require.NotEqual(t, -1, end)
+
+	return sql[start:end]
+}
+
+func TestOptimizedQueryTemplate_ChangeLogUsesExistsForMainAnchor(t *testing.T) {
+	sql, err := renderTemplate(optimizedQuerySQLTemplate, map[string]any{
+		"EAVTable":             "eav_data",
+		"MainTable":            "entity_main",
+		"ChangeLogTable":       "change_log",
+		"MainProjection":       "m.ltbase_schema_id, m.ltbase_row_id",
+		"SchemaID":             "$1",
+		"UseMainTableAsAnchor": true,
+		"Anchor": map[string]any{
+			"Condition": "m.\"text_01\" = $2",
+		},
+		"SortKeys": []AttributeOrder{},
+		"Limit":    "$3",
+		"Offset":   "$4",
+		"PageSize": "$3",
+	})
+	require.NoError(t, err)
+	anchor := anchorCTESegment(t, sql)
+
+	require.Contains(t, anchor, "FROM change_log cl")
+	require.Contains(t, anchor, "AND EXISTS (")
+	require.Contains(t, anchor, "FROM entity_main m")
+	require.NotContains(t, anchor, "INNER JOIN entity_main m")
+	require.NotContains(t, anchor, "SELECT DISTINCT cl.row_id")
+}
+
+func TestOptimizedQueryTemplate_ChangeLogUsesExistsForEAVAnchor(t *testing.T) {
+	sql, err := renderTemplate(optimizedQuerySQLTemplate, map[string]any{
+		"EAVTable":             "eav_data",
+		"MainTable":            "entity_main",
+		"ChangeLogTable":       "change_log",
+		"MainProjection":       "m.ltbase_schema_id, m.ltbase_row_id",
+		"SchemaID":             "$1",
+		"UseMainTableAsAnchor": false,
+		"Anchor": map[string]any{
+			"Condition": "t.attr_id = 42",
+		},
+		"SortKeys": []AttributeOrder{},
+		"Limit":    "$3",
+		"Offset":   "$4",
+		"PageSize": "$3",
+	})
+	require.NoError(t, err)
+	anchor := anchorCTESegment(t, sql)
+
+	require.Contains(t, anchor, "FROM change_log cl")
+	require.Contains(t, anchor, "AND EXISTS (")
+	require.Contains(t, anchor, "FROM eav_data t")
+	require.NotContains(t, anchor, "INNER JOIN eav_data t")
+	require.NotContains(t, anchor, "SELECT DISTINCT cl.row_id")
+}
+
+func TestOptimizedQueryTemplate_WithoutChangeLogHasNoUnionBranch(t *testing.T) {
+	sql, err := renderTemplate(optimizedQuerySQLTemplate, map[string]any{
+		"EAVTable":             "eav_data",
+		"MainTable":            "entity_main",
+		"ChangeLogTable":       "",
+		"MainProjection":       "m.ltbase_schema_id, m.ltbase_row_id",
+		"SchemaID":             "$1",
+		"UseMainTableAsAnchor": true,
+		"Anchor": map[string]any{
+			"Condition": "m.\"text_01\" = $2",
+		},
+		"SortKeys": []AttributeOrder{},
+		"Limit":    "$3",
+		"Offset":   "$4",
+		"PageSize": "$3",
+	})
+	require.NoError(t, err)
+	anchor := anchorCTESegment(t, sql)
+
+	require.NotContains(t, anchor, "FROM change_log cl")
+	require.NotContains(t, anchor, "-- Include real-time buffer rows from change_log")
+	require.NotContains(t, anchor, "UNION")
+}


### PR DESCRIPTION
 Keep the anchor condition consistent across union branches in the advanced query.
 
 This prevents change_log rows from bypassing original predicates (e.g., type=call) when flushed_at = 0.