### PR TITLE
Fix lenient parsing for bare RFC3339 values

### DIFF
--- a/internal/conditionexpr/parser.go
+++ b/internal/conditionexpr/parser.go
@@ -21,6 +21,10 @@ type SQLOperatorResult struct {
 
 // ParseOperatorValueLenient parses "op:value"; malformed pairs fallback to equals(raw).
 func ParseOperatorValueLenient(raw string) OperatorValue {
+	if _, err := ParseRFC3339OrUnixMs(raw); err == nil {
+		return OperatorValue{Operator: "equals", Value: raw}
+	}
+
 	if before, after, ok := strings.Cut(raw, ":"); ok {
 		opPart := before
 		valPart := after

--- a/internal/conditionexpr/parser_test.go
+++ b/internal/conditionexpr/parser_test.go
@@ -38,6 +38,29 @@ func TestParseOperatorValueStrict(t *testing.T) {
 	}
 }
 
+func TestParseOperatorValueLenient(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantOp    string
+		wantValue string
+	}{
+		{name: "bare text", raw: "abc", wantOp: "equals", wantValue: "abc"},
+		{name: "supported operator", raw: "gt:10", wantOp: "gt", wantValue: "10"},
+		{name: "bare rfc3339 literal", raw: "2020-01-02T03:04:05Z", wantOp: "equals", wantValue: "2020-01-02T03:04:05Z"},
+		{name: "unknown operator still preserved", raw: "unknownop:bar", wantOp: "unknownop", wantValue: "bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseOperatorValueLenient(tt.raw)
+			if got.Operator != tt.wantOp || got.Value != tt.wantValue {
+				t.Fatalf("unexpected parse result %+v", got)
+			}
+		})
+	}
+}
+
 func TestToSQLOperator(t *testing.T) {
 	got, err := ToSQLOperator("eq", "42")
 	if err != nil {


### PR DESCRIPTION
## Summary
- treat bare RFC3339 and unix-millisecond literals as `equals` in `ParseOperatorValueLenient`
- preserve existing lenient behavior for explicit operators such as `gt:10` and unknown operator prefixes
- add regression coverage for bare text, explicit operators, bare RFC3339 values, and unknown operator prefixes