### PR TITLE
add federated query benchmark foundation

### DIFF
--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	os.Exit(runBenchmarkMain(ctx, os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func runBenchmarkMain(ctx context.Context, args []string, out, errOut io.Writer) int {
+	if len(args) == 0 {
+		printUsage(out)
+		return 1
+	}
+	switch args[0] {
+	case "describe":
+		return runDescribe(out)
+	case "run":
+		return runBenchmark(ctx, args[1:], out, errOut)
+	default:
+		fmt.Fprintf(errOut, "unknown command %q\n", args[0])
+		printUsage(out)
+		return 1
+	}
+}
+
+func printUsage(out io.Writer) {
+	fmt.Fprintln(out, "Usage: benchmark <command> [options]")
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Commands:")
+	fmt.Fprintln(out, "  describe   Print benchmark schemas, workloads, and defaults")
+	fmt.Fprintln(out, "  run        Execute the scaffolded benchmark runner")
+}
+
+func runDescribe(out io.Writer) int {
+	payload := struct {
+		SchemaDir    string                     `json:"schema_dir"`
+		Defaults     bench.Config               `json:"defaults"`
+		Generator    bench.GeneratorConfig      `json:"generator_defaults"`
+		ScalePresets []bench.ScalePreset        `json:"scale_presets"`
+		TierProfiles []bench.TierMixProfile     `json:"tier_profiles"`
+		Schemas      []bench.SchemaFixture      `json:"schemas"`
+		Workloads    []bench.WorkloadDefinition `json:"workloads"`
+	}{
+		SchemaDir:    bench.FixturesDir(),
+		Defaults:     bench.DefaultConfig(),
+		Generator:    bench.DefaultGeneratorConfig(),
+		ScalePresets: bench.DefaultScalePresets(),
+		TierProfiles: bench.DefaultTierMixProfiles(),
+		Schemas:      bench.DefaultSchemaFixtures(),
+		Workloads:    bench.DefaultWorkloads(),
+	}
+	return writeJSON(out, payload)
+}
+
+func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int {
+	flags := flag.NewFlagSet("run", flag.ContinueOnError)
+	flags.SetOutput(errOut)
+	mode := flags.String("mode", string(bench.ExecutionModeSmoke), "Execution mode: smoke or plan")
+	scale := flags.String("scale", string(bench.ScaleSmall), "Dataset scale: small, medium, or large")
+	distribution := flags.String("distribution", string(bench.DistributionUniform), "Data distribution preset")
+	iterations := flags.Int("iterations", 1, "Number of iterations to schedule")
+	concurrency := flags.Int("concurrency", 1, "Number of concurrent workers to schedule")
+	pageSize := flags.Int("page-size", 20, "Default page size for workload planning")
+	seed := flags.Int64("seed", 42, "Deterministic benchmark seed")
+	workloads := flags.String("workloads", "", "Comma-separated workload names (defaults to all)")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	cfg := bench.Config{
+		Mode:         bench.ExecutionMode(*mode),
+		Scale:        bench.Scale(*scale),
+		Distribution: bench.Distribution(*distribution),
+		Iterations:   *iterations,
+		Concurrency:  *concurrency,
+		PageSize:     *pageSize,
+		Seed:         *seed,
+		Workloads:    parseWorkloads(*workloads),
+	}.WithDefaults()
+	runner, err := bench.NewRunner(cfg)
+	if err != nil {
+		fmt.Fprintf(errOut, "benchmark setup failed: %v\n", err)
+		return 1
+	}
+	result, err := runner.Run(ctx)
+	if err != nil {
+		fmt.Fprintf(errOut, "benchmark run failed: %v\n", err)
+		return 1
+	}
+	return writeJSON(out, result)
+}
+
+func parseWorkloads(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name != "" {
+			result = append(result, name)
+		}
+	}
+	return result
+}
+
+func writeJSON(out io.Writer, payload any) int {
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode JSON: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(out, string(encoded))
+	return 0
+}

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestRunBenchmarkMainDescribe(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"describe"}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("describe returned exit code %d: %s", exitCode, errOut.String())
+	}
+	if out.Len() == 0 {
+		t.Fatalf("describe should emit JSON output")
+	}
+}
+
+func TestRunBenchmarkMainSmoke(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"run", "-mode", "smoke"}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("run returned exit code %d: %s", exitCode, errOut.String())
+	}
+	if out.Len() == 0 {
+		t.Fatalf("run should emit JSON output")
+	}
+}

--- a/docs/cn/federated-query-benchmark-hld.md
+++ b/docs/cn/federated-query-benchmark-hld.md
@@ -1,0 +1,345 @@
+# Federated Query Benchmark 高层设计
+
+更新时间：2026-04-17  
+适用仓库：`forma`
+
+## 1. 背景
+
+Forma 当前已经具备联邦查询、冷热分层、CDC flush、compaction、基础分页与性能测试能力，但还缺少一个专门面向混合查询的系统性 benchmark。现有性能测试更偏向通用回归，尚未覆盖以下关键问题：
+
+- 基于真实业务模型的冷热联合查询负载
+- 多种数据分布对谓词下推和路由策略的影响
+- 深分页与大页码跳转的性能退化
+- 冷热重叠、软删除、去重和最近版本覆盖的正确性与成本
+
+本设计提出一个参考 TPC-E 数据特征、但适配 Forma 存储模型的 Federated Query Benchmark，用于评估 cold + hot 联邦查询路径的正确性、性能和可观测性。
+
+## 2. 目标
+
+- 为 Forma 提供可重复、可扩展、可对比的混合查询 benchmark。
+- 使用 TPC-E 风格的金融交易域数据，覆盖交易、客户、证券三类核心实体。
+- 同时覆盖热字段列绑定和长尾 EAV 字段查询。
+- 系统测试不同数据分布下的分页、过滤、排序、深分页和冷热 merge 行为。
+- 为后续优化提供统一指标，包括延迟分位数、吞吐、冷热命中比例、去重比例和谓词下推效率。
+
+## 3. 非目标
+
+- 不追求 TPC-E 官方规范兼容，不实现完整的 33 张表和 12 类事务。
+- 不作为官方 TPC-E 成绩发布工具，不涉及审计规则。
+- 不替代现有 `internal/e2e_harness/federated` 功能测试，只在其基础上扩展 benchmark 能力。
+- 第一阶段不实现分布式执行、不实现跨机器 driver，不以峰值吞吐为首要目标。
+
+## 4. 设计原则
+
+- 与现有 e2e harness 对齐，优先复用已有容器化测试基础设施。
+- 数据模型参考 TPC-E 业务语义，但要贴合 Forma 的 `entity_main + eav_data + change_log + parquet` 结构。
+- Benchmark 结果必须可复现，同一随机种子下应生成同一批数据。
+- 工作负载要同时覆盖 correctness 与 performance，而不是只做压测。
+- 深分页单独建模，明确区分传统 `LIMIT/OFFSET` 与未来可能的 keyset/two-phase 方案。
+
+## 5. 逻辑架构
+
+Benchmark 系统由六个逻辑层组成：
+
+1. Schema Mapping Layer
+2. Data Generation Layer
+3. Tier Preparation Layer
+4. Workload Definition Layer
+5. Benchmark Runner Layer
+6. Metrics and Report Layer
+
+### 5.1 Schema Mapping Layer
+
+该层负责把 TPC-E 风格实体映射到 Forma schema。
+
+首批引入三个 benchmark schema：
+
+- `trade`
+- `customer`
+- `security`
+
+其中：
+
+- 高频过滤和排序字段映射到 hot columns
+- 长尾属性保留在 EAV
+- 每个 schema 都要包含可过滤字段、可排序字段、以及只存在于 EAV 的字段
+
+建议的 `trade` schema：
+
+- Hot: `symbol`, `trade_type`, `quantity`, `price`, `trade_time`, `customer_id`
+- EAV: `exchange`, `commission`, `is_cash`, `broker_id`, `order_channel`
+
+这样可以覆盖：
+
+- 纯 hot pushdown
+- 纯 EAV filter
+- hot + EAV 混合条件
+- 基于时间的排序与分页
+
+### 5.2 Data Generation Layer
+
+该层生成 benchmark 数据，要求同时支持规模、分布和冷热重叠配置。
+
+支持的分布类型：
+
+- `uniform`：均匀分布，作为基线
+- `zipf`：热点客户、热点 symbol、热点 region
+- `temporal`：越新的数据越密集，模拟真实写入热度
+- `partition-skew`：不同 region 或 sector 严重不均衡
+- `hotspot-overlap`：固定比例 row_id 在 cold 和 hot 同时存在
+
+生成器输出的逻辑数据需满足：
+
+- 同一 `row_id` 可跨 tier 出现多个版本
+- 更新时间单调递增，满足 last-write-wins 检验
+- 部分记录带软删除标记，用于测试 anti-join 与删除覆盖
+- 可精确控制 selectivity，以支持高、中、低选择性 workload
+
+### 5.3 Tier Preparation Layer
+
+该层负责把生成好的记录分配到三个 tier：
+
+- Cold/Base: 历史 parquet，大文件，低更新
+- Warm/Delta: 最近 flush 的 parquet，小文件，较新
+- Hot: Postgres `entity_main + eav_data + change_log` 中的未 flush 数据
+
+默认 tier 配比：
+
+- Base: 60%
+- Delta: 30%
+- Hot: 10%
+
+但 benchmark 需要允许覆盖以下变化：
+
+- 高热度模式：40/20/40
+- 长尾历史模式：85/10/5
+- 高重叠模式：Base 与 Hot 有 5%-10% 主键重叠
+
+Tier Preparation 还需要负责：
+
+- 把 cold/warm 记录写入 base/delta parquet
+- 把 hot 记录写入 Postgres 三张表
+- 标记 overlap、delete、update、restore 等特殊样本
+
+### 5.4 Workload Definition Layer
+
+该层定义 benchmark 查询模板。首期工作负载分为五类。
+
+#### A. 基线分页
+
+- 无过滤，按 `trade_time DESC`
+- 高选择性过滤 + 分页
+- 低选择性过滤 + 分页
+- EAV 过滤 + 分页
+- hot + EAV 组合条件 + 分页
+
+#### B. 深分页
+
+- `page = 1`
+- `page = 100`
+- `page = 1,000`
+- `page = 100,000`
+
+要求固定 page size，例如 `20` 或 `50`，并明确记录 offset 规模。
+
+#### C. 冷热命中模式
+
+- 只命中 hot
+- 只命中 cold
+- 同时命中 cold + hot
+- 同时命中 cold + warm + hot
+
+#### D. 去重与覆盖
+
+- 冷热同 key，不同版本
+- 热 tier 删除冷 tier 中已有记录
+- 冷记录被热记录更新部分 EAV 属性
+
+#### E. 路由与策略对比
+
+- `PreferHot = true`
+- `RoutingStrategyHybrid`
+- 小结果集走 Postgres
+- 大结果集走 DuckDB
+
+### 5.5 Benchmark Runner Layer
+
+Runner 负责 benchmark 生命周期管理：
+
+1. 注册 schema
+2. 生成数据
+3. 写入 tier
+4. 预热
+5. 重复执行 workload
+6. 汇总 latency 与 correctness 指标
+7. 输出结构化报告
+
+Runner 需要支持：
+
+- 串行运行
+- 固定并发运行
+- 指定 workload 子集运行
+- 指定 scale factor 和 distribution 运行
+- 指定随机种子运行
+
+推荐 scale：
+
+- `small`: 100K
+- `medium`: 1M
+- `large`: 10M
+
+### 5.6 Metrics and Report Layer
+
+需要输出以下指标：
+
+- `p50`, `p95`, `p99`, `max`, `avg`
+- `qps`
+- `result_count`
+- `hot_hit_ratio`
+- `cold_hit_ratio`
+- `dedup_count`
+- `delete_filtered_count`
+- `pushdown_efficiency`
+- `memory_peak_mb`
+
+报告格式：
+
+- 控制台摘要
+- JSON 结果文件
+- Markdown 报告
+
+这样既可用于本地分析，也可作为 CI artifact 或回归基线。
+
+## 6. 数据模型设计
+
+### 6.1 TPC-E 风格实体
+
+虽然不完全复刻 TPC-E，但借鉴其金融交易域特征：
+
+- `trade`: 高频写入，高时间局部性
+- `customer`: 中频更新，适合做过滤维度
+- `security`: 低频变更，适合作为冷数据维表
+
+### 6.2 Hot/EAV 设计要求
+
+每个 schema 至少满足：
+
+- 2 个可排序 hot 字段
+- 2 个高选择性 hot 过滤字段
+- 1 个低选择性 hot 过滤字段
+- 2 个 EAV 字段
+- 1 个会参与冷热覆盖冲突的字段
+
+## 7. 分页设计
+
+深分页是本 benchmark 的重点。
+
+### 7.1 当前基线
+
+使用现有分页语义：
+
+- `LIMIT page_size OFFSET offset`
+
+这可以真实测出当前系统在 merged result 上的性能退化。
+
+### 7.2 深分页关注点
+
+需要重点观察：
+
+- offset 增大后，DuckDB 读取和排序成本是否线性或超线性上升
+- 热数据和冷数据 merge 后再分页的成本
+- 小结果集策略是否会误走 DuckDB
+- 大页码跳转时总数统计是否变成瓶颈
+
+### 7.3 大页码测试点
+
+建议至少固定以下 case：
+
+- `page_size=20, page=1`
+- `page_size=20, page=100`
+- `page_size=20, page=1,000`
+- `page_size=20, page=100,000`
+
+同时保留等价 keyset case，作为未来优化对照组，但第一阶段可以只输出设计接口，不强制实现替代算法。
+
+## 8. 正确性要求
+
+Benchmark 不仅测性能，还要校验语义正确。
+
+必须校验：
+
+- cold/warm/hot 合并后记录数是否正确
+- 同一 `row_id` 的最新版本是否胜出
+- 软删除是否能遮蔽冷层旧版本
+- EAV 属性在跨 tier 合并时是否按更新时间选中正确版本
+- 分页结果是否稳定、有序、无重复
+
+## 9. 可观测性要求
+
+Runner 应记录每次 workload 的关键上下文：
+
+- query name
+- distribution
+- scale
+- page size
+- offset/page number
+- returned rows
+- source tier mix
+- duration
+- error
+
+如果执行计划可获取，还应记录：
+
+- 是否走 DuckDB
+- 是否 PreferHot
+- 每个 source 的返回行数
+- merge 耗时
+
+## 10. 与现有系统的集成
+
+优先复用现有以下能力：
+
+- `internal/e2e_harness/federated/fixtures.go`
+- `internal/e2e_harness/federated/seeding.go`
+- `internal/e2e_harness/federated/query.go`
+- `internal/e2e_harness/federated/performance_test.go`
+- `internal/federated_pagination.go`
+- `internal/federated_merge.go`
+- `internal/federated_routing.go`
+
+新增 benchmark 不应复制一套完全独立的测试系统，而应在现有 harness 上增量扩展。
+
+## 11. 风险与取舍
+
+### 11.1 风险
+
+- 现有测试查询模型较简化，可能不足以表达复杂 hybrid 过滤
+- 大规模数据写入会拉长 benchmark 初始化时间
+- 深分页在当前实现下可能需要全量 merge，large scale 成本很高
+- 不同分布下的 selectivity 难以精确命中，需要生成器提供可校准参数
+
+### 11.2 取舍
+
+- 第一阶段优先做可复现、可落地的 benchmark，不先做复杂优化器仿真
+- 第一阶段使用已有 federated query 能力，不强推新的查询 DSL
+- 第一阶段接受 `medium` 作为主回归规模，`large` 作为单独性能实验规模
+
+## 12. 里程碑
+
+建议按四个里程碑推进：
+
+1. 定义 schema、分布模型和 workload
+2. 实现数据生成、tier 装载和 benchmark runner
+3. 补齐深分页、冷热重叠、正确性校验和报告输出
+4. 建立回归基线并接入 CI 或人工性能回归流程
+
+## 13. 交付物
+
+第一阶段交付物包括：
+
+- benchmark HLD 文档
+- benchmark implementation plan
+- benchmark issue backlog
+- benchmark scaffolding 代码
+- 至少一组 `small` 和 `medium` 数据集结果样例
+- 深分页专项报告

--- a/docs/federated-query/federated-query-benchmark-hld-en.md
+++ b/docs/federated-query/federated-query-benchmark-hld-en.md
@@ -1,0 +1,345 @@
+# Federated Query Benchmark High-Level Design
+
+Last updated: 2026-04-17  
+Repository: `forma`
+
+## 1. Background
+
+Forma already has federated querying, cold/hot tiering, CDC flush, compaction, basic pagination, and baseline performance tests. What it does not yet have is a dedicated benchmark that focuses on the hard parts of hybrid querying across cold and hot data.
+
+The current performance suite is useful for regression coverage, but it does not systematically answer the following questions:
+
+- How does the system behave under domain-shaped hybrid query workloads?
+- How do different data distributions affect routing, predicate pushdown, and merge cost?
+- How badly does deep pagination degrade as page numbers grow?
+- What is the correctness and performance cost of overlap, soft deletes, and last-write-wins merging across tiers?
+
+This design defines a TPC-E-inspired benchmark adapted to Forma's storage model and execution paths.
+
+## 2. Goals
+
+- Provide a repeatable, extensible, and comparable benchmark for Forma hybrid queries.
+- Use a financial trading domain inspired by TPC-E, centered on trade, customer, and security entities.
+- Cover both hot-column access and long-tail EAV filters.
+- Exercise pagination, sorting, filtering, deep page jumps, and cross-tier merge behavior under multiple data distributions.
+- Produce a stable set of metrics for optimization work, including latency percentiles, throughput, tier hit ratios, dedup rate, and pushdown efficiency.
+
+## 3. Non-Goals
+
+- Full TPC-E compliance is out of scope. This benchmark will not implement all 33 tables or the full transaction mix.
+- This is not an official TPC benchmark publication framework and does not target auditability requirements.
+- It does not replace the existing `internal/e2e_harness/federated` test suite. It extends it with benchmark-oriented workload coverage.
+- Phase 1 does not target distributed execution or multi-host load generation.
+
+## 4. Design Principles
+
+- Reuse the existing E2E harness wherever possible.
+- Preserve TPC-E-style business semantics while fitting Forma's `entity_main + eav_data + change_log + parquet` architecture.
+- Ensure reproducibility through deterministic data generation with explicit seeds.
+- Cover both correctness and performance. The benchmark is not just a load test.
+- Treat deep pagination as a first-class problem, and explicitly model `LIMIT/OFFSET` behavior alongside future keyset alternatives.
+
+## 5. Logical Architecture
+
+The benchmark is split into six logical layers:
+
+1. Schema Mapping Layer
+2. Data Generation Layer
+3. Tier Preparation Layer
+4. Workload Definition Layer
+5. Benchmark Runner Layer
+6. Metrics and Report Layer
+
+### 5.1 Schema Mapping Layer
+
+This layer maps TPC-E-inspired entities into Forma schemas.
+
+The initial benchmark will define three core schemas:
+
+- `trade`
+- `customer`
+- `security`
+
+Each schema must include:
+
+- hot fields suitable for indexed filtering and sorting
+- EAV fields that force dynamic attribute access
+- fields that participate in overlap and merge cases
+
+Recommended `trade` schema:
+
+- Hot: `symbol`, `trade_type`, `quantity`, `price`, `trade_time`, `customer_id`
+- EAV: `exchange`, `commission`, `is_cash`, `broker_id`, `order_channel`
+
+This shape allows the benchmark to cover:
+
+- pure hot pushdown
+- pure EAV filtering
+- hybrid hot + EAV predicates
+- time-ordered pagination
+
+### 5.2 Data Generation Layer
+
+This layer generates benchmark datasets with configurable scale, distribution, and overlap patterns.
+
+The benchmark must support these data distributions:
+
+- `uniform`: baseline distribution
+- `zipf`: hot customers, hot symbols, and hot regions
+- `temporal`: higher density in recent time windows
+- `partition-skew`: heavily imbalanced region or sector partitions
+- `hotspot-overlap`: a controlled fraction of row IDs present in both cold and hot tiers
+
+The generator output must guarantee:
+
+- multiple versions of the same `row_id` can appear across tiers
+- timestamps increase in a way that allows clear last-write-wins validation
+- some records carry soft-delete markers
+- selectivity can be calibrated for high-, medium-, and low-selectivity filters
+
+### 5.3 Tier Preparation Layer
+
+This layer assigns generated rows into three tiers:
+
+- Cold/Base: historical parquet, larger files, low churn
+- Warm/Delta: recently flushed parquet, smaller files, newer data
+- Hot: unflushed Postgres data in `entity_main`, `eav_data`, and `change_log`
+
+Default tier mix:
+
+- Base: 60%
+- Delta: 30%
+- Hot: 10%
+
+The benchmark must also support alternative mixes such as:
+
+- high-hotness: 40/20/40
+- long-tail history: 85/10/5
+- high-overlap: 5%-10% key overlap between Base and Hot
+
+Tier preparation is responsible for:
+
+- writing cold and warm data to base and delta parquet
+- inserting hot rows into Postgres
+- marking overlap, delete, update, and restore scenarios
+
+### 5.4 Workload Definition Layer
+
+The initial workload set is organized into five categories.
+
+#### A. Baseline Pagination
+
+- unfiltered pagination ordered by `trade_time DESC`
+- high-selectivity filter + pagination
+- low-selectivity filter + pagination
+- EAV filter + pagination
+- mixed hot + EAV predicates + pagination
+
+#### B. Deep Pagination
+
+- `page = 1`
+- `page = 100`
+- `page = 1,000`
+- `page = 100,000`
+
+The benchmark must keep page size fixed, for example `20` or `50`, and explicitly record the offset size.
+
+#### C. Tier Hit Modes
+
+- hot-only hits
+- cold-only hits
+- cold + hot hits
+- cold + warm + hot hits
+
+#### D. Dedup and Override Cases
+
+- same key in cold and hot with different versions
+- hot-tier delete hiding a cold-tier row
+- cold data partially overridden by hot-tier EAV updates
+
+#### E. Routing and Strategy Comparisons
+
+- `PreferHot = true`
+- `RoutingStrategyHybrid`
+- small result sets routed to Postgres
+- large result sets routed to DuckDB
+
+### 5.5 Benchmark Runner Layer
+
+The runner manages the full benchmark lifecycle:
+
+1. register schemas
+2. generate data
+3. prepare tiers
+4. warm up the system
+5. execute workloads repeatedly
+6. aggregate latency and correctness metrics
+7. export structured reports
+
+The runner must support:
+
+- serial execution
+- fixed-concurrency execution
+- running a subset of workloads
+- explicit scale and distribution selection
+- explicit random seed control
+
+Recommended scales:
+
+- `small`: 100K rows
+- `medium`: 1M rows
+- `large`: 10M rows
+
+### 5.6 Metrics and Report Layer
+
+The benchmark must emit:
+
+- `p50`, `p95`, `p99`, `max`, `avg`
+- `qps`
+- `result_count`
+- `hot_hit_ratio`
+- `cold_hit_ratio`
+- `dedup_count`
+- `delete_filtered_count`
+- `pushdown_efficiency`
+- `memory_peak_mb`
+
+Output formats:
+
+- console summary
+- JSON result file
+- Markdown report
+
+This allows the same benchmark to serve local tuning, CI artifact generation, and regression analysis.
+
+## 6. Data Model
+
+### 6.1 TPC-E-Inspired Entities
+
+The benchmark does not attempt a full TPC-E schema port. Instead, it borrows the domain shape:
+
+- `trade`: high write frequency and strong time locality
+- `customer`: medium update frequency and selective filtering value
+- `security`: low update frequency and cold-reference behavior
+
+### 6.2 Hot and EAV Requirements
+
+Each schema should include at least:
+
+- 2 sortable hot fields
+- 2 high-selectivity hot filter fields
+- 1 low-selectivity hot filter field
+- 2 EAV fields
+- 1 field likely to participate in cross-tier override cases
+
+## 7. Pagination Design
+
+Deep pagination is a primary focus of this benchmark.
+
+### 7.1 Baseline Path
+
+Phase 1 uses the current pagination semantics:
+
+- `LIMIT page_size OFFSET offset`
+
+This gives a direct measurement of the current cost profile on merged results.
+
+### 7.2 Deep Pagination Concerns
+
+The benchmark must measure:
+
+- how DuckDB read and sort cost changes as offset grows
+- the cost of merge-before-pagination when both hot and cold paths contribute rows
+- whether small-result heuristics misroute some workloads
+- whether total-count computation becomes the bottleneck on very large page jumps
+
+### 7.3 Large Page Jump Cases
+
+The benchmark should include at least these fixed cases:
+
+- `page_size=20, page=1`
+- `page_size=20, page=100`
+- `page_size=20, page=1,000`
+- `page_size=20, page=100,000`
+
+Equivalent keyset-style cases should be preserved as future comparison points, even if the keyset execution path is not implemented in phase 1.
+
+## 8. Correctness Requirements
+
+The benchmark must validate semantics, not just latency.
+
+It must check:
+
+- correct merged row counts across cold, warm, and hot tiers
+- correct winner selection for the latest version of the same `row_id`
+- correct suppression of cold rows by hot soft deletes
+- correct EAV attribute winner selection during cross-tier merges
+- stable, ordered, and duplicate-free pagination results
+
+## 9. Observability Requirements
+
+Each workload execution should capture:
+
+- query name
+- distribution
+- scale
+- page size
+- offset or page number
+- returned rows
+- source tier mix
+- duration
+- error status
+
+When execution-plan details are available, the benchmark should also capture:
+
+- whether DuckDB was used
+- whether `PreferHot` was enabled
+- per-source row counts
+- merge duration
+
+## 10. Integration with Existing Code
+
+The benchmark should build on the existing components instead of creating a separate test system:
+
+- `internal/e2e_harness/federated/fixtures.go`
+- `internal/e2e_harness/federated/seeding.go`
+- `internal/e2e_harness/federated/query.go`
+- `internal/e2e_harness/federated/performance_test.go`
+- `internal/federated_pagination.go`
+- `internal/federated_merge.go`
+- `internal/federated_routing.go`
+
+## 11. Risks and Tradeoffs
+
+### 11.1 Risks
+
+- The current harness query model is relatively simple and may need extension for richer hybrid predicates.
+- Large-scale dataset preparation may dominate benchmark runtime.
+- Deep pagination may be expensive at large scale if it requires full merge before slicing.
+- Matching exact selectivity targets across different distributions requires calibration support in the generator.
+
+### 11.2 Tradeoffs
+
+- Phase 1 prioritizes a reproducible and useful benchmark over optimizer-level sophistication.
+- Phase 1 reuses the current federated query stack rather than introducing a separate benchmark-only query DSL.
+- Phase 1 should treat `medium` as the main regression scale and `large` as a controlled performance experiment scale.
+
+## 12. Milestones
+
+Recommended milestones:
+
+1. define schemas, distributions, and workload matrix
+2. implement data generation, tier loading, and benchmark runner
+3. add deep-pagination, overlap, correctness checks, and reporting
+4. establish baseline results and wire them into CI or a repeatable performance review flow
+
+## 13. Deliverables
+
+Phase 1 deliverables:
+
+- benchmark HLD document
+- benchmark implementation plan
+- benchmark issue backlog
+- benchmark scaffolding code
+- at least one sample result set for `small` and `medium`
+- a dedicated deep-pagination report

--- a/docs/federated-query/federated-query-benchmark-implementation-plan.md
+++ b/docs/federated-query/federated-query-benchmark-implementation-plan.md
@@ -1,0 +1,201 @@
+# Federated Query Benchmark Implementation Plan
+
+Last updated: 2026-04-17  
+Repository: `forma`
+
+## 1. Scope
+
+This plan implements a TPC-E-inspired benchmark for hybrid cold + hot queries in Forma. The benchmark will extend the existing federated E2E harness rather than introducing a fully separate runtime or test framework.
+
+The implementation is organized into four phases:
+
+1. benchmark scaffolding and schema definitions
+2. deterministic dataset generation and tier preparation
+3. workload execution, correctness checks, and reporting
+4. baseline runs and operational integration
+
+## 2. Phase Breakdown
+
+### Phase 1: Scaffolding and Schema Definitions
+
+Deliver a minimal runnable benchmark skeleton.
+
+Tasks:
+
+- create a benchmark package or command entrypoint
+- define benchmark config types
+- define workload interfaces and result types
+- add TPC-E-inspired schema fixtures for `trade`, `customer`, and `security`
+- document CLI and config expectations
+
+Exit criteria:
+
+- benchmark command can initialize and parse config
+- schema registration path is wired into the existing harness
+- workload matrix is declared in code, even if some cases are stubbed
+
+### Phase 2: Data Generation and Tier Preparation
+
+Implement deterministic dataset generation with tier-aware loading.
+
+Tasks:
+
+- extend the generator to support `uniform`, `zipf`, `temporal`, `partition-skew`, and `hotspot-overlap`
+- add calibration helpers for selectivity targets
+- define tier mix profiles such as `60/30/10`, `40/20/40`, and `85/10/5`
+- write base and delta parquet files through the existing harness
+- insert hot rows into Postgres using existing seed helpers
+- support overlap rows, update rows, delete rows, and restore rows
+
+Exit criteria:
+
+- same seed always produces the same dataset shape
+- tiered dataset preparation works for at least `small` scale
+- overlap and delete scenarios are represented in generated data
+
+### Phase 3: Workloads, Correctness, and Reporting
+
+Implement the workload matrix and result capture.
+
+Tasks:
+
+- add baseline pagination workloads
+- add deep-pagination workloads including page `100,000`
+- add cold-only, hot-only, and mixed-tier workloads
+- add dedup, delete-shadowing, and last-write-wins validation cases
+- capture latency, row count, tier mix, and execution metadata
+- export console, JSON, and Markdown reports
+
+Exit criteria:
+
+- benchmark can run a chosen workload subset end to end
+- each workload returns both performance metrics and correctness verdicts
+- report files are generated in a stable format suitable for artifact retention
+
+### Phase 4: Baselines and Operational Integration
+
+Turn the benchmark into a repeatable engineering tool.
+
+Tasks:
+
+- run baseline results for `small` and `medium`
+- document recommended run commands and expected runtimes
+- define which workloads are safe for CI and which should be manual or nightly
+- add operator guidance for interpreting results
+- record known limitations and future optimization hooks such as keyset pagination
+
+Exit criteria:
+
+- at least one documented baseline exists for `small` and `medium`
+- the repository contains a clear runbook for benchmark use
+- the benchmark is ready for iterative optimization work
+
+## 3. Proposed Code Layout
+
+Suggested initial layout:
+
+```text
+internal/e2e_harness/federated/benchmark/
+  config.go
+  schema.go
+  generator.go
+  dataset.go
+  workload.go
+  runner.go
+  report.go
+
+cmd/benchmark/
+  main.go
+
+docs/federated-query/
+  federated-query-benchmark-hld-en.md
+  federated-query-benchmark-implementation-plan.md
+
+docs/cn/
+  federated-query-benchmark-hld.md
+```
+
+This layout keeps benchmark logic close to the existing harness while allowing a dedicated CLI.
+
+## 4. Workload Matrix
+
+The initial workload set should include:
+
+- baseline pagination
+- high-selectivity hot filter + pagination
+- low-selectivity hot filter + pagination
+- EAV filter + pagination
+- mixed hot + EAV filter + pagination
+- deep page jumps at 1, 100, 1,000, and 100,000
+- hot-only time window queries
+- cold-only historical queries
+- mixed cold + hot window queries
+- overlap and soft-delete correctness cases
+
+Each workload should declare:
+
+- name
+- target schema
+- supported distributions
+- scale eligibility
+- page size
+- offset or page number
+- expected correctness assertions
+
+## 5. Verification Strategy
+
+Verification has three layers:
+
+### 5.1 Generator Verification
+
+- validate row count
+- validate distribution shape
+- validate overlap ratio
+- validate delete ratio
+- validate reproducibility by seed
+
+### 5.2 Query Correctness Verification
+
+- compare merged results against expected deduplicated row sets
+- verify stable ordering across repeated runs
+- verify delete shadowing behavior
+- verify attribute-level merge correctness for overlapping rows
+
+### 5.3 Performance Verification
+
+- record p50, p95, p99, and max
+- record QPS for concurrent runs
+- compare deep-pagination workloads across offsets
+- compare distribution-specific performance regressions
+
+## 6. Rollout Strategy
+
+Recommended rollout order:
+
+1. land documents and issue backlog
+2. land scaffolding and schema fixtures
+3. land generator and tier-prep support
+4. land workload runner and result export
+5. capture baselines and publish guidance
+
+This keeps the implementation incremental and reviewable.
+
+## 7. Deferred Work
+
+The following items are explicitly deferred beyond phase 1:
+
+- keyset-pagination execution path as a production benchmark alternative
+- optimizer-driven dynamic workload shaping
+- distributed benchmark agents
+- automated benchmark trend dashboards
+- official CI gating on large-scale benchmark thresholds
+
+## 8. Success Criteria
+
+The implementation is successful when:
+
+- engineers can run the benchmark locally and in controlled environments
+- benchmark datasets are reproducible
+- deep-pagination behavior is measurable and comparable
+- hybrid cold + hot correctness is automatically validated
+- reports are useful enough to guide performance optimization work

--- a/docs/federated-query/federated-query-benchmark-issues.md
+++ b/docs/federated-query/federated-query-benchmark-issues.md
@@ -1,0 +1,34 @@
+# Federated Query Benchmark Issue Breakdown
+
+Last updated: 2026-04-17  
+Repository: `forma`
+
+## Issue Set
+
+This backlog decomposes the federated query benchmark into a small set of deliverable GitHub issues.
+
+1. `#33` Umbrella issue for benchmark scope, deliverables, and acceptance criteria
+2. `#34` Benchmark scaffolding and TPC-E-inspired schema fixtures
+3. `#35` Deterministic generator and distribution models
+4. `#36` Tier preparation and overlap/delete dataset support
+5. `#37` Workload matrix including deep pagination and large page jumps
+6. `#38` Reporting, metrics export, and baseline capture guidance
+7. `#39` CI and operational documentation for repeatable benchmark execution
+
+## Mapping
+
+| Area | Primary Issue Goal |
+|---|---|
+| Project framing | `#33` Align scope, phases, and acceptance criteria |
+| Scaffolding | `#34` Create config, runner, schema fixtures, and CLI shell |
+| Data generation | `#35` Add reproducible scale and distribution-aware datasets |
+| Tier loading | `#36` Prepare base, delta, and hot data with overlap semantics |
+| Workloads | `#37` Add pagination, mixed filters, deep pages, and correctness checks |
+| Reporting | `#38` Export machine-readable and human-readable benchmark results |
+| Operations | `#39` Define how the benchmark runs in CI, nightly, and local workflows |
+
+## Notes
+
+- Issue titles should stay imperative and implementation-oriented.
+- Phase 1 should prefer medium-scale reproducibility over large-scale sophistication.
+- Deep pagination should be tracked as a first-class benchmark area, not as a side case.

--- a/docs/federated-query/issues/01-federated-query-benchmark-umbrella.md
+++ b/docs/federated-query/issues/01-federated-query-benchmark-umbrella.md
@@ -1,0 +1,36 @@
+## Summary
+
+Create the umbrella tracking issue for the TPC-E-inspired federated query benchmark for Forma.
+
+## Why
+
+The repository already has federated correctness and performance coverage, but it does not yet have a benchmark focused on hybrid cold + hot query behavior, multiple data distributions, and deep pagination scenarios such as page `100,000`.
+
+## Scope
+
+- define the benchmark scope and phase boundaries
+- reference the HLD and implementation plan
+- track the execution issues required for phase 1
+- establish acceptance criteria for the first usable benchmark release
+
+## Acceptance Criteria
+
+- HLD and implementation plan documents are linked
+- phase 1 deliverables are listed explicitly
+- execution issues are linked from the umbrella issue
+- the issue can be used as the single coordination entrypoint for the benchmark effort
+
+## Execution Issues
+
+- [ ] #34 Add benchmark scaffolding and TPC-E-inspired schema fixtures
+- [ ] #35 Implement deterministic benchmark generator and distribution models
+- [ ] #36 Add tier preparation and overlap/delete dataset support
+- [ ] #37 Implement workload matrix and deep pagination benchmark cases
+- [ ] #38 Add benchmark reporting and baseline capture support
+- [ ] #39 Document CI and operator guidance for benchmark execution
+
+## References
+
+- `docs/cn/federated-query-benchmark-hld.md`
+- `docs/federated-query/federated-query-benchmark-hld-en.md`
+- `docs/federated-query/federated-query-benchmark-implementation-plan.md`

--- a/docs/federated-query/issues/02-benchmark-scaffolding-and-schema-fixtures.md
+++ b/docs/federated-query/issues/02-benchmark-scaffolding-and-schema-fixtures.md
@@ -1,0 +1,28 @@
+## Summary
+
+Add benchmark scaffolding and TPC-E-inspired schema fixtures for `trade`, `customer`, and `security`.
+
+## Why
+
+The benchmark needs a stable entrypoint, shared config model, and benchmark-specific schema definitions before any workload or dataset work can be built on top of it.
+
+## Scope
+
+- add benchmark config and result types
+- add workload registration interfaces
+- create benchmark package layout near the federated harness
+- add schema fixtures for `trade`, `customer`, and `security`
+- add a thin CLI entrypoint for benchmark execution
+
+## Acceptance Criteria
+
+- benchmark config can be parsed and validated
+- schema registration can be invoked through the harness
+- benchmark package layout is committed and documented
+- schema fixtures cover both hot fields and EAV fields
+- a no-op or smoke benchmark run can execute end to end
+
+## References
+
+- `docs/federated-query/federated-query-benchmark-hld-en.md`
+- `docs/federated-query/federated-query-benchmark-implementation-plan.md`

--- a/docs/federated-query/issues/03-generator-and-distribution-models.md
+++ b/docs/federated-query/issues/03-generator-and-distribution-models.md
@@ -1,0 +1,27 @@
+## Summary
+
+Implement a deterministic benchmark generator with multiple distribution models.
+
+## Why
+
+The benchmark must evaluate hybrid query behavior under realistic data shapes rather than only uniform synthetic samples.
+
+## Scope
+
+- support `uniform`, `zipf`, `temporal`, `partition-skew`, and `hotspot-overlap`
+- make generation reproducible by seed
+- calibrate selectivity for common filter scenarios
+- define scale presets for `small`, `medium`, and `large`
+- add generator-level verification helpers
+
+## Acceptance Criteria
+
+- generator output is reproducible for a fixed seed
+- distribution-specific datasets can be produced through a public benchmark API
+- selectivity calibration helpers exist for high-, medium-, and low-selectivity filters
+- small-scale generation is covered by tests
+
+## References
+
+- `docs/cn/federated-query-benchmark-hld.md`
+- `docs/federated-query/federated-query-benchmark-implementation-plan.md`

--- a/docs/federated-query/issues/04-tier-preparation-and-overlap-support.md
+++ b/docs/federated-query/issues/04-tier-preparation-and-overlap-support.md
@@ -1,0 +1,27 @@
+## Summary
+
+Add tier-aware dataset preparation for base, delta, and hot data, including overlap and soft-delete cases.
+
+## Why
+
+Hybrid query behavior depends on how data is split across parquet and Postgres, not just on row count. The benchmark must be able to prepare realistic cold, warm, and hot datasets with controlled overlap.
+
+## Scope
+
+- add tier mix profiles such as `60/30/10`, `40/20/40`, and `85/10/5`
+- write base and delta data to parquet via the existing harness
+- insert hot rows into Postgres via seed helpers
+- support overlap rows across tiers
+- support update, delete, and restore cases
+
+## Acceptance Criteria
+
+- tier preparation works for at least `small` scale
+- overlap ratio and delete ratio can be configured
+- generated datasets can include last-write-wins cases across tiers
+- dataset loading is reusable by all benchmark workloads
+
+## References
+
+- `docs/cn/federated-query-benchmark-hld.md`
+- `docs/federated-query/federated-query-benchmark-implementation-plan.md`

--- a/docs/federated-query/issues/05-workload-matrix-and-deep-pagination.md
+++ b/docs/federated-query/issues/05-workload-matrix-and-deep-pagination.md
@@ -1,0 +1,28 @@
+## Summary
+
+Implement the benchmark workload matrix, including deep pagination and large page jumps.
+
+## Why
+
+Deep pagination is one of the highest-risk areas in hybrid cold + hot querying, especially when merged results must be ordered and sliced after combining sources.
+
+## Scope
+
+- add baseline pagination workloads
+- add high- and low-selectivity filter workloads
+- add EAV-only and hybrid hot + EAV workloads
+- add hot-only, cold-only, and mixed-tier workloads
+- add deep page jumps for pages `1`, `100`, `1,000`, and `100,000`
+- add correctness assertions for ordering, dedup, and delete shadowing
+
+## Acceptance Criteria
+
+- workload definitions are declarative and runnable through the benchmark runner
+- page `100,000` benchmark cases are included
+- workload outputs capture both latency and correctness results
+- repeated runs produce stable ordering and duplicate-free page slices
+
+## References
+
+- `docs/cn/federated-query-benchmark-hld.md`
+- `docs/federated-query/federated-query-benchmark-hld-en.md`

--- a/docs/federated-query/issues/06-reporting-and-baseline-capture.md
+++ b/docs/federated-query/issues/06-reporting-and-baseline-capture.md
@@ -1,0 +1,26 @@
+## Summary
+
+Add benchmark reporting, metrics export, and baseline capture support.
+
+## Why
+
+The benchmark is only useful if its output can be compared across runs and used to guide optimization work.
+
+## Scope
+
+- export console summaries
+- export JSON result files
+- export Markdown reports
+- record latency percentiles, QPS, result count, tier mix, dedup count, and pushdown efficiency
+- add baseline capture guidance for `small` and `medium`
+
+## Acceptance Criteria
+
+- benchmark output can be consumed by both humans and automation
+- report formats are stable across runs
+- at least one documented baseline procedure exists for `small` and `medium`
+- deep-pagination cases are clearly identifiable in exported results
+
+## References
+
+- `docs/federated-query/federated-query-benchmark-implementation-plan.md`

--- a/docs/federated-query/issues/07-ci-and-operator-guidance.md
+++ b/docs/federated-query/issues/07-ci-and-operator-guidance.md
@@ -1,0 +1,27 @@
+## Summary
+
+Document repeatable benchmark execution for local runs, CI, and manual performance review.
+
+## Why
+
+Some workloads should be safe for routine regression use, while others should be reserved for manual or nightly execution. The repository needs a clear operating model.
+
+## Scope
+
+- document local benchmark commands
+- classify workloads into smoke, regular regression, and heavy-run groups
+- describe expected runtime and environment needs
+- explain how to interpret benchmark results and common failure modes
+- document deferred follow-up areas such as keyset pagination comparisons
+
+## Acceptance Criteria
+
+- repository docs describe how to run benchmark subsets safely
+- CI-suitable and non-CI workloads are clearly separated
+- operators have guidance for reading reports and spotting regressions
+- known limitations and deferred work are documented
+
+## References
+
+- `docs/federated-query/federated-query-benchmark-hld-en.md`
+- `docs/federated-query/federated-query-benchmark-implementation-plan.md`

--- a/internal/e2e_harness/federated/benchmark/calibration.go
+++ b/internal/e2e_harness/federated/benchmark/calibration.go
@@ -1,0 +1,130 @@
+package benchmark
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+// SelectivityBand classifies a filter candidate by match ratio.
+type SelectivityBand string
+
+const (
+	SelectivityBandHigh   SelectivityBand = "high"
+	SelectivityBandMedium SelectivityBand = "medium"
+	SelectivityBandLow    SelectivityBand = "low"
+)
+
+// CalibrationCandidate represents an attribute/value pair suitable for a filter benchmark.
+type CalibrationCandidate struct {
+	Attribute string          `json:"attribute"`
+	Value     string          `json:"value"`
+	Matches   int             `json:"matches"`
+	Ratio     float64         `json:"ratio"`
+	Band      SelectivityBand `json:"band"`
+}
+
+// TradeCalibration groups selectivity candidates for trade workloads.
+type TradeCalibration struct {
+	High   CalibrationCandidate `json:"high"`
+	Medium CalibrationCandidate `json:"medium"`
+	Low    CalibrationCandidate `json:"low"`
+}
+
+// CalibrateTradeFilters computes representative trade filter values for the three selectivity bands.
+func CalibrateTradeFilters(records []GeneratedRecord) (TradeCalibration, error) {
+	tradeRecords := LatestRecords(filterRecordsBySchema(records, "trade"))
+	if len(tradeRecords) == 0 {
+		return TradeCalibration{}, fmt.Errorf("no trade records available for calibration")
+	}
+	high, err := selectCandidate(tradeRecords, []string{"symbol"}, SelectivityBandHigh)
+	if err != nil {
+		return TradeCalibration{}, err
+	}
+	medium, err := selectCandidate(tradeRecords, []string{"tradeType", "exchange"}, SelectivityBandMedium)
+	if err != nil {
+		return TradeCalibration{}, err
+	}
+	low, err := selectCandidate(tradeRecords, []string{"region", "orderChannel"}, SelectivityBandLow)
+	if err != nil {
+		return TradeCalibration{}, err
+	}
+	return TradeCalibration{High: high, Medium: medium, Low: low}, nil
+}
+
+func selectCandidate(records []GeneratedRecord, attributes []string, band SelectivityBand) (CalibrationCandidate, error) {
+	total := len(records)
+	if total == 0 {
+		return CalibrationCandidate{}, fmt.Errorf("cannot calibrate with no records")
+	}
+	minRatio, maxRatio, target := bandRange(band)
+	best := CalibrationCandidate{}
+	bestDistance := math.MaxFloat64
+	fallback := CalibrationCandidate{}
+	fallbackDistance := math.MaxFloat64
+	found := false
+	fallbackFound := false
+	for _, attribute := range attributes {
+		counts := make(map[string]int)
+		for _, record := range records {
+			value, ok := record.Attributes[attribute]
+			if !ok {
+				continue
+			}
+			counts[fmt.Sprint(value)]++
+		}
+		keys := make([]string, 0, len(counts))
+		for key := range counts {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			matches := counts[key]
+			ratio := float64(matches) / float64(total)
+			distance := math.Abs(target - ratio)
+			if !fallbackFound || distance < fallbackDistance {
+				fallback = CalibrationCandidate{Attribute: attribute, Value: key, Matches: matches, Ratio: ratio, Band: band}
+				fallbackDistance = distance
+				fallbackFound = true
+			}
+			if ratio < minRatio || ratio > maxRatio {
+				continue
+			}
+			if !found || distance < bestDistance {
+				best = CalibrationCandidate{Attribute: attribute, Value: key, Matches: matches, Ratio: ratio, Band: band}
+				bestDistance = distance
+				found = true
+			}
+		}
+	}
+	if !found {
+		if fallbackFound {
+			return fallback, nil
+		}
+		return CalibrationCandidate{}, fmt.Errorf("no candidate found for %s selectivity", band)
+	}
+	return best, nil
+}
+
+func bandRange(band SelectivityBand) (float64, float64, float64) {
+	switch band {
+	case SelectivityBandHigh:
+		return 0, 0.02, 0.01
+	case SelectivityBandMedium:
+		return 0.02, 0.20, 0.10
+	case SelectivityBandLow:
+		return 0.20, 1, 0.30
+	default:
+		return 0, 1, 0.10
+	}
+}
+
+func filterRecordsBySchema(records []GeneratedRecord, schemaName string) []GeneratedRecord {
+	out := make([]GeneratedRecord, 0)
+	for _, record := range records {
+		if record.SchemaName == schemaName {
+			out = append(out, cloneGeneratedRecord(record))
+		}
+	}
+	return out
+}

--- a/internal/e2e_harness/federated/benchmark/config.go
+++ b/internal/e2e_harness/federated/benchmark/config.go
@@ -1,0 +1,140 @@
+package benchmark
+
+import "fmt"
+
+// Scale identifies the dataset size preset for benchmark execution.
+type Scale string
+
+const (
+	ScaleSmall  Scale = "small"
+	ScaleMedium Scale = "medium"
+	ScaleLarge  Scale = "large"
+)
+
+// Distribution identifies the synthetic data distribution used by the benchmark.
+type Distribution string
+
+const (
+	DistributionUniform       Distribution = "uniform"
+	DistributionZipf          Distribution = "zipf"
+	DistributionTemporal      Distribution = "temporal"
+	DistributionPartitionSkew Distribution = "partition-skew"
+	DistributionHotspot       Distribution = "hotspot-overlap"
+)
+
+// ExecutionMode controls how far the scaffolded runner goes.
+type ExecutionMode string
+
+const (
+	ExecutionModeSmoke ExecutionMode = "smoke"
+	ExecutionModePlan  ExecutionMode = "plan"
+)
+
+// Config describes a benchmark run.
+type Config struct {
+	Mode         ExecutionMode `json:"mode"`
+	Scale        Scale         `json:"scale"`
+	Distribution Distribution  `json:"distribution"`
+	Iterations   int           `json:"iterations"`
+	Concurrency  int           `json:"concurrency"`
+	PageSize     int           `json:"page_size"`
+	Seed         int64         `json:"seed"`
+	Workloads    []string      `json:"workloads"`
+}
+
+// DefaultConfig returns the phase-1 benchmark scaffold defaults.
+func DefaultConfig() Config {
+	return Config{
+		Mode:         ExecutionModeSmoke,
+		Scale:        ScaleSmall,
+		Distribution: DistributionUniform,
+		Iterations:   1,
+		Concurrency:  1,
+		PageSize:     20,
+		Seed:         42,
+		Workloads:    DefaultWorkloadNames(),
+	}
+}
+
+// WithDefaults applies defaults to omitted fields.
+func (c Config) WithDefaults() Config {
+	defaults := DefaultConfig()
+	if c.Mode == "" {
+		c.Mode = defaults.Mode
+	}
+	if c.Scale == "" {
+		c.Scale = defaults.Scale
+	}
+	if c.Distribution == "" {
+		c.Distribution = defaults.Distribution
+	}
+	if c.Iterations <= 0 {
+		c.Iterations = defaults.Iterations
+	}
+	if c.Concurrency <= 0 {
+		c.Concurrency = defaults.Concurrency
+	}
+	if c.PageSize <= 0 {
+		c.PageSize = defaults.PageSize
+	}
+	if c.Seed == 0 {
+		c.Seed = defaults.Seed
+	}
+	if len(c.Workloads) == 0 {
+		c.Workloads = defaults.Workloads
+	}
+	return c
+}
+
+// Validate ensures the configuration is internally consistent.
+func (c Config) Validate() error {
+	if !isValidMode(c.Mode) {
+		return fmt.Errorf("invalid mode %q", c.Mode)
+	}
+	if !isValidScale(c.Scale) {
+		return fmt.Errorf("invalid scale %q", c.Scale)
+	}
+	if !isValidDistribution(c.Distribution) {
+		return fmt.Errorf("invalid distribution %q", c.Distribution)
+	}
+	if c.Iterations <= 0 {
+		return fmt.Errorf("iterations must be greater than zero")
+	}
+	if c.Concurrency <= 0 {
+		return fmt.Errorf("concurrency must be greater than zero")
+	}
+	if c.PageSize <= 0 {
+		return fmt.Errorf("page size must be greater than zero")
+	}
+	if _, err := ResolveWorkloads(c.Workloads); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isValidMode(mode ExecutionMode) bool {
+	switch mode {
+	case ExecutionModeSmoke, ExecutionModePlan:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidScale(scale Scale) bool {
+	switch scale {
+	case ScaleSmall, ScaleMedium, ScaleLarge:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidDistribution(dist Distribution) bool {
+	switch dist {
+	case DistributionUniform, DistributionZipf, DistributionTemporal, DistributionPartitionSkew, DistributionHotspot:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/config_test.go
+++ b/internal/e2e_harness/federated/benchmark/config_test.go
@@ -1,0 +1,18 @@
+package benchmark
+
+import "testing"
+
+func TestDefaultConfigValidate(t *testing.T) {
+	cfg := DefaultConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("DefaultConfig should validate: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsUnknownWorkload(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Workloads = []string{"does-not-exist"}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate should reject unknown workloads")
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/dataset.go
+++ b/internal/e2e_harness/federated/benchmark/dataset.go
@@ -1,0 +1,263 @@
+package benchmark
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var defaultBaseTime = time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// ScalePreset defines the default entity counts and generation ratios for a scale.
+type ScalePreset struct {
+	Scale          Scale   `json:"scale"`
+	TradeCount     int     `json:"trade_count"`
+	CustomerCount  int     `json:"customer_count"`
+	SecurityCount  int     `json:"security_count"`
+	OverlapRatio   float64 `json:"overlap_ratio"`
+	DeleteRatio    float64 `json:"delete_ratio"`
+	TimeWindowDays int     `json:"time_window_days"`
+}
+
+// GeneratorConfig controls dataset generation.
+type GeneratorConfig struct {
+	Scale          Scale        `json:"scale"`
+	Distribution   Distribution `json:"distribution"`
+	Seed           int64        `json:"seed"`
+	TradeCount     int          `json:"trade_count"`
+	CustomerCount  int          `json:"customer_count"`
+	SecurityCount  int          `json:"security_count"`
+	OverlapRatio   float64      `json:"overlap_ratio"`
+	DeleteRatio    float64      `json:"delete_ratio"`
+	TimeWindowDays int          `json:"time_window_days"`
+	BaseTime       time.Time    `json:"base_time"`
+}
+
+// GeneratedRecord is the canonical benchmark row representation before tier assignment.
+type GeneratedRecord struct {
+	SchemaID   int16          `json:"schema_id"`
+	SchemaName string         `json:"schema_name"`
+	RowID      uuid.UUID      `json:"row_id"`
+	Version    int            `json:"version"`
+	ChangedAt  int64          `json:"changed_at"`
+	DeletedAt  int64          `json:"deleted_at,omitempty"`
+	Attributes map[string]any `json:"attributes"`
+}
+
+// DatasetSummary captures high-level dataset statistics.
+type DatasetSummary struct {
+	TotalRecords      int            `json:"total_records"`
+	UniqueRows        int            `json:"unique_rows"`
+	DuplicateVersions int            `json:"duplicate_versions"`
+	DeletedRecords    int            `json:"deleted_records"`
+	OverlapRecords    int            `json:"overlap_records"`
+	CountsBySchema    map[string]int `json:"counts_by_schema"`
+}
+
+// GeneratedDataset contains the rows and summary for a generated dataset.
+type GeneratedDataset struct {
+	Config  GeneratorConfig   `json:"config"`
+	Records []GeneratedRecord `json:"records"`
+	Summary DatasetSummary    `json:"summary"`
+}
+
+// DefaultGeneratorConfig returns defaults for small-scale generation.
+func DefaultGeneratorConfig() GeneratorConfig {
+	preset := MustScalePreset(ScaleSmall)
+	return GeneratorConfig{
+		Scale:          preset.Scale,
+		Distribution:   DistributionUniform,
+		Seed:           42,
+		TradeCount:     preset.TradeCount,
+		CustomerCount:  preset.CustomerCount,
+		SecurityCount:  preset.SecurityCount,
+		OverlapRatio:   preset.OverlapRatio,
+		DeleteRatio:    preset.DeleteRatio,
+		TimeWindowDays: preset.TimeWindowDays,
+		BaseTime:       defaultBaseTime,
+	}
+}
+
+// GeneratorConfigFromBenchmark derives a generator config from the benchmark config.
+func GeneratorConfigFromBenchmark(cfg Config) GeneratorConfig {
+	resolved := cfg.WithDefaults()
+	genCfg := DefaultGeneratorConfig()
+	genCfg.Scale = resolved.Scale
+	genCfg.Distribution = resolved.Distribution
+	genCfg.Seed = resolved.Seed
+	return genCfg.WithDefaults()
+}
+
+// WithDefaults applies scale defaults to missing fields.
+func (c GeneratorConfig) WithDefaults() GeneratorConfig {
+	defaults := DefaultGeneratorConfig()
+	if c.Scale == "" {
+		c.Scale = defaults.Scale
+	}
+	preset := MustScalePreset(c.Scale)
+	if c.Distribution == "" {
+		c.Distribution = defaults.Distribution
+	}
+	if c.Seed == 0 {
+		c.Seed = defaults.Seed
+	}
+	if c.TradeCount <= 0 {
+		c.TradeCount = preset.TradeCount
+	}
+	if c.CustomerCount <= 0 {
+		c.CustomerCount = preset.CustomerCount
+	}
+	if c.SecurityCount <= 0 {
+		c.SecurityCount = preset.SecurityCount
+	}
+	if c.OverlapRatio <= 0 {
+		c.OverlapRatio = preset.OverlapRatio
+	}
+	if c.DeleteRatio <= 0 {
+		c.DeleteRatio = preset.DeleteRatio
+	}
+	if c.TimeWindowDays <= 0 {
+		c.TimeWindowDays = preset.TimeWindowDays
+	}
+	if c.BaseTime.IsZero() {
+		c.BaseTime = defaults.BaseTime
+	}
+	return c
+}
+
+// Validate ensures generation inputs are coherent.
+func (c GeneratorConfig) Validate() error {
+	if !isValidScale(c.Scale) {
+		return fmt.Errorf("invalid scale %q", c.Scale)
+	}
+	if !isValidDistribution(c.Distribution) {
+		return fmt.Errorf("invalid distribution %q", c.Distribution)
+	}
+	if c.TradeCount <= 0 {
+		return fmt.Errorf("trade count must be greater than zero")
+	}
+	if c.CustomerCount <= 0 {
+		return fmt.Errorf("customer count must be greater than zero")
+	}
+	if c.SecurityCount <= 0 {
+		return fmt.Errorf("security count must be greater than zero")
+	}
+	if c.OverlapRatio < 0 || c.OverlapRatio >= 1 {
+		return fmt.Errorf("overlap ratio must be in [0,1)")
+	}
+	if c.DeleteRatio < 0 || c.DeleteRatio >= 1 {
+		return fmt.Errorf("delete ratio must be in [0,1)")
+	}
+	if c.TimeWindowDays <= 0 {
+		return fmt.Errorf("time window days must be greater than zero")
+	}
+	if c.BaseTime.IsZero() {
+		return fmt.Errorf("base time must be set")
+	}
+	return nil
+}
+
+// MustScalePreset returns the preset or panics if it is unknown.
+func MustScalePreset(scale Scale) ScalePreset {
+	preset, err := ScalePresetFor(scale)
+	if err != nil {
+		panic(err)
+	}
+	return preset
+}
+
+// ScalePresetFor returns the preset associated with a scale.
+func ScalePresetFor(scale Scale) (ScalePreset, error) {
+	switch scale {
+	case ScaleSmall:
+		return ScalePreset{Scale: ScaleSmall, TradeCount: 100000, CustomerCount: 10000, SecurityCount: 1000, OverlapRatio: 0.05, DeleteRatio: 0.03, TimeWindowDays: 30}, nil
+	case ScaleMedium:
+		return ScalePreset{Scale: ScaleMedium, TradeCount: 1000000, CustomerCount: 100000, SecurityCount: 10000, OverlapRatio: 0.05, DeleteRatio: 0.03, TimeWindowDays: 30}, nil
+	case ScaleLarge:
+		return ScalePreset{Scale: ScaleLarge, TradeCount: 10000000, CustomerCount: 1000000, SecurityCount: 100000, OverlapRatio: 0.05, DeleteRatio: 0.03, TimeWindowDays: 30}, nil
+	default:
+		return ScalePreset{}, fmt.Errorf("unknown scale %q", scale)
+	}
+}
+
+// DefaultScalePresets returns all known scale presets.
+func DefaultScalePresets() []ScalePreset {
+	return []ScalePreset{MustScalePreset(ScaleSmall), MustScalePreset(ScaleMedium), MustScalePreset(ScaleLarge)}
+}
+
+// RecordsForSchema returns the records for one schema, sorted deterministically.
+func (d GeneratedDataset) RecordsForSchema(schemaName string) []GeneratedRecord {
+	var out []GeneratedRecord
+	for _, record := range d.Records {
+		if record.SchemaName == schemaName {
+			out = append(out, record)
+		}
+	}
+	sortGeneratedRecords(out)
+	return out
+}
+
+// LatestRecords keeps only the latest version of each row ID.
+func LatestRecords(records []GeneratedRecord) []GeneratedRecord {
+	latest := make(map[string]GeneratedRecord, len(records))
+	for _, record := range records {
+		key := fmt.Sprintf("%d:%s", record.SchemaID, record.RowID)
+		existing, ok := latest[key]
+		if !ok || record.ChangedAt > existing.ChangedAt || (record.ChangedAt == existing.ChangedAt && record.Version > existing.Version) {
+			latest[key] = cloneGeneratedRecord(record)
+		}
+	}
+	out := make([]GeneratedRecord, 0, len(latest))
+	for _, record := range latest {
+		out = append(out, record)
+	}
+	sortGeneratedRecords(out)
+	return out
+}
+
+func summarizeDataset(records []GeneratedRecord) DatasetSummary {
+	summary := DatasetSummary{CountsBySchema: make(map[string]int)}
+	seen := make(map[string]int)
+	for _, record := range records {
+		summary.TotalRecords++
+		summary.CountsBySchema[record.SchemaName]++
+		if record.DeletedAt > 0 {
+			summary.DeletedRecords++
+		}
+		key := fmt.Sprintf("%d:%s", record.SchemaID, record.RowID)
+		seen[key]++
+	}
+	for _, count := range seen {
+		summary.UniqueRows++
+		if count > 1 {
+			summary.DuplicateVersions += count - 1
+			summary.OverlapRecords += count
+		}
+	}
+	return summary
+}
+
+func sortGeneratedRecords(records []GeneratedRecord) {
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].SchemaID != records[j].SchemaID {
+			return records[i].SchemaID < records[j].SchemaID
+		}
+		if records[i].RowID != records[j].RowID {
+			return records[i].RowID.String() < records[j].RowID.String()
+		}
+		return records[i].Version < records[j].Version
+	})
+}
+
+func cloneGeneratedRecord(record GeneratedRecord) GeneratedRecord {
+	clone := record
+	if record.Attributes != nil {
+		clone.Attributes = make(map[string]any, len(record.Attributes))
+		for key, value := range record.Attributes {
+			clone.Attributes[key] = value
+		}
+	}
+	return clone
+}

--- a/internal/e2e_harness/federated/benchmark/generator.go
+++ b/internal/e2e_harness/federated/benchmark/generator.go
@@ -1,0 +1,306 @@
+package benchmark
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	benchmarkRegions       = []string{"NA", "EU", "APAC", "LATAM"}
+	benchmarkExchanges     = []string{"NYSE", "NASDAQ", "CBOE", "IEX"}
+	benchmarkOrderChannels = []string{"web", "mobile", "branch", "api"}
+)
+
+type benchmarkCustomer struct {
+	rowID  uuid.UUID
+	taxID  string
+	region string
+	status int
+	name   string
+	email  string
+}
+
+type benchmarkSecurity struct {
+	rowID  uuid.UUID
+	symbol string
+	sector int
+	name   string
+}
+
+// Generator produces deterministic benchmark datasets.
+type Generator struct {
+	config       GeneratorConfig
+	rand         *rand.Rand
+	securityZipf *rand.Zipf
+	customerZipf *rand.Zipf
+}
+
+// NewGenerator creates a generator with deterministic random sources.
+func NewGenerator(cfg GeneratorConfig) (*Generator, error) {
+	resolved := cfg.WithDefaults()
+	if err := resolved.Validate(); err != nil {
+		return nil, err
+	}
+	r := rand.New(rand.NewSource(resolved.Seed))
+	return &Generator{config: resolved, rand: r, securityZipf: newZipf(r, resolved.SecurityCount), customerZipf: newZipf(r, resolved.CustomerCount)}, nil
+}
+
+// Generate creates the benchmark dataset for all benchmark schemas.
+func (g *Generator) Generate() (*GeneratedDataset, error) {
+	customers := g.generateCustomers()
+	securities := g.generateSecurities()
+	records := make([]GeneratedRecord, 0, g.config.CustomerCount+g.config.SecurityCount+g.config.TradeCount)
+	for _, customer := range customers {
+		records = append(records, g.customerRecord(customer))
+	}
+	for _, security := range securities {
+		records = append(records, g.securityRecord(security))
+	}
+	records = append(records, g.generateTrades(customers, securities)...)
+	sortGeneratedRecords(records)
+	return &GeneratedDataset{Config: g.config, Records: records, Summary: summarizeDataset(records)}, nil
+}
+
+func (g *Generator) generateCustomers() []benchmarkCustomer {
+	customers := make([]benchmarkCustomer, 0, g.config.CustomerCount)
+	for i := 0; i < g.config.CustomerCount; i++ {
+		customers = append(customers, benchmarkCustomer{
+			rowID:  deterministicRowID(g.config.Seed, "customer", i),
+			taxID:  fmt.Sprintf("TAX-%08d", i+1),
+			region: g.pickRegion(),
+			status: i % 4,
+			name:   fmt.Sprintf("Customer %08d", i+1),
+			email:  fmt.Sprintf("customer-%08d@example.com", i+1),
+		})
+	}
+	return customers
+}
+
+func (g *Generator) generateSecurities() []benchmarkSecurity {
+	securities := make([]benchmarkSecurity, 0, g.config.SecurityCount)
+	for i := 0; i < g.config.SecurityCount; i++ {
+		symbol := fmt.Sprintf("SYM%05d", i+1)
+		securities = append(securities, benchmarkSecurity{
+			rowID:  deterministicRowID(g.config.Seed, "security", i),
+			symbol: symbol,
+			sector: i % 32,
+			name:   fmt.Sprintf("Security %s", symbol),
+		})
+	}
+	return securities
+}
+
+func (g *Generator) generateTrades(customers []benchmarkCustomer, securities []benchmarkSecurity) []GeneratedRecord {
+	base := make([]GeneratedRecord, 0, g.config.TradeCount)
+	for i := 0; i < g.config.TradeCount; i++ {
+		customer := customers[g.pickCustomerIndex()]
+		security := securities[g.pickSecurityIndex()]
+		changedAt := g.pickChangedAt(i)
+		price := round2(10 + g.rand.Float64()*490)
+		quantity := int64((i%25)+1) * 10
+		tradeType := i % 6
+		deletedAt := int64(0)
+		if g.rand.Float64() < g.config.DeleteRatio {
+			deletedAt = changedAt + int64((i%900)+1)*1000
+		}
+		base = append(base, GeneratedRecord{
+			SchemaID:   SchemaIDTrade,
+			SchemaName: "trade",
+			RowID:      deterministicRowID(g.config.Seed, "trade", i),
+			Version:    1,
+			ChangedAt:  changedAt,
+			DeletedAt:  deletedAt,
+			Attributes: map[string]any{
+				"symbol":       security.symbol,
+				"tradeType":    tradeType,
+				"quantity":     quantity,
+				"price":        price,
+				"tradeTime":    time.UnixMilli(changedAt).UTC().Format(time.RFC3339),
+				"customerId":   customer.rowID.String(),
+				"region":       customer.region,
+				"exchange":     g.pickExchange(security.symbol),
+				"commission":   round2(price * float64(quantity) * 0.001),
+				"isCash":       g.rand.Intn(2) == 0,
+				"brokerId":     fmt.Sprintf("BRK-%04d", (i%250)+1),
+				"orderChannel": benchmarkOrderChannels[i%len(benchmarkOrderChannels)],
+			},
+		})
+	}
+	if g.config.Distribution != DistributionHotspot {
+		return base
+	}
+	overlapCount := int(float64(g.config.TradeCount) * g.config.OverlapRatio)
+	if overlapCount == 0 {
+		return base
+	}
+	records := make([]GeneratedRecord, 0, len(base)+overlapCount)
+	records = append(records, base...)
+	for i := 0; i < overlapCount && i < len(base); i++ {
+		baseRecord := cloneGeneratedRecord(base[i])
+		price := attributeFloat64(baseRecord.Attributes, "price")
+		quantity := attributeInt64(baseRecord.Attributes, "quantity")
+		changedAt := baseRecord.ChangedAt + int64((i%3600)+1)*1000
+		updated := cloneGeneratedRecord(baseRecord)
+		updated.Version = 2
+		updated.ChangedAt = changedAt
+		updated.Attributes["price"] = round2(price * 1.015)
+		updated.Attributes["commission"] = round2((price * 1.015) * float64(quantity) * 0.0012)
+		updated.Attributes["isCash"] = !attributeBool(baseRecord.Attributes, "isCash")
+		updated.Attributes["orderChannel"] = benchmarkOrderChannels[(i+1)%len(benchmarkOrderChannels)]
+		updated.Attributes["tradeTime"] = time.UnixMilli(changedAt).UTC().Format(time.RFC3339)
+		if i%7 == 0 {
+			updated.DeletedAt = changedAt + 5000
+		}
+		records = append(records, updated)
+	}
+	return records
+}
+
+func (g *Generator) customerRecord(customer benchmarkCustomer) GeneratedRecord {
+	changedAt := g.config.BaseTime.Add(-45 * 24 * time.Hour).UnixMilli()
+	return GeneratedRecord{SchemaID: SchemaIDCustomer, SchemaName: "customer", RowID: customer.rowID, Version: 1, ChangedAt: changedAt, Attributes: map[string]any{"taxId": customer.taxID, "status": customer.status, "region": customer.region, "name": customer.name, "email": customer.email, "creditRating": 500 + float64((customer.status*73)%300)}}
+}
+
+func (g *Generator) securityRecord(security benchmarkSecurity) GeneratedRecord {
+	changedAt := g.config.BaseTime.Add(-60 * 24 * time.Hour).UnixMilli()
+	return GeneratedRecord{SchemaID: SchemaIDSecurity, SchemaName: "security", RowID: security.rowID, Version: 1, ChangedAt: changedAt, Attributes: map[string]any{"symbol": security.symbol, "sector": security.sector, "companyName": security.name, "dividend": round2(float64((security.sector%7)+1) * 0.12), "marketCap": float64((security.sector+1)*1000000) + float64(len(security.symbol))*1000}}
+}
+
+func (g *Generator) pickRegion() string {
+	weights := []int{25, 25, 25, 25}
+	switch g.config.Distribution {
+	case DistributionPartitionSkew:
+		weights = []int{50, 30, 15, 5}
+	case DistributionZipf:
+		weights = []int{45, 25, 20, 10}
+	case DistributionTemporal:
+		weights = []int{40, 25, 20, 15}
+	case DistributionHotspot:
+		weights = []int{55, 20, 15, 10}
+	}
+	return weightedChoice(g.rand, benchmarkRegions, weights)
+}
+
+func (g *Generator) pickExchange(symbol string) string {
+	switch g.config.Distribution {
+	case DistributionZipf:
+		if len(symbol) > 0 && symbol[len(symbol)-1]%2 == 0 {
+			return benchmarkExchanges[0]
+		}
+	case DistributionPartitionSkew:
+		return weightedChoice(g.rand, benchmarkExchanges, []int{45, 30, 15, 10})
+	}
+	return benchmarkExchanges[g.rand.Intn(len(benchmarkExchanges))]
+}
+
+func (g *Generator) pickCustomerIndex() int {
+	if g.customerZipf != nil && g.config.Distribution == DistributionZipf {
+		return int(g.customerZipf.Uint64())
+	}
+	return g.rand.Intn(g.config.CustomerCount)
+}
+
+func (g *Generator) pickSecurityIndex() int {
+	if g.securityZipf != nil && (g.config.Distribution == DistributionZipf || g.config.Distribution == DistributionHotspot) {
+		return int(g.securityZipf.Uint64())
+	}
+	return g.rand.Intn(g.config.SecurityCount)
+}
+
+func (g *Generator) pickChangedAt(index int) int64 {
+	windowMillis := int64(g.config.TimeWindowDays) * 24 * int64(time.Hour/time.Millisecond)
+	var fraction float64
+	switch g.config.Distribution {
+	case DistributionTemporal, DistributionHotspot:
+		fraction = math.Pow(g.rand.Float64(), 4)
+	case DistributionZipf:
+		fraction = math.Pow(g.rand.Float64(), 2)
+	default:
+		fraction = g.rand.Float64()
+	}
+	ageMillis := int64(fraction * float64(windowMillis))
+	changedAt := g.config.BaseTime.UnixMilli() - ageMillis
+	return changedAt + int64(index%1000)
+}
+
+func newZipf(r *rand.Rand, size int) *rand.Zipf {
+	if size <= 1 {
+		return nil
+	}
+	return rand.NewZipf(r, 1.2, 1, uint64(size-1))
+}
+
+func deterministicRowID(seed int64, schema string, index int) uuid.UUID {
+	name := fmt.Sprintf("seed:%d:schema:%s:index:%d", seed, schema, index)
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(name))
+}
+
+func weightedChoice(r *rand.Rand, values []string, weights []int) string {
+	total := 0
+	for _, weight := range weights {
+		total += weight
+	}
+	pick := r.Intn(total)
+	for idx, weight := range weights {
+		if pick < weight {
+			return values[idx]
+		}
+		pick -= weight
+	}
+	return values[len(values)-1]
+}
+
+func round2(value float64) float64 {
+	return math.Round(value*100) / 100
+}
+
+func attributeFloat64(attrs map[string]any, key string) float64 {
+	value, ok := attrs[key]
+	if !ok {
+		return 0
+	}
+	switch v := value.(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case string:
+		parsed, _ := strconv.ParseFloat(v, 64)
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func attributeInt64(attrs map[string]any, key string) int64 {
+	value, ok := attrs[key]
+	if !ok {
+		return 0
+	}
+	switch v := value.(type) {
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case float64:
+		return int64(v)
+	default:
+		return 0
+	}
+}
+
+func attributeBool(attrs map[string]any, key string) bool {
+	value, ok := attrs[key]
+	if !ok {
+		return false
+	}
+	v, _ := value.(bool)
+	return v
+}

--- a/internal/e2e_harness/federated/benchmark/generator_test.go
+++ b/internal/e2e_harness/federated/benchmark/generator_test.go
@@ -1,0 +1,100 @@
+package benchmark
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestScalePresetForScale(t *testing.T) {
+	preset, err := ScalePresetFor(ScaleSmall)
+	if err != nil {
+		t.Fatalf("ScalePresetFor failed: %v", err)
+	}
+	if preset.TradeCount != 100000 {
+		t.Fatalf("unexpected small trade count: %d", preset.TradeCount)
+	}
+}
+
+func TestGeneratorDeterministic(t *testing.T) {
+	cfg := GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform, Seed: 99, TradeCount: 40, CustomerCount: 10, SecurityCount: 5, OverlapRatio: 0.05, DeleteRatio: 0.03, BaseTime: defaultBaseTime}.WithDefaults()
+	g1, err := NewGenerator(cfg)
+	if err != nil {
+		t.Fatalf("NewGenerator failed: %v", err)
+	}
+	g2, err := NewGenerator(cfg)
+	if err != nil {
+		t.Fatalf("NewGenerator failed: %v", err)
+	}
+	d1, err := g1.Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	d2, err := g2.Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if !reflect.DeepEqual(d1.Summary, d2.Summary) {
+		t.Fatalf("deterministic summaries differ: %+v vs %+v", d1.Summary, d2.Summary)
+	}
+	if len(d1.Records) != len(d2.Records) {
+		t.Fatalf("record lengths differ")
+	}
+	for i := range d1.Records {
+		if d1.Records[i].RowID != d2.Records[i].RowID || d1.Records[i].Version != d2.Records[i].Version || d1.Records[i].ChangedAt != d2.Records[i].ChangedAt {
+			t.Fatalf("record %d differs between deterministic runs", i)
+		}
+	}
+}
+
+func TestGeneratorProducesAllSchemas(t *testing.T) {
+	g, err := NewGenerator(GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform, Seed: 42, TradeCount: 60, CustomerCount: 12, SecurityCount: 6, BaseTime: defaultBaseTime})
+	if err != nil {
+		t.Fatalf("NewGenerator failed: %v", err)
+	}
+	dataset, err := g.Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if dataset.Summary.CountsBySchema["trade"] == 0 || dataset.Summary.CountsBySchema["customer"] == 0 || dataset.Summary.CountsBySchema["security"] == 0 {
+		t.Fatalf("expected non-zero counts for all schemas: %+v", dataset.Summary.CountsBySchema)
+	}
+}
+
+func TestHotspotDistributionCreatesDuplicateVersions(t *testing.T) {
+	g, err := NewGenerator(GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionHotspot, Seed: 7, TradeCount: 100, CustomerCount: 20, SecurityCount: 10, OverlapRatio: 0.10, BaseTime: defaultBaseTime})
+	if err != nil {
+		t.Fatalf("NewGenerator failed: %v", err)
+	}
+	dataset, err := g.Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if dataset.Summary.DuplicateVersions == 0 {
+		t.Fatalf("expected duplicate versions for hotspot distribution")
+	}
+	tradeRecords := dataset.RecordsForSchema("trade")
+	if len(LatestRecords(tradeRecords)) >= len(tradeRecords) {
+		t.Fatalf("expected deduped trade records to be fewer than raw trade records")
+	}
+}
+
+func TestCalibrateTradeFilters(t *testing.T) {
+	g, err := NewGenerator(GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform, Seed: 42, TradeCount: 200, CustomerCount: 40, SecurityCount: 20, BaseTime: defaultBaseTime})
+	if err != nil {
+		t.Fatalf("NewGenerator failed: %v", err)
+	}
+	dataset, err := g.Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	calibration, err := CalibrateTradeFilters(dataset.Records)
+	if err != nil {
+		t.Fatalf("CalibrateTradeFilters failed: %v", err)
+	}
+	if calibration.High.Band != SelectivityBandHigh || calibration.Medium.Band != SelectivityBandMedium || calibration.Low.Band != SelectivityBandLow {
+		t.Fatalf("unexpected selectivity bands: %+v", calibration)
+	}
+	if calibration.High.Matches == 0 || calibration.Medium.Matches == 0 || calibration.Low.Matches == 0 {
+		t.Fatalf("expected all calibration buckets to have matches: %+v", calibration)
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -1,0 +1,114 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	forma "github.com/lychee-technology/forma"
+)
+
+// RunResult captures the phase-1 scaffold output.
+type RunResult struct {
+	Config         Config               `json:"config"`
+	Generator      GeneratorConfig      `json:"generator"`
+	StartedAt      time.Time            `json:"started_at"`
+	CompletedAt    time.Time            `json:"completed_at"`
+	ValidationOnly bool                 `json:"validation_only"`
+	Schemas        []SchemaFixture      `json:"schemas"`
+	Workloads      []WorkloadDefinition `json:"workloads"`
+	Notes          []string             `json:"notes"`
+}
+
+// Runner validates benchmark inputs and prepares the phase-1 execution plan.
+type Runner struct {
+	config    Config
+	registry  forma.SchemaRegistry
+	schemas   []SchemaFixture
+	workloads []WorkloadDefinition
+	genConfig GeneratorConfig
+}
+
+// NewRunner builds a runner using the benchmark fixture registry.
+func NewRunner(cfg Config) (*Runner, error) {
+	resolved := cfg.WithDefaults()
+	if err := resolved.Validate(); err != nil {
+		return nil, err
+	}
+	registry, err := LoadFixtureRegistry()
+	if err != nil {
+		return nil, err
+	}
+	workloads, err := ResolveWorkloads(resolved.Workloads)
+	if err != nil {
+		return nil, err
+	}
+	return &Runner{
+		config:    resolved,
+		registry:  registry,
+		schemas:   DefaultSchemaFixtures(),
+		workloads: workloads,
+		genConfig: GeneratorConfigFromBenchmark(resolved),
+	}, nil
+}
+
+// RegisterSchemas loads the benchmark schema entries into a harness-backed registry table.
+func (r *Runner) RegisterSchemas(registrar SchemaRegistrar) error {
+	return RegisterFixtureSchemas(registrar)
+}
+
+// Run executes the scaffolded benchmark flow.
+func (r *Runner) Run(ctx context.Context) (*RunResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	startedAt := time.Now()
+	if err := r.validateFixtures(); err != nil {
+		return nil, err
+	}
+	result := &RunResult{
+		Config:         r.config,
+		Generator:      r.genConfig,
+		StartedAt:      startedAt,
+		ValidationOnly: true,
+		Schemas:        append([]SchemaFixture(nil), r.schemas...),
+		Workloads:      append([]WorkloadDefinition(nil), r.workloads...),
+	}
+	switch r.config.Mode {
+	case ExecutionModeSmoke:
+		result.Notes = []string{
+			"validated benchmark configuration",
+			"loaded TPC-E-inspired schema fixtures",
+			"resolved workload matrix",
+			fmt.Sprintf("prepared generator for scale=%s distribution=%s", r.genConfig.Scale, r.genConfig.Distribution),
+			"phase-1 scaffold stops before query execution",
+		}
+	case ExecutionModePlan:
+		result.Notes = []string{
+			"validated benchmark configuration",
+			"loaded TPC-E-inspired schema fixtures",
+			fmt.Sprintf("prepared generator for scale=%s distribution=%s", r.genConfig.Scale, r.genConfig.Distribution),
+			"built execution plan only",
+		}
+	default:
+		return nil, fmt.Errorf("unsupported execution mode %q", r.config.Mode)
+	}
+	result.CompletedAt = time.Now()
+	return result, nil
+}
+
+func (r *Runner) validateFixtures() error {
+	for _, fixture := range r.schemas {
+		id, _, err := r.registry.GetSchemaAttributeCacheByName(fixture.Name)
+		if err != nil {
+			return fmt.Errorf("validate fixture %s: %w", fixture.Name, err)
+		}
+		if id != fixture.ID {
+			return fmt.Errorf("fixture %s expected schema ID %d, got %d", fixture.Name, fixture.ID, id)
+		}
+		if _, _, err := r.registry.GetSchemaByName(fixture.Name); err != nil {
+			return fmt.Errorf("load JSON schema for %s: %w", fixture.Name, err)
+		}
+	}
+	return nil
+}

--- a/internal/e2e_harness/federated/benchmark/runner_test.go
+++ b/internal/e2e_harness/federated/benchmark/runner_test.go
@@ -1,0 +1,26 @@
+package benchmark
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunnerRunSmoke(t *testing.T) {
+	runner, err := NewRunner(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewRunner failed: %v", err)
+	}
+	result, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !result.ValidationOnly {
+		t.Fatalf("expected validation-only result")
+	}
+	if len(result.Workloads) == 0 {
+		t.Fatalf("expected resolved workloads")
+	}
+	if len(result.Schemas) == 0 {
+		t.Fatalf("expected loaded schemas")
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/schema.go
+++ b/internal/e2e_harness/federated/benchmark/schema.go
@@ -1,0 +1,74 @@
+package benchmark
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	forma "github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal"
+)
+
+const (
+	SchemaIDCustomer int16 = 100
+	SchemaIDSecurity int16 = 101
+	SchemaIDTrade    int16 = 102
+)
+
+// SchemaFixture describes a benchmark schema fixture.
+type SchemaFixture struct {
+	ID          int16  `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// SchemaRegistrar is the narrow harness contract needed by the benchmark scaffold.
+type SchemaRegistrar interface {
+	SetupSchema(schemaID int16, schemaName string) error
+}
+
+// DefaultSchemaFixtures returns the TPC-E-inspired schema set for the benchmark.
+func DefaultSchemaFixtures() []SchemaFixture {
+	return []SchemaFixture{
+		{ID: SchemaIDCustomer, Name: "customer", Description: "customer dimension with hot filter and EAV profile fields"},
+		{ID: SchemaIDSecurity, Name: "security", Description: "security reference data with hot symbol lookup and cold metrics"},
+		{ID: SchemaIDTrade, Name: "trade", Description: "trade fact entity with hybrid pagination and filter attributes"},
+	}
+}
+
+// FixturesDir returns the on-disk schema fixture directory.
+func FixturesDir() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(file), "schemas")
+}
+
+// LoadFixtureRegistry loads the benchmark schema fixtures through the standard file registry.
+func LoadFixtureRegistry() (forma.SchemaRegistry, error) {
+	registry, err := internal.NewFileSchemaRegistryFromDirectory(FixturesDir())
+	if err != nil {
+		return nil, fmt.Errorf("load fixture registry: %w", err)
+	}
+	for _, fixture := range DefaultSchemaFixtures() {
+		id, _, err := registry.GetSchemaAttributeCacheByName(fixture.Name)
+		if err != nil {
+			return nil, fmt.Errorf("load fixture %s: %w", fixture.Name, err)
+		}
+		if id != fixture.ID {
+			return nil, fmt.Errorf("fixture %s expected schema ID %d, got %d", fixture.Name, fixture.ID, id)
+		}
+	}
+	return registry, nil
+}
+
+// RegisterFixtureSchemas wires the benchmark fixtures into a harness-backed schema registry table.
+func RegisterFixtureSchemas(registrar SchemaRegistrar) error {
+	for _, fixture := range DefaultSchemaFixtures() {
+		if err := registrar.SetupSchema(fixture.ID, fixture.Name); err != nil {
+			return fmt.Errorf("register fixture %s: %w", fixture.Name, err)
+		}
+	}
+	return nil
+}

--- a/internal/e2e_harness/federated/benchmark/schema_test.go
+++ b/internal/e2e_harness/federated/benchmark/schema_test.go
@@ -1,0 +1,47 @@
+package benchmark
+
+import "testing"
+
+func TestLoadFixtureRegistry(t *testing.T) {
+	registry, err := LoadFixtureRegistry()
+	if err != nil {
+		t.Fatalf("LoadFixtureRegistry failed: %v", err)
+	}
+	for _, fixture := range DefaultSchemaFixtures() {
+		id, cache, err := registry.GetSchemaAttributeCacheByName(fixture.Name)
+		if err != nil {
+			t.Fatalf("GetSchemaAttributeCacheByName(%q) failed: %v", fixture.Name, err)
+		}
+		if id != fixture.ID {
+			t.Fatalf("fixture %s expected schema ID %d, got %d", fixture.Name, fixture.ID, id)
+		}
+		if len(cache) == 0 {
+			t.Fatalf("fixture %s loaded an empty attribute cache", fixture.Name)
+		}
+	}
+}
+
+func TestRegisterFixtureSchemas(t *testing.T) {
+	registrar := &captureRegistrar{}
+	if err := RegisterFixtureSchemas(registrar); err != nil {
+		t.Fatalf("RegisterFixtureSchemas failed: %v", err)
+	}
+	fixtures := DefaultSchemaFixtures()
+	if len(registrar.calls) != len(fixtures) {
+		t.Fatalf("expected %d calls, got %d", len(fixtures), len(registrar.calls))
+	}
+	for i, fixture := range fixtures {
+		if registrar.calls[i].ID != fixture.ID || registrar.calls[i].Name != fixture.Name {
+			t.Fatalf("call %d mismatch: got %+v want ID=%d Name=%s", i, registrar.calls[i], fixture.ID, fixture.Name)
+		}
+	}
+}
+
+type captureRegistrar struct {
+	calls []SchemaFixture
+}
+
+func (r *captureRegistrar) SetupSchema(schemaID int16, schemaName string) error {
+	r.calls = append(r.calls, SchemaFixture{ID: schemaID, Name: schemaName})
+	return nil
+}

--- a/internal/e2e_harness/federated/benchmark/schemas/customer.json
+++ b/internal/e2e_harness/federated/benchmark/schemas/customer.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Benchmark Customer",
+  "description": "TPC-E-inspired customer benchmark schema",
+  "type": "object",
+  "required": [
+    "taxId",
+    "status",
+    "region"
+  ],
+  "properties": {
+    "taxId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "status": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "region": {
+      "type": "string",
+      "enum": [
+        "NA",
+        "EU",
+        "APAC",
+        "LATAM"
+      ]
+    },
+    "name": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "creditRating": {
+      "type": "number",
+      "minimum": 300,
+      "maximum": 850
+    }
+  }
+}

--- a/internal/e2e_harness/federated/benchmark/schemas/customer_attributes.json
+++ b/internal/e2e_harness/federated/benchmark/schemas/customer_attributes.json
@@ -1,0 +1,35 @@
+{
+  "taxId": {
+    "attributeID": 1,
+    "valueType": "text",
+    "column_binding": {
+      "col_name": "text_01"
+    }
+  },
+  "status": {
+    "attributeID": 2,
+    "valueType": "smallint",
+    "column_binding": {
+      "col_name": "smallint_01"
+    }
+  },
+  "region": {
+    "attributeID": 3,
+    "valueType": "text",
+    "column_binding": {
+      "col_name": "text_02"
+    }
+  },
+  "name": {
+    "attributeID": 4,
+    "valueType": "text"
+  },
+  "email": {
+    "attributeID": 5,
+    "valueType": "text"
+  },
+  "creditRating": {
+    "attributeID": 6,
+    "valueType": "numeric"
+  }
+}

--- a/internal/e2e_harness/federated/benchmark/schemas/security.json
+++ b/internal/e2e_harness/federated/benchmark/schemas/security.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Benchmark Security",
+  "description": "TPC-E-inspired security benchmark schema",
+  "type": "object",
+  "required": [
+    "symbol",
+    "sector"
+  ],
+  "properties": {
+    "symbol": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 16
+    },
+    "sector": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 50
+    },
+    "companyName": {
+      "type": "string"
+    },
+    "dividend": {
+      "type": "number",
+      "minimum": 0
+    },
+    "marketCap": {
+      "type": "number",
+      "minimum": 0
+    }
+  }
+}

--- a/internal/e2e_harness/federated/benchmark/schemas/security_attributes.json
+++ b/internal/e2e_harness/federated/benchmark/schemas/security_attributes.json
@@ -1,0 +1,28 @@
+{
+  "symbol": {
+    "attributeID": 1,
+    "valueType": "text",
+    "column_binding": {
+      "col_name": "text_01"
+    }
+  },
+  "sector": {
+    "attributeID": 2,
+    "valueType": "smallint",
+    "column_binding": {
+      "col_name": "smallint_01"
+    }
+  },
+  "companyName": {
+    "attributeID": 3,
+    "valueType": "text"
+  },
+  "dividend": {
+    "attributeID": 4,
+    "valueType": "numeric"
+  },
+  "marketCap": {
+    "attributeID": 5,
+    "valueType": "numeric"
+  }
+}

--- a/internal/e2e_harness/federated/benchmark/schemas/trade.json
+++ b/internal/e2e_harness/federated/benchmark/schemas/trade.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Benchmark Trade",
+  "description": "TPC-E-inspired trade benchmark schema",
+  "type": "object",
+  "required": [
+    "symbol",
+    "tradeType",
+    "quantity",
+    "price",
+    "tradeTime",
+    "customerId"
+  ],
+  "properties": {
+    "symbol": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 16
+    },
+    "tradeType": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "quantity": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "price": {
+      "type": "number",
+      "minimum": 0
+    },
+    "tradeTime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "customerId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "region": {
+      "type": "string",
+      "enum": [
+        "NA",
+        "EU",
+        "APAC",
+        "LATAM"
+      ]
+    },
+    "exchange": {
+      "type": "string"
+    },
+    "commission": {
+      "type": "number",
+      "minimum": 0
+    },
+    "isCash": {
+      "type": "boolean"
+    },
+    "brokerId": {
+      "type": "string"
+    },
+    "orderChannel": {
+      "type": "string",
+      "enum": [
+        "web",
+        "mobile",
+        "branch",
+        "api"
+      ]
+    }
+  }
+}

--- a/internal/e2e_harness/federated/benchmark/schemas/trade_attributes.json
+++ b/internal/e2e_harness/federated/benchmark/schemas/trade_attributes.json
@@ -1,0 +1,72 @@
+{
+  "symbol": {
+    "attributeID": 1,
+    "valueType": "text",
+    "column_binding": {
+      "col_name": "text_01"
+    }
+  },
+  "tradeType": {
+    "attributeID": 2,
+    "valueType": "smallint",
+    "column_binding": {
+      "col_name": "smallint_01"
+    }
+  },
+  "quantity": {
+    "attributeID": 3,
+    "valueType": "bigint",
+    "column_binding": {
+      "col_name": "bigint_01"
+    }
+  },
+  "price": {
+    "attributeID": 4,
+    "valueType": "numeric",
+    "column_binding": {
+      "col_name": "double_01"
+    }
+  },
+  "tradeTime": {
+    "attributeID": 5,
+    "valueType": "datetime",
+    "column_binding": {
+      "col_name": "bigint_02",
+      "encoding": "unix_ms"
+    }
+  },
+  "customerId": {
+    "attributeID": 6,
+    "valueType": "uuid",
+    "column_binding": {
+      "col_name": "uuid_01"
+    }
+  },
+  "region": {
+    "attributeID": 7,
+    "valueType": "text",
+    "column_binding": {
+      "col_name": "text_02"
+    }
+  },
+  "exchange": {
+    "attributeID": 8,
+    "valueType": "text"
+  },
+  "commission": {
+    "attributeID": 9,
+    "valueType": "numeric"
+  },
+  "isCash": {
+    "attributeID": 10,
+    "valueType": "bool"
+  },
+  "brokerId": {
+    "attributeID": 11,
+    "valueType": "text"
+  },
+  "orderChannel": {
+    "attributeID": 12,
+    "valueType": "text"
+  }
+}

--- a/internal/e2e_harness/federated/benchmark/tier.go
+++ b/internal/e2e_harness/federated/benchmark/tier.go
@@ -1,0 +1,235 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
+)
+
+// TierMixProfile defines the cold/warm/hot allocation ratios.
+type TierMixProfile struct {
+	Name       string  `json:"name"`
+	BaseRatio  float64 `json:"base_ratio"`
+	DeltaRatio float64 `json:"delta_ratio"`
+	HotRatio   float64 `json:"hot_ratio"`
+}
+
+// TieredDataset holds benchmark records split by storage tier.
+type TieredDataset struct {
+	Profile TierMixProfile     `json:"profile"`
+	Base    []GeneratedRecord  `json:"base"`
+	Delta   []GeneratedRecord  `json:"delta"`
+	Hot     []GeneratedRecord  `json:"hot"`
+	Summary TieredDatasetStats `json:"summary"`
+}
+
+// TieredDatasetStats summarizes split results.
+type TieredDatasetStats struct {
+	BaseCount       int `json:"base_count"`
+	DeltaCount      int `json:"delta_count"`
+	HotCount        int `json:"hot_count"`
+	OverlappingKeys int `json:"overlapping_keys"`
+	DeletedInHot    int `json:"deleted_in_hot"`
+}
+
+// TierLoader is the harness contract needed to load a tiered dataset.
+type TierLoader interface {
+	SetupSchema(schemaID int16, schemaName string) error
+	ClearAllData(ctx context.Context) error
+	WriteParquet(ctx context.Context, tier, filename string, records []federated.TestRecord) error
+	SeedHotRecordsWithData(ctx context.Context, records []federated.TestRecord) error
+}
+
+var (
+	TierMixBalanced    = TierMixProfile{Name: "balanced-60-30-10", BaseRatio: 0.60, DeltaRatio: 0.30, HotRatio: 0.10}
+	TierMixHighHot     = TierMixProfile{Name: "high-hot-40-20-40", BaseRatio: 0.40, DeltaRatio: 0.20, HotRatio: 0.40}
+	TierMixLongHistory = TierMixProfile{Name: "long-history-85-10-5", BaseRatio: 0.85, DeltaRatio: 0.10, HotRatio: 0.05}
+)
+
+// DefaultTierMixProfiles returns the supported tier layouts.
+func DefaultTierMixProfiles() []TierMixProfile {
+	return []TierMixProfile{TierMixBalanced, TierMixHighHot, TierMixLongHistory}
+}
+
+// SplitIntoTiers partitions the generated dataset into base, delta, and hot tiers.
+func SplitIntoTiers(dataset *GeneratedDataset, profile TierMixProfile) (*TieredDataset, error) {
+	if dataset == nil {
+		return nil, fmt.Errorf("dataset cannot be nil")
+	}
+	if err := validateTierMixProfile(profile); err != nil {
+		return nil, err
+	}
+	base := make([]GeneratedRecord, 0)
+	delta := make([]GeneratedRecord, 0)
+	hot := make([]GeneratedRecord, 0)
+	base = append(base, filterRecordsBySchema(dataset.Records, "customer")...)
+	base = append(base, filterRecordsBySchema(dataset.Records, "security")...)
+	tradeRecords := dataset.RecordsForSchema("trade")
+	groups := groupBySchemaRowKey(tradeRecords)
+	keys := make([]string, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	baseCutoff, deltaCutoff := tierCutoffs(len(keys), profile)
+	stats := TieredDatasetStats{}
+	for idx, key := range keys {
+		versions := groups[key]
+		sortGeneratedRecords(versions)
+		latest := versions[len(versions)-1]
+		hasOverlap := len(versions) > 1
+		switch {
+		case idx < baseCutoff:
+			base = append(base, cloneGeneratedRecord(latest))
+		case idx < deltaCutoff:
+			delta = append(delta, cloneGeneratedRecord(latest))
+		default:
+			hot = append(hot, cloneGeneratedRecord(latest))
+		}
+		if hasOverlap {
+			stats.OverlappingKeys++
+			baseVersion := cloneGeneratedRecord(versions[0])
+			switch {
+			case idx < baseCutoff:
+				base = append(base, baseVersion)
+				if latest.Version > baseVersion.Version {
+					hot = append(hot, cloneGeneratedRecord(latest))
+				}
+			case idx < deltaCutoff:
+				base = append(base, baseVersion)
+				delta = append(delta, cloneGeneratedRecord(latest))
+			default:
+				base = append(base, baseVersion)
+				hot = append(hot, cloneGeneratedRecord(latest))
+			}
+		}
+	}
+	stats.BaseCount = len(base)
+	stats.DeltaCount = len(delta)
+	stats.HotCount = len(hot)
+	for _, record := range hot {
+		if record.DeletedAt > 0 {
+			stats.DeletedInHot++
+		}
+	}
+	sortGeneratedRecords(base)
+	sortGeneratedRecords(delta)
+	sortGeneratedRecords(hot)
+	return &TieredDataset{Profile: profile, Base: base, Delta: delta, Hot: hot, Summary: stats}, nil
+}
+
+// LoadTieredDataset loads a tiered dataset into the federated harness.
+func LoadTieredDataset(ctx context.Context, loader TierLoader, dataset *TieredDataset) error {
+	if loader == nil {
+		return fmt.Errorf("loader cannot be nil")
+	}
+	if dataset == nil {
+		return fmt.Errorf("dataset cannot be nil")
+	}
+	if err := loader.ClearAllData(ctx); err != nil {
+		return fmt.Errorf("clear existing data: %w", err)
+	}
+	for _, fixture := range DefaultSchemaFixtures() {
+		if err := loader.SetupSchema(fixture.ID, fixture.Name); err != nil {
+			return fmt.Errorf("setup schema %s: %w", fixture.Name, err)
+		}
+	}
+	if len(dataset.Base) > 0 {
+		if err := loader.WriteParquet(ctx, "base", "benchmark_base.parquet", ToTestRecords(dataset.Base)); err != nil {
+			return fmt.Errorf("write base parquet: %w", err)
+		}
+	}
+	if len(dataset.Delta) > 0 {
+		if err := loader.WriteParquet(ctx, "delta", "benchmark_delta.parquet", ToTestRecords(dataset.Delta)); err != nil {
+			return fmt.Errorf("write delta parquet: %w", err)
+		}
+	}
+	if len(dataset.Hot) > 0 {
+		if err := loader.SeedHotRecordsWithData(ctx, ToTestRecords(dataset.Hot)); err != nil {
+			return fmt.Errorf("seed hot records: %w", err)
+		}
+	}
+	return nil
+}
+
+// ToTestRecords converts generated records into harness test records.
+func ToTestRecords(records []GeneratedRecord) []federated.TestRecord {
+	out := make([]federated.TestRecord, 0, len(records))
+	for _, record := range records {
+		attrs := make(map[string]any, len(record.Attributes)+1)
+		for key, value := range record.Attributes {
+			attrs[key] = value
+		}
+		attrs["version"] = record.Version
+		if _, ok := attrs["name"]; !ok {
+			attrs["name"] = benchmarkDisplayName(record)
+		}
+		out = append(out, federated.TestRecord{
+			RowID:      record.RowID,
+			SchemaID:   record.SchemaID,
+			Attributes: attrs,
+			ChangedAt:  record.ChangedAt,
+			DeletedAt:  record.DeletedAt,
+			FlushedAt:  0,
+		})
+	}
+	return out
+}
+
+func validateTierMixProfile(profile TierMixProfile) error {
+	if profile.Name == "" {
+		return fmt.Errorf("tier profile name is required")
+	}
+	total := profile.BaseRatio + profile.DeltaRatio + profile.HotRatio
+	if profile.BaseRatio < 0 || profile.DeltaRatio < 0 || profile.HotRatio < 0 {
+		return fmt.Errorf("tier ratios must be non-negative")
+	}
+	if total < 0.999 || total > 1.001 {
+		return fmt.Errorf("tier ratios must sum to 1.0")
+	}
+	return nil
+}
+
+func tierCutoffs(total int, profile TierMixProfile) (int, int) {
+	baseCutoff := int(float64(total) * profile.BaseRatio)
+	deltaCutoff := baseCutoff + int(float64(total)*profile.DeltaRatio)
+	if total > 0 && baseCutoff == 0 && profile.BaseRatio > 0 {
+		baseCutoff = 1
+	}
+	if deltaCutoff < baseCutoff {
+		deltaCutoff = baseCutoff
+	}
+	if deltaCutoff > total {
+		deltaCutoff = total
+	}
+	return baseCutoff, deltaCutoff
+}
+
+func groupBySchemaRowKey(records []GeneratedRecord) map[string][]GeneratedRecord {
+	groups := make(map[string][]GeneratedRecord)
+	for _, record := range records {
+		key := schemaRowKey(record.SchemaID, record.RowID)
+		groups[key] = append(groups[key], cloneGeneratedRecord(record))
+	}
+	return groups
+}
+
+func schemaRowKey(schemaID int16, rowID uuid.UUID) string {
+	return fmt.Sprintf("%d:%s", schemaID, rowID)
+}
+
+func benchmarkDisplayName(record GeneratedRecord) string {
+	switch record.SchemaName {
+	case "customer":
+		return fmt.Sprint(record.Attributes["name"])
+	case "security":
+		return fmt.Sprint(record.Attributes["companyName"])
+	case "trade":
+		return fmt.Sprintf("trade-%s", record.RowID.String()[:8])
+	default:
+		return record.SchemaName
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/tier_test.go
+++ b/internal/e2e_harness/federated/benchmark/tier_test.go
@@ -1,0 +1,106 @@
+package benchmark
+
+import (
+	"context"
+	"testing"
+
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
+)
+
+func TestSplitIntoTiersBalanced(t *testing.T) {
+	g, err := NewGenerator(GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionHotspot, Seed: 42, TradeCount: 120, CustomerCount: 10, SecurityCount: 5, OverlapRatio: 0.10, BaseTime: defaultBaseTime})
+	if err != nil {
+		t.Fatalf("NewGenerator failed: %v", err)
+	}
+	dataset, err := g.Generate()
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	tiered, err := SplitIntoTiers(dataset, TierMixBalanced)
+	if err != nil {
+		t.Fatalf("SplitIntoTiers failed: %v", err)
+	}
+	if len(tiered.Base) == 0 || len(tiered.Delta) == 0 || len(tiered.Hot) == 0 {
+		t.Fatalf("expected all three tiers to be populated: %+v", tiered.Summary)
+	}
+	if tiered.Summary.OverlappingKeys == 0 {
+		t.Fatalf("expected overlap keys to be tracked")
+	}
+}
+
+func TestToTestRecordsPreservesKeyFields(t *testing.T) {
+	records := []GeneratedRecord{{
+		SchemaID:   SchemaIDTrade,
+		SchemaName: "trade",
+		RowID:      deterministicRowID(1, "trade", 1),
+		Version:    2,
+		ChangedAt:  defaultBaseTime.UnixMilli(),
+		Attributes: map[string]any{"symbol": "SYM00001", "tradeType": 1},
+	}}
+	converted := ToTestRecords(records)
+	if len(converted) != 1 {
+		t.Fatalf("expected one converted record")
+	}
+	if converted[0].Attributes["version"] != 2 {
+		t.Fatalf("expected version to be preserved")
+	}
+	if converted[0].SchemaID != SchemaIDTrade {
+		t.Fatalf("unexpected schema ID %d", converted[0].SchemaID)
+	}
+}
+
+func TestLoadTieredDatasetUsesLoader(t *testing.T) {
+	loader := &captureTierLoader{}
+	dataset := &TieredDataset{
+		Profile: TierMixBalanced,
+		Base:    []GeneratedRecord{{SchemaID: SchemaIDCustomer, SchemaName: "customer", RowID: deterministicRowID(1, "customer", 1), Attributes: map[string]any{"name": "customer"}}},
+		Delta:   []GeneratedRecord{{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: deterministicRowID(1, "trade", 1), Attributes: map[string]any{"symbol": "SYM00001"}}},
+		Hot:     []GeneratedRecord{{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: deterministicRowID(1, "trade", 2), Attributes: map[string]any{"symbol": "SYM00002"}}},
+	}
+	if err := LoadTieredDataset(context.Background(), loader, dataset); err != nil {
+		t.Fatalf("LoadTieredDataset failed: %v", err)
+	}
+	if !loader.cleared {
+		t.Fatalf("expected ClearAllData to be called")
+	}
+	if len(loader.schemas) != len(DefaultSchemaFixtures()) {
+		t.Fatalf("expected fixture schemas to be registered")
+	}
+	if len(loader.baseWrites) != 1 || len(loader.deltaWrites) != 1 || len(loader.hotWrites) != 1 {
+		t.Fatalf("expected one write per tier")
+	}
+}
+
+type captureTierLoader struct {
+	cleared     bool
+	schemas     []SchemaFixture
+	baseWrites  [][]federated.TestRecord
+	deltaWrites [][]federated.TestRecord
+	hotWrites   [][]federated.TestRecord
+}
+
+func (c *captureTierLoader) SetupSchema(schemaID int16, schemaName string) error {
+	c.schemas = append(c.schemas, SchemaFixture{ID: schemaID, Name: schemaName})
+	return nil
+}
+
+func (c *captureTierLoader) ClearAllData(context.Context) error {
+	c.cleared = true
+	return nil
+}
+
+func (c *captureTierLoader) WriteParquet(_ context.Context, tier, _ string, records []federated.TestRecord) error {
+	copyRecords := append([]federated.TestRecord(nil), records...)
+	switch tier {
+	case "base":
+		c.baseWrites = append(c.baseWrites, copyRecords)
+	case "delta":
+		c.deltaWrites = append(c.deltaWrites, copyRecords)
+	}
+	return nil
+}
+
+func (c *captureTierLoader) SeedHotRecordsWithData(_ context.Context, records []federated.TestRecord) error {
+	c.hotWrites = append(c.hotWrites, append([]federated.TestRecord(nil), records...))
+	return nil
+}

--- a/internal/e2e_harness/federated/benchmark/workload.go
+++ b/internal/e2e_harness/federated/benchmark/workload.go
@@ -1,0 +1,135 @@
+package benchmark
+
+import "fmt"
+
+// WorkloadCategory groups benchmark workloads by intent.
+type WorkloadCategory string
+
+const (
+	WorkloadCategoryPagination WorkloadCategory = "pagination"
+	WorkloadCategoryFilter     WorkloadCategory = "filter"
+	WorkloadCategoryDeepPage   WorkloadCategory = "deep-pagination"
+	WorkloadCategoryTierMix    WorkloadCategory = "tier-mix"
+)
+
+// WorkloadDefinition declares a benchmark workload.
+type WorkloadDefinition struct {
+	Name                   string           `json:"name"`
+	Description            string           `json:"description"`
+	Category               WorkloadCategory `json:"category"`
+	TargetSchema           string           `json:"target_schema"`
+	PageSize               int              `json:"page_size"`
+	PageNumber             int              `json:"page_number"`
+	SupportsDistributions  []Distribution   `json:"supports_distributions"`
+	PreferHot              bool             `json:"prefer_hot,omitempty"`
+	UsesEAVFilter          bool             `json:"uses_eav_filter,omitempty"`
+	LargePageJump          bool             `json:"large_page_jump,omitempty"`
+	Phase1ExecutionStubbed bool             `json:"phase1_execution_stubbed"`
+}
+
+// DefaultWorkloads returns the initial declarative workload matrix.
+func DefaultWorkloads() []WorkloadDefinition {
+	return []WorkloadDefinition{
+		{
+			Name:                   "baseline-page-1",
+			Description:            "Unfiltered first page ordered by trade time descending.",
+			Category:               WorkloadCategoryPagination,
+			TargetSchema:           "trade",
+			PageSize:               20,
+			PageNumber:             1,
+			SupportsDistributions:  allDistributions(),
+			Phase1ExecutionStubbed: true,
+		},
+		{
+			Name:                   "hot-selective-page",
+			Description:            "High-selectivity hot-column filter with pagination on trade rows.",
+			Category:               WorkloadCategoryFilter,
+			TargetSchema:           "trade",
+			PageSize:               20,
+			PageNumber:             1,
+			SupportsDistributions:  allDistributions(),
+			Phase1ExecutionStubbed: true,
+		},
+		{
+			Name:                   "eav-selective-page",
+			Description:            "EAV-backed filter with paginated trade results.",
+			Category:               WorkloadCategoryFilter,
+			TargetSchema:           "trade",
+			PageSize:               20,
+			PageNumber:             1,
+			SupportsDistributions:  allDistributions(),
+			UsesEAVFilter:          true,
+			Phase1ExecutionStubbed: true,
+		},
+		{
+			Name:                   "mixed-tier-window",
+			Description:            "Time-window query expected to touch cold and hot tiers.",
+			Category:               WorkloadCategoryTierMix,
+			TargetSchema:           "trade",
+			PageSize:               50,
+			PageNumber:             1,
+			SupportsDistributions:  []Distribution{DistributionTemporal, DistributionHotspot, DistributionUniform},
+			Phase1ExecutionStubbed: true,
+		},
+		{
+			Name:                   "deep-page-1000",
+			Description:            "Deep pagination baseline at page 1,000 using LIMIT/OFFSET semantics.",
+			Category:               WorkloadCategoryDeepPage,
+			TargetSchema:           "trade",
+			PageSize:               20,
+			PageNumber:             1000,
+			SupportsDistributions:  allDistributions(),
+			LargePageJump:          true,
+			Phase1ExecutionStubbed: true,
+		},
+		{
+			Name:                   "deep-page-100000",
+			Description:            "Large page jump benchmark at page 100,000.",
+			Category:               WorkloadCategoryDeepPage,
+			TargetSchema:           "trade",
+			PageSize:               20,
+			PageNumber:             100000,
+			SupportsDistributions:  allDistributions(),
+			LargePageJump:          true,
+			Phase1ExecutionStubbed: true,
+		},
+	}
+}
+
+// DefaultWorkloadNames returns the full phase-1 workload set.
+func DefaultWorkloadNames() []string {
+	workloads := DefaultWorkloads()
+	names := make([]string, 0, len(workloads))
+	for _, workload := range workloads {
+		names = append(names, workload.Name)
+	}
+	return names
+}
+
+// ResolveWorkloads resolves named workloads from the default matrix.
+func ResolveWorkloads(names []string) ([]WorkloadDefinition, error) {
+	all := DefaultWorkloads()
+	index := make(map[string]WorkloadDefinition, len(all))
+	for _, workload := range all {
+		index[workload.Name] = workload
+	}
+	resolved := make([]WorkloadDefinition, 0, len(names))
+	for _, name := range names {
+		workload, ok := index[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown workload %q", name)
+		}
+		resolved = append(resolved, workload)
+	}
+	return resolved, nil
+}
+
+func allDistributions() []Distribution {
+	return []Distribution{
+		DistributionUniform,
+		DistributionZipf,
+		DistributionTemporal,
+		DistributionPartitionSkew,
+		DistributionHotspot,
+	}
+}

--- a/internal/e2e_harness/federated/benchmark_scaffold_test.go
+++ b/internal/e2e_harness/federated/benchmark_scaffold_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+package federated_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
+	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBenchmarkScaffold_SchemaRegistration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	h, err := federated.NewFederatedTestHarness(ctx)
+	require.NoError(t, err)
+	defer h.Cleanup(ctx)
+
+	runner, err := bench.NewRunner(bench.DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, runner.RegisterSchemas(h))
+
+	for _, fixture := range bench.DefaultSchemaFixtures() {
+		var schemaName string
+		err := h.PGDB.QueryRowContext(ctx,
+			`SELECT schema_name FROM schema_registry WHERE schema_id = $1`,
+			fixture.ID,
+		).Scan(&schemaName)
+		require.NoError(t, err)
+		require.Equal(t, fixture.Name, schemaName)
+	}
+}

--- a/internal/e2e_harness/federated/benchmark_tier_load_test.go
+++ b/internal/e2e_harness/federated/benchmark_tier_load_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+package federated_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
+	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBenchmarkTierLoad_SmallDataset(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	h, err := federated.NewFederatedTestHarness(ctx)
+	require.NoError(t, err)
+	defer h.Cleanup(ctx)
+
+	g, err := bench.NewGenerator(bench.GeneratorConfig{
+		Scale:         bench.ScaleSmall,
+		Distribution:  bench.DistributionHotspot,
+		Seed:          42,
+		TradeCount:    120,
+		CustomerCount: 12,
+		SecurityCount: 6,
+		OverlapRatio:  0.10,
+		DeleteRatio:   0.05,
+	})
+	require.NoError(t, err)
+	dataset, err := g.Generate()
+	require.NoError(t, err)
+	tiered, err := bench.SplitIntoTiers(dataset, bench.TierMixBalanced)
+	require.NoError(t, err)
+	require.NoError(t, bench.LoadTieredDataset(ctx, h, tiered))
+
+	baseFiles, err := h.ListParquetFiles(ctx, "base")
+	require.NoError(t, err)
+	deltaFiles, err := h.ListParquetFiles(ctx, "delta")
+	require.NoError(t, err)
+	require.NotEmpty(t, baseFiles)
+	require.NotEmpty(t, deltaFiles)
+	require.Greater(t, h.CountUnflushedRecords(ctx), 0)
+	if tiered.Summary.DeletedInHot > 0 {
+		var deletedHot int
+		err = h.PGDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM change_log WHERE schema_id = $1 AND flushed_at = 0 AND deleted_at > 0`, bench.SchemaIDTrade).Scan(&deletedHot)
+		require.NoError(t, err)
+		require.Greater(t, deletedHot, 0)
+	}
+}

--- a/internal/e2e_harness/federated/harness.go
+++ b/internal/e2e_harness/federated/harness.go
@@ -274,6 +274,13 @@ func (h *FederatedTestHarness) initDatabaseSchema(ctx context.Context) error {
 		`CREATE TABLE IF NOT EXISTS entity_main (
 			ltbase_schema_id SMALLINT NOT NULL,
 			ltbase_row_id UUID NOT NULL,
+			text_01 TEXT,
+			text_02 TEXT,
+			smallint_01 SMALLINT,
+			bigint_01 BIGINT,
+			bigint_02 BIGINT,
+			double_01 DOUBLE PRECISION,
+			uuid_01 UUID,
 			ltbase_created_at BIGINT NOT NULL,
 			ltbase_updated_at BIGINT NOT NULL,
 			ltbase_deleted_at BIGINT,

--- a/internal/e2e_harness/federated/s3_operations.go
+++ b/internal/e2e_harness/federated/s3_operations.go
@@ -3,10 +3,13 @@ package federated
 import (
 	"bytes"
 	"context"
+	"encoding/csv"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -65,25 +68,85 @@ func (h *FederatedTestHarness) writeRecordsToCSV(path string, records []TestReco
 	}
 	defer f.Close()
 
-	// Header
-	_, _ = f.WriteString("row_id,schema_id,changed_at,deleted_at,name,version\n")
+	attrKeys := collectCSVAttributeKeys(records)
+	writer := csv.NewWriter(f)
+	header := []string{"row_id", "schema_id", "changed_at", "deleted_at", "name", "version"}
+	header = append(header, attrKeys...)
+	if err := writer.Write(header); err != nil {
+		return err
+	}
 
 	for _, r := range records {
-		name := ""
-		version := 0
-		if v, ok := r.Attributes["name"].(string); ok {
-			name = v
+		row := []string{
+			r.RowID.String(),
+			strconv.FormatInt(int64(r.SchemaID), 10),
+			strconv.FormatInt(r.ChangedAt, 10),
+			strconv.FormatInt(r.DeletedAt, 10),
+			attributeStringValue(r.Attributes, "name"),
+			attributeStringValue(r.Attributes, "version"),
 		}
-		if v, ok := r.Attributes["version"].(int); ok {
-			version = v
+		for _, key := range attrKeys {
+			row = append(row, attributeStringValue(r.Attributes, key))
 		}
-
-		line := fmt.Sprintf("%s,%d,%d,%d,%s,%d\n",
-			r.RowID.String(), r.SchemaID, r.ChangedAt, r.DeletedAt, name, version)
-		_, _ = f.WriteString(line)
+		if err := writer.Write(row); err != nil {
+			return err
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func collectCSVAttributeKeys(records []TestRecord) []string {
+	keys := make(map[string]struct{})
+	for _, record := range records {
+		for key := range record.Attributes {
+			if key == "name" || key == "version" {
+				continue
+			}
+			keys[key] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func attributeStringValue(attrs map[string]any, key string) string {
+	if attrs == nil {
+		return ""
+	}
+	value, ok := attrs[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return v
+	case int:
+		return strconv.Itoa(v)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprint(v)
+	}
 }
 
 // uploadToS3 uploads a local file to S3.


### PR DESCRIPTION
## Summary
- add federated query benchmark design docs, implementation plan, and tracked issue backlog
- add a benchmark scaffold with CLI entrypoint, TPC-E-inspired schema fixtures, deterministic dataset generation, and tier split/load helpers
- extend the federated E2E harness so benchmark datasets can be loaded into parquet and hot storage with unit and e2e coverage

## Why
This lays down the minimum reproducible foundation for a federated query benchmark that matches the existing codebase terminology and execution model. It gives us a stable place to iterate on workload execution, deep pagination cases, correctness assertions, and reporting in follow-up changes instead of mixing all of that into one large review.

## Included In This PR
- benchmark HLD in Chinese and English
- implementation plan and issue breakdown docs
- `cmd/benchmark` scaffold with `describe` and validation-oriented `run`
- benchmark schema fixtures for `customer`, `security`, and `trade`
- deterministic generator with `uniform`, `zipf`, `temporal`, `partition-skew`, and `hotspot-overlap`
- scale presets and selectivity calibration helpers
- tier mix profiles and tiered dataset loading helpers
- harness updates needed to write richer benchmark records into parquet and hot storage
- unit tests and e2e tests for schema registration and small-scale tier loading

## Not Yet Included
- real benchmark workload execution against federated query paths
- deep pagination assertions over executed queries
- benchmark reporting/export beyond scaffold output
- CI wiring for recurring benchmark runs

## Validation
- `go test ./cmd/benchmark ./internal/e2e_harness/federated/benchmark/...`
- `go test -v ./internal/e2e_harness/federated/... -run 'TestBenchmarkScaffold_SchemaRegistration|TestBenchmarkTierLoad_SmallDataset' -tags=e2e -timeout=10m`
- `go run ./cmd/benchmark describe`
- `go run ./cmd/benchmark run -mode plan -distribution zipf`

## Follow-ups
- #37 Implement workload matrix and deep pagination benchmark cases
- #38 Add benchmark reporting and baseline capture support
- #39 Document CI and operator guidance for benchmark execution