### PR TITLE
unblock flusher processSchema coverage

### DIFF
--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -256,14 +256,25 @@ type schemaFlushContext struct {
 	schemaRegistry   forma.SchemaRegistry
 	manifestStore    manifest.Store
 	manifestResolver manifest.PathResolver
+	acquireLock      func(context.Context, *sql.DB, int16) (bool, error)
+	releaseLock      func(context.Context, *sql.DB, int16) error
 }
 
 // processSchema handles the flush process for a single schema.
 func (c *schemaFlushContext) processSchema(ctx context.Context, schemaID int16) error {
 	c.logger.Sugar().Infow("processing schema", "schema_id", schemaID)
 
+	acquireLock := c.acquireLock
+	if acquireLock == nil {
+		acquireLock = AcquireSchemaLock
+	}
+	releaseLock := c.releaseLock
+	if releaseLock == nil {
+		releaseLock = ReleaseSchemaLock
+	}
+
 	// Try advisory lock
-	locked, err := AcquireSchemaLock(ctx, c.db, schemaID)
+	locked, err := acquireLock(ctx, c.db, schemaID)
 	if err != nil {
 		return fmt.Errorf("acquire schema lock: %w", err)
 	}
@@ -271,7 +282,7 @@ func (c *schemaFlushContext) processSchema(ctx context.Context, schemaID int16) 
 		c.logger.Sugar().Infow("lock not acquired, skipping", "schema_id", schemaID)
 		return nil
 	}
-	defer func() { _ = ReleaseSchemaLock(ctx, c.db, schemaID) }()
+	defer func() { _ = releaseLock(ctx, c.db, schemaID) }()
 
 	// Check if flush is needed
 	cnt, oldest, err := GetChangeLogStats(ctx, c.db, c.tableName, schemaID)

--- a/internal/cdc/flusher_test.go
+++ b/internal/cdc/flusher_test.go
@@ -284,6 +284,127 @@ func TestExecuteFlush_NoSelectedRowIDsReturnsWithoutExportWork(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestProcessSchema_SkipsWhenSchemaLockIsAlreadyHeld(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	lockAttempts := 0
+	releaseCalls := 0
+	flushCtx := &schemaFlushContext{
+		db:     db,
+		cfg:    CDCConfig{MinRecords: 1, MaxAgeMs: 1000},
+		logger: zap.NewNop(),
+		acquireLock: func(context.Context, *sql.DB, int16) (bool, error) {
+			lockAttempts++
+			return false, nil
+		},
+		releaseLock: func(context.Context, *sql.DB, int16) error {
+			releaseCalls++
+			return nil
+		},
+	}
+
+	err = flushCtx.processSchema(context.Background(), 7)
+	require.NoError(t, err)
+	require.Equal(t, 1, lockAttempts)
+	require.Zero(t, releaseCalls)
+}
+
+func TestProcessSchema_ReturnsErrorWhenChangeLogStatsCannotBeRead(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	releaseCalls := 0
+	flushCtx := &schemaFlushContext{
+		db:        db,
+		cfg:       CDCConfig{MinRecords: 1, MaxAgeMs: 1000},
+		tableName: "missing_change_log",
+		logger:    zap.NewNop(),
+		acquireLock: func(context.Context, *sql.DB, int16) (bool, error) {
+			return true, nil
+		},
+		releaseLock: func(context.Context, *sql.DB, int16) error {
+			releaseCalls++
+			return nil
+		},
+	}
+
+	err = flushCtx.processSchema(context.Background(), 7)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "get changelog stats")
+	require.Equal(t, 1, releaseCalls)
+}
+
+func TestProcessSchema_SkipsWhenNoPendingRowsExist(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+
+	releaseCalls := 0
+	flushCtx := &schemaFlushContext{
+		db:        db,
+		cfg:       CDCConfig{MinRecords: 1, MaxAgeMs: 1000},
+		tableName: "change_log",
+		logger:    zap.NewNop(),
+		acquireLock: func(context.Context, *sql.DB, int16) (bool, error) {
+			return true, nil
+		},
+		releaseLock: func(context.Context, *sql.DB, int16) error {
+			releaseCalls++
+			return nil
+		},
+	}
+
+	err = flushCtx.processSchema(ctx, 7)
+	require.NoError(t, err)
+	require.Equal(t, 1, releaseCalls)
+}
+
+func TestProcessSchema_SkipsWhenThresholdsAreNotMet(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, 0)", time.Now().UnixMilli())
+	require.NoError(t, err)
+
+	releaseCalls := 0
+	flushCtx := &schemaFlushContext{
+		db:        db,
+		cfg:       CDCConfig{MinRecords: 10, MaxAgeMs: 1_000_000},
+		tableName: "change_log",
+		logger:    zap.NewNop(),
+		acquireLock: func(context.Context, *sql.DB, int16) (bool, error) {
+			return true, nil
+		},
+		releaseLock: func(context.Context, *sql.DB, int16) error {
+			releaseCalls++
+			return nil
+		},
+	}
+
+	err = flushCtx.processSchema(ctx, 7)
+	require.NoError(t, err)
+	require.Equal(t, 1, releaseCalls)
+}
+
 func TestUpdateManifest_NilStore(t *testing.T) {
 	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
 	err := updateManifest(


### PR DESCRIPTION
## Summary
- add a minimal injectable advisory-lock seam to `schemaFlushContext` so `processSchema` can be exercised without Postgres advisory lock functions in local tests
- cover the previously blocked `processSchema` branches for lock contention, changelog stats errors, no pending rows, and threshold skips

## Testing
- go test ./internal/cdc -run 'Test(ProcessSchema_(SkipsWhenSchemaLockIsAlreadyHeld|ReturnsErrorWhenChangeLogStatsCannotBeRead|SkipsWhenNoPendingRowsExist|SkipsWhenThresholdsAreNotMet)|ExecuteFlush_NoSelectedRowIDsReturnsWithoutExportWork|ShouldFlush|GetUnflushedSchemaIDs|UpdateManifest_.*)'
- go test ./internal/cdc -run 'Test(RunOnce_RequiresSchemaRegistry|ResolveS3Clients_.*|SetupPostgresConnection_.*|ShouldFlush|MinMaxRowID|GetUnflushedSchemaIDs.*|ExecuteFlush_NoSelectedRowIDsReturnsWithoutExportWork|ProcessSchema_.*|UpdateManifest_.*)'