### PR TITLE
align DuckDB federated queries with production mixed-tier execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.out
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   GO_VERSION: '1.26.0'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   lint:

--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -10,6 +10,9 @@ on:
         description: "Module version tag (e.g., v1.2.3)"
         required: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/internal/advanced_query_template_duckdb.go
+++ b/internal/advanced_query_template_duckdb.go
@@ -3,9 +3,7 @@ package internal
 import "text/template"
 
 // AdvancedQueryTemplateDuckDB is the DuckDB SQL template used for federated queries.
-// Placeholders expected to be substituted by the renderer:
-//
-//	$SCHEMA_ID, $PG_CONN, $PG_WHERE_CLAUSE, $LOGICAL_WHERE_CLAUSE, $S3_PATHS, $PAGE_SIZE, $OFFSET
+// Placeholders expected to be substituted by the renderer via Go template fields.
 var AdvancedQueryTemplateDuckDB = template.Must(template.New("optimizedQueryDuckDB").Funcs(template.FuncMap{
 	"add": func(a, b int) int { return a + b },
 }).Parse(`
@@ -14,19 +12,20 @@ PRAGMA memory_limit='4GB';
 PRAGMA threads=4;
 
 -- Parameters:
--- $SCHEMA_ID       : integer
--- $PG_CONN         : postgres connection string for postgres_scan
--- $PG_WHERE_CLAUSE : pushdown predicate for entity_main (physical columns)
--- $LOGICAL_WHERE_CLAUSE : logical predicate for final filtering (DuckDB / Parquet columns)
--- $S3_PATHS        : comma-separated paths for read_parquet()
--- $PAGE_SIZE, $OFFSET
+-- .SCHEMA_ID             : integer
+-- .PG_CONN               : postgres connection string for postgres_scan
+-- .PG_WHERE_CLAUSE       : pushdown predicate for entity_main (physical columns)
+-- .LOGICAL_WHERE_CLAUSE  : logical predicate for final filtering (DuckDB / Parquet columns)
+-- .S3_PATHS              : comma-separated paths for read_parquet()
+-- .PAGE_SIZE, .OFFSET
 
 WITH
 -- Dirty set: rows currently present/dirty in PG change_log (flushed_at = 0)
 dirty_ids AS (
   SELECT row_id
-  FROM postgres_scan($PG_CONN, 'change_log', 'flushed_at = 0')
-  WHERE schema_id = $SCHEMA_ID
+  FROM postgres_scan('{{.PG_CONN}}', 'public', 'change_log_dev')
+  WHERE schema_id = {{.SCHEMA_ID}}
+    AND flushed_at = 0
 ),
 
 -- S3 source (Cold/Warm). Read Parquet files and apply logical filters + anti-join
@@ -42,11 +41,11 @@ s3_source AS (
     age,
     tag
 
-  FROM read_parquet($S3_PATHS)
+  FROM read_parquet({{.S3_PATHS}})
   WHERE
-    ($LOGICAL_WHERE_CLAUSE)
+    ({{.LOGICAL_WHERE_CLAUSE}})
     -- Anti-join: exclude rows that are present in the Dirty Set (PG hot buffer)
-    AND row_id NOT IN (SELECT row_id FROM dirty_ids)
+    AND CAST(row_id AS UUID) NOT IN (SELECT row_id FROM dirty_ids)
 ),
 
 -- PG source (Hot). Use postgres_scan with pushdown for entity_main, pivot EAV attributes.
@@ -64,21 +63,23 @@ pg_source AS (
     -- EAV pivot (explicit casts). Replace attr_id constants with dynamic mapping if needed.
     MAX(CASE WHEN e.attr_id = 205 THEN CAST(e.value_text AS VARCHAR) END) AS tag
 
-  FROM postgres_scan($PG_CONN, 'change_log', 'flushed_at = 0') cl
+  FROM postgres_scan('{{.PG_CONN}}', 'public', 'change_log_dev') cl
 
-  -- Pushdown: restrict entity_main at the scan-level using $PG_WHERE_CLAUSE
-  JOIN postgres_scan($PG_CONN,
-    'SELECT * FROM entity_main_dev
-     WHERE ltbase_schema_id = ' || $SCHEMA_ID || '
-       AND (' || $PG_WHERE_CLAUSE || ')'
+  -- Pushdown: restrict entity_main at the scan-level using .PG_WHERE_CLAUSE
+  JOIN postgres_scan('{{.PG_CONN}}',
+    'public',
+    'entity_main_dev'
   ) m
     ON cl.schema_id = m.ltbase_schema_id
     AND cl.row_id = m.ltbase_row_id
 
-  LEFT JOIN postgres_scan($PG_CONN, 'eav_data_dev') e
+  LEFT JOIN postgres_scan('{{.PG_CONN}}', 'public', 'eav_data_dev') e
     ON cl.schema_id = e.schema_id AND cl.row_id = e.row_id
 
-  WHERE cl.schema_id = $SCHEMA_ID
+  WHERE cl.schema_id = {{.SCHEMA_ID}}
+    AND cl.flushed_at = 0
+    AND m.ltbase_schema_id = {{.SCHEMA_ID}}
+    AND ({{.PG_WHERE_CLAUSE}})
   GROUP BY m.ltbase_row_id, m.ltbase_created_at, cl.changed_at, cl.deleted_at, m.text_01, m.integer_01
 ),
 
@@ -94,19 +95,25 @@ unified AS (
 -- - Remove soft-deleted rows
 -- - Deduplicate using Last-Write-Wins (ver_ts ordering)
 SELECT
-  row_id,
-  name,
-  age,
-  tag,
-  created_at
+  {{.SCHEMA_ID}}::SMALLINT AS ltbase_schema_id,
+  CAST(row_id AS UUID) AS ltbase_row_id,
+  created_at AS ltbase_created_at,
+  ver_ts AS ltbase_updated_at,
+  deleted_ts AS ltbase_deleted_at,
+  name AS text_01,
+  age AS integer_01,
+  '[]'::TEXT AS attributes_json,
+  COUNT(*) OVER() AS total_records,
+  CEIL(COUNT(*) OVER()::DOUBLE / NULLIF({{.PAGE_SIZE}}, 0))::BIGINT AS total_pages,
+  (FLOOR({{.OFFSET}}::DOUBLE / NULLIF({{.PAGE_SIZE}}, 0)) + 1)::BIGINT AS current_page
 FROM unified
 WHERE
-  ($LOGICAL_WHERE_CLAUSE)
+  ({{.LOGICAL_WHERE_CLAUSE}})
   AND (deleted_ts IS NULL OR deleted_ts = 0)
 
 -- Deduplicate: keep most recent version per row_id
 QUALIFY ROW_NUMBER() OVER (PARTITION BY row_id ORDER BY ver_ts DESC) = 1
 
 ORDER BY created_at DESC
-LIMIT $PAGE_SIZE OFFSET $OFFSET;
+LIMIT {{.PAGE_SIZE}} OFFSET {{.OFFSET}};
 `))

--- a/internal/cdc/export_sql_shared_test.go
+++ b/internal/cdc/export_sql_shared_test.go
@@ -163,6 +163,14 @@ func TestBuildMainEntityQuery_OmitsDeletedGuardWhenActiveOnlyIsFalse(t *testing.
 	require.Contains(t, query, "AND ltbase_row_id IS NOT NULL")
 }
 
+func TestBuildMainEntityQuery_IncludesDeletedGuardWhenActiveOnlyIsTrue(t *testing.T) {
+	query := buildMainEntityQuery("entity_main", 7, []string{"ltbase_row_id", "text_01"}, "ltbase_row_id IS NOT NULL", true)
+
+	require.Contains(t, query, "FROM entity_main")
+	require.Contains(t, query, "ltbase_deleted_at IS NULL")
+	require.Contains(t, query, "AND ltbase_row_id IS NOT NULL")
+}
+
 func TestBuildEAVQuery_OmitsAttrFilterWhenAttrIDsAreEmpty(t *testing.T) {
 	query := buildEAVQuery("eav_data", 9, "row_id IS NOT NULL", nil)
 
@@ -207,6 +215,75 @@ func TestBuildSchemaDrivenProjection_DeduplicatesMainColumnsAndSeparatesEAVAggre
 	require.Contains(t, projection.eavAgg[0], "attr_id = 12")
 	require.Contains(t, projection.eavAgg[0], "AS is_active")
 	require.Equal(t, []int16{12}, projection.eavAttrIDs)
+}
+
+func TestBuildParquetCopyOptions_FormatsResolvedOptionsForDuckDB(t *testing.T) {
+	options := buildParquetCopyOptions(exportSQLOptions{
+		compression:      "zstd",
+		compressionLevel: 7,
+		memoryLimit:      "3GB",
+		parquetVersion:   "V2",
+	})
+
+	require.Equal(t, "FORMAT PARQUET, PARQUET_VERSION V2, COMPRESSION 'ZSTD', COMPRESSION_LEVEL 7", options)
+}
+
+func TestBuildSchemaDrivenProjection_MixedBoundAndUnboundAttributesKeepCastsAliasesAndAttrIDsAligned(t *testing.T) {
+	projection := buildSchemaDrivenProjection(forma.SchemaAttributeCache{
+		"display_name": {
+			AttributeName: "display_name",
+			AttributeID:   20,
+			ValueType:     forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnText01},
+		},
+		"employee_count": {
+			AttributeName: "employee_count",
+			AttributeID:   21,
+			ValueType:     forma.ValueTypeInteger,
+		},
+		"is_active": {
+			AttributeName: "is_active",
+			AttributeID:   22,
+			ValueType:     forma.ValueTypeBool,
+		},
+	})
+
+	require.Contains(t, projection.mainColumns, string(forma.MainColumnText01))
+	require.Len(t, projection.mainProjections, 1)
+	require.Contains(t, projection.mainProjections[0], "CAST(m.text_01 AS VARCHAR)")
+	require.Contains(t, projection.mainProjections[0], "AS display_name")
+	require.Len(t, projection.eavAgg, 2)
+	require.Contains(t, projection.eavAgg[0], "attr_id = 21")
+	require.Contains(t, projection.eavAgg[0], "TRY_CAST(value_text AS INTEGER)")
+	require.Contains(t, projection.eavAgg[0], "AS employee_count")
+	require.Contains(t, projection.eavAgg[1], "attr_id = 22")
+	require.Contains(t, projection.eavAgg[1], "lower(value_text) IN ('true','1','t','yes','y')")
+	require.Contains(t, projection.eavAgg[1], "ELSE NULL END")
+	require.Contains(t, projection.eavAgg[1], "AS is_active")
+	require.Equal(t, []string{"e.employee_count", "e.is_active"}, projection.eavSelect)
+	require.Equal(t, []int16{21, 22}, projection.eavAttrIDs)
+}
+
+func TestBuildSchemaDrivenProjection_PreservesProjectionSplitAcrossBoundAndUnboundAttributes(t *testing.T) {
+	projection := buildSchemaDrivenProjection(forma.SchemaAttributeCache{
+		"company_name": {
+			AttributeName: "company_name",
+			AttributeID:   30,
+			ValueType:     forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnText02},
+		},
+		"annual_revenue": {
+			AttributeName: "annual_revenue",
+			AttributeID:   31,
+			ValueType:     forma.ValueTypeNumeric,
+		},
+	})
+
+	require.Contains(t, projection.mainColumns, string(forma.MainColumnText02))
+	require.Equal(t, []string{"CAST(m.text_02 AS VARCHAR) AS company_name"}, projection.mainProjections)
+	require.Equal(t, []string{"MAX(CASE WHEN attr_id = 31 THEN TRY_CAST(value_text AS DOUBLE) END) AS annual_revenue"}, projection.eavAgg)
+	require.Equal(t, []string{"e.annual_revenue"}, projection.eavSelect)
+	require.Equal(t, []int16{31}, projection.eavAttrIDs)
 }
 
 func TestBuildEAVAggregationSQL_GroupsByRowIDWhenNoAggregatesExist(t *testing.T) {

--- a/internal/duckdb_template_renderer.go
+++ b/internal/duckdb_template_renderer.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/google/uuid"
@@ -26,6 +28,8 @@ func RenderDuckDBQuery(tpl *template.Template, params any, whereArgs []any) (str
 // params so the template (or tests) can observe the pushdown fragment. Dirty-ID exclusions
 // are appended to the DuckDB clause regardless of source.
 func BuildDuckDBQuery(tpl *template.Template, params any, q *FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *DualClauses) (string, []any, error) {
+	isAdvancedTemplate := tpl == AdvancedQueryTemplateDuckDB
+
 	// Prepare where variables
 	var whereClause string
 	var whereArgs []any
@@ -47,12 +51,13 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *FederatedAttributeQ
 	// If dual clauses provided, prefer them; otherwise fall back to legacy generator.
 	if dual != nil && dual.DuckClause != "" {
 		whereClause = dual.DuckClause
-		whereArgs = make([]any, 0, len(dual.DuckArgs))
+		whereArgs = make([]any, 0, len(dual.DuckArgs)+len(dual.PgMainArgs)+len(dual.DuckArgs))
 		if len(dual.DuckArgs) > 0 {
 			whereArgs = append(whereArgs, dual.DuckArgs...)
 		}
-		// Append dirty exclusions
-		if len(dirtyIDs) > 0 {
+		// Generic templates need the dirty-id exclusion physically appended into the clause.
+		// The production DuckDB federated template manages dirty IDs via its own CTE/anti-join.
+		if !isAdvancedTemplate && len(dirtyIDs) > 0 {
 			var exclArgs []any
 			whereClause, exclArgs = AppendDirtyExclusion(whereClause, dirtyIDs)
 			whereArgs = append(whereArgs, exclArgs...)
@@ -63,18 +68,99 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *FederatedAttributeQ
 		m["PgMainClause"] = dual.PgMainClause
 		m["PgMainArgs"] = dual.PgMainArgs
 		m["HasPgMainClause"] = dual.PgMainClause != ""
+		if isAdvancedTemplate {
+			m["LOGICAL_WHERE_CLAUSE"] = dual.DuckClause
+			m["PG_WHERE_CLAUSE"] = defaultIfEmpty(dual.PgMainClause, "1=1")
+			if len(dual.PgMainArgs) > 0 {
+				whereArgs = append(whereArgs, dual.PgMainArgs...)
+			}
+			if len(dual.DuckArgs) > 0 {
+				whereArgs = append(whereArgs, dual.DuckArgs...)
+			}
+		}
+		injectDuckDBTemplateParams(m, q, dual)
+		if !isAdvancedTemplate && len(dual.PgMainArgs) > 0 {
+			whereArgs = append(whereArgs, dual.PgMainArgs...)
+		}
 
 		merged := MergeTemplateParamsWithDirtyIDs(m, dirtyIDs)
 		return RenderDuckDBQuery(tpl, merged, whereArgs)
 	}
 
 	// Legacy path
-	whereClause, whereArgs, err = GenerateDuckDBWhereClauseWithExclusions(q, dirtyIDs)
+	if isAdvancedTemplate {
+		whereClause, whereArgs, err = GenerateDuckDBWhereClause(q)
+	} else {
+		whereClause, whereArgs, err = GenerateDuckDBWhereClauseWithExclusions(q, dirtyIDs)
+	}
 	if err != nil {
 		return "", nil, err
 	}
 	anchor["Condition"] = whereClause
+	if isAdvancedTemplate {
+		m["LOGICAL_WHERE_CLAUSE"] = whereClause
+		if len(whereArgs) > 0 {
+			whereArgs = append(whereArgs, whereArgs...)
+		}
+	}
+	injectDuckDBTemplateParams(m, q, nil)
 
 	merged := MergeTemplateParamsWithDirtyIDs(m, dirtyIDs)
 	return RenderDuckDBQuery(tpl, merged, whereArgs)
+}
+
+func defaultIfEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func injectDuckDBTemplateParams(params map[string]any, q *FederatedAttributeQuery, dual *DualClauses) {
+	if q == nil {
+		return
+	}
+
+	params["SCHEMA_ID"] = q.SchemaID
+	params["PAGE_SIZE"] = q.Limit
+	params["OFFSET"] = q.Offset
+
+	if _, ok := params["PG_WHERE_CLAUSE"]; !ok {
+		pgWhere := "1=1"
+		if dual != nil && dual.PgMainClause != "" {
+			pgWhere = dual.PgMainClause
+		}
+		params["PG_WHERE_CLAUSE"] = pgWhere
+	}
+
+	if _, ok := params["LOGICAL_WHERE_CLAUSE"]; !ok {
+		if anchor, ok := params["Anchor"].(map[string]any); ok {
+			if cond, ok := anchor["Condition"].(string); ok && cond != "" {
+				params["LOGICAL_WHERE_CLAUSE"] = cond
+			}
+		}
+	}
+
+	if _, ok := params["PG_CONN"]; !ok {
+		if raw, ok := params["DuckDBPGConnString"].(string); ok && raw != "" {
+			params["PG_CONN"] = raw
+		}
+	}
+
+	if _, ok := params["S3_PATHS"]; !ok {
+		if paths, ok := params["DuckDBS3Paths"].([]string); ok && len(paths) > 0 {
+			params["S3_PATHS"] = formatDuckDBPathList(paths)
+		}
+	}
+}
+
+func formatDuckDBPathList(paths []string) string {
+	quoted := make([]string, 0, len(paths))
+	for _, path := range paths {
+		quoted = append(quoted, fmt.Sprintf("'%s'", path))
+	}
+	if len(quoted) == 1 {
+		return quoted[0]
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
 }

--- a/internal/health_and_renderer_test.go
+++ b/internal/health_and_renderer_test.go
@@ -52,13 +52,38 @@ func TestBuildDuckDBQuery_Injection(t *testing.T) {
 		DuckClause:   "age > ?",
 		DuckArgs:     []any{18},
 		PgMainClause: "integer_01 > 18",
-		PgMainArgs:   []any{},
+		PgMainArgs:   []any{18},
 	}
 
 	sql, args, err := BuildDuckDBQuery(tpl, map[string]any{}, nil, nil, dual)
 	require.NoError(t, err)
 	require.Contains(t, sql, "PGCLAUSE:integer_01 > 18")
 	require.Contains(t, sql, "COND:age > ?")
+	require.Len(t, args, 2)
+	require.Equal(t, 18, args[0])
+	require.Equal(t, 18, args[1])
+}
+
+func TestBuildDuckDBQuery_PreservesInjectedProductionTemplateParams(t *testing.T) {
+	tpl := template.Must(template.New("test").Parse("PG={{.PG_CONN}}|S3={{.S3_PATHS}}|SCHEMA={{.SCHEMA_ID}}|PAGE={{.PAGE_SIZE}}|OFFSET={{.OFFSET}}|LOGICAL={{.LOGICAL_WHERE_CLAUSE}}|PUSH={{.PG_WHERE_CLAUSE}}"))
+	dual := &DualClauses{
+		DuckClause:   "age > ?",
+		DuckArgs:     []any{18},
+		PgMainClause: "integer_01 > 18",
+	}
+	q := &FederatedAttributeQuery{
+		AttributeQuery: AttributeQuery{SchemaID: 42, Limit: 25, Offset: 5},
+	}
+
+	sql, args, err := BuildDuckDBQuery(tpl, map[string]any{"DuckDBPGConnString": "host=pg port=5432", "S3_PATHS": "'s3://bucket/prefix/42/base/*.parquet'", "Anchor": map[string]any{}}, q, nil, dual)
+	require.NoError(t, err)
+	require.Contains(t, sql, "PG=host=pg port=5432")
+	require.Contains(t, sql, "S3='s3://bucket/prefix/42/base/*.parquet'")
+	require.Contains(t, sql, "SCHEMA=42")
+	require.Contains(t, sql, "PAGE=25")
+	require.Contains(t, sql, "OFFSET=5")
+	require.Contains(t, sql, "LOGICAL=age > ?")
+	require.Contains(t, sql, "PUSH=integer_01 > 18")
 	require.Len(t, args, 1)
 	require.Equal(t, 18, args[0])
 }

--- a/internal/postgres_duckdb_federated_production_e2e_test.go
+++ b/internal/postgres_duckdb_federated_production_e2e_test.go
@@ -1,0 +1,478 @@
+//go:build e2e
+
+package internal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type productionFederatedE2EEnv struct {
+	ctx         context.Context
+	pgContainer testcontainers.Container
+	s3Container testcontainers.Container
+	pool        *pgxpool.Pool
+	duck        *DuckDBClient
+	s3Client    *s3.Client
+	bucket      string
+	prefix      string
+	tmpDir      string
+	repo        *DBPersistentRecordRepository
+	tables      StorageTables
+	pgConn      string
+}
+
+type productionTestRecord struct {
+	RowID     uuid.UUID
+	SchemaID  int16
+	Name      string
+	Age       int32
+	Tag       string
+	ChangedAt int64
+	DeletedAt int64
+}
+
+func setupProductionFederatedE2EEnv(t *testing.T) *productionFederatedE2EEnv {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	pgContainer, pool, host, port := startProductionFederatedPostgres(t, ctx)
+	s3Container, endpoint := startProductionFederatedS3(t, ctx)
+	s3Client := newProductionFederatedS3Client(t, ctx, endpoint)
+	bucket := "test-bucket"
+	_, _ = s3Client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
+
+	tmpDir, err := os.MkdirTemp("", "prod-fed-e2e-*")
+	require.NoError(t, err)
+
+	duckCfg := forma.DuckDBConfig{
+		Enabled:        true,
+		DBPath:         ":memory:",
+		MemoryLimitMB:  512,
+		EnableS3:       true,
+		EnableParquet:  true,
+		S3Endpoint:     endpoint,
+		S3AccessKey:    "minio",
+		S3SecretKey:    "minio",
+		S3Region:       "us-east-1",
+		MaxConnections: 1,
+		QueryTimeout:   60 * time.Second,
+		MaxParallelism: 1,
+	}
+	duck, err := NewDuckDBClient(duckCfg)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if duck != nil {
+			require.NoError(t, duck.Close())
+		}
+		if pool != nil {
+			pool.Close()
+		}
+		if s3Container != nil {
+			require.NoError(t, s3Container.Terminate(context.Background()))
+		}
+		if pgContainer != nil {
+			require.NoError(t, pgContainer.Terminate(context.Background()))
+		}
+		require.NoError(t, os.RemoveAll(tmpDir))
+	})
+
+	require.NoError(t, createProductionFederatedSchema(ctx, pool))
+	metadata := loadProductionFederatedMetadata(t, ctx, pool)
+	repo := NewDBPersistentRecordRepository(pool, metadata, duck, duckCfg)
+
+	return &productionFederatedE2EEnv{
+		ctx:         ctx,
+		pgContainer: pgContainer,
+		s3Container: s3Container,
+		pool:        pool,
+		duck:        duck,
+		s3Client:    s3Client,
+		bucket:      bucket,
+		prefix:      "prod-fed-tests",
+		tmpDir:      tmpDir,
+		repo:        repo,
+		tables:      StorageTables{EntityMain: "entity_main_dev", EAVData: "eav_data_dev", ChangeLog: "change_log_dev"},
+		pgConn:      fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s", host, port, "postgres", "password", "postgres"),
+	}
+}
+
+func startProductionFederatedPostgres(t *testing.T, ctx context.Context) (testcontainers.Container, *pgxpool.Pool, string, string) {
+	t.Helper()
+	req := testcontainers.ContainerRequest{
+		Image:        "postgres:16",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_PASSWORD": "password",
+			"POSTGRES_USER":     "postgres",
+			"POSTGRES_DB":       "postgres",
+		},
+		WaitingFor: wait.ForListeningPort("5432/tcp").WithStartupTimeout(30 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: req, Started: true})
+	require.NoError(t, err)
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	mapped, err := container.MappedPort(ctx, "5432")
+	require.NoError(t, err)
+	dsn := fmt.Sprintf("postgres://postgres:password@%s:%s/postgres?sslmode=disable", host, mapped.Port())
+	cfg, err := pgxpool.ParseConfig(dsn)
+	require.NoError(t, err)
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return pool.Ping(ctx) == nil }, 20*time.Second, 200*time.Millisecond)
+	return container, pool, host, mapped.Port()
+}
+
+func startProductionFederatedS3(t *testing.T, ctx context.Context) (testcontainers.Container, string) {
+	t.Helper()
+	req := testcontainers.ContainerRequest{
+		Image:        "rustfs/rustfs:latest",
+		ExposedPorts: []string{"9000/tcp"},
+		Env: map[string]string{
+			"RUSTFS_ACCESS_KEY": "minio",
+			"RUSTFS_SECRET_KEY": "minio",
+		},
+		WaitingFor: wait.ForListeningPort("9000/tcp").WithStartupTimeout(30 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: req, Started: true})
+	require.NoError(t, err)
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	mapped, err := container.MappedPort(ctx, "9000")
+	require.NoError(t, err)
+	return container, fmt.Sprintf("http://%s:%s", host, mapped.Port())
+}
+
+func newProductionFederatedS3Client(t *testing.T, ctx context.Context, endpoint string) *s3.Client {
+	t.Helper()
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("minio", "minio", "")),
+	)
+	require.NoError(t, err)
+	return s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+		o.UsePathStyle = true
+	})
+}
+
+func createProductionFederatedSchema(ctx context.Context, pool *pgxpool.Pool) error {
+	stmts := []string{
+		`DROP TABLE IF EXISTS schema_registry`,
+		`DROP TABLE IF EXISTS change_log_dev`,
+		`DROP TABLE IF EXISTS eav_data_dev`,
+		`DROP TABLE IF EXISTS entity_main_dev`,
+		`CREATE TABLE schema_registry (schema_name TEXT PRIMARY KEY, schema_id SMALLINT NOT NULL)`,
+		`CREATE TABLE entity_main_dev (
+			ltbase_schema_id SMALLINT NOT NULL,
+			ltbase_row_id UUID NOT NULL,
+			ltbase_created_at BIGINT NOT NULL,
+			ltbase_updated_at BIGINT NOT NULL,
+			ltbase_deleted_at BIGINT,
+			text_01 TEXT,
+			integer_01 INTEGER,
+			PRIMARY KEY (ltbase_schema_id, ltbase_row_id)
+		)`,
+		`CREATE TABLE eav_data_dev (
+			schema_id SMALLINT NOT NULL,
+			row_id UUID NOT NULL,
+			attr_id SMALLINT NOT NULL,
+			array_indices TEXT NOT NULL DEFAULT '',
+			value_text TEXT,
+			value_numeric DOUBLE PRECISION,
+			PRIMARY KEY (schema_id, row_id, attr_id, array_indices)
+		)`,
+		`CREATE TABLE change_log_dev (
+			schema_id SMALLINT NOT NULL,
+			row_id UUID NOT NULL,
+			flushed_at BIGINT NOT NULL DEFAULT 0,
+			changed_at BIGINT NOT NULL,
+			deleted_at BIGINT,
+			PRIMARY KEY (schema_id, row_id, flushed_at)
+		)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	for name, id := range map[string]int16{"activity": 100, "lead": 101, "visit": 102, "communication": 103, "log": 104} {
+		if _, err := pool.Exec(ctx, `INSERT INTO schema_registry (schema_name, schema_id) VALUES ($1, $2)`, name, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadProductionFederatedMetadata(t *testing.T, ctx context.Context, pool *pgxpool.Pool) *MetadataCache {
+	t.Helper()
+	loader := NewMetadataLoader(pool, "schema_registry", "../cmd/server/schemas")
+	metadata, err := loader.LoadMetadata(ctx)
+	require.NoError(t, err)
+	return metadata
+}
+
+func withProductionDuckDBTemplateDescriptors(t *testing.T) {
+	t.Helper()
+	orig := entityMainColumnDescriptors
+	entityMainColumnDescriptors = []columnDescriptor{
+		{name: "ltbase_schema_id", kind: columnKindSmallint},
+		{name: "ltbase_row_id", kind: columnKindText},
+		{name: "ltbase_created_at", kind: columnKindBigint},
+		{name: "ltbase_updated_at", kind: columnKindBigint},
+		{name: "ltbase_deleted_at", kind: columnKindBigint},
+		{name: "text_01", kind: columnKindText},
+		{name: "integer_01", kind: columnKindInteger},
+	}
+	t.Cleanup(func() {
+		entityMainColumnDescriptors = orig
+	})
+}
+
+func clearProductionFederatedData(t *testing.T, env *productionFederatedE2EEnv, schemaID int16) {
+	t.Helper()
+	_, err := env.pool.Exec(env.ctx, `DELETE FROM change_log_dev WHERE schema_id = $1`, schemaID)
+	require.NoError(t, err)
+	_, err = env.pool.Exec(env.ctx, `DELETE FROM eav_data_dev WHERE schema_id = $1`, schemaID)
+	require.NoError(t, err)
+	_, err = env.pool.Exec(env.ctx, `DELETE FROM entity_main_dev WHERE ltbase_schema_id = $1`, schemaID)
+	require.NoError(t, err)
+	resp, err := env.s3Client.ListObjectsV2(env.ctx, &s3.ListObjectsV2Input{Bucket: aws.String(env.bucket), Prefix: aws.String(env.prefix)})
+	require.NoError(t, err)
+	for _, obj := range resp.Contents {
+		_, err = env.s3Client.DeleteObject(env.ctx, &s3.DeleteObjectInput{Bucket: aws.String(env.bucket), Key: obj.Key})
+		require.NoError(t, err)
+	}
+}
+
+func writeProductionParquet(t *testing.T, env *productionFederatedE2EEnv, tier, filename string, records []productionTestRecord) {
+	t.Helper()
+	csvPath := filepath.Join(env.tmpDir, filename+".csv")
+	parquetPath := filepath.Join(env.tmpDir, filename)
+	var csv bytes.Buffer
+	csv.WriteString("row_id,ltbase_created_at,ltbase_updated_at,ltbase_deleted_at,name,age,tag\n")
+	for _, r := range records {
+		csv.WriteString(fmt.Sprintf("%s,%d,%d,%d,%s,%d,%s\n", r.RowID.String(), r.ChangedAt, r.ChangedAt, r.DeletedAt, r.Name, r.Age, r.Tag))
+	}
+	require.NoError(t, os.WriteFile(csvPath, csv.Bytes(), 0o644))
+	_, err := env.duck.DB.ExecContext(env.ctx, fmt.Sprintf(`CREATE OR REPLACE TABLE temp_export AS SELECT * FROM read_csv_auto('%s')`, csvPath))
+	require.NoError(t, err)
+	_, err = env.duck.DB.ExecContext(env.ctx, fmt.Sprintf(`COPY temp_export TO '%s' (FORMAT PARQUET, COMPRESSION ZSTD)`, parquetPath))
+	require.NoError(t, err)
+	data, err := os.ReadFile(parquetPath)
+	require.NoError(t, err)
+	key := fmt.Sprintf("%s/%d/%s/%s", env.prefix, records[0].SchemaID, tier, filename)
+	_, err = env.s3Client.PutObject(env.ctx, &s3.PutObjectInput{Bucket: aws.String(env.bucket), Key: aws.String(key), Body: bytes.NewReader(data)})
+	require.NoError(t, err)
+}
+
+func insertProductionHotRecord(t *testing.T, env *productionFederatedE2EEnv, schemaID int16, rowID uuid.UUID, changedAt int64, name string, age int32) {
+	t.Helper()
+	_, err := env.pool.Exec(env.ctx, `
+		INSERT INTO entity_main_dev (ltbase_schema_id, ltbase_row_id, ltbase_created_at, ltbase_updated_at, ltbase_deleted_at, text_01, integer_01)
+		VALUES ($1, $2, $3, $4, NULL, $5, $6)
+		ON CONFLICT (ltbase_schema_id, ltbase_row_id) DO UPDATE SET
+			ltbase_updated_at = EXCLUDED.ltbase_updated_at,
+			text_01 = EXCLUDED.text_01,
+			integer_01 = EXCLUDED.integer_01
+	`, schemaID, rowID, changedAt, changedAt, name, age)
+	require.NoError(t, err)
+	_, err = env.pool.Exec(env.ctx, `
+		INSERT INTO change_log_dev (schema_id, row_id, flushed_at, changed_at, deleted_at)
+		VALUES ($1, $2, 0, $3, NULL)
+		ON CONFLICT (schema_id, row_id, flushed_at) DO UPDATE SET changed_at = EXCLUDED.changed_at
+	`, schemaID, rowID, changedAt)
+	require.NoError(t, err)
+}
+
+func TestStreamDuckDBFederatedQuery_GivenBaseAndHotVersions_WhenQueried_ThenLatestHotVersionWins(t *testing.T) {
+	withProductionDuckDBTemplateDescriptors(t)
+	env := setupProductionFederatedE2EEnv(t)
+	clearProductionFederatedData(t, env, 100)
+
+	rowID := uuid.Must(uuid.NewV7())
+	baseTime := time.Now().Add(-24 * time.Hour).UnixMilli()
+	hotTime := time.Now().UnixMilli()
+
+	writeProductionParquet(t, env, "base", "base_hot.parquet", []productionTestRecord{{
+		RowID:     rowID,
+		SchemaID:  100,
+		Name:      "base-version",
+		Age:       21,
+		Tag:       "base-tag",
+		ChangedAt: baseTime,
+	}})
+	writeProductionParquet(t, env, "delta", "empty_delta.parquet", []productionTestRecord{{
+		RowID:     uuid.Must(uuid.NewV7()),
+		SchemaID:  100,
+		Name:      "placeholder",
+		Age:       0,
+		Tag:       "placeholder",
+		ChangedAt: 0,
+		DeletedAt: time.Now().UnixMilli(),
+	}})
+	insertProductionHotRecord(t, env, 100, rowID, hotTime, "hot-version", 42)
+
+	q := &FederatedAttributeQuery{
+		AttributeQuery: AttributeQuery{SchemaID: 100, Limit: 10, Offset: 0},
+		DuckDBHints: &DuckDBRenderHints{
+			S3ParquetPathTemplate: fmt.Sprintf("s3://%s/%s/{{.SchemaID}}/base/*.parquet, s3://%s/%s/{{.SchemaID}}/delta/*.parquet", env.bucket, env.prefix, env.bucket, env.prefix),
+		},
+	}
+	var got []*PersistentRecord
+	total, err := env.repo.StreamDuckDBFederatedQuery(env.ctx, env.tables, q, 10, 0, nil, nil, func(_ context.Context, record *PersistentRecord) error {
+		got = append(got, record)
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, got, 1)
+	require.Equal(t, hotTime, got[0].UpdatedAt)
+	require.Equal(t, "hot-version", got[0].TextItems["text_01"])
+	require.Equal(t, int32(42), got[0].Int32Items["integer_01"])
+}
+
+func TestStreamDuckDBFederatedQuery_GivenDirtyHotRow_WhenColdVersionExists_ThenColdVersionIsExcluded(t *testing.T) {
+	withProductionDuckDBTemplateDescriptors(t)
+	env := setupProductionFederatedE2EEnv(t)
+	clearProductionFederatedData(t, env, 100)
+
+	rowID := uuid.Must(uuid.NewV7())
+	baseTime := time.Now().Add(-48 * time.Hour).UnixMilli()
+	hotTime := time.Now().Add(-1 * time.Hour).UnixMilli()
+
+	writeProductionParquet(t, env, "base", "dirty_exclusion.parquet", []productionTestRecord{{
+		RowID:     rowID,
+		SchemaID:  100,
+		Name:      "cold-version",
+		Age:       18,
+		Tag:       "cold-tag",
+		ChangedAt: baseTime,
+	}})
+	writeProductionParquet(t, env, "delta", "empty_delta.parquet", []productionTestRecord{{
+		RowID:     uuid.Must(uuid.NewV7()),
+		SchemaID:  100,
+		Name:      "placeholder",
+		Age:       0,
+		Tag:       "placeholder",
+		ChangedAt: 0,
+		DeletedAt: time.Now().UnixMilli(),
+	}})
+	insertProductionHotRecord(t, env, 100, rowID, hotTime, "dirty-hot-version", 99)
+
+	plan := &ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}}
+	opts := &FederatedQueryOptions{IncludeExecutionPlan: true, ExecutionPlan: plan}
+	q := &FederatedAttributeQuery{
+		AttributeQuery: AttributeQuery{SchemaID: 100, Limit: 10, Offset: 0},
+		DuckDBHints: &DuckDBRenderHints{
+			S3ParquetPathTemplate: fmt.Sprintf("s3://%s/%s/{{.SchemaID}}/base/*.parquet, s3://%s/%s/{{.SchemaID}}/delta/*.parquet", env.bucket, env.prefix, env.bucket, env.prefix),
+		},
+	}
+
+	var got []*PersistentRecord
+	total, err := env.repo.StreamDuckDBFederatedQuery(env.ctx, env.tables, q, 10, 0, nil, opts, func(_ context.Context, record *PersistentRecord) error {
+		got = append(got, record)
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, got, 1)
+	require.Equal(t, hotTime, got[0].UpdatedAt)
+	require.Equal(t, "dirty-hot-version", got[0].TextItems["text_01"])
+	require.NotEmpty(t, opts.ExecutionPlan.Sources)
+	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Sources), "postgres")
+	require.Contains(t, opts.ExecutionPlan.Timings, "duckdb_fetch")
+	require.Contains(t, opts.ExecutionPlan.Timings, "total")
+	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Notes), "StreamDuckDBFederatedQuery started")
+	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Notes), "pushdown_efficiency=")
+}
+
+func TestStreamDuckDBFederatedQuery_GivenBaseDeltaAndHotRows_WhenQueried_ThenAllNonOverlappingRowsAreReturned(t *testing.T) {
+	withProductionDuckDBTemplateDescriptors(t)
+	env := setupProductionFederatedE2EEnv(t)
+	clearProductionFederatedData(t, env, 100)
+
+	baseRowID := uuid.Must(uuid.NewV7())
+	deltaRowID := uuid.Must(uuid.NewV7())
+	hotRowID := uuid.Must(uuid.NewV7())
+	now := time.Now()
+
+	writeProductionParquet(t, env, "base", "three_tier_base.parquet", []productionTestRecord{{
+		RowID:     baseRowID,
+		SchemaID:  100,
+		Name:      "base-record",
+		Age:       11,
+		Tag:       "base-tag",
+		ChangedAt: now.Add(-72 * time.Hour).UnixMilli(),
+	}})
+	writeProductionParquet(t, env, "delta", "three_tier_delta.parquet", []productionTestRecord{{
+		RowID:     deltaRowID,
+		SchemaID:  100,
+		Name:      "delta-record",
+		Age:       22,
+		Tag:       "delta-tag",
+		ChangedAt: now.Add(-12 * time.Hour).UnixMilli(),
+	}})
+	insertProductionHotRecord(t, env, 100, hotRowID, now.UnixMilli(), "hot-record", 33)
+
+	plan := &ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}}
+	opts := &FederatedQueryOptions{IncludeExecutionPlan: true, ExecutionPlan: plan}
+	q := &FederatedAttributeQuery{
+		AttributeQuery: AttributeQuery{SchemaID: 100, Limit: 10, Offset: 0},
+		DuckDBHints: &DuckDBRenderHints{
+			S3ParquetPathTemplate: fmt.Sprintf("s3://%s/%s/{{.SchemaID}}/base/*.parquet, s3://%s/%s/{{.SchemaID}}/delta/*.parquet", env.bucket, env.prefix, env.bucket, env.prefix),
+		},
+	}
+
+	var got []*PersistentRecord
+	total, err := env.repo.StreamDuckDBFederatedQuery(env.ctx, env.tables, q, 10, 0, nil, opts, func(_ context.Context, record *PersistentRecord) error {
+		got = append(got, record)
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, got, 3)
+
+	names := map[string]bool{}
+	ages := map[int32]bool{}
+	for _, record := range got {
+		names[record.TextItems["text_01"]] = true
+		ages[record.Int32Items["integer_01"]] = true
+	}
+
+	require.Equal(t, map[string]bool{
+		"base-record":  true,
+		"delta-record": true,
+		"hot-record":   true,
+	}, names)
+	require.Equal(t, map[int32]bool{11: true, 22: true, 33: true}, ages)
+	require.NotEmpty(t, opts.ExecutionPlan.Sources)
+	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Sources), "postgres")
+	require.Contains(t, opts.ExecutionPlan.Timings, "duckdb_fetch")
+	require.Contains(t, opts.ExecutionPlan.Timings, "total")
+	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Notes), "StreamDuckDBFederatedQuery started")
+	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Notes), "pushdown_efficiency=")
+}

--- a/internal/postgres_duckdb_federated_production_e2e_test.go
+++ b/internal/postgres_duckdb_federated_production_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -305,6 +306,23 @@ func insertProductionHotRecord(t *testing.T, env *productionFederatedE2EEnv, sch
 	require.NoError(t, err)
 }
 
+func requireExecutionPlanHasSource(t *testing.T, sources []DataSourcePlan, engine string, reasonSubstring string, predicatePushdown *bool) {
+	t.Helper()
+	for _, source := range sources {
+		if source.Engine != engine {
+			continue
+		}
+		if reasonSubstring != "" && !strings.Contains(source.Reason, reasonSubstring) {
+			continue
+		}
+		if predicatePushdown != nil && source.PredicatePushdown != *predicatePushdown {
+			continue
+		}
+		return
+	}
+	t.Fatalf("expected execution plan source engine=%q reason~=%q predicatePushdown=%v, got %#v", engine, reasonSubstring, predicatePushdown, sources)
+}
+
 func TestStreamDuckDBFederatedQuery_GivenBaseAndHotVersions_WhenQueried_ThenLatestHotVersionWins(t *testing.T) {
 	withProductionDuckDBTemplateDescriptors(t)
 	env := setupProductionFederatedE2EEnv(t)
@@ -402,7 +420,10 @@ func TestStreamDuckDBFederatedQuery_GivenDirtyHotRow_WhenColdVersionExists_ThenC
 	require.Equal(t, hotTime, got[0].UpdatedAt)
 	require.Equal(t, "dirty-hot-version", got[0].TextItems["text_01"])
 	require.NotEmpty(t, opts.ExecutionPlan.Sources)
-	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Sources), "postgres")
+	require.Len(t, opts.ExecutionPlan.Sources, 3)
+	requireExecutionPlanHasSource(t, opts.ExecutionPlan.Sources, "postgres", "dirty", nil)
+	requireExecutionPlanHasSource(t, opts.ExecutionPlan.Sources, "postgres", "pushdown", nil)
+	requireExecutionPlanHasSource(t, opts.ExecutionPlan.Sources, "duckdb", "template rendered", nil)
 	require.Contains(t, opts.ExecutionPlan.Timings, "duckdb_fetch")
 	require.Contains(t, opts.ExecutionPlan.Timings, "total")
 	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Notes), "StreamDuckDBFederatedQuery started")
@@ -470,9 +491,62 @@ func TestStreamDuckDBFederatedQuery_GivenBaseDeltaAndHotRows_WhenQueried_ThenAll
 	}, names)
 	require.Equal(t, map[int32]bool{11: true, 22: true, 33: true}, ages)
 	require.NotEmpty(t, opts.ExecutionPlan.Sources)
-	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Sources), "postgres")
+	require.Len(t, opts.ExecutionPlan.Sources, 3)
+	requireExecutionPlanHasSource(t, opts.ExecutionPlan.Sources, "postgres", "dirty", nil)
+	requireExecutionPlanHasSource(t, opts.ExecutionPlan.Sources, "postgres", "pushdown", nil)
+	requireExecutionPlanHasSource(t, opts.ExecutionPlan.Sources, "duckdb", "template rendered", nil)
 	require.Contains(t, opts.ExecutionPlan.Timings, "duckdb_fetch")
 	require.Contains(t, opts.ExecutionPlan.Timings, "total")
 	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Notes), "StreamDuckDBFederatedQuery started")
 	require.Contains(t, fmt.Sprint(opts.ExecutionPlan.Notes), "pushdown_efficiency=")
+}
+
+func TestStreamDuckDBFederatedQuery_GivenBaseDeltaAndHotOverlap_WhenQueried_ThenNewestHotVersionWins(t *testing.T) {
+	withProductionDuckDBTemplateDescriptors(t)
+	env := setupProductionFederatedE2EEnv(t)
+	clearProductionFederatedData(t, env, 100)
+
+	rowID := uuid.Must(uuid.NewV7())
+	now := time.Now()
+	baseTime := now.Add(-72 * time.Hour).UnixMilli()
+	deltaTime := now.Add(-24 * time.Hour).UnixMilli()
+	hotTime := now.UnixMilli()
+
+	writeProductionParquet(t, env, "base", "overlap_base.parquet", []productionTestRecord{{
+		RowID:     rowID,
+		SchemaID:  100,
+		Name:      "base-version",
+		Age:       10,
+		Tag:       "base-tag",
+		ChangedAt: baseTime,
+	}})
+	writeProductionParquet(t, env, "delta", "overlap_delta.parquet", []productionTestRecord{{
+		RowID:     rowID,
+		SchemaID:  100,
+		Name:      "delta-version",
+		Age:       20,
+		Tag:       "delta-tag",
+		ChangedAt: deltaTime,
+	}})
+	insertProductionHotRecord(t, env, 100, rowID, hotTime, "hot-version", 30)
+
+	q := &FederatedAttributeQuery{
+		AttributeQuery: AttributeQuery{SchemaID: 100, Limit: 10, Offset: 0},
+		DuckDBHints: &DuckDBRenderHints{
+			S3ParquetPathTemplate: fmt.Sprintf("s3://%s/%s/{{.SchemaID}}/base/*.parquet, s3://%s/%s/{{.SchemaID}}/delta/*.parquet", env.bucket, env.prefix, env.bucket, env.prefix),
+		},
+	}
+
+	var got []*PersistentRecord
+	total, err := env.repo.StreamDuckDBFederatedQuery(env.ctx, env.tables, q, 10, 0, nil, nil, func(_ context.Context, record *PersistentRecord) error {
+		got = append(got, record)
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, got, 1)
+	require.Equal(t, hotTime, got[0].UpdatedAt)
+	require.Equal(t, "hot-version", got[0].TextItems["text_01"])
+	require.Equal(t, int32(30), got[0].Int32Items["integer_01"])
 }

--- a/internal/postgres_duckdb_query.go
+++ b/internal/postgres_duckdb_query.go
@@ -3,9 +3,11 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lychee-technology/forma"
 )
 
@@ -161,6 +163,13 @@ func (r *DBPersistentRecordRepository) buildDuckDBQueryWithPlan(
 		"PageSize": limit,
 	}
 
+	if connStr := r.duckDBPostgresConnString(); connStr != "" {
+		sqlParams["DuckDBPGConnString"] = connStr
+	}
+	if paths := duckDBParquetPathsForQuery(q); len(paths) > 0 {
+		sqlParams["DuckDBS3Paths"] = paths
+	}
+
 	startTranslate := time.Now()
 
 	// Build dual clauses (PG pushdown + DuckDB logical) if metadata cache available
@@ -187,6 +196,45 @@ func (r *DBPersistentRecordRepository) buildDuckDBQueryWithPlan(
 	}
 
 	return sqlStr, args, translateMs, nil
+}
+
+func (r *DBPersistentRecordRepository) duckDBPostgresConnString() string {
+	if r.pool == nil {
+		return ""
+	}
+	if cfgPool, ok := r.pool.(*pgxpool.Pool); ok && cfgPool != nil {
+		cfg := cfgPool.Config()
+		if cfg != nil {
+			connCfg := cfg.ConnConfig
+			return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s",
+				connCfg.Host,
+				connCfg.Port,
+				connCfg.User,
+				connCfg.Password,
+				connCfg.Database,
+			)
+		}
+	}
+	return ""
+}
+
+func duckDBParquetPathsForQuery(q *FederatedAttributeQuery) []string {
+	if q == nil || q.DuckDBHints == nil || q.DuckDBHints.S3ParquetPathTemplate == "" {
+		return nil
+	}
+	rendered, err := RenderS3ParquetPath(q.DuckDBHints.S3ParquetPathTemplate, q.SchemaID)
+	if err != nil {
+		return nil
+	}
+	parts := strings.Split(rendered, ",")
+	paths := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			paths = append(paths, trimmed)
+		}
+	}
+	return paths
 }
 
 // streamDuckDBRows iterates through DuckDB rows and invokes the handler.


### PR DESCRIPTION
## Summary
- align the production DuckDB federated template and renderer with the actual mixed-tier execution contract, including postgres_scan usage, parquet path rendering, output shape, and advanced-template argument ordering
- add production-path e2e coverage for Base+Hot last-write-wins, dirty-id exclusion, and Base+Delta+Hot non-overlap queries using real Postgres, DuckDB, and parquet files
- strengthen execution plan and renderer regression coverage around production DuckDB template parameter injection

## Testing
- go test ./internal -run 'Test(BuildDuckDBQuery_(Injection|PreservesInjectedProductionTemplateParams|SimpleTemplate|WithDirtyIDs)|StreamDuckDBFederatedQuery_(RowHandlerErrorStopsIteration|DirtyIDFetcherErrorIsInjectable|QueryBuilderErrorIsInjectable|RowsIteratorErrorPropagates))'
- go test ./internal -run 'TestStreamDuckDBFederatedQuery_Given(BaseAndHotVersions|DirtyHotRow|BaseDeltaAndHotRows)' -tags=e2e