### PR TITLE
cover flusher manifest and failure paths

### DIFF
--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -258,6 +258,8 @@ type schemaFlushContext struct {
 	manifestResolver manifest.PathResolver
 	acquireLock      func(context.Context, *sql.DB, int16) (bool, error)
 	releaseLock      func(context.Context, *sql.DB, int16) error
+	executeSingle    func(*flushBatchExecutor, []uuid.UUID) error
+	executeInChunks  func(*flushBatchExecutor, []uuid.UUID, int) error
 }
 
 // processSchema handles the flush process for a single schema.
@@ -333,18 +335,21 @@ type flushBatchExecutor struct {
 	logger           *zap.Logger
 	manifestStore    manifest.Store
 	manifestResolver manifest.PathResolver
-}
-
-var executeFlushSingleFn = executeFlushSingle
-var executeFlushInChunksFn = executeFlushInChunks
-var exportSnapshotToTmpFn = func(e *DuckExporter, ctx context.Context, cfg CDCConfig, pgConnStr string, s3TmpPath string, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
-	return e.ExportSnapshotToTmp(ctx, cfg, pgConnStr, s3TmpPath, schemaID, snapshotTS, rowIDs, attrCache)
+	executeSingle    func(*flushBatchExecutor, []uuid.UUID) error
+	executeInChunks  func(*flushBatchExecutor, []uuid.UUID, int) error
+	exportSnapshot   func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error
 }
 
 func (e *flushBatchExecutor) executeBatch(batchIDs []uuid.UUID, tmpKey string, finalKey string, batchKind string) error {
 	s3TmpPath := fmt.Sprintf("s3://%s/%s", e.cfg.S3Bucket, tmpKey)
+	exportSnapshot := e.exportSnapshot
+	if exportSnapshot == nil {
+		exportSnapshot = func(duck *DuckExporter, ctx context.Context, cfg CDCConfig, pgConnStr string, s3TmpPath string, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
+			return duck.ExportSnapshotToTmp(ctx, cfg, pgConnStr, s3TmpPath, schemaID, snapshotTS, rowIDs, attrCache)
+		}
+	}
 
-	if err := exportSnapshotToTmpFn(e.duck, e.ctx, e.cfg, e.pgConnForDuck, s3TmpPath, e.schemaID, e.snapshot, batchIDs, e.attrCache); err != nil {
+	if err := exportSnapshot(e.duck, e.ctx, e.cfg, e.pgConnForDuck, s3TmpPath, e.schemaID, e.snapshot, batchIDs, e.attrCache); err != nil {
 		return fmt.Errorf("duck export snapshot (%s): %w", batchKind, err)
 	}
 
@@ -438,6 +443,17 @@ func (c *schemaFlushContext) executeFlush(ctx context.Context, schemaID int16) e
 		logger:           c.logger,
 		manifestStore:    c.manifestStore,
 		manifestResolver: c.manifestResolver,
+		executeSingle:    c.executeSingle,
+		executeInChunks:  c.executeInChunks,
+	}
+
+	executeInChunks := executor.executeInChunks
+	if executeInChunks == nil {
+		executeInChunks = executeFlushInChunks
+	}
+	executeSingle := executor.executeSingle
+	if executeSingle == nil {
+		executeSingle = executeFlushSingle
 	}
 
 	batchIDs := ids
@@ -448,10 +464,10 @@ func (c *schemaFlushContext) executeFlush(ctx context.Context, schemaID int16) e
 
 	if maxRows > 0 && len(batchIDs) > maxRows {
 		c.logger.Sugar().Infow("splitting batch to meet byte target", "schema_id", schemaID, "from_rows", len(batchIDs), "chunk_rows", maxRows)
-		return executeFlushInChunksFn(executor, batchIDs, maxRows)
+		return executeInChunks(executor, batchIDs, maxRows)
 	}
 
-	return executeFlushSingleFn(executor, batchIDs)
+	return executeSingle(executor, batchIDs)
 }
 
 func executeFlushInChunks(

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -337,11 +337,14 @@ type flushBatchExecutor struct {
 
 var executeFlushSingleFn = executeFlushSingle
 var executeFlushInChunksFn = executeFlushInChunks
+var exportSnapshotToTmpFn = func(e *DuckExporter, ctx context.Context, cfg CDCConfig, pgConnStr string, s3TmpPath string, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
+	return e.ExportSnapshotToTmp(ctx, cfg, pgConnStr, s3TmpPath, schemaID, snapshotTS, rowIDs, attrCache)
+}
 
 func (e *flushBatchExecutor) executeBatch(batchIDs []uuid.UUID, tmpKey string, finalKey string, batchKind string) error {
 	s3TmpPath := fmt.Sprintf("s3://%s/%s", e.cfg.S3Bucket, tmpKey)
 
-	if err := e.duck.ExportSnapshotToTmp(e.ctx, e.cfg, e.pgConnForDuck, s3TmpPath, e.schemaID, e.snapshot, batchIDs, e.attrCache); err != nil {
+	if err := exportSnapshotToTmpFn(e.duck, e.ctx, e.cfg, e.pgConnForDuck, s3TmpPath, e.schemaID, e.snapshot, batchIDs, e.attrCache); err != nil {
 		return fmt.Errorf("duck export snapshot (%s): %w", batchKind, err)
 	}
 

--- a/internal/cdc/flusher_test.go
+++ b/internal/cdc/flusher_test.go
@@ -56,6 +56,16 @@ func (c *objectOnlyS3Client) DeleteObject(_ context.Context, _ *s3.DeleteObjectI
 	return &s3.DeleteObjectOutput{}, nil
 }
 
+type copyFailingS3Client struct{}
+
+func (c *copyFailingS3Client) CopyObject(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	return nil, errors.New("copy failed")
+}
+
+func (c *copyFailingS3Client) DeleteObject(_ context.Context, _ *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	return &s3.DeleteObjectOutput{}, nil
+}
+
 type fullS3ClientMock struct {
 	objectOnlyS3Client
 }
@@ -528,6 +538,164 @@ func TestExecuteFlush_SplitsBatchWhenByteTargetIsExceeded(t *testing.T) {
 	err = flushCtx.executeFlush(ctx, 7)
 	require.NoError(t, err)
 	require.True(t, chunkCalled)
+}
+
+func TestExecuteBatch_SucceedsWhenManifestUpdateFails(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
+	snapshot := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
+	require.NoError(t, err)
+
+	origExport := exportSnapshotToTmpFn
+	t.Cleanup(func() {
+		exportSnapshotToTmpFn = origExport
+	})
+	exportCalled := false
+	exportSnapshotToTmpFn = func(_ *DuckExporter, _ context.Context, _ CDCConfig, _ string, s3TmpPath string, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
+		exportCalled = true
+		require.Equal(t, int16(7), schemaID)
+		require.Equal(t, snapshot, snapshotTS)
+		require.Equal(t, []uuid.UUID{rowID}, rowIDs)
+		require.Contains(t, s3TmpPath, "s3://test-bucket/cdc/7/_tmp/")
+		require.Nil(t, attrCache)
+		return nil
+	}
+
+	store := newInMemoryManifestStore()
+	store.loadErr = errors.New("boom")
+	resolver := manifest.PathResolver{Prefix: "cdc", PathTemplate: "manifest/{{.SchemaID}}.json"}
+
+	executor := &flushBatchExecutor{
+		ctx:              ctx,
+		db:               db,
+		duck:             &DuckExporter{Logger: zap.NewNop()},
+		s3Client:         &objectOnlyS3Client{},
+		cfg:              CDCConfig{S3Bucket: "test-bucket", S3Prefix: "cdc"},
+		tableName:        "change_log",
+		schemaID:         7,
+		snapshot:         snapshot,
+		pgConnForDuck:    "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
+		logger:           zap.NewNop(),
+		manifestStore:    store,
+		manifestResolver: resolver,
+	}
+
+	err = executor.executeBatch([]uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
+	require.NoError(t, err)
+	require.True(t, exportCalled)
+
+	var flushedAt int64
+	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
+	require.NoError(t, err)
+	require.NotZero(t, flushedAt)
+	require.Zero(t, store.saved)
+}
+
+func TestExecuteBatch_ReturnsErrorWhenExportFailsAndDoesNotAdvanceState(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
+	snapshot := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
+	require.NoError(t, err)
+
+	origExport := exportSnapshotToTmpFn
+	t.Cleanup(func() {
+		exportSnapshotToTmpFn = origExport
+	})
+	exportSnapshotToTmpFn = func(_ *DuckExporter, _ context.Context, _ CDCConfig, _ string, _ string, _ int16, _ int64, _ []uuid.UUID, _ forma.SchemaAttributeCache) error {
+		return errors.New("export failed")
+	}
+
+	store := newInMemoryManifestStore()
+	executor := &flushBatchExecutor{
+		ctx:           ctx,
+		db:            db,
+		duck:          &DuckExporter{Logger: zap.NewNop()},
+		s3Client:      &objectOnlyS3Client{},
+		cfg:           CDCConfig{S3Bucket: "test-bucket", S3Prefix: "cdc"},
+		tableName:     "change_log",
+		schemaID:      7,
+		snapshot:      snapshot,
+		pgConnForDuck: "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
+		logger:        zap.NewNop(),
+		manifestStore: store,
+	}
+
+	err = executor.executeBatch([]uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duck export snapshot")
+
+	var flushedAt int64
+	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
+	require.NoError(t, err)
+	require.Zero(t, flushedAt)
+	require.Zero(t, store.saved)
+}
+
+func TestExecuteBatch_ReturnsErrorWhenCopyFailsAndDoesNotAdvanceState(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
+	snapshot := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
+	require.NoError(t, err)
+
+	origExport := exportSnapshotToTmpFn
+	t.Cleanup(func() {
+		exportSnapshotToTmpFn = origExport
+	})
+	exportSnapshotToTmpFn = func(_ *DuckExporter, _ context.Context, _ CDCConfig, _ string, _ string, _ int16, _ int64, _ []uuid.UUID, _ forma.SchemaAttributeCache) error {
+		return nil
+	}
+
+	store := newInMemoryManifestStore()
+	executor := &flushBatchExecutor{
+		ctx:           ctx,
+		db:            db,
+		duck:          &DuckExporter{Logger: zap.NewNop()},
+		s3Client:      &copyFailingS3Client{},
+		cfg:           CDCConfig{S3Bucket: "test-bucket", S3Prefix: "cdc"},
+		tableName:     "change_log",
+		schemaID:      7,
+		snapshot:      snapshot,
+		pgConnForDuck: "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
+		logger:        zap.NewNop(),
+		manifestStore: store,
+	}
+
+	err = executor.executeBatch([]uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "copy tmp to final")
+
+	var flushedAt int64
+	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
+	require.NoError(t, err)
+	require.Zero(t, flushedAt)
+	require.Zero(t, store.saved)
 }
 
 func TestUpdateManifest_NilStore(t *testing.T) {

--- a/internal/cdc/flusher_test.go
+++ b/internal/cdc/flusher_test.go
@@ -452,25 +452,7 @@ func TestExecuteFlush_FallsBackToGenericProjectionWhenSchemaLookupFails(t *testi
 	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, time.Now().UnixMilli())
 	require.NoError(t, err)
 
-	origSingle := executeFlushSingleFn
-	origChunks := executeFlushInChunksFn
-	t.Cleanup(func() {
-		executeFlushSingleFn = origSingle
-		executeFlushInChunksFn = origChunks
-	})
-
 	called := false
-	executeFlushSingleFn = func(executor *flushBatchExecutor, batchIDs []uuid.UUID) error {
-		called = true
-		require.Len(t, batchIDs, 1)
-		require.Nil(t, executor.attrCache)
-		require.Equal(t, int16(7), executor.schemaID)
-		return nil
-	}
-	executeFlushInChunksFn = func(*flushBatchExecutor, []uuid.UUID, int) error {
-		return errors.New("unexpected chunk execution")
-	}
-
 	flushCtx := &schemaFlushContext{
 		db:             db,
 		cfg:            CDCConfig{BatchSize: 10, PGHost: "localhost", PGPort: 5432, PGUser: "pguser", PGDB: "forma"},
@@ -478,6 +460,16 @@ func TestExecuteFlush_FallsBackToGenericProjectionWhenSchemaLookupFails(t *testi
 		pgPassword:     "secret",
 		logger:         zap.NewNop(),
 		schemaRegistry: errorSchemaRegistry{err: errors.New("schema unavailable")},
+		executeSingle: func(executor *flushBatchExecutor, batchIDs []uuid.UUID) error {
+			called = true
+			require.Len(t, batchIDs, 1)
+			require.Nil(t, executor.attrCache)
+			require.Equal(t, int16(7), executor.schemaID)
+			return nil
+		},
+		executeInChunks: func(*flushBatchExecutor, []uuid.UUID, int) error {
+			return errors.New("unexpected chunk execution")
+		},
 	}
 
 	err = flushCtx.executeFlush(ctx, 7)
@@ -508,31 +500,23 @@ func TestExecuteFlush_SplitsBatchWhenByteTargetIsExceeded(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	origSingle := executeFlushSingleFn
-	origChunks := executeFlushInChunksFn
-	t.Cleanup(func() {
-		executeFlushSingleFn = origSingle
-		executeFlushInChunksFn = origChunks
-	})
-
 	chunkCalled := false
-	executeFlushSingleFn = func(*flushBatchExecutor, []uuid.UUID) error {
-		return errors.New("unexpected single execution")
-	}
-	executeFlushInChunksFn = func(executor *flushBatchExecutor, batchIDs []uuid.UUID, maxRows int) error {
-		chunkCalled = true
-		require.Equal(t, 1, maxRows)
-		require.Len(t, batchIDs, 3)
-		require.Equal(t, int16(7), executor.schemaID)
-		return nil
-	}
-
 	flushCtx := &schemaFlushContext{
 		db:         db,
 		cfg:        CDCConfig{BatchSize: 10, MaxBatchBytes: 10, EstimatedRowBytes: 10, PGHost: "localhost", PGPort: 5432, PGUser: "pguser", PGDB: "forma"},
 		tableName:  "change_log",
 		pgPassword: "secret",
 		logger:     zap.NewNop(),
+		executeSingle: func(*flushBatchExecutor, []uuid.UUID) error {
+			return errors.New("unexpected single execution")
+		},
+		executeInChunks: func(executor *flushBatchExecutor, batchIDs []uuid.UUID, maxRows int) error {
+			chunkCalled = true
+			require.Equal(t, 1, maxRows)
+			require.Len(t, batchIDs, 3)
+			require.Equal(t, int16(7), executor.schemaID)
+			return nil
+		},
 	}
 
 	err = flushCtx.executeFlush(ctx, 7)
@@ -555,20 +539,7 @@ func TestExecuteBatch_SucceedsWhenManifestUpdateFails(t *testing.T) {
 	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
 	require.NoError(t, err)
 
-	origExport := exportSnapshotToTmpFn
-	t.Cleanup(func() {
-		exportSnapshotToTmpFn = origExport
-	})
 	exportCalled := false
-	exportSnapshotToTmpFn = func(_ *DuckExporter, _ context.Context, _ CDCConfig, _ string, s3TmpPath string, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
-		exportCalled = true
-		require.Equal(t, int16(7), schemaID)
-		require.Equal(t, snapshot, snapshotTS)
-		require.Equal(t, []uuid.UUID{rowID}, rowIDs)
-		require.Contains(t, s3TmpPath, "s3://test-bucket/cdc/7/_tmp/")
-		require.Nil(t, attrCache)
-		return nil
-	}
 
 	store := newInMemoryManifestStore()
 	store.loadErr = errors.New("boom")
@@ -587,6 +558,15 @@ func TestExecuteBatch_SucceedsWhenManifestUpdateFails(t *testing.T) {
 		logger:           zap.NewNop(),
 		manifestStore:    store,
 		manifestResolver: resolver,
+		exportSnapshot: func(_ *DuckExporter, _ context.Context, _ CDCConfig, _ string, s3TmpPath string, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
+			exportCalled = true
+			require.Equal(t, int16(7), schemaID)
+			require.Equal(t, snapshot, snapshotTS)
+			require.Equal(t, []uuid.UUID{rowID}, rowIDs)
+			require.Contains(t, s3TmpPath, "s3://test-bucket/cdc/7/_tmp/")
+			require.Nil(t, attrCache)
+			return nil
+		},
 	}
 
 	err = executor.executeBatch([]uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
@@ -615,14 +595,6 @@ func TestExecuteBatch_ReturnsErrorWhenExportFailsAndDoesNotAdvanceState(t *testi
 	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
 	require.NoError(t, err)
 
-	origExport := exportSnapshotToTmpFn
-	t.Cleanup(func() {
-		exportSnapshotToTmpFn = origExport
-	})
-	exportSnapshotToTmpFn = func(_ *DuckExporter, _ context.Context, _ CDCConfig, _ string, _ string, _ int16, _ int64, _ []uuid.UUID, _ forma.SchemaAttributeCache) error {
-		return errors.New("export failed")
-	}
-
 	store := newInMemoryManifestStore()
 	executor := &flushBatchExecutor{
 		ctx:           ctx,
@@ -636,6 +608,9 @@ func TestExecuteBatch_ReturnsErrorWhenExportFailsAndDoesNotAdvanceState(t *testi
 		pgConnForDuck: "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
 		logger:        zap.NewNop(),
 		manifestStore: store,
+		exportSnapshot: func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error {
+			return errors.New("export failed")
+		},
 	}
 
 	err = executor.executeBatch([]uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
@@ -664,14 +639,6 @@ func TestExecuteBatch_ReturnsErrorWhenCopyFailsAndDoesNotAdvanceState(t *testing
 	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
 	require.NoError(t, err)
 
-	origExport := exportSnapshotToTmpFn
-	t.Cleanup(func() {
-		exportSnapshotToTmpFn = origExport
-	})
-	exportSnapshotToTmpFn = func(_ *DuckExporter, _ context.Context, _ CDCConfig, _ string, _ string, _ int16, _ int64, _ []uuid.UUID, _ forma.SchemaAttributeCache) error {
-		return nil
-	}
-
 	store := newInMemoryManifestStore()
 	executor := &flushBatchExecutor{
 		ctx:           ctx,
@@ -685,6 +652,9 @@ func TestExecuteBatch_ReturnsErrorWhenCopyFailsAndDoesNotAdvanceState(t *testing
 		pgConnForDuck: "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
 		logger:        zap.NewNop(),
 		manifestStore: store,
+		exportSnapshot: func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error {
+			return nil
+		},
 	}
 
 	err = executor.executeBatch([]uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")


### PR DESCRIPTION
## Summary
- add a minimal export seam for `executeBatch` so tests can drive export success and failure paths without changing production defaults
- cover the non-critical manifest failure path after a successful flush batch
- cover export and copy failures to verify `executeBatch` returns an error without advancing flushed state or manifest data

## Testing
- go test ./internal/cdc -run 'Test(ProcessSchema_(SkipsWhenSchemaLockIsAlreadyHeld|ReturnsErrorWhenChangeLogStatsCannotBeRead|SkipsWhenNoPendingRowsExist|SkipsWhenThresholdsAreNotMet)|ExecuteFlush_(NoSelectedRowIDsReturnsWithoutExportWork|FallsBackToGenericProjectionWhenSchemaLookupFails|SplitsBatchWhenByteTargetIsExceeded)|ExecuteBatch_(SucceedsWhenManifestUpdateFails|ReturnsErrorWhenExportFailsAndDoesNotAdvanceState|ReturnsErrorWhenCopyFailsAndDoesNotAdvanceState)|ShouldFlush|GetUnflushedSchemaIDs.*|UpdateManifest_.*)'
- go test ./internal/cdc -run 'Test(RunOnce_RequiresSchemaRegistry|ResolveS3Clients_.*|SetupPostgresConnection_.*|ShouldFlush|MinMaxRowID|GetUnflushedSchemaIDs.*|ExecuteFlush_.*|ExecuteBatch_.*|ProcessSchema_.*|UpdateManifest_.*)'