### PR TITLE
docs: add e2e test matrix docs and k6 runner scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ local-only/
 internal/e2e_harness/e2e_artifacts
 *.parquet
 node_modules/
+
+# k6 build artifacts and test run outputs
+tests/e2e/k6/dist/
+tests/e2e/reports/

--- a/docs/e2e-tests-cn.md
+++ b/docs/e2e-tests-cn.md
@@ -1,0 +1,109 @@
+# Forma E2E 测试矩阵
+
+更新时间：2026-03-09  
+适用仓库：`forma`
+
+## 总览
+
+当前仓库中的 E2E 测试分成两条主线：
+
+- `internal/e2e_harness`：Go 容器化系统级 E2E，作为主测试体系
+- `tests/e2e`：Bun/k6 脚本化黑盒流程验证，作为补充验证体系
+
+代码是事实来源，README 用于导航。当前可确认的范围如下：
+
+- Go harness：`68` 个 federated case，外加 `3` 个 suite/baseline 入口
+- Bun/k6：`6` 个流程脚本，外加 `3` 个 k6 负载场景
+
+默认执行口径：
+
+- Go 侧默认通过 `go test` 入口运行，功能类与一致性类属于主路径
+- Go 性能类存在于 federated suite 中，但建议单独执行并单独设置 timeout
+- Bun 侧默认 `bun run test` 只执行 `register-schemas -> gen-data -> cdc-flush -> federated-check`
+- `cdc-init`、`compactor`、k6 均属于存在但不在默认主流程中的扩展步骤
+
+## 单一视图矩阵
+
+| Case/脚本名 | 所属体系 | 层级 | 测试目标 | 覆盖链路 | 运行命令 | 是否默认执行 | 依赖条件 | 备注/限制 |
+|---|---|---|---|---|---|---|---|---|
+| `TestE2EHarnessMinimal` | Go E2E Harness | 基础设施/Smoke | 验证 Postgres、S3、DuckDB 基础设施可启动并连通 | 容器启动 -> Parquet 写入 -> S3 上传 -> DuckDB 读取 | `go test -v ./internal/e2e_harness/... -run TestE2EHarnessMinimal -timeout=5m` | 是 | Go、Docker | 基础设施烟测，不覆盖三层语义 |
+| `TestSuite_Smoke` | Go E2E Harness | 基础设施/Smoke | 验证 harness 初始化、基础数据读写、S3 操作 | Harness 初始化 -> Seed -> Query -> S3 操作 | `go test -v ./internal/e2e_harness/federated/... -run TestSuite_Smoke -tags=e2e -timeout=10m` | 是 | Go、Docker | 关注环境可用性，不覆盖性能 |
+| `TestSuite_Integration` | Go E2E Harness | 数据链路一致性 | 验证完整生命周期无重复和无明显断链 | Seed All Tiers -> Federated Query -> Postgres Query -> CDC Flush -> Compaction -> Verify | `go test -v ./internal/e2e_harness/federated/... -run TestSuite_Integration -tags=e2e -timeout=10m` | 是 | Go、Docker | 适合作为回归入口 |
+| `TC-01 Three-Tier Data Architecture` | Go E2E Harness | 功能正确性 | 验证 Base/Delta/Hot 单层与三层联合查询 | Base/Delta/Hot -> Federated Query | `go test -v ./internal/e2e_harness/federated/... -run TestDataTier -tags=e2e` | 是 | Go、Docker | 共 7 个测试，覆盖空层与分页 |
+| `TC-02 Merge-on-Read Logic` | Go E2E Harness | 功能正确性 | 验证跨层 `UNION ALL`、版本优先级和 dirty ID 排除 | Base + Delta + Hot -> Merge-on-Read | `go test -v ./internal/e2e_harness/federated/... -run TestMergeOnRead -tags=e2e` | 是 | Go、Docker | 共 7 个测试，覆盖 last-write-wins |
+| `TC-03 Global Deduplication` | Go E2E Harness | 功能正确性 | 验证单层和跨层去重语义 | Same Tier/Cross Tier -> QUALIFY/ROW_NUMBER | `go test -v ./internal/e2e_harness/federated/... -run TestDeduplication -tags=e2e` | 是 | Go、Docker | 共 6 个测试，含 10K 级批量场景 |
+| `TC-04 Soft Delete Filtering` | Go E2E Harness | 功能正确性 | 验证软删除过滤、恢复和 row_id 复用 | Deleted/Restored Records -> Federated Query | `go test -v ./internal/e2e_harness/federated/... -run TestSoftDelete -tags=e2e` | 是 | Go、Docker | 共 7 个测试，覆盖 `NULL`/`0` 语义 |
+| `TC-05 CDC Smart Flushing` | Go E2E Harness | 数据链路一致性 | 验证 flush 触发条件、advisory lock、批处理和 delta 文件生成 | Hot Buffer -> CDC Flush -> Delta Parquet | `go test -v ./internal/e2e_harness/federated/... -run TestCDCFlush -tags=e2e` | 是 | Go、Docker | 共 7 个测试，关注 flush 结果而非真实生产调度 |
+| `TC-06 Compaction Strategy` | Go E2E Harness | 数据链路一致性 | 验证 delta 合并进 base 后的正确性与 no-op 行为 | Delta Parquet -> Compaction -> Base Parquet | `go test -v ./internal/e2e_harness/federated/... -run TestCompaction -tags=e2e` | 是 | Go、Docker | 共 9 个测试，覆盖低脏比、高脏比、空 delta |
+| `TC-07 Data Consistency` | Go E2E Harness | 数据链路一致性 | 验证 Postgres 与 Federated 结果一致 | Postgres Query <-> Federated Query | `go test -v ./internal/e2e_harness/federated/... -run TestConsistency -tags=e2e` | 是 | Go、Docker | 共 9 个测试，覆盖 count、checksum、属性值 |
+| `TC-08 Performance Benchmarks` | Go E2E Harness | 性能与故障注入 | 验证分页、复杂过滤、全表扫描、并发、flush、compaction 的耗时门槛 | Federated Query / CDC / Compaction | `go test -v ./internal/e2e_harness/federated/... -run TestPerformance -tags=e2e -timeout=60m` | 否 | Go、Docker | 共 8 个测试，建议单独执行 |
+| `TC-09 Failure Modes` | Go E2E Harness | 性能与故障注入 | 验证 S3、Postgres、损坏 parquet、timeout 等故障场景下的降级和恢复 | Failure Injection -> Federated Query / Recovery | `go test -v ./internal/e2e_harness/federated/... -run TestFailureMode -tags=e2e` | 是 | Go、Docker | 共 8 个测试，重点是 graceful degradation |
+| `register-schemas` | Bun E2E Scripts | 基础设施/Smoke | 校验 `lead`、`visit`、`log` schema 已可查询或可注册 | Schema Files -> API | `cd tests/e2e && bun run register-schemas` | 是 | Bun、运行中的 server | 默认主流程第一步，生成 `schema-registration.json` |
+| `gen-data` | Bun E2E Scripts | 功能正确性 | 通过 API 为多个 schema 批量造数并保留交叉引用 | API Write Path -> Postgres Hot Tier | `cd tests/e2e && bun run gen-data -- --schema all --count 10000` | 是 | Bun、运行中的 server | 默认主流程第二步，生成 `data-gen.json` |
+| `cdc-init` | Bun E2E Scripts | 数据链路一致性 | 为存量数据初始化 base parquet | Postgres Main/EAV -> Base Parquet | `cd tests/e2e && bun run cdc-init` | 否 | Bun、Go tools binary、S3、Postgres | 适用于开启 CDC 前的回填，不在 `bun run test` 中 |
+| `cdc-flush` | Bun E2E Scripts | 数据链路一致性 | 调用 `tools` 二进制执行 flush 并导出 delta parquet | Change Log -> Delta Parquet -> Manifest | `cd tests/e2e && bun run cdc-flush` | 是 | Bun、Go tools binary、S3、Postgres | 默认主流程第三步，支持 `--dry-run` |
+| `compactor` | Bun E2E Scripts | 数据链路一致性 | 调用 `tools` 二进制把 delta 合并进 base | Delta Parquet -> Base Parquet | `cd tests/e2e && bun run compactor -- --all` | 否 | Bun、Go tools binary、S3 | 扩展步骤，不在 `bun run test` 中 |
+| `federated-check` | Bun E2E Scripts | 数据链路一致性 | 对比 Forma API 与 Postgres 直查结果 | Forma API <-> Postgres Direct Query | `cd tests/e2e && bun run federated-check -- --schema all --sample-size 100` | 是 | Bun、运行中的 server、Postgres | 默认主流程第四步，支持 `--full-scan` |
+| `k6 smoke/full/perf` | Bun k6 | 性能与故障注入 | 验证分页、排序、`advanced_query` 的 SLA | HTTP Query Load -> API/Federated Query | `cd tests/e2e && bun run build-k6 && bun run k6-full` | 否 | Bun、运行中的 server、k6 或 Docker | `smoke=5 VUs/30s`，`full=30 VUs/2m`，`perf=100 VUs/5m` |
+
+## 运行方式
+
+### Go 主路径
+
+```bash
+# 基础设施验证
+go test -v ./internal/e2e_harness/... -timeout=5m
+
+# Federated 功能与一致性
+go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=30m
+
+# 性能类单独跑
+go test -v ./internal/e2e_harness/federated/... -run TestPerformance -tags=e2e -timeout=60m
+```
+
+### Bun 主路径
+
+```bash
+cd tests/e2e
+bun run test
+```
+
+`bun run test` 等价于：
+
+```bash
+bun run register-schemas
+bun run gen-data
+bun run cdc-flush
+bun run federated-check
+```
+
+### Bun 扩展步骤
+
+```bash
+cd tests/e2e
+bun run cdc-init
+bun run compactor -- --all
+bun run build-k6
+bun run k6-smoke
+bun run k6-full
+bun run k6-perf
+```
+
+## 覆盖缺口与注意事项
+
+- Go harness 已是主 E2E 体系，适合验证三层语义、CDC、Compaction、故障和性能门槛。
+- Bun 侧更偏黑盒流程验证，重点是 API 造数、工具链执行、对账和压测，不替代 Go harness 的语义级断言。
+- `tests/e2e/package.json` 的默认 `test` 不包含 `cdc-init`、`compactor`、k6；这些步骤必须手动执行。
+- `tests/e2e/README.md` 过去未列出 `cdc-init.ts` 和 `compactor.ts`；当前文档与 README 已对齐。
+- `internal/e2e_harness/README.md` 的 TC 列表与代码当前实现一致，可继续作为 Go harness 侧的分类索引。
+
+## 事实来源
+
+- `internal/e2e_harness/README.md`
+- `internal/e2e_harness/e2e_test.go`
+- `internal/e2e_harness/federated/suite_test.go`
+- `internal/e2e_harness/federated/*_test.go`
+- `tests/e2e/README.md`
+- `tests/e2e/package.json`
+- `tests/e2e/scripts/*.ts`
+- `tests/e2e/k6/scenarios.ts`

--- a/docs/e2e-tests-en.md
+++ b/docs/e2e-tests-en.md
@@ -1,0 +1,109 @@
+# Forma E2E Test Matrix
+
+Last updated: 2026-03-09  
+Repository: `forma`
+
+## Overview
+
+The repository currently has two E2E tracks:
+
+- `internal/e2e_harness`: Go-based containerized system E2E, treated as the primary test system
+- `tests/e2e`: Bun/k6 script-based black-box validation, treated as the supplementary flow and load-test system
+
+Code is the source of truth. README files are navigation aids. The current inventory is:
+
+- Go harness: `68` federated cases plus `3` suite/baseline entries
+- Bun/k6: `6` workflow scripts plus `3` k6 load scenarios
+
+Default execution rules:
+
+- Go uses `go test` as the default entrypoint; functional and consistency groups are part of the normal path
+- Go performance cases exist in the federated suite, but should be run explicitly with a longer timeout
+- Bun default `bun run test` only runs `register-schemas -> gen-data -> cdc-flush -> federated-check`
+- `cdc-init`, `compactor`, and k6 scenarios exist but are not part of the default Bun path
+
+## Single-View Matrix
+
+| Case / Script | System | Layer | Goal | Covered Path | Run Command | Default | Prerequisites | Notes / Limits |
+|---|---|---|---|---|---|---|---|---|
+| `TestE2EHarnessMinimal` | Go E2E Harness | Infrastructure / Smoke | Verify Postgres, S3, and DuckDB can start and communicate | Container startup -> Parquet write -> S3 upload -> DuckDB read | `go test -v ./internal/e2e_harness/... -run TestE2EHarnessMinimal -timeout=5m` | Yes | Go, Docker | Infrastructure smoke only; no three-tier semantics |
+| `TestSuite_Smoke` | Go E2E Harness | Infrastructure / Smoke | Verify harness initialization, baseline data operations, and S3 operations | Harness init -> Seed -> Query -> S3 ops | `go test -v ./internal/e2e_harness/federated/... -run TestSuite_Smoke -tags=e2e -timeout=10m` | Yes | Go, Docker | Focuses on environment health, not performance |
+| `TestSuite_Integration` | Go E2E Harness | Data Pipeline Consistency | Verify the full lifecycle with no obvious break or duplicates | Seed All Tiers -> Federated Query -> Postgres Query -> CDC Flush -> Compaction -> Verify | `go test -v ./internal/e2e_harness/federated/... -run TestSuite_Integration -tags=e2e -timeout=10m` | Yes | Go, Docker | Good regression entrypoint |
+| `TC-01 Three-Tier Data Architecture` | Go E2E Harness | Functional Correctness | Verify Base, Delta, Hot, and merged querying behavior | Base/Delta/Hot -> Federated Query | `go test -v ./internal/e2e_harness/federated/... -run TestDataTier -tags=e2e` | Yes | Go, Docker | 7 tests including empty-tier and pagination cases |
+| `TC-02 Merge-on-Read Logic` | Go E2E Harness | Functional Correctness | Verify `UNION ALL`, version precedence, and dirty-ID exclusion | Base + Delta + Hot -> Merge-on-Read | `go test -v ./internal/e2e_harness/federated/... -run TestMergeOnRead -tags=e2e` | Yes | Go, Docker | 7 tests including last-write-wins |
+| `TC-03 Global Deduplication` | Go E2E Harness | Functional Correctness | Verify single-tier and cross-tier dedup semantics | Same Tier / Cross Tier -> QUALIFY / ROW_NUMBER | `go test -v ./internal/e2e_harness/federated/... -run TestDeduplication -tags=e2e` | Yes | Go, Docker | 6 tests including 10K-scale bulk coverage |
+| `TC-04 Soft Delete Filtering` | Go E2E Harness | Functional Correctness | Verify soft-delete filtering, restore, and row_id reuse | Deleted / Restored Records -> Federated Query | `go test -v ./internal/e2e_harness/federated/... -run TestSoftDelete -tags=e2e` | Yes | Go, Docker | 7 tests including `NULL` / `0` semantics |
+| `TC-05 CDC Smart Flushing` | Go E2E Harness | Data Pipeline Consistency | Verify flush triggers, advisory locking, batching, and delta output | Hot Buffer -> CDC Flush -> Delta Parquet | `go test -v ./internal/e2e_harness/federated/... -run TestCDCFlush -tags=e2e` | Yes | Go, Docker | 7 tests focused on flush behavior, not production scheduling |
+| `TC-06 Compaction Strategy` | Go E2E Harness | Data Pipeline Consistency | Verify correctness after delta-to-base compaction and no-op paths | Delta Parquet -> Compaction -> Base Parquet | `go test -v ./internal/e2e_harness/federated/... -run TestCompaction -tags=e2e` | Yes | Go, Docker | 9 tests covering low dirty ratio, high dirty ratio, and empty delta |
+| `TC-07 Data Consistency` | Go E2E Harness | Data Pipeline Consistency | Verify Postgres and Federated results stay aligned | Postgres Query <-> Federated Query | `go test -v ./internal/e2e_harness/federated/... -run TestConsistency -tags=e2e` | Yes | Go, Docker | 9 tests covering count, checksum, and attribute values |
+| `TC-08 Performance Benchmarks` | Go E2E Harness | Performance and Failure Injection | Verify latency thresholds for query, flush, and compaction paths | Federated Query / CDC / Compaction | `go test -v ./internal/e2e_harness/federated/... -run TestPerformance -tags=e2e -timeout=60m` | No | Go, Docker | 8 tests; recommended to run separately |
+| `TC-09 Failure Modes` | Go E2E Harness | Performance and Failure Injection | Verify degradation and recovery under S3, Postgres, timeout, and corrupted-parquet failures | Failure Injection -> Federated Query / Recovery | `go test -v ./internal/e2e_harness/federated/... -run TestFailureMode -tags=e2e` | Yes | Go, Docker | 8 tests focused on graceful degradation |
+| `register-schemas` | Bun E2E Scripts | Infrastructure / Smoke | Verify `lead`, `visit`, and `log` schemas are queryable or registerable | Schema Files -> API | `cd tests/e2e && bun run register-schemas` | Yes | Bun, running server | First step in the default Bun flow; writes `schema-registration.json` |
+| `gen-data` | Bun E2E Scripts | Functional Correctness | Create batch test data via API and preserve cross references | API Write Path -> Postgres Hot Tier | `cd tests/e2e && bun run gen-data -- --schema all --count 10000` | Yes | Bun, running server | Second step in the default Bun flow; writes `data-gen.json` |
+| `cdc-init` | Bun E2E Scripts | Data Pipeline Consistency | Initialize base parquet files for existing data | Postgres Main / EAV -> Base Parquet | `cd tests/e2e && bun run cdc-init` | No | Bun, Go tools binary, S3, Postgres | Backfill-only step; not part of `bun run test` |
+| `cdc-flush` | Bun E2E Scripts | Data Pipeline Consistency | Run the `tools` binary to flush change-log data into delta parquet | Change Log -> Delta Parquet -> Manifest | `cd tests/e2e && bun run cdc-flush` | Yes | Bun, Go tools binary, S3, Postgres | Third step in the default Bun flow; supports `--dry-run` |
+| `compactor` | Bun E2E Scripts | Data Pipeline Consistency | Run the `tools` binary to merge delta into base | Delta Parquet -> Base Parquet | `cd tests/e2e && bun run compactor -- --all` | No | Bun, Go tools binary, S3 | Extended step; not part of `bun run test` |
+| `federated-check` | Bun E2E Scripts | Data Pipeline Consistency | Compare Forma API results with direct Postgres results | Forma API <-> Postgres Direct Query | `cd tests/e2e && bun run federated-check -- --schema all --sample-size 100` | Yes | Bun, running server, Postgres | Fourth step in the default Bun flow; supports `--full-scan` |
+| `k6 smoke/full/perf` | Bun k6 | Performance and Failure Injection | Validate SLA for pagination, sorting, and `advanced_query` | HTTP Query Load -> API / Federated Query | `cd tests/e2e && bun run build-k6 && bun run k6-full` | No | Bun, running server, k6 or Docker | `smoke=5 VUs/30s`, `full=30 VUs/2m`, `perf=100 VUs/5m` |
+
+## Execution Paths
+
+### Go Primary Path
+
+```bash
+# Infrastructure verification
+go test -v ./internal/e2e_harness/... -timeout=5m
+
+# Federated functionality and consistency
+go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=30m
+
+# Performance only
+go test -v ./internal/e2e_harness/federated/... -run TestPerformance -tags=e2e -timeout=60m
+```
+
+### Bun Primary Path
+
+```bash
+cd tests/e2e
+bun run test
+```
+
+`bun run test` expands to:
+
+```bash
+bun run register-schemas
+bun run gen-data
+bun run cdc-flush
+bun run federated-check
+```
+
+### Bun Extended Steps
+
+```bash
+cd tests/e2e
+bun run cdc-init
+bun run compactor -- --all
+bun run build-k6
+bun run k6-smoke
+bun run k6-full
+bun run k6-perf
+```
+
+## Coverage Gaps and Notes
+
+- Go harness is the primary E2E system for three-tier semantics, CDC, compaction, failure handling, and performance thresholds.
+- Bun is better treated as black-box workflow validation for API data generation, tooling execution, reconciliation, and load testing.
+- `tests/e2e/package.json` default `test` does not include `cdc-init`, `compactor`, or k6; those must be run explicitly.
+- `tests/e2e/README.md` previously omitted `cdc-init.ts` and `compactor.ts`; the README and this matrix are now aligned.
+- `internal/e2e_harness/README.md` remains accurate for the Go harness category index and can continue to be used as the per-suite reference.
+
+## Sources of Truth
+
+- `internal/e2e_harness/README.md`
+- `internal/e2e_harness/e2e_test.go`
+- `internal/e2e_harness/federated/suite_test.go`
+- `internal/e2e_harness/federated/*_test.go`
+- `tests/e2e/README.md`
+- `tests/e2e/package.json`
+- `tests/e2e/scripts/*.ts`
+- `tests/e2e/k6/scenarios.ts`

--- a/internal/e2e_harness/README.md
+++ b/internal/e2e_harness/README.md
@@ -2,6 +2,8 @@
 
 End-to-end test harness for validating the federated query system, including the three-tier data architecture, CDC flushing, compaction, and data consistency.
 
+This README documents the Go harness only. For the repo-wide E2E inventory that also covers `tests/e2e` Bun/k6 workflows, see [../../docs/e2e-tests-cn.md](../../docs/e2e-tests-cn.md) and [../../docs/e2e-tests-en.md](../../docs/e2e-tests-en.md).
+
 ## Prerequisites
 
 - **Go 1.21+**

--- a/scripts/run_local_k6_full.sh
+++ b/scripts/run_local_k6_full.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+E2E_DIR="$PROJECT_DIR/tests/e2e"
+SERVER_SCRIPT="$PROJECT_DIR/scripts/local_server.sh"
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+HEALTH_URL="${HEALTH_URL:-$BASE_URL/health}"
+SERVER_LOG="${SERVER_LOG:-/tmp/forma-local-server.log}"
+STARTUP_TIMEOUT_SECONDS="${STARTUP_TIMEOUT_SECONDS:-180}"
+SERVER_PID=""
+ACTIVE_PID=""
+
+print_info() {
+  printf '[INFO] %s\n' "$1"
+}
+
+print_error() {
+  printf '[ERROR] %s\n' "$1" >&2
+}
+
+cleanup() {
+  set +e
+
+  if [ -n "$ACTIVE_PID" ] && kill -0 "$ACTIVE_PID" >/dev/null 2>&1; then
+    print_info "Stopping active step (pid=$ACTIVE_PID)"
+    kill -TERM -- "-$ACTIVE_PID" >/dev/null 2>&1 || kill -TERM "$ACTIVE_PID" >/dev/null 2>&1 || true
+    wait "$ACTIVE_PID" >/dev/null 2>&1 || true
+    ACTIVE_PID=""
+  fi
+
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    print_info "Stopping local Forma server (pid=$SERVER_PID)"
+    kill -TERM -- "-$SERVER_PID" >/dev/null 2>&1 || kill -TERM "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+
+  if command -v docker >/dev/null 2>&1; then
+    print_info "Stopping Docker services"
+    docker compose -f "$PROJECT_DIR/deploy/docker-compose.yml" down --remove-orphans >/dev/null 2>&1 || true
+  fi
+}
+
+handle_signal() {
+  print_error "Interrupted"
+  trap - EXIT
+  cleanup
+  exit 130
+}
+
+run_step() {
+  local label="$1"
+  shift
+
+  print_info "$label"
+  "$@" &
+  ACTIVE_PID=$!
+
+  local rc=0
+  set +e
+  wait "$ACTIVE_PID"
+  rc=$?
+  set -e
+  ACTIVE_PID=""
+
+  return "$rc"
+}
+
+trap cleanup EXIT
+trap handle_signal INT TERM
+
+if ! command -v curl >/dev/null 2>&1; then
+  print_error "curl is required"
+  exit 1
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  print_error "bun is required"
+  exit 1
+fi
+
+if [ ! -x "$SERVER_SCRIPT" ]; then
+  print_error "server bootstrap script is missing or not executable: $SERVER_SCRIPT"
+  exit 1
+fi
+
+print_info "Starting Forma server via $SERVER_SCRIPT"
+"$SERVER_SCRIPT" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+print_info "Server logs: $SERVER_LOG"
+
+deadline=$((SECONDS + STARTUP_TIMEOUT_SECONDS))
+while true; do
+  if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+    print_info "Server is healthy at $HEALTH_URL"
+    break
+  fi
+
+  if ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    print_error "Forma server exited before becoming healthy"
+    tail -n 80 "$SERVER_LOG" >&2 || true
+    exit 1
+  fi
+
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    print_error "Timed out waiting for Forma server health endpoint: $HEALTH_URL"
+    tail -n 80 "$SERVER_LOG" >&2 || true
+    exit 1
+  fi
+
+  sleep 2
+done
+
+run_step "Building k6 bundle" bash -lc "cd \"$E2E_DIR\" && bun run build-k6"
+
+run_step "Running k6 full scenario against $BASE_URL" bash -lc "cd \"$E2E_DIR\" && BASE_URL=\"$BASE_URL\" bun run k6-full"
+
+print_info "k6 full scenario completed"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -2,10 +2,12 @@
 
 End-to-end tests for validating Forma's CDC (Change Data Capture) and Federated Query functionality.
 
+For the repo-wide E2E inventory across both Go harness tests and Bun/k6 workflows, see [../../docs/e2e-tests-cn.md](../../docs/e2e-tests-cn.md) and [../../docs/e2e-tests-en.md](../../docs/e2e-tests-en.md).
+
 ## Prerequisites
 
 - [Bun](https://bun.sh/) runtime
-- [k6](https://k6.io/) for load testing
+- [k6](https://k6.io/) for load testing, or Docker for the built-in fallback runner
 - Docker & Docker Compose (for local infrastructure)
 - Go toolchain (for building CDC tools)
 
@@ -20,8 +22,16 @@ cd tests/e2e
 cp .env.example .env
 bun install
 
-# 3. Run full E2E suite
+# 3. Run the default Bun E2E flow
 bun run test
+```
+
+`bun run test` only runs `register-schemas -> gen-data -> cdc-flush -> federated-check`. `cdc-init`, `compactor`, and k6 are available as manual follow-up steps.
+
+For a one-shot local performance run that starts Forma, waits for `/health`, runs `k6-full`, and then cleans up, use:
+
+```bash
+./scripts/run_local_k6_full.sh
 ```
 
 ## Project Structure
@@ -34,7 +44,9 @@ tests/e2e/
 ├── scripts/
 │   ├── register-schemas.ts  # Register lead/visit/log schemas
 │   ├── gen-data.ts          # Generate test data via API
+│   ├── cdc-init.ts          # Backfill base parquet from existing data
 │   ├── cdc-flush.ts         # Trigger CDC flush to S3
+│   ├── compactor.ts         # Merge delta parquet files into base
 │   └── federated-check.ts   # Validate federated query consistency
 ├── k6/
 │   ├── scenarios.ts    # k6 load test scenarios
@@ -46,6 +58,12 @@ tests/e2e/
 ```
 
 ## Scripts
+
+### Default Flow vs Extended Steps
+
+- Default flow: `bun run test`
+- Included by default: `register-schemas`, `gen-data`, `cdc-flush`, `federated-check`
+- Manual extensions: `cdc-init`, `compactor`, `build-k6`, `k6-smoke`, `k6-full`, `k6-perf`
 
 ### Register Schemas
 
@@ -70,6 +88,21 @@ bun run gen-data -- --schema all --count 5000
 bun run gen-data
 ```
 
+### CDC Init
+
+Initializes base parquet files from existing `entity_main` + `eav_data`. This is mainly used for backfilling an existing deployment before incremental CDC takes over.
+
+```bash
+# Initialize all schemas
+bun run cdc-init
+
+# Dry run
+bun run cdc-init -- --dry-run
+
+# Single schema with custom target file size
+bun run cdc-init -- --schema-id 101 --target-file-size-mb 256
+```
+
 ### CDC Flush
 
 Triggers the CDC flush process to export change_log data to S3 as Parquet files:
@@ -85,6 +118,21 @@ bun run cdc-flush -- --dry-run
 Notes:
 - Schema registry is required: set `SCHEMA_TABLE` and `SCHEMA_DIR` in `.env` so the CDC tools can generate schema-aware parquet.
 - Optional: tune `CDC_EST_ROW_BYTES` and `CDC_MAX_BATCH_BYTES` to split batches by estimated file size (targets 10–50MB).
+
+### Compactor
+
+Runs compaction to merge delta parquet files into the base tier.
+
+```bash
+# Compact the default schema
+bun run compactor
+
+# Compact all known schemas
+bun run compactor -- --all
+
+# Compact one schema
+bun run compactor -- --schema-id 101
+```
 
 ### Federated Check
 
@@ -125,6 +173,8 @@ bun run k6-perf
 k6 run -e BASE_URL=http://localhost:8080 -e SCENARIO=full k6/dist/bundle.js
 ```
 
+The `k6-*` scripts prefer a local `k6` binary. If `k6` is not installed, they automatically fall back to `docker run grafana/k6` when Docker is available.
+
 ### k6 Thresholds
 
 | Metric | Threshold | Description |
@@ -160,31 +210,48 @@ See `.env.example` for all available configuration options:
 
 All scripts generate JSON reports in the `reports/` directory:
 
+- `schema-registration.json` - Schema registration results
 - `data-gen.json` - Data generation results
+- `cdc-init.json` - CDC base initialization results
 - `cdc-flush.json` - CDC flush results
+- `compactor.json` - Compaction results
 - `federated-check.json` - Federated query validation results
 - `k6-*.json` - k6 load test results
 
 ## Full E2E Flow
 
-The complete E2E test validates:
+The default Bun E2E flow validates:
 
 1. **Schema Registration** - Registers schemas via API
 2. **Data Generation** - Creates test records in Postgres (hot tier)
 3. **CDC Flush** - Exports data to S3 as Parquet (cold tier)
 4. **Federated Check** - Validates query consistency across tiers
-5. **Load Testing** - Validates p95 latency under load
 
 ```bash
-# Run the complete flow
+# Run the default flow
 bun run test
+```
 
-# Or run steps individually
+Extended validation is available as manual follow-up:
+
+1. **CDC Init** - Backfills base parquet for existing data
+2. **Compaction** - Merges delta parquet files into base
+3. **Load Testing** - Validates p95 latency under load
+
+```bash
+# Optional backfill
+bun run cdc-init
+
+# Default flow steps
 bun run register-schemas
 bun run gen-data -- --schema all --count 10000
 bun run cdc-flush
 bun run federated-check
-bun run build-k6 && bun run k6-full
+
+# Optional compaction and load
+bun run compactor -- --all
+bun run build-k6
+bun run k6-full
 ```
 
 ## Troubleshooting
@@ -215,7 +282,9 @@ bun run register-schemas
 
 ### k6 not found
 
-Install k6:
+Either install k6 locally, or rely on the Docker fallback used by `bun run k6-smoke|k6-full|k6-perf`.
+
+Install k6 locally:
 
 ```bash
 # macOS

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -11,9 +11,9 @@
     "compactor": "bun run scripts/compactor.ts",
     "federated-check": "bun run scripts/federated-check.ts",
     "build-k6": "bunx esbuild k6/scenarios.ts --bundle --format=esm --target=es2020 --platform=neutral --external:k6 --external:'k6/*' --outfile=k6/dist/bundle.js",
-    "k6-smoke": "k6 run --out json=reports/k6-smoke.json -e SCENARIO=smoke k6/dist/bundle.js",
-    "k6-full": "k6 run --out json=reports/k6-full.json -e SCENARIO=full k6/dist/bundle.js",
-    "k6-perf": "k6 run --out json=reports/k6-perf.json -e SCENARIO=perf k6/dist/bundle.js",
+    "k6-smoke": "bash scripts/run-k6.sh smoke",
+    "k6-full": "bash scripts/run-k6.sh full",
+    "k6-perf": "bash scripts/run-k6.sh perf",
     "test": "bun run register-schemas && bun run gen-data && bun run cdc-flush && bun run federated-check"
   },
   "dependencies": {

--- a/tests/e2e/scripts/run-k6.sh
+++ b/tests/e2e/scripts/run-k6.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <smoke|full|perf> [extra k6 args...]" >&2
+  exit 1
+fi
+
+SCENARIO="$1"
+shift
+
+case "$SCENARIO" in
+  smoke|full|perf)
+    ;;
+  *)
+    echo "unsupported scenario: $SCENARIO" >&2
+    echo "expected one of: smoke, full, perf" >&2
+    exit 1
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUNDLE_PATH="$ROOT_DIR/k6/dist/bundle.js"
+REPORT_PATH="reports/k6-${SCENARIO}.json"
+
+if [ ! -f "$BUNDLE_PATH" ]; then
+  echo "k6 bundle not found: $BUNDLE_PATH" >&2
+  echo "run 'bun run build-k6' in tests/e2e first." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+if command -v k6 >/dev/null 2>&1; then
+  exec k6 run --out "json=${REPORT_PATH}" -e "SCENARIO=${SCENARIO}" k6/dist/bundle.js "$@"
+fi
+
+if command -v docker >/dev/null 2>&1; then
+  exec docker run --rm -i \
+    -u "$(id -u):$(id -g)" \
+    -v "$ROOT_DIR:/work" \
+    -w /work \
+    -e BASE_URL \
+    -e AUTH_TOKEN \
+    -e SCHEMAS \
+    grafana/k6 \
+    run --out "json=${REPORT_PATH}" -e "SCENARIO=${SCENARIO}" k6/dist/bundle.js "$@"
+fi
+
+echo "k6 is not installed and Docker is unavailable." >&2
+echo "install k6 locally or run with Docker available." >&2
+exit 127


### PR DESCRIPTION
## Summary

- Adds bilingual (EN/CN) E2E test documentation: `docs/e2e-tests-en.md`, `docs/e2e-tests-cn.md`.
- Adds `tests/e2e/scripts/run-k6.sh`: CI-ready k6 runner with configurable target URL, VU count, and duration.
- Adds `scripts/run_local_k6_full.sh`: convenience script for running the full k6 suite locally.
- Updates `internal/e2e_harness/README.md` and `tests/e2e/README.md` with usage instructions.
- Updates `tests/e2e/package.json` with k6 build/run scripts.
- Adds `tests/e2e/k6/dist/` and `tests/e2e/reports/` to `.gitignore` to prevent build artifacts and failed-run outputs from being committed.