### PR TITLE
fix: resolve autoresearch root from git common dir

### DIFF
--- a/tools/autoresearch/testing/scripts/common.sh
+++ b/tools/autoresearch/testing/scripts/common.sh
@@ -2,7 +2,19 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(git rev-parse --show-toplevel)"
+resolve_repo_root_dir() {
+  local common_dir
+
+  common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [[ -n "$common_dir" && "$(basename "$common_dir")" == ".git" ]]; then
+    dirname "$common_dir"
+    return 0
+  fi
+
+  git rev-parse --show-toplevel
+}
+
+ROOT_DIR="$(resolve_repo_root_dir)"
 AR_DIR="$ROOT_DIR/tools/autoresearch/testing"
 REPORT_DIR="$AR_DIR/reports"
 


### PR DESCRIPTION
## Summary
- resolve the autoresearch repository root from Git's common directory instead of `git rev-parse --show-toplevel`
- keep linked worktrees pointed at the shared repository root so `autoloop.sh` reuses the canonical `.worktrees/autoresearch-*` directories

## Validation
- from a linked worktree, source `tools/autoresearch/testing/scripts/common.sh` and confirm `ROOT_DIR` resolves to `/home/ruoshi/code/github/forma`
- from a linked worktree, run:
  - `"/home/ruoshi/code/github/forma/.worktrees/pr-autoresearch-root-resolution-20260416/tools/autoresearch/testing/scripts/autoloop.sh" --model opencode-go/minimax-m2.7 --target postgres_repo_query --iterations 1 --dry-run --force --skip-local-infra`
  - verified that `WORKTREE_DIR` resolves to `/home/ruoshi/code/github/forma/.worktrees/autoresearch-postgres_repo_query` and the dry-run completes without trying to create a nested `.worktrees` directory
