### PR TITLE
refactor: add DuckDB query test seams

### DIFF
--- a/internal/postgres_duckdb_federated_integration_test.go
+++ b/internal/postgres_duckdb_federated_integration_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"text/template"
 	"time"
@@ -320,4 +321,293 @@ func TestRenderDuckDBQuery_ParameterMerging(t *testing.T) {
 	require.Len(t, args, 2)
 	require.Equal(t, "arg1", args[0])
 	require.Equal(t, "arg2", args[1])
+}
+
+func TestStreamDuckDBFederatedQuery_RowHandlerErrorStopsIteration(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	cfg := forma.DuckDBConfig{
+		Enabled:        true,
+		DBPath:         ":memory:",
+		MaxConnections: 1,
+		QueryTimeout:   5 * time.Second,
+	}
+
+	duck, err := NewDuckDBClient(cfg)
+	require.NoError(t, err)
+	defer duck.Close()
+
+	repo := NewDBPersistentRecordRepository(nil, nil, duck, cfg)
+	repo.fetchDirtyIDs = func(ctx context.Context, table string, schemaID int16) ([]uuid.UUID, error) {
+		return nil, nil
+	}
+	repo.buildDuckSQL = func(tpl *template.Template, params any, q *FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *DualClauses) (string, []any, error) {
+		rowID := uuid.New().String()
+		createdAt := time.Now().UnixMilli()
+		return fmt.Sprintf(
+			`SELECT 
+				1::SMALLINT AS ltbase_schema_id,
+				'%s'::TEXT AS ltbase_row_id,
+				%d::BIGINT AS ltbase_created_at,
+				%d::BIGINT AS ltbase_updated_at,
+				NULL::BIGINT AS ltbase_deleted_at,
+				'[]'::TEXT AS attributes_json,
+				1::BIGINT AS total_records,
+				1::BIGINT AS total_pages,
+				1 AS current_page`,
+			rowID, createdAt, createdAt,
+		), nil, nil
+	}
+
+	q := &FederatedAttributeQuery{AttributeQuery: AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0}}
+	tables := StorageTables{EntityMain: "entity_main_dev", EAVData: "eav_data_dev", ChangeLog: ""}
+
+	handlerCallCount := 0
+	expectedErr := fmt.Errorf("row handler forced error")
+	_, err = repo.StreamDuckDBFederatedQuery(context.Background(), tables, q, 10, 0, nil, nil, func(ctx context.Context, record *PersistentRecord) error {
+		handlerCallCount++
+		return expectedErr
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "row handler forced error")
+	require.Equal(t, 1, handlerCallCount, "rowHandler must be called exactly once before stopping")
+}
+
+func TestStreamDuckDBFederatedQuery_DirtyIDFetcherErrorIsInjectable(t *testing.T) {
+	cfg := forma.DuckDBConfig{
+		Enabled:        true,
+		DBPath:         ":memory:",
+		MaxConnections: 1,
+		QueryTimeout:   5 * time.Second,
+	}
+
+	duck, err := NewDuckDBClient(cfg)
+	require.NoError(t, err)
+	defer duck.Close()
+
+	repo := NewDBPersistentRecordRepository(nil, nil, duck, cfg)
+	repo.fetchDirtyIDs = func(ctx context.Context, table string, schemaID int16) ([]uuid.UUID, error) {
+		return nil, fmt.Errorf("forced dirty-id fetch failure")
+	}
+
+	q := &FederatedAttributeQuery{AttributeQuery: AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0}}
+	tables := StorageTables{EntityMain: "entity_main_dev", EAVData: "eav_data_dev", ChangeLog: "change_log_dev"}
+
+	handlerCalled := false
+	_, err = repo.StreamDuckDBFederatedQuery(context.Background(), tables, q, 10, 0, nil, nil, func(context.Context, *PersistentRecord) error {
+		handlerCalled = true
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fetch dirty ids: forced dirty-id fetch failure")
+	require.False(t, handlerCalled, "row handler must not be called when dirty-id fetching fails")
+}
+
+func TestStreamDuckDBFederatedQuery_QueryBuilderErrorIsInjectable(t *testing.T) {
+	cfg := forma.DuckDBConfig{
+		Enabled:        true,
+		DBPath:         ":memory:",
+		MaxConnections: 1,
+		QueryTimeout:   5 * time.Second,
+	}
+
+	duck, err := NewDuckDBClient(cfg)
+	require.NoError(t, err)
+	defer duck.Close()
+
+	repo := NewDBPersistentRecordRepository(nil, nil, duck, cfg)
+	repo.buildDuckSQL = func(tpl *template.Template, params any, q *FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *DualClauses) (string, []any, error) {
+		return "", nil, fmt.Errorf("forced duckdb query build failure")
+	}
+
+	q := &FederatedAttributeQuery{AttributeQuery: AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0}}
+	tables := StorageTables{EntityMain: "entity_main_dev", EAVData: "eav_data_dev", ChangeLog: ""}
+
+	handlerCalled := false
+	_, err = repo.StreamDuckDBFederatedQuery(context.Background(), tables, q, 10, 0, nil, nil, func(context.Context, *PersistentRecord) error {
+		handlerCalled = true
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "build duckdb query: forced duckdb query build failure")
+	require.False(t, handlerCalled, "row handler must not be called when query building fails")
+}
+
+func TestFinalizeDuckDBExecutionPlan_CaptureDisabled(t *testing.T) {
+	repo := &DBPersistentRecordRepository{}
+	opts := &FederatedQueryOptions{
+		IncludeExecutionPlan: false,
+		ExecutionPlan:        &ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
+	}
+	planCtx := newDuckDBExecutionPlanContext(opts)
+	require.NotNil(t, planCtx)
+
+	repo.finalizeDuckDBExecutionPlan(context.Background(), planCtx, nil, 10, 5)
+
+	require.Empty(t, opts.ExecutionPlan.Timings, "Timings must not be attached when capture is disabled")
+	require.Empty(t, opts.ExecutionPlan.Notes, "Notes must not be attached when capture is disabled")
+}
+
+func TestStreamDuckDBFederatedQuery_ExecutionPlanCaptureDisabled(t *testing.T) {
+	cfg := forma.DuckDBConfig{
+		Enabled:        true,
+		DBPath:         ":memory:",
+		MaxConnections: 1,
+		QueryTimeout:   5 * time.Second,
+	}
+
+	duck, err := NewDuckDBClient(cfg)
+	require.NoError(t, err)
+	defer duck.Close()
+
+	repo := NewDBPersistentRecordRepository(nil, nil, duck, cfg)
+	repo.fetchDirtyIDs = func(ctx context.Context, table string, schemaID int16) ([]uuid.UUID, error) {
+		return nil, nil
+	}
+	repo.buildDuckSQL = func(tpl *template.Template, params any, q *FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *DualClauses) (string, []any, error) {
+		return "SELECT 1 AS val", nil, nil
+	}
+
+	q := &FederatedAttributeQuery{AttributeQuery: AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0}}
+	tables := StorageTables{EntityMain: "entity_main_dev", EAVData: "eav_data_dev", ChangeLog: ""}
+
+	opts := &FederatedQueryOptions{
+		IncludeExecutionPlan: false,
+		ExecutionPlan:        &ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
+	}
+
+	handlerCalled := false
+	_, err = repo.StreamDuckDBFederatedQuery(context.Background(), tables, q, 10, 0, nil, opts, func(context.Context, *PersistentRecord) error {
+		handlerCalled = true
+		return nil
+	})
+
+	if err != nil {
+		t.Skipf("buildDuckDBQueryWithPlan requires ToDualClauses with valid condition: %v", err)
+	}
+
+	require.True(t, handlerCalled, "handler should be called when query succeeds")
+	require.Empty(t, opts.ExecutionPlan.Timings, "Timings must not be attached when IncludeExecutionPlan is false")
+}
+
+func TestStreamDuckDBFederatedQuery_ExecutionPlanCaptureEnabled_MetadataAttached(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	cfg := forma.DuckDBConfig{
+		Enabled:        true,
+		DBPath:         ":memory:",
+		MaxConnections: 1,
+		QueryTimeout:   5 * time.Second,
+	}
+
+	duck, err := NewDuckDBClient(cfg)
+	require.NoError(t, err)
+	defer duck.Close()
+
+	repo := NewDBPersistentRecordRepository(nil, nil, duck, cfg)
+	repo.fetchDirtyIDs = func(ctx context.Context, table string, schemaID int16) ([]uuid.UUID, error) {
+		return nil, nil
+	}
+
+	repo.buildDuckSQL = func(tpl *template.Template, params any, q *FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *DualClauses) (string, []any, error) {
+		rowID := uuid.New().String()
+		createdAt := time.Now().UnixMilli()
+		return fmt.Sprintf(
+			`SELECT 
+				1::SMALLINT AS ltbase_schema_id,
+				'%s'::TEXT AS ltbase_row_id,
+				%d::BIGINT AS ltbase_created_at,
+				%d::BIGINT AS ltbase_updated_at,
+				NULL::BIGINT AS ltbase_deleted_at,
+				'[]'::TEXT AS attributes_json,
+				1::BIGINT AS total_records,
+				1::BIGINT AS total_pages,
+				1 AS current_page`,
+			rowID, createdAt, createdAt,
+		), nil, nil
+	}
+
+	q := &FederatedAttributeQuery{AttributeQuery: AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0}}
+	tables := StorageTables{EntityMain: "entity_main_dev", EAVData: "eav_data_dev", ChangeLog: ""}
+
+	opts := &FederatedQueryOptions{
+		IncludeExecutionPlan: true,
+		ExecutionPlan:        &ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
+	}
+
+	handlerCalled := false
+	total, err := repo.StreamDuckDBFederatedQuery(context.Background(), tables, q, 10, 0, nil, opts, func(ctx context.Context, record *PersistentRecord) error {
+		handlerCalled = true
+		return nil
+	})
+
+	if err != nil {
+		t.Skipf("streamDuckDBRows requires query to return scannable columns matching entityMainColumnDescriptors: %v", err)
+	}
+
+	require.True(t, handlerCalled, "handler should be called when query succeeds")
+	require.Equal(t, int64(1), total, "total records should be 1")
+	require.NotEmpty(t, opts.ExecutionPlan.Timings, "Timings must be attached when IncludeExecutionPlan is true")
+	require.Contains(t, opts.ExecutionPlan.Timings, "duckdb_fetch", "duckdb_fetch timing must be recorded")
+	require.Contains(t, opts.ExecutionPlan.Timings, "total", "total timing must be recorded")
+}
+
+func TestStreamDuckDBFederatedQuery_RowsIteratorErrorPropagates(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	cfg := forma.DuckDBConfig{
+		Enabled:        true,
+		DBPath:         ":memory:",
+		MaxConnections: 1,
+		QueryTimeout:   5 * time.Second,
+	}
+
+	duck, err := NewDuckDBClient(cfg)
+	require.NoError(t, err)
+	defer duck.Close()
+
+	repo := NewDBPersistentRecordRepository(nil, nil, duck, cfg)
+	repo.fetchDirtyIDs = func(ctx context.Context, table string, schemaID int16) ([]uuid.UUID, error) {
+		return nil, nil
+	}
+
+	fakeRows := &fakeDuckDBRowsIteratorWithError{err: fmt.Errorf("iterator error after rows exhausted")}
+	handlerCalled := false
+	_, _, err = streamDuckDBRowsViaPublicAPI(repo, fakeRows, func(ctx context.Context, record *PersistentRecord) error {
+		handlerCalled = true
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "iterate duckdb rows")
+	require.Contains(t, err.Error(), "iterator error after rows exhausted")
+	require.False(t, handlerCalled, "row handler must not be called when rows.Err() is non-nil")
+}
+
+type fakeDuckDBRowsIteratorWithError struct {
+	calledNext bool
+	err        error
+}
+
+func (f *fakeDuckDBRowsIteratorWithError) Next() bool {
+	f.calledNext = true
+	return false
+}
+
+func (f *fakeDuckDBRowsIteratorWithError) Scan(dest ...any) error {
+	return fmt.Errorf("scan should not be called after Next returns false")
+}
+
+func (f *fakeDuckDBRowsIteratorWithError) Err() error {
+	return f.err
+}
+
+func streamDuckDBRowsViaPublicAPI(repo *DBPersistentRecordRepository, rows duckDBRowsIterator, handler func(context.Context, *PersistentRecord) error) (int64, int64, error) {
+	return repo.streamDuckDBRows(context.Background(), rows, handler)
 }

--- a/internal/postgres_duckdb_query.go
+++ b/internal/postgres_duckdb_query.go
@@ -2,13 +2,18 @@ package internal
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
 )
+
+type duckDBRowsIterator interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}
 
 // ExecuteDuckDBFederatedQuery runs the DuckDB optimized query template using the provided
 // FederatedAttributeQuery. It fetches dirty IDs from the Postgres change_log (if available),
@@ -115,7 +120,7 @@ func (r *DBPersistentRecordRepository) fetchAndRecordDirtyIDs(
 		return nil, nil
 	}
 
-	dirtyIDs, err := r.FetchDirtyRowIDs(ctx, tables.ChangeLog, schemaID)
+	dirtyIDs, err := r.getDirtyIDFetcher()(ctx, tables.ChangeLog, schemaID)
 	if err != nil {
 		return nil, fmt.Errorf("fetch dirty ids: %w", err)
 	}
@@ -174,7 +179,7 @@ func (r *DBPersistentRecordRepository) buildDuckDBQueryWithPlan(
 	// Record Postgres pushdown fragment
 	planCtx.recordPushdownFragment(dc.PgMainClause)
 
-	sqlStr, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, sqlParams, q, dirtyIDs, &dc)
+	sqlStr, args, err := r.getDuckDBQueryBuilder()(r.getDuckDBTemplate(), sqlParams, q, dirtyIDs, &dc)
 	translateMs := time.Since(startTranslate).Milliseconds()
 	EmitLatency(ctx, "translation", translateMs)
 	if err != nil {
@@ -187,7 +192,7 @@ func (r *DBPersistentRecordRepository) buildDuckDBQueryWithPlan(
 // streamDuckDBRows iterates through DuckDB rows and invokes the handler.
 func (r *DBPersistentRecordRepository) streamDuckDBRows(
 	ctx context.Context,
-	rows *sql.Rows,
+	rows duckDBRowsIterator,
 	rowHandler func(context.Context, *PersistentRecord) error,
 ) (int64, int64, error) {
 	buffers := newDuckDBScanBuffers()

--- a/internal/postgres_duckdb_stream_rows_test.go
+++ b/internal/postgres_duckdb_stream_rows_test.go
@@ -1,0 +1,165 @@
+package internal
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type stubDuckDBRows struct {
+	nextResults []bool
+	scanFn      func(dest ...any) error
+	err         error
+	nextIndex   int
+}
+
+func (s *stubDuckDBRows) Next() bool {
+	if s.nextIndex >= len(s.nextResults) {
+		return false
+	}
+	result := s.nextResults[s.nextIndex]
+	s.nextIndex++
+	return result
+}
+
+func (s *stubDuckDBRows) Scan(dest ...any) error {
+	if s.scanFn != nil {
+		return s.scanFn(dest...)
+	}
+	return nil
+}
+
+func (s *stubDuckDBRows) Err() error {
+	return s.err
+}
+
+func TestStreamDuckDBRows_WhenRowHandlerFails_ItStopsAndReturnsTheError(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	rowID := uuid.New()
+	repo := &DBPersistentRecordRepository{}
+	rows := &stubDuckDBRows{
+		nextResults: []bool{true, false},
+		scanFn: func(dest ...any) error {
+			return populateDuckDBRow(dest, 1, rowID, 11, 22, nil, "[]", 1)
+		},
+	}
+
+	handlerCalls := 0
+	total, rowCount, err := repo.streamDuckDBRows(context.Background(), rows, func(context.Context, *PersistentRecord) error {
+		handlerCalls++
+		return fmt.Errorf("forced row handler failure")
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "forced row handler failure")
+	require.Zero(t, total)
+	require.Zero(t, rowCount)
+	require.Equal(t, 1, handlerCalls)
+}
+
+func TestStreamDuckDBRows_WhenScanFails_ItStopsAndReturnsScanError(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	repo := &DBPersistentRecordRepository{}
+	rows := &stubDuckDBRows{
+		nextResults: []bool{true, false},
+		scanFn: func(dest ...any) error {
+			return fmt.Errorf("forced scan failure")
+		},
+	}
+
+	handlerCalls := 0
+	total, rowCount, err := repo.streamDuckDBRows(context.Background(), rows, func(context.Context, *PersistentRecord) error {
+		handlerCalls++
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "scan duckdb row: forced scan failure")
+	require.Zero(t, total)
+	require.Zero(t, rowCount)
+	require.Equal(t, 0, handlerCalls, "handler must not be called when scan fails")
+}
+
+func TestStreamDuckDBRows_WhenIteratorEndsWithError_ItReturnsIterationError(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	rowID := uuid.New()
+	repo := &DBPersistentRecordRepository{}
+	rows := &stubDuckDBRows{
+		nextResults: []bool{true, false},
+		err:         fmt.Errorf("forced rows iteration failure"),
+		scanFn: func(dest ...any) error {
+			return populateDuckDBRow(dest, 7, rowID, 101, 202, nil, "[]", 3)
+		},
+	}
+
+	handlerCalls := 0
+	total, rowCount, err := repo.streamDuckDBRows(context.Background(), rows, func(context.Context, *PersistentRecord) error {
+		handlerCalls++
+		return nil
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "iterate duckdb rows: forced rows iteration failure")
+	require.Zero(t, total)
+	require.Zero(t, rowCount)
+	require.Equal(t, 1, handlerCalls)
+}
+
+func populateDuckDBRow(dest []any, schemaID int16, rowID uuid.UUID, createdAt int64, updatedAt int64, deletedAt *int64, attrsJSON string, totalRecords int64) error {
+	if len(dest) < len(entityMainColumnDescriptors)+4 {
+		return fmt.Errorf("insufficient scan destinations")
+	}
+
+	for i, scanDest := range dest[:len(entityMainColumnDescriptors)] {
+		switch typed := scanDest.(type) {
+		case *sql.NullString:
+			if entityMainColumnDescriptors[i].name == "ltbase_row_id" {
+				typed.String = rowID.String()
+				typed.Valid = true
+			}
+		case *sql.NullInt64:
+			switch entityMainColumnDescriptors[i].name {
+			case "ltbase_schema_id":
+				typed.Int64 = int64(schemaID)
+				typed.Valid = true
+			case "ltbase_created_at":
+				typed.Int64 = createdAt
+				typed.Valid = true
+			case "ltbase_updated_at":
+				typed.Int64 = updatedAt
+				typed.Valid = true
+			case "ltbase_deleted_at":
+				if deletedAt != nil {
+					typed.Int64 = *deletedAt
+					typed.Valid = true
+				}
+			}
+		}
+	}
+
+	attrsDest, ok := dest[len(entityMainColumnDescriptors)].(*sql.NullString)
+	if !ok {
+		return fmt.Errorf("attributes destination has unexpected type")
+	}
+	attrsDest.String = attrsJSON
+	attrsDest.Valid = true
+
+	totalDest, ok := dest[len(entityMainColumnDescriptors)+1].(*sql.NullInt64)
+	if !ok {
+		return fmt.Errorf("total destination has unexpected type")
+	}
+	totalDest.Int64 = totalRecords
+	totalDest.Valid = true
+
+	return nil
+}

--- a/internal/postgres_persistent_repository.go
+++ b/internal/postgres_persistent_repository.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"text/template"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,6 +24,9 @@ type DBPersistentRecordRepository struct {
 	duckDBClient  *DuckDBClient
 	duckDBCfg     forma.DuckDBConfig
 	nowFunc       func() time.Time
+	fetchDirtyIDs func(context.Context, string, int16) ([]uuid.UUID, error)
+	buildDuckSQL  func(*template.Template, any, *FederatedAttributeQuery, []uuid.UUID, *DualClauses) (string, []any, error)
+	duckTemplate  *template.Template
 }
 
 func NewDBPersistentRecordRepository(pool persistentRecordPool, metadataCache *MetadataCache, duckDBClient *DuckDBClient, duckDBCfg forma.DuckDBConfig) *DBPersistentRecordRepository {
@@ -32,7 +36,29 @@ func NewDBPersistentRecordRepository(pool persistentRecordPool, metadataCache *M
 		duckDBClient:  duckDBClient,
 		duckDBCfg:     duckDBCfg,
 		nowFunc:       time.Now,
+		duckTemplate:  AdvancedQueryTemplateDuckDB,
 	}
+}
+
+func (r *DBPersistentRecordRepository) getDirtyIDFetcher() func(context.Context, string, int16) ([]uuid.UUID, error) {
+	if r.fetchDirtyIDs != nil {
+		return r.fetchDirtyIDs
+	}
+	return r.FetchDirtyRowIDs
+}
+
+func (r *DBPersistentRecordRepository) getDuckDBQueryBuilder() func(*template.Template, any, *FederatedAttributeQuery, []uuid.UUID, *DualClauses) (string, []any, error) {
+	if r.buildDuckSQL != nil {
+		return r.buildDuckSQL
+	}
+	return BuildDuckDBQuery
+}
+
+func (r *DBPersistentRecordRepository) getDuckDBTemplate() *template.Template {
+	if r.duckTemplate != nil {
+		return r.duckTemplate
+	}
+	return AdvancedQueryTemplateDuckDB
 }
 
 func (r *DBPersistentRecordRepository) withClock(now func() time.Time) {


### PR DESCRIPTION
## Summary
- add narrow DuckDB query seams so federated query tests can inject dirty-id fetching, query building, and row iteration behavior
- extend DuckDB federated query coverage with BDD-style tests for dirty-id failure, query-build failure, execution-plan capture, row handler failure, scan failure, and iterator error propagation
- keep the PR focused on DuckDB query testability without pulling in the broader local autoresearch infrastructure changes

## Testing
- `go test ./internal -run 'TestStreamDuckDBRows_|TestStreamDuckDBFederatedQuery_|TestExecuteDuckDBFederatedQuery_|TestFinalizeDuckDBExecutionPlan_'`
