### PR TITLE
test: harden autoresearch decision recovery

### DIFF
--- a/tools/autoresearch/testing/README.md
+++ b/tools/autoresearch/testing/README.md
@@ -125,7 +125,9 @@ The controller reads this and decides commit vs. revert. The model never touches
 When `issue_*` fields are present, the controller also appends an entry to `issues.tsv` with deduplication.
 
 For resilience, single-candidate runs also ask the agent to print the same decision block to stdout wrapped in `AUTORESEARCH_DECISION_BEGIN` / `AUTORESEARCH_DECISION_END`.
-If the decision file is missing but the stdout fallback block is present, the controller reconstructs the decision artifact from stdout and continues the run.
+If the decision file is missing but the stdout fallback block is present with all required fields, the controller reconstructs the decision artifact from stdout and continues the run.
+This fallback also applies when `opencode run` exits non-zero after already printing a complete decision block, so a late controller/model exit does not automatically waste the iteration.
+When recovery fails, the controller records a more specific harness reason such as missing stdout logs, missing fallback markers, or incomplete decision fields.
 
 ## Gate scripts
 

--- a/tools/autoresearch/testing/scripts/autoloop.sh
+++ b/tools/autoresearch/testing/scripts/autoloop.sh
@@ -531,6 +531,39 @@ recover_decision_from_stdout() {
   python3 "$SCRIPT_DIR/extract_decision_from_stdout.py" "$stdout_log" "$decision_file"
 }
 
+diagnose_decision_recovery_failure() {
+  local run_index="$1"
+  local stdout_log
+
+  stdout_log="$(test_log_path "${LOG_PREFIX}-${TARGET}-run-${run_index}.stdout")"
+  if [[ ! -f "$stdout_log" ]]; then
+    printf '%s' 'stdout log missing'
+    return 0
+  fi
+
+  if ! rg -q 'AUTORESEARCH_DECISION_BEGIN' "$stdout_log"; then
+    printf '%s' 'stdout fallback block missing begin marker'
+    return 0
+  fi
+
+  if ! rg -q 'AUTORESEARCH_DECISION_END' "$stdout_log"; then
+    printf '%s' 'stdout fallback block missing end marker'
+    return 0
+  fi
+
+  printf '%s' 'stdout fallback block missing one or more required decision fields'
+}
+
+cleanup_iteration_state() {
+  local decision_file="$1"
+
+  rm -f "$decision_file"
+
+  if [[ "$DRY_RUN" -ne 1 ]]; then
+    cleanup_synced_assets
+  fi
+}
+
 sanitize_tsv_field() {
   printf '%s' "$1" | tr '\t\r\n' '   '
 }
@@ -694,36 +727,51 @@ discard_candidate() {
 run_iteration() {
   local run_index="$1"
   local decision_file="$WORKTREE_DIR/.autoresearch-decision-$run_index.txt"
+  local iteration_status=0
+  local run_status=0
+  local recovered_from_stdout=0
+  local recovery_failure_reason=""
+  local status=""
+  local reason=""
+  local scenario=""
+  local description=""
+  local evidence=""
 
   rm -f "$decision_file"
 
   run_single_candidate "$run_index" "$decision_file"
-  local run_status=$?
+  run_status=$?
 
   if [[ "$DRY_RUN" -eq 1 ]]; then
     append_loop_log "run $run_index dry-run complete"
     return 0
   fi
 
-  if [[ "$run_status" -ne 0 ]]; then
-    append_loop_log "run $run_index failed with exit $run_status"
-    printf 'n/a\t%s\t%s\terror\tn/a\trun %d failed with exit %d\tn/a\n' "$TARGET" "$(resolve_target_pkg "$TARGET")" "$run_index" "$run_status" >> "$AR_DIR/results.tsv"
-    append_issue "harness" "$TARGET" "tools/autoresearch/testing/scripts/autoloop.sh" "Autoresearch run exited before writing a decision" "run ${run_index} failed with exit ${run_status}" "Inspect OpenCode run logs for model/config/controller failures and harden prompt or runtime validation"
-    return 1
-  fi
-
   if [[ ! -f "$decision_file" ]]; then
     if recover_decision_from_stdout "$run_index" "$decision_file"; then
+      recovered_from_stdout=1
       append_loop_log "run $run_index recovered decision file from stdout fallback"
     else
-      append_loop_log "run $run_index produced no decision file"
-      append_issue "harness" "$TARGET" "tools/autoresearch/testing/scripts/autoloop.sh" "Autoresearch run produced no decision artifact" "run ${run_index} produced no decision file" "Tighten prompt compliance or add controller-side fallback capture for interrupted runs"
+      recovery_failure_reason="$(diagnose_decision_recovery_failure "$run_index")"
+      if [[ "$run_status" -ne 0 ]]; then
+        append_loop_log "run $run_index failed with exit $run_status and no usable decision artifact (${recovery_failure_reason})"
+        printf 'n/a\t%s\t%s\terror\tn/a\trun %d failed with exit %d; %s\tn/a\n' "$TARGET" "$(resolve_target_pkg "$TARGET")" "$run_index" "$run_status" "$recovery_failure_reason" >> "$AR_DIR/results.tsv"
+        append_issue "harness" "$TARGET" "tools/autoresearch/testing/scripts/autoloop.sh" "Autoresearch run exited without a usable decision" "run ${run_index} failed with exit ${run_status}; ${recovery_failure_reason}" "Inspect the stdout log and controller recovery path; keep stdout fallback parseable even when opencode exits non-zero"
+      else
+        append_loop_log "run $run_index produced no usable decision artifact (${recovery_failure_reason})"
+        append_issue "harness" "$TARGET" "tools/autoresearch/testing/scripts/autoloop.sh" "Autoresearch run produced no usable decision artifact" "run ${run_index} produced no decision file; ${recovery_failure_reason}" "Inspect the stdout log and tighten decision-block emission or fallback parsing"
+      fi
       discard_candidate "$run_index" "no_decision_file" "n/a" "n/a" "no_decision_file"
-      return 1
+      iteration_status=1
+      cleanup_iteration_state "$decision_file"
+      return "$iteration_status"
     fi
   fi
 
-  local status reason scenario description evidence
+  if [[ "$run_status" -ne 0 ]]; then
+    append_loop_log "run $run_index exited with $run_status after producing a usable decision artifact"
+  fi
+
   status="$(get_decision_field "$decision_file" status)"
   reason="$(get_decision_field "$decision_file" reason)"
   scenario="$(get_decision_field "$decision_file" scenario)"
@@ -733,13 +781,16 @@ run_iteration() {
   record_issue_from_decision "$decision_file"
 
   append_loop_log "run $run_index decision: status=$status reason=$reason"
+  if [[ "$recovered_from_stdout" -eq 1 ]]; then
+    append_loop_log "run $run_index using stdout-recovered decision artifact"
+  fi
 
   case "$status" in
     keep)
       BLOCKED_STREAK=0
       if ! commit_candidate "$run_index" "$scenario" "$description" "$evidence"; then
         append_loop_log "iteration $run_index failed during keep path"
-        return 1
+        iteration_status=1
       fi
       ;;
     discard)
@@ -757,8 +808,8 @@ run_iteration() {
       ;;
   esac
 
-  rm -f "$decision_file"
-  cleanup_synced_assets
+  cleanup_iteration_state "$decision_file"
+  return "$iteration_status"
 }
 
 append_loop_log() {
@@ -766,71 +817,78 @@ append_loop_log() {
   printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$line" | tee -a "$LOOP_LOG"
 }
 
-cd "$ROOT_DIR"
+autoloop_main() {
+  cd "$ROOT_DIR"
 
-if [[ "$PRINT_PROMPT" -eq 1 ]]; then
-  print_prompt
-  exit 0
-fi
-
-BRANCH_DATE="$(date '+%Y%m%d')"
-RESEARCH_BRANCH="autoresearch/${TARGET}-${BRANCH_DATE}"
-WORKTREE_DIR="$ROOT_DIR/.worktrees/autoresearch-$TARGET"
-ensure_report_dirs
-LOOP_LOG="$(test_log_path "$LOG_PREFIX-$TARGET")"
-
-append_loop_log "target=$TARGET research_branch=$RESEARCH_BRANCH worktree=$WORKTREE_DIR model=${MODEL:-default}"
-
-if [[ "$DRY_RUN" -ne 1 ]]; then
-  if ! ensure_main_clean; then
-    if [[ "$FORCE" -ne 1 ]]; then
-      exit 1
-    fi
+  if [[ "$PRINT_PROMPT" -eq 1 ]]; then
+    print_prompt
+    return 0
   fi
-  ensure_local_infra
-  init_worktree
-  ensure_worktree_clean
-  ensure_worktree_on_research
-fi
 
-if [[ "$RUN_BASELINE" -eq 1 ]]; then
-  append_loop_log "running baseline"
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf 'baseline package: %s\n' "$(resolve_target_pkg "$TARGET")"
-    printf 'baseline coverprofile: %s\n' "$REPORT_DIR/baseline/${TARGET}.cover.out"
-  else
-    (
-      cd "$WORKTREE_DIR"
-      ./tools/autoresearch/testing/scripts/baseline.sh "$TARGET"
-    )
-    append_loop_log "baseline complete"
-  fi
-fi
+  BRANCH_DATE="$(date '+%Y%m%d')"
+  RESEARCH_BRANCH="autoresearch/${TARGET}-${BRANCH_DATE}"
+  WORKTREE_DIR="$ROOT_DIR/.worktrees/autoresearch-$TARGET"
+  ensure_report_dirs
+  LOOP_LOG="$(test_log_path "$LOG_PREFIX-$TARGET")"
 
-for ((run_index = 1; run_index <= ITERATIONS; run_index++)); do
+  append_loop_log "target=$TARGET research_branch=$RESEARCH_BRANCH worktree=$WORKTREE_DIR model=${MODEL:-default}"
+
   if [[ "$DRY_RUN" -ne 1 ]]; then
-    sync_autoresearch_assets
-  fi
-  append_loop_log "=== iteration $run_index of $ITERATIONS ==="
-  run_iteration "$run_index" || iter_status=$?
-  iter_status=${iter_status:-0}
-
-  if [[ "$iter_status" -ne 0 ]]; then
-    append_loop_log "iteration $run_index did not complete successfully"
-  fi
-
-  if [[ "$BLOCKED_STREAK" -ge "$CONSECUTIVE_BLOCKED_LIMIT" ]]; then
-    append_loop_log "stopping early after $BLOCKED_STREAK consecutive blocked discards; target guidance likely too restrictive"
-    break
+    if ! ensure_main_clean; then
+      if [[ "$FORCE" -ne 1 ]]; then
+        return 1
+      fi
+    fi
+    ensure_local_infra
+    init_worktree
+    ensure_worktree_clean
+    ensure_worktree_on_research
   fi
 
-  if [[ "$run_index" -lt "$ITERATIONS" && "$SLEEP_SECONDS" -gt 0 ]]; then
+  if [[ "$RUN_BASELINE" -eq 1 ]]; then
+    append_loop_log "running baseline"
     if [[ "$DRY_RUN" -eq 1 ]]; then
-      printf 'sleep %s\n' "$SLEEP_SECONDS"
+      printf 'baseline package: %s\n' "$(resolve_target_pkg "$TARGET")"
+      printf 'baseline coverprofile: %s\n' "$REPORT_DIR/baseline/${TARGET}.cover.out"
     else
-      sleep "$SLEEP_SECONDS"
+      (
+        cd "$WORKTREE_DIR"
+        ./tools/autoresearch/testing/scripts/baseline.sh "$TARGET"
+      )
+      append_loop_log "baseline complete"
     fi
   fi
-done
 
-append_loop_log "autoloop finished: $ITERATIONS iterations completed for target=$TARGET"
+  for ((run_index = 1; run_index <= ITERATIONS; run_index++)); do
+    if [[ "$DRY_RUN" -ne 1 ]]; then
+      ensure_worktree_clean
+      sync_autoresearch_assets
+    fi
+    append_loop_log "=== iteration $run_index of $ITERATIONS ==="
+    run_iteration "$run_index" || iter_status=$?
+    iter_status=${iter_status:-0}
+
+    if [[ "$iter_status" -ne 0 ]]; then
+      append_loop_log "iteration $run_index did not complete successfully"
+    fi
+
+    if [[ "$BLOCKED_STREAK" -ge "$CONSECUTIVE_BLOCKED_LIMIT" ]]; then
+      append_loop_log "stopping early after $BLOCKED_STREAK consecutive blocked discards; target guidance likely too restrictive"
+      break
+    fi
+
+    if [[ "$run_index" -lt "$ITERATIONS" && "$SLEEP_SECONDS" -gt 0 ]]; then
+      if [[ "$DRY_RUN" -eq 1 ]]; then
+        printf 'sleep %s\n' "$SLEEP_SECONDS"
+      else
+        sleep "$SLEEP_SECONDS"
+      fi
+    fi
+  done
+
+  append_loop_log "autoloop finished: $ITERATIONS iterations completed for target=$TARGET"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  autoloop_main "$@"
+fi

--- a/tools/autoresearch/testing/scripts/extract_decision_from_stdout.py
+++ b/tools/autoresearch/testing/scripts/extract_decision_from_stdout.py
@@ -24,14 +24,25 @@ def main() -> int:
     if finish == -1:
         return 1
 
+    required_fields = {
+        "status",
+        "reason",
+        "scenario",
+        "description",
+        "evidence",
+    }
     lines = []
+    seen_fields = set()
     for raw in text[start:finish].splitlines():
         line = raw.strip()
         if not line or "=" not in line:
             continue
         lines.append(line)
+        key = line.split("=", 1)[0].strip()
+        if key:
+            seen_fields.add(key)
 
-    if not any(line.startswith("status=") for line in lines):
+    if not required_fields.issubset(seen_fields):
         return 1
 
     decision_path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/tools/autoresearch/testing/scripts/test_autoloop_decision_recovery.sh
+++ b/tools/autoresearch/testing/scripts/test_autoloop_decision_recovery.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/autoresearch/testing/scripts/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cp "$SCRIPT_DIR/autoloop.sh" "$tmp_dir/autoloop.sh"
+cp "$SCRIPT_DIR/common.sh" "$tmp_dir/common.sh"
+cp "$SCRIPT_DIR/extract_decision_from_stdout.py" "$tmp_dir/extract_decision_from_stdout.py"
+
+# shellcheck source=/dev/null
+source "$tmp_dir/autoloop.sh"
+
+WORKTREE_DIR="$tmp_dir/worktree"
+mkdir -p "$WORKTREE_DIR"
+TARGET="postgres_repo_query"
+LOG_PREFIX="controller-test"
+LOOP_LOG="$tmp_dir/controller.log"
+AR_DIR="$tmp_dir/ar"
+REPORT_DIR="$AR_DIR/reports"
+ensure_report_dirs
+DRY_RUN=0
+
+sync_autoresearch_assets() { :; }
+cleanup_synced_assets() {
+  printf 'cleanup\n' >> "$tmp_dir/cleanup.log"
+}
+commit_candidate() {
+  printf '%s|%s|%s|%s\n' "$1" "$2" "$3" "$4" >> "$tmp_dir/commit.log"
+}
+discard_candidate() {
+  printf '%s|%s|%s|%s|%s\n' "$1" "$2" "$3" "$4" "$5" >> "$tmp_dir/discard.log"
+}
+record_issue_from_decision() { :; }
+append_issue() {
+  printf '%s|%s|%s|%s|%s|%s\n' "$1" "$2" "$3" "$4" "$5" "$6" >> "$tmp_dir/issues.log"
+}
+resolve_target_pkg() {
+  printf '%s\n' './internal'
+}
+
+run_single_candidate() {
+  local run_index="$1"
+  local decision_file="$2"
+  local stdout_log
+
+  stdout_log="$(test_log_path "${LOG_PREFIX}-${TARGET}-run-${run_index}.stdout")"
+  mkdir -p "$(dirname "$stdout_log")"
+  rm -f "$stdout_log" "$decision_file"
+
+  case "$TEST_CASE" in
+    recover_exit_zero)
+      cat > "$stdout_log" <<EOF
+AUTORESEARCH_DECISION_BEGIN
+status=discard
+reason=stdout fallback worked
+scenario=n/a
+description=recovered with zero exit
+evidence=n/a
+AUTORESEARCH_DECISION_END
+EOF
+      return 0
+      ;;
+    recover_exit_nonzero)
+      cat > "$stdout_log" <<EOF
+AUTORESEARCH_DECISION_BEGIN
+status=keep
+reason=stdout fallback survived non-zero exit
+scenario=Given stdout fallback only, when controller parses it, then keep still works
+description=Uses stdout fallback after a non-zero opencode exit
+evidence=n/a
+AUTORESEARCH_DECISION_END
+EOF
+      return 17
+      ;;
+    missing_markers)
+      printf 'plain stdout without markers\n' > "$stdout_log"
+      return 0
+      ;;
+    missing_fields)
+      cat > "$stdout_log" <<EOF
+AUTORESEARCH_DECISION_BEGIN
+status=discard
+reason=missing fields
+AUTORESEARCH_DECISION_END
+EOF
+      return 0
+      ;;
+    missing_end_marker)
+      cat > "$stdout_log" <<EOF
+AUTORESEARCH_DECISION_BEGIN
+status=discard
+reason=missing end marker
+scenario=n/a
+description=incomplete stdout fallback block
+evidence=n/a
+EOF
+      return 0
+      ;;
+    *)
+      printf 'unknown test case: %s\n' "$TEST_CASE" >&2
+      return 99
+      ;;
+  esac
+}
+
+assert_contains() {
+  local path="$1"
+  local pattern="$2"
+
+  rg -F "$pattern" "$path" >/dev/null
+}
+
+assert_not_exists() {
+  local path="$1"
+
+  [[ ! -e "$path" ]]
+}
+
+run_case() {
+  local case_name="$1"
+  local run_index="$2"
+
+  TEST_CASE="$case_name"
+  : > "$tmp_dir/cleanup.log"
+  : > "$tmp_dir/commit.log"
+  : > "$tmp_dir/discard.log"
+  : > "$tmp_dir/issues.log"
+  : > "$tmp_dir/controller.log"
+  : > "$AR_DIR/results.tsv"
+  BLOCKED_STREAK=0
+
+  run_iteration "$run_index" || case_status=$?
+  case_status=${case_status:-0}
+}
+
+run_case recover_exit_zero 1
+[[ "$case_status" -eq 0 ]]
+assert_contains "$tmp_dir/discard.log" '1|stdout fallback worked|n/a|recovered with zero exit|n/a'
+assert_contains "$tmp_dir/cleanup.log" 'cleanup'
+assert_not_exists "$WORKTREE_DIR/.autoresearch-decision-1.txt"
+
+run_case recover_exit_nonzero 2
+[[ "$case_status" -eq 0 ]]
+assert_contains "$tmp_dir/commit.log" '2|Given stdout fallback only, when controller parses it, then keep still works|Uses stdout fallback after a non-zero opencode exit|n/a'
+assert_contains "$tmp_dir/controller.log" 'exited with 17 after producing a usable decision artifact'
+assert_contains "$tmp_dir/controller.log" 'using stdout-recovered decision artifact'
+assert_contains "$tmp_dir/cleanup.log" 'cleanup'
+assert_not_exists "$WORKTREE_DIR/.autoresearch-decision-2.txt"
+
+run_case missing_markers 3
+[[ "$case_status" -eq 1 ]]
+assert_contains "$tmp_dir/discard.log" '3|no_decision_file|n/a|n/a|no_decision_file'
+assert_contains "$tmp_dir/issues.log" 'harness|postgres_repo_query|tools/autoresearch/testing/scripts/autoloop.sh|Autoresearch run produced no usable decision artifact|run 3 produced no decision file; stdout fallback block missing begin marker|Inspect the stdout log and tighten decision-block emission or fallback parsing'
+assert_contains "$tmp_dir/cleanup.log" 'cleanup'
+
+run_case missing_fields 4
+[[ "$case_status" -eq 1 ]]
+assert_contains "$tmp_dir/discard.log" '4|no_decision_file|n/a|n/a|no_decision_file'
+assert_contains "$tmp_dir/issues.log" 'harness|postgres_repo_query|tools/autoresearch/testing/scripts/autoloop.sh|Autoresearch run produced no usable decision artifact|run 4 produced no decision file; stdout fallback block missing one or more required decision fields|Inspect the stdout log and tighten decision-block emission or fallback parsing'
+assert_contains "$tmp_dir/cleanup.log" 'cleanup'
+
+run_case missing_end_marker 5
+[[ "$case_status" -eq 1 ]]
+assert_contains "$tmp_dir/discard.log" '5|no_decision_file|n/a|n/a|no_decision_file'
+assert_contains "$tmp_dir/issues.log" 'harness|postgres_repo_query|tools/autoresearch/testing/scripts/autoloop.sh|Autoresearch run produced no usable decision artifact|run 5 produced no decision file; stdout fallback block missing end marker|Inspect the stdout log and tighten decision-block emission or fallback parsing'
+assert_contains "$tmp_dir/cleanup.log" 'cleanup'
+
+printf 'autoloop decision recovery controller test passed\n'


### PR DESCRIPTION
## Summary
- recover stdout decision artifacts even when `opencode run` exits non-zero, and log more specific harness failure reasons when recovery fails
- ensure each autoloop iteration always cleans up synced assets and re-validates worktree cleanliness before the next run
- tighten stdout decision extraction to require all decision fields and add controller-level shell coverage for recovered and malformed fallback blocks

## Validation
- bash tools/autoresearch/testing/scripts/test_recover_decision_from_stdout.sh
- bash tools/autoresearch/testing/scripts/test_autoloop_decision_recovery.sh
- bash -n tools/autoresearch/testing/scripts/autoloop.sh
- bash -n tools/autoresearch/testing/scripts/test_autoloop_decision_recovery.sh
- python3 -m py_compile tools/autoresearch/testing/scripts/extract_decision_from_stdout.py
- ./tools/autoresearch/testing/scripts/autoloop.sh --target dualpath_sql_generator --iterations 1 --skip-local-infra --sleep-seconds 0 --force