### PR TITLE
refactor: enhance compactor logic for manifest updates

### DIFF
--- a/internal/compaction/compactor.go
+++ b/internal/compaction/compactor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/lychee-technology/forma/internal/cdc"
@@ -19,6 +20,10 @@ var ErrConcurrentModification = errors.New("manifest concurrently modified")
 // FileProvider fetches manifest and lists actual files (optionally cross-check).
 type FileProvider interface {
 	LoadManifest(ctx context.Context, schemaID int16) (*manifest.Manifest, string, error)
+	// SaveManifest persists the manifest as a commit point.
+	// Implementations must advance manifest metadata on successful save
+	// (at least a monotonic Version increment and UpdatedAtMs refresh).
+	// Compactor relies on this contract and does not mutate those fields directly.
 	SaveManifest(ctx context.Context, schemaID int16, m *manifest.Manifest, etag string) (string, error)
 }
 
@@ -150,11 +155,12 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 
 	baseTotalMB := baseTotalBytes / (1024 * 1024)
 	deltaTotalMB := deltaTotalBytes / (1024 * 1024)
+	dirtyRatio := c.computeDirtyRatio(baseFiles, deltaFiles)
 
 	// Decision: promote deltas to base if delta total > target base size
 	// or rewrite base if dirty ratio exceeded
 	needsPromotion := deltaTotalMB >= int64(cfg.TargetBaseSizeMB)
-	needsRewrite := len(baseFiles) > 0 && c.computeDirtyRatio(baseFiles, deltaFiles) > float64(cfg.DirtyRatioPct)/100.0
+	needsRewrite := len(baseFiles) > 0 && dirtyRatio > float64(cfg.DirtyRatioPct)/100.0
 
 	if !needsPromotion && !needsRewrite {
 		c.Logger.Debug("compaction not needed",
@@ -166,6 +172,7 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 
 	// For MVP: simple promotion - move delta files to base tier
 	// Full rewrite (reading + merging parquet) deferred to later iteration
+	applied := false
 	if needsPromotion {
 		c.Logger.Info("promoting deltas to base tier",
 			zap.Int16("schema_id", schemaID),
@@ -173,15 +180,30 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 
 		// Update file entries: change tier from delta to base
 		for i := range m.Files {
-			if m.Files[i].Tier == "delta" {
+			if strings.EqualFold(m.Files[i].Tier, "delta") {
 				m.Files[i].Tier = "base"
+				applied = true
 			}
 		}
 	}
 
-	// Update manifest
-	m.UpdatedAtMs = time.Now().UnixMilli()
-	m.Version++
+	if needsRewrite && !applied {
+		c.Logger.Warn("rewrite needed but not implemented; skipping manifest update",
+			zap.Int16("schema_id", schemaID),
+			zap.Float64("dirty_ratio", dirtyRatio),
+			zap.Int("dirty_ratio_pct", cfg.DirtyRatioPct),
+			zap.Int64("base_mb", baseTotalMB),
+			zap.Int64("delta_mb", deltaTotalMB))
+		return nil
+	}
+
+	if !applied {
+		c.Logger.Warn("compaction decision resulted in no manifest changes; skipping manifest update",
+			zap.Int16("schema_id", schemaID),
+			zap.Bool("needs_promotion", needsPromotion),
+			zap.Bool("needs_rewrite", needsRewrite))
+		return nil
+	}
 
 	newEtag, err := c.Provider.SaveManifest(ctx, schemaID, m, etag)
 	if err != nil {

--- a/internal/compaction/compactor_test.go
+++ b/internal/compaction/compactor_test.go
@@ -32,6 +32,14 @@ func (m *mockProvider) SaveManifest(ctx context.Context, schemaID int16, mani *m
 	if m.saveErr != nil {
 		return "", m.saveErr
 	}
+	if mani != nil {
+		mani.UpdatedAtMs = time.Now().UnixMilli()
+		if mani.Version == 0 {
+			mani.Version = 1
+		} else {
+			mani.Version++
+		}
+	}
 	m.manifest = mani
 	m.savedEtag = "new-etag"
 	return m.savedEtag, nil
@@ -125,6 +133,75 @@ func TestCompactor_RunOnce_PromotsDeltas(t *testing.T) {
 	for _, f := range provider.manifest.Files {
 		require.Equal(t, "base", f.Tier)
 	}
+	require.Equal(t, "new-etag", provider.savedEtag)
+	require.Equal(t, int64(2), provider.manifest.Version)
+}
+
+func TestCompactor_RunOnce_PromotesDeltasCaseInsensitiveTier(t *testing.T) {
+	logger := zap.NewNop()
+	// FilterByTier is case-insensitive, so compactor must also promote DELTA entries.
+	m := &manifest.Manifest{
+		SchemaID:    1,
+		Version:     1,
+		UpdatedAtMs: time.Now().UnixMilli(),
+		Files: []manifest.FileEntry{
+			{Tier: "DELTA", Path: "delta_upper.parquet", SizeBytes: 256 * 1024 * 1024, RowCount: 1000},
+		},
+	}
+	provider := &mockProvider{manifest: m, etag: "etag-1"}
+
+	c := &Compactor{
+		Logger: logger,
+		Config: cdc.CompactionConfig{
+			SchemaID:         1,
+			TargetBaseSizeMB: 256,
+		},
+		Provider: provider,
+	}
+
+	err := c.RunOnce(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, "base", provider.manifest.Files[0].Tier)
+	require.Equal(t, "new-etag", provider.savedEtag)
+	require.Equal(t, int64(2), provider.manifest.Version)
+}
+
+func TestCompactor_RunOnce_NeedsRewriteWithoutPromotion_SkipsManifestUpdate(t *testing.T) {
+	logger := zap.NewNop()
+	// Force needsRewrite=true (delta/base rows = 100/1000 = 10% > 5%)
+	// while keeping needsPromotion=false (10MB < 256MB).
+	m := &manifest.Manifest{
+		SchemaID:    1,
+		Version:     1,
+		UpdatedAtMs: time.Now().UnixMilli(),
+		Files: []manifest.FileEntry{
+			{Tier: "base", Path: "base.parquet", SizeBytes: 300 * 1024 * 1024, RowCount: 1000},
+			{Tier: "delta", Path: "delta.parquet", SizeBytes: 10 * 1024 * 1024, RowCount: 100},
+		},
+	}
+	provider := &mockProvider{manifest: m, etag: "etag-1"}
+
+	c := &Compactor{
+		Logger: logger,
+		Config: cdc.CompactionConfig{
+			SchemaID:         1,
+			TargetBaseSizeMB: 256,
+			DirtyRatioPct:    5,
+		},
+		Provider: provider,
+	}
+
+	err := c.RunOnce(context.Background())
+	require.NoError(t, err)
+
+	// Rewrite is not implemented yet, so manifest should not be persisted.
+	require.Equal(t, "", provider.savedEtag)
+	require.Equal(t, int64(1), provider.manifest.Version)
+
+	// No rewrite/promotion happened in current implementation.
+	require.Equal(t, "base", provider.manifest.Files[0].Tier)
+	require.Equal(t, "delta", provider.manifest.Files[1].Tier)
 }
 
 func TestCompactor_RunOnce_LoadManifestError(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix compaction no-op/metadata drift issues in `internal/compaction`:

1. Rewrite-only path (`needsRewrite=true`, `needsPromotion=false`) now **does not** update manifest.
2. Delta promotion now uses a case-insensitive tier match (`DELTA` and `delta` both work).
3. `FileProvider.SaveManifest` contract is documented: successful save must advance manifest metadata.

## Why These Changes

- Rewrite-only execution previously could advance manifest metadata without any real compaction effect, creating a false “compaction completed” signal.
- Tier handling was inconsistent: decision logic was case-insensitive, but promotion mutation was case-sensitive, which could produce `needsPromotion=true` but actually no-op.
- Compactor relies on provider-side metadata advancement during save, but this responsibility was not documented at the interface level.