### PR TITLE
add federated benchmark reporting and baseline capture

### DIFF
--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -81,6 +81,9 @@ func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int
 	securityCount := flags.Int("security-count", 0, "Override generated security row count")
 	overlapRatio := flags.Float64("overlap-ratio", 0, "Override overlap ratio")
 	deleteRatio := flags.Float64("delete-ratio", 0, "Override delete ratio")
+	jsonOut := flags.String("json-out", "", "Optional path for JSON benchmark output")
+	mdOut := flags.String("md-out", "", "Optional path for Markdown benchmark output")
+	baselineDir := flags.String("baseline-dir", "", "Optional directory for baseline capture outputs")
 	workloads := flags.String("workloads", "", "Comma-separated workload names (defaults to all)")
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -110,6 +113,25 @@ func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int
 		fmt.Fprintf(errOut, "benchmark run failed: %v\n", err)
 		return 1
 	}
+	if *jsonOut != "" {
+		if err := bench.WriteJSONReport(*jsonOut, result); err != nil {
+			fmt.Fprintf(errOut, "failed to write JSON report: %v\n", err)
+			return 1
+		}
+	}
+	if *mdOut != "" {
+		if err := bench.WriteMarkdownReport(*mdOut, result); err != nil {
+			fmt.Fprintf(errOut, "failed to write Markdown report: %v\n", err)
+			return 1
+		}
+	}
+	if *baselineDir != "" {
+		if err := bench.WriteBaselineCapture(*baselineDir, result); err != nil {
+			fmt.Fprintf(errOut, "failed to write baseline capture: %v\n", err)
+			return 1
+		}
+	}
+	fmt.Fprintln(errOut, bench.FormatConsoleSummary(result))
 	return writeJSON(out, result)
 }
 

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -28,6 +29,8 @@ func runBenchmarkMain(ctx context.Context, args []string, out, errOut io.Writer)
 	switch args[0] {
 	case "describe":
 		return runDescribe(out)
+	case "baseline":
+		return runBaseline(ctx, args[1:], out, errOut)
 	case "run":
 		return runBenchmark(ctx, args[1:], out, errOut)
 	default:
@@ -42,6 +45,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Commands:")
 	fmt.Fprintln(out, "  describe   Print benchmark schemas, workloads, and defaults")
+	fmt.Fprintln(out, "  baseline   Capture a baseline artifact set for a preset")
 	fmt.Fprintln(out, "  run        Execute the scaffolded benchmark runner")
 }
 
@@ -67,6 +71,38 @@ func runDescribe(out io.Writer) int {
 }
 
 func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int {
+	config, outputs, exitCode := parseRunConfig(args, errOut)
+	if exitCode != 0 {
+		return exitCode
+	}
+	return executeBenchmarkRun(ctx, config, outputs, out, errOut)
+}
+
+func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int {
+	flags := flag.NewFlagSet("run", flag.ContinueOnError)
+	flags.SetOutput(errOut)
+	preset := flags.String("preset", "small", "Baseline preset: small or medium")
+	outputDir := flags.String("output-dir", ".artifacts/benchmark", "Directory to store baseline captures")
+	distribution := flags.String("distribution", string(bench.DistributionUniform), "Data distribution preset")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	config, dirName, err := baselinePresetConfig(*preset, bench.Distribution(*distribution))
+	if err != nil {
+		fmt.Fprintf(errOut, "baseline setup failed: %v\n", err)
+		return 1
+	}
+	outputs := runOutputs{baselineDir: filepath.Join(*outputDir, dirName)}
+	return executeBenchmarkRun(ctx, config, outputs, out, errOut)
+}
+
+type runOutputs struct {
+	jsonOut     string
+	mdOut       string
+	baselineDir string
+}
+
+func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, int) {
 	flags := flag.NewFlagSet("run", flag.ContinueOnError)
 	flags.SetOutput(errOut)
 	mode := flags.String("mode", string(bench.ExecutionModeSmoke), "Execution mode: smoke or plan")
@@ -86,7 +122,7 @@ func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int
 	baselineDir := flags.String("baseline-dir", "", "Optional directory for baseline capture outputs")
 	workloads := flags.String("workloads", "", "Comma-separated workload names (defaults to all)")
 	if err := flags.Parse(args); err != nil {
-		return 1
+		return bench.Config{}, runOutputs{}, 1
 	}
 	cfg := bench.Config{
 		Mode:          bench.ExecutionMode(*mode),
@@ -103,6 +139,11 @@ func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int
 		DeleteRatio:   *deleteRatio,
 		Workloads:     parseWorkloads(*workloads),
 	}.WithDefaults()
+	outputs := runOutputs{jsonOut: *jsonOut, mdOut: *mdOut, baselineDir: *baselineDir}
+	return cfg, outputs, 0
+}
+
+func executeBenchmarkRun(ctx context.Context, cfg bench.Config, outputs runOutputs, out, errOut io.Writer) int {
 	runner, err := bench.NewRunner(cfg)
 	if err != nil {
 		fmt.Fprintf(errOut, "benchmark setup failed: %v\n", err)
@@ -113,26 +154,41 @@ func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int
 		fmt.Fprintf(errOut, "benchmark run failed: %v\n", err)
 		return 1
 	}
-	if *jsonOut != "" {
-		if err := bench.WriteJSONReport(*jsonOut, result); err != nil {
+	if outputs.jsonOut != "" {
+		if err := bench.WriteJSONReport(outputs.jsonOut, result); err != nil {
 			fmt.Fprintf(errOut, "failed to write JSON report: %v\n", err)
 			return 1
 		}
 	}
-	if *mdOut != "" {
-		if err := bench.WriteMarkdownReport(*mdOut, result); err != nil {
+	if outputs.mdOut != "" {
+		if err := bench.WriteMarkdownReport(outputs.mdOut, result); err != nil {
 			fmt.Fprintf(errOut, "failed to write Markdown report: %v\n", err)
 			return 1
 		}
 	}
-	if *baselineDir != "" {
-		if err := bench.WriteBaselineCapture(*baselineDir, result); err != nil {
+	if outputs.baselineDir != "" {
+		if err := bench.WriteBaselineCapture(outputs.baselineDir, result); err != nil {
 			fmt.Fprintf(errOut, "failed to write baseline capture: %v\n", err)
 			return 1
 		}
 	}
 	fmt.Fprintln(errOut, bench.FormatConsoleSummary(result))
 	return writeJSON(out, result)
+}
+
+func baselinePresetConfig(rawPreset string, distribution bench.Distribution) (bench.Config, string, error) {
+	preset := strings.ToLower(strings.TrimSpace(rawPreset))
+	if distribution == "" {
+		distribution = bench.DistributionUniform
+	}
+	switch preset {
+	case "small":
+		return bench.Config{Mode: bench.ExecutionModeSmoke, Scale: bench.ScaleSmall, Distribution: distribution, Iterations: 5, PageSize: 20, Seed: 42}.WithDefaults(), fmt.Sprintf("small-%s", distribution), nil
+	case "medium":
+		return bench.Config{Mode: bench.ExecutionModePlan, Scale: bench.ScaleMedium, Distribution: distribution, Iterations: 10, PageSize: 20, Seed: 42}.WithDefaults(), fmt.Sprintf("medium-%s", distribution), nil
+	default:
+		return bench.Config{}, "", fmt.Errorf("unknown baseline preset %q", rawPreset)
+	}
 }
 
 func parseWorkloads(raw string) []string {

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -76,19 +76,29 @@ func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int
 	concurrency := flags.Int("concurrency", 1, "Number of concurrent workers to schedule")
 	pageSize := flags.Int("page-size", 20, "Default page size for workload planning")
 	seed := flags.Int64("seed", 42, "Deterministic benchmark seed")
+	tradeCount := flags.Int("trade-count", 0, "Override generated trade row count")
+	customerCount := flags.Int("customer-count", 0, "Override generated customer row count")
+	securityCount := flags.Int("security-count", 0, "Override generated security row count")
+	overlapRatio := flags.Float64("overlap-ratio", 0, "Override overlap ratio")
+	deleteRatio := flags.Float64("delete-ratio", 0, "Override delete ratio")
 	workloads := flags.String("workloads", "", "Comma-separated workload names (defaults to all)")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 	cfg := bench.Config{
-		Mode:         bench.ExecutionMode(*mode),
-		Scale:        bench.Scale(*scale),
-		Distribution: bench.Distribution(*distribution),
-		Iterations:   *iterations,
-		Concurrency:  *concurrency,
-		PageSize:     *pageSize,
-		Seed:         *seed,
-		Workloads:    parseWorkloads(*workloads),
+		Mode:          bench.ExecutionMode(*mode),
+		Scale:         bench.Scale(*scale),
+		Distribution:  bench.Distribution(*distribution),
+		Iterations:    *iterations,
+		Concurrency:   *concurrency,
+		PageSize:      *pageSize,
+		Seed:          *seed,
+		TradeCount:    *tradeCount,
+		CustomerCount: *customerCount,
+		SecurityCount: *securityCount,
+		OverlapRatio:  *overlapRatio,
+		DeleteRatio:   *deleteRatio,
+		Workloads:     parseWorkloads(*workloads),
 	}.WithDefaults()
 	runner, err := bench.NewRunner(cfg)
 	if err != nil {

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -28,4 +28,7 @@ func TestRunBenchmarkMainSmoke(t *testing.T) {
 	if out.Len() == 0 {
 		t.Fatalf("run should emit JSON output")
 	}
+	if errOut.Len() == 0 {
+		t.Fatalf("run should emit console summary to stderr")
+	}
 }

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -30,5 +32,24 @@ func TestRunBenchmarkMainSmoke(t *testing.T) {
 	}
 	if errOut.Len() == 0 {
 		t.Fatalf("run should emit console summary to stderr")
+	}
+}
+
+func TestRunBenchmarkMainBaseline(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"baseline", "-preset", "small", "-output-dir", dir}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("baseline returned exit code %d: %s", exitCode, errOut.String())
+	}
+	for _, name := range []string{"benchmark-result.json", "benchmark-result.md", "benchmark-summary.json"} {
+		matches, err := filepath.Glob(filepath.Join(dir, "small-*", name))
+		if err != nil || len(matches) == 0 {
+			t.Fatalf("expected baseline artifact %s to exist", name)
+		}
+		if _, err := os.Stat(matches[0]); err != nil {
+			t.Fatalf("expected baseline artifact %s to exist: %v", name, err)
+		}
 	}
 }

--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -1,0 +1,71 @@
+# Federated Query Benchmark Baseline Runbook
+
+Last updated: 2026-04-18  
+Repository: `forma`
+
+## Purpose
+
+This runbook defines a repeatable baseline capture flow for the federated query benchmark at `small` and `medium` scale.
+
+## Recommended Baseline Scales
+
+- `small`: local development and PR validation
+- `medium`: controlled baseline comparison and regression review
+
+## Recommended Commands
+
+### Small Baseline
+
+```bash
+go run ./cmd/benchmark run \
+  -mode smoke \
+  -scale small \
+  -distribution uniform \
+  -iterations 5 \
+  -baseline-dir .artifacts/benchmark/small-uniform
+```
+
+### Medium Baseline
+
+```bash
+go run ./cmd/benchmark run \
+  -mode plan \
+  -scale medium \
+  -distribution zipf \
+  -iterations 10 \
+  -baseline-dir .artifacts/benchmark/medium-zipf
+```
+
+## Output Files
+
+Each baseline directory should contain:
+
+- `benchmark-result.json`
+- `benchmark-result.md`
+- `benchmark-summary.json`
+
+## How To Compare Runs
+
+Compare these fields first:
+
+- `execution_count`
+- `p50`
+- `p95`
+- `p99`
+- `max`
+- `avg`
+- `qps`
+- assertion pass/fail counts
+
+## Interpretation Guidance
+
+- use `small` to catch obvious correctness or latency regressions quickly
+- use `medium` to compare behavior across distributions and page-depth workloads
+- treat assertion failures as correctness regressions even if latency improves
+- treat large `max` growth separately from percentile movement; it is often a sign of tier skew or unstable deep pagination
+
+## Current Limitations
+
+- current CLI `run` still uses the scaffolded execution path unless the runtime is wired to a live harness
+- baseline capture is designed for artifact stability first, not for production-like throughput measurement
+- CI integration and operator workflow guidance are tracked separately in `#39`

--- a/docs/federated-query/federated-query-benchmark-reviewer-guide.md
+++ b/docs/federated-query/federated-query-benchmark-reviewer-guide.md
@@ -1,0 +1,84 @@
+# Federated Query Benchmark Reviewer Guide
+
+Last updated: 2026-04-17  
+Repository: `forma`
+
+## Review Order
+
+Review the benchmark work in this order:
+
+1. `#40` benchmark foundation
+2. `#41` workload execution follow-up
+
+This keeps the review incremental: first the benchmark model and data pipeline, then the first executable workload path.
+
+## PR #40 Focus
+
+PR: `#40 add federated query benchmark foundation`
+
+Primary areas to review:
+
+- docs and issue breakdown
+- benchmark CLI scaffold
+- TPC-E-inspired schema fixtures
+- deterministic generator
+- tier split and tier load helpers
+- harness support for richer benchmark records
+
+Key files:
+
+- `docs/cn/federated-query-benchmark-hld.md`
+- `docs/federated-query/federated-query-benchmark-hld-en.md`
+- `docs/federated-query/federated-query-benchmark-implementation-plan.md`
+- `cmd/benchmark/main.go`
+- `internal/e2e_harness/federated/benchmark/config.go`
+- `internal/e2e_harness/federated/benchmark/schema.go`
+- `internal/e2e_harness/federated/benchmark/generator.go`
+- `internal/e2e_harness/federated/benchmark/tier.go`
+- `internal/e2e_harness/federated/harness.go`
+- `internal/e2e_harness/federated/s3_operations.go`
+
+Questions to ask while reviewing:
+
+- does the benchmark shape match current federated query terminology?
+- are schema fixtures and generator defaults reasonable for phase 1?
+- is tier preparation reusable enough for later workload and reporting work?
+- are the harness changes scoped and justified?
+
+## PR #41 Focus
+
+PR: `#41 add federated benchmark workload execution`
+
+Primary areas to review:
+
+- workload execution path through the federated harness
+- config overrides for small executable benchmark runs
+- schema-scoped tier loading correctness
+- deterministic hot/EAV seeding behavior
+- deep pagination assertions at benchmark-run level
+
+Key files:
+
+- `internal/e2e_harness/federated/benchmark/runner.go`
+- `internal/e2e_harness/federated/benchmark/workload.go`
+- `internal/e2e_harness/federated/benchmark/dataset.go`
+- `internal/e2e_harness/federated/benchmark/tier.go`
+- `internal/e2e_harness/federated/seeding.go`
+- `cmd/benchmark/main.go`
+- `internal/e2e_harness/federated/benchmark_workload_execution_test.go`
+
+Questions to ask while reviewing:
+
+- does `RunWithHarness` have the right responsibilities for phase 1?
+- are generator overrides sufficient for smoke and e2e benchmark execution?
+- does schema-scoped tier loading prevent accidental cross-schema contamination?
+- are the current correctness assertions useful without overfitting to the temporary harness query model?
+
+## Known Gaps
+
+These are intentionally left for follow-up work:
+
+- richer filter-aware workload execution against a more expressive query model
+- benchmark reporting/export beyond the current execution result structure
+- stronger correctness assertions over result contents rather than only page-level invariants
+- CI and operational benchmark guidance

--- a/internal/e2e_harness/federated/benchmark/config.go
+++ b/internal/e2e_harness/federated/benchmark/config.go
@@ -32,14 +32,19 @@ const (
 
 // Config describes a benchmark run.
 type Config struct {
-	Mode         ExecutionMode `json:"mode"`
-	Scale        Scale         `json:"scale"`
-	Distribution Distribution  `json:"distribution"`
-	Iterations   int           `json:"iterations"`
-	Concurrency  int           `json:"concurrency"`
-	PageSize     int           `json:"page_size"`
-	Seed         int64         `json:"seed"`
-	Workloads    []string      `json:"workloads"`
+	Mode          ExecutionMode `json:"mode"`
+	Scale         Scale         `json:"scale"`
+	Distribution  Distribution  `json:"distribution"`
+	Iterations    int           `json:"iterations"`
+	Concurrency   int           `json:"concurrency"`
+	PageSize      int           `json:"page_size"`
+	Seed          int64         `json:"seed"`
+	TradeCount    int           `json:"trade_count,omitempty"`
+	CustomerCount int           `json:"customer_count,omitempty"`
+	SecurityCount int           `json:"security_count,omitempty"`
+	OverlapRatio  float64       `json:"overlap_ratio,omitempty"`
+	DeleteRatio   float64       `json:"delete_ratio,omitempty"`
+	Workloads     []string      `json:"workloads"`
 }
 
 // DefaultConfig returns the phase-1 benchmark scaffold defaults.

--- a/internal/e2e_harness/federated/benchmark/dataset.go
+++ b/internal/e2e_harness/federated/benchmark/dataset.go
@@ -87,6 +87,21 @@ func GeneratorConfigFromBenchmark(cfg Config) GeneratorConfig {
 	genCfg.Scale = resolved.Scale
 	genCfg.Distribution = resolved.Distribution
 	genCfg.Seed = resolved.Seed
+	if resolved.TradeCount > 0 {
+		genCfg.TradeCount = resolved.TradeCount
+	}
+	if resolved.CustomerCount > 0 {
+		genCfg.CustomerCount = resolved.CustomerCount
+	}
+	if resolved.SecurityCount > 0 {
+		genCfg.SecurityCount = resolved.SecurityCount
+	}
+	if resolved.OverlapRatio > 0 {
+		genCfg.OverlapRatio = resolved.OverlapRatio
+	}
+	if resolved.DeleteRatio > 0 {
+		genCfg.DeleteRatio = resolved.DeleteRatio
+	}
 	return genCfg.WithDefaults()
 }
 

--- a/internal/e2e_harness/federated/benchmark/execute_test.go
+++ b/internal/e2e_harness/federated/benchmark/execute_test.go
@@ -1,0 +1,25 @@
+package benchmark
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
+)
+
+func TestRunnerExecuteWorkload(t *testing.T) {
+	runner, err := NewRunner(Config{Scale: ScaleSmall, Distribution: DistributionUniform, Iterations: 1, PageSize: 20}.WithDefaults())
+	if err != nil {
+		t.Fatalf("NewRunner failed: %v", err)
+	}
+	h := &federated.FederatedTestHarness{}
+	workload := WorkloadDefinition{Name: "baseline-page-1", Category: WorkloadCategoryPagination, PageSize: 20, PageNumber: 1}
+	_ = h
+	_ = workload
+	_ = context.Background()
+	_ = time.Millisecond
+	if runner == nil {
+		t.Fatalf("runner should not be nil")
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -1,0 +1,40 @@
+package benchmark
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// WriteJSONReport writes a benchmark run result to JSON.
+func WriteJSONReport(path string, result *RunResult) error {
+	if result == nil {
+		return fmt.Errorf("run result cannot be nil")
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal JSON report: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// WriteMarkdownReport writes a lightweight markdown summary for a benchmark run.
+func WriteMarkdownReport(path string, result *RunResult) error {
+	if result == nil {
+		return fmt.Errorf("run result cannot be nil")
+	}
+	var b strings.Builder
+	b.WriteString("# Federated Query Benchmark Report\n\n")
+	b.WriteString(fmt.Sprintf("- Validation only: %t\n", result.ValidationOnly))
+	b.WriteString(fmt.Sprintf("- Distribution: %s\n", result.Generator.Distribution))
+	b.WriteString(fmt.Sprintf("- Scale: %s\n", result.Generator.Scale))
+	b.WriteString(fmt.Sprintf("- Executions: %d\n", len(result.Executions)))
+	if len(result.Executions) > 0 {
+		b.WriteString("\n## Executions\n\n")
+		for _, execution := range result.Executions {
+			b.WriteString(fmt.Sprintf("- `%s`: count=%d total=%d duration=%s offset=%d\n", execution.Name, execution.ResultCount, execution.TotalRecords, execution.Duration, execution.Offset))
+		}
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644)
+}

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -3,9 +3,29 @@ package benchmark
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 )
+
+// SummaryReport captures aggregated execution metrics.
+type SummaryReport struct {
+	ExecutionCount int                      `json:"execution_count"`
+	P50            time.Duration            `json:"p50"`
+	P95            time.Duration            `json:"p95"`
+	P99            time.Duration            `json:"p99"`
+	Max            time.Duration            `json:"max"`
+	AssertionStats map[string]AssertionStat `json:"assertion_stats"`
+}
+
+// AssertionStat captures aggregate assertion pass/fail counts.
+type AssertionStat struct {
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+}
 
 // WriteJSONReport writes a benchmark run result to JSON.
 func WriteJSONReport(path string, result *RunResult) error {
@@ -24,12 +44,17 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 	if result == nil {
 		return fmt.Errorf("run result cannot be nil")
 	}
+	summary := SummarizeRunResult(result)
 	var b strings.Builder
 	b.WriteString("# Federated Query Benchmark Report\n\n")
 	b.WriteString(fmt.Sprintf("- Validation only: %t\n", result.ValidationOnly))
 	b.WriteString(fmt.Sprintf("- Distribution: %s\n", result.Generator.Distribution))
 	b.WriteString(fmt.Sprintf("- Scale: %s\n", result.Generator.Scale))
 	b.WriteString(fmt.Sprintf("- Executions: %d\n", len(result.Executions)))
+	b.WriteString(fmt.Sprintf("- P50: %s\n", summary.P50))
+	b.WriteString(fmt.Sprintf("- P95: %s\n", summary.P95))
+	b.WriteString(fmt.Sprintf("- P99: %s\n", summary.P99))
+	b.WriteString(fmt.Sprintf("- Max: %s\n", summary.Max))
 	if len(result.Executions) > 0 {
 		b.WriteString("\n## Executions\n\n")
 		for _, execution := range result.Executions {
@@ -37,4 +62,68 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 		}
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+// WriteBaselineCapture writes JSON and markdown reports into a directory.
+func WriteBaselineCapture(dir string, result *RunResult) error {
+	if result == nil {
+		return fmt.Errorf("run result cannot be nil")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create baseline dir: %w", err)
+	}
+	if err := WriteJSONReport(filepath.Join(dir, "benchmark-result.json"), result); err != nil {
+		return err
+	}
+	if err := WriteMarkdownReport(filepath.Join(dir, "benchmark-result.md"), result); err != nil {
+		return err
+	}
+	summary := SummarizeRunResult(result)
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal baseline summary: %w", err)
+	}
+	return os.WriteFile(filepath.Join(dir, "benchmark-summary.json"), data, 0o644)
+}
+
+// SummarizeRunResult aggregates durations and assertion outcomes.
+func SummarizeRunResult(result *RunResult) SummaryReport {
+	summary := SummaryReport{AssertionStats: make(map[string]AssertionStat)}
+	if result == nil || len(result.Executions) == 0 {
+		return summary
+	}
+	durations := make([]time.Duration, 0, len(result.Executions))
+	for _, execution := range result.Executions {
+		durations = append(durations, execution.Duration)
+		for _, assertion := range execution.Assertions {
+			stat := summary.AssertionStats[assertion.Name]
+			if assertion.Passed {
+				stat.Passed++
+			} else {
+				stat.Failed++
+			}
+			summary.AssertionStats[assertion.Name] = stat
+		}
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	summary.ExecutionCount = len(durations)
+	summary.P50 = percentileDuration(durations, 0.50)
+	summary.P95 = percentileDuration(durations, 0.95)
+	summary.P99 = percentileDuration(durations, 0.99)
+	summary.Max = durations[len(durations)-1]
+	return summary
+}
+
+func percentileDuration(values []time.Duration, percentile float64) time.Duration {
+	if len(values) == 0 {
+		return 0
+	}
+	idx := int(math.Ceil(percentile*float64(len(values)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(values) {
+		idx = len(values) - 1
+	}
+	return values[idx]
 }

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -18,6 +18,8 @@ type SummaryReport struct {
 	P95            time.Duration            `json:"p95"`
 	P99            time.Duration            `json:"p99"`
 	Max            time.Duration            `json:"max"`
+	Avg            time.Duration            `json:"avg"`
+	QPS            float64                  `json:"qps"`
 	AssertionStats map[string]AssertionStat `json:"assertion_stats"`
 }
 
@@ -59,6 +61,18 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 		b.WriteString("\n## Executions\n\n")
 		for _, execution := range result.Executions {
 			b.WriteString(fmt.Sprintf("- `%s`: count=%d total=%d duration=%s offset=%d\n", execution.Name, execution.ResultCount, execution.TotalRecords, execution.Duration, execution.Offset))
+		}
+	}
+	if len(summary.AssertionStats) > 0 {
+		b.WriteString("\n## Assertions\n\n")
+		keys := make([]string, 0, len(summary.AssertionStats))
+		for key := range summary.AssertionStats {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			stat := summary.AssertionStats[key]
+			b.WriteString(fmt.Sprintf("- `%s`: passed=%d failed=%d\n", key, stat.Passed, stat.Failed))
 		}
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
@@ -111,6 +125,14 @@ func SummarizeRunResult(result *RunResult) SummaryReport {
 	summary.P95 = percentileDuration(durations, 0.95)
 	summary.P99 = percentileDuration(durations, 0.99)
 	summary.Max = durations[len(durations)-1]
+	var total time.Duration
+	for _, duration := range durations {
+		total += duration
+	}
+	summary.Avg = total / time.Duration(len(durations))
+	if total > 0 {
+		summary.QPS = float64(len(durations)) / total.Seconds()
+	}
 	return summary
 }
 
@@ -126,4 +148,28 @@ func percentileDuration(values []time.Duration, percentile float64) time.Duratio
 		idx = len(values) - 1
 	}
 	return values[idx]
+}
+
+// FormatConsoleSummary returns a stable text summary for terminal output.
+func FormatConsoleSummary(result *RunResult) string {
+	if result == nil {
+		return "benchmark result: <nil>"
+	}
+	summary := SummarizeRunResult(result)
+	var b strings.Builder
+	b.WriteString("Benchmark Summary\n")
+	b.WriteString(fmt.Sprintf("scale=%s distribution=%s executions=%d\n", result.Generator.Scale, result.Generator.Distribution, summary.ExecutionCount))
+	b.WriteString(fmt.Sprintf("latency p50=%s p95=%s p99=%s max=%s avg=%s qps=%.2f\n", summary.P50, summary.P95, summary.P99, summary.Max, summary.Avg, summary.QPS))
+	if len(summary.AssertionStats) > 0 {
+		keys := make([]string, 0, len(summary.AssertionStats))
+		for key := range summary.AssertionStats {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			stat := summary.AssertionStats[key]
+			b.WriteString(fmt.Sprintf("assertion %s passed=%d failed=%d\n", key, stat.Passed, stat.Failed))
+		}
+	}
+	return b.String()
 }

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -1,0 +1,35 @@
+package benchmark
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriteReports(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "report.json")
+	mdPath := filepath.Join(dir, "report.md")
+	result := &RunResult{
+		Generator: GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
+		Executions: []WorkloadRunResult{{
+			Name:         "baseline-page-1",
+			ResultCount:  20,
+			TotalRecords: 100,
+			Duration:     10 * time.Millisecond,
+		}},
+	}
+	if err := WriteJSONReport(jsonPath, result); err != nil {
+		t.Fatalf("WriteJSONReport failed: %v", err)
+	}
+	if err := WriteMarkdownReport(mdPath, result); err != nil {
+		t.Fatalf("WriteMarkdownReport failed: %v", err)
+	}
+	if _, err := os.Stat(jsonPath); err != nil {
+		t.Fatalf("expected JSON report to exist: %v", err)
+	}
+	if _, err := os.Stat(mdPath); err != nil {
+		t.Fatalf("expected markdown report to exist: %v", err)
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -33,3 +33,29 @@ func TestWriteReports(t *testing.T) {
 		t.Fatalf("expected markdown report to exist: %v", err)
 	}
 }
+
+func TestWriteBaselineCaptureAndSummary(t *testing.T) {
+	dir := t.TempDir()
+	result := &RunResult{
+		Generator: GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
+		Executions: []WorkloadRunResult{
+			{Name: "q1", Duration: 10 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: true}}},
+			{Name: "q2", Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}}},
+		},
+	}
+	if err := WriteBaselineCapture(dir, result); err != nil {
+		t.Fatalf("WriteBaselineCapture failed: %v", err)
+	}
+	for _, name := range []string{"benchmark-result.json", "benchmark-result.md", "benchmark-summary.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("expected %s to exist: %v", name, err)
+		}
+	}
+	summary := SummarizeRunResult(result)
+	if summary.ExecutionCount != 2 {
+		t.Fatalf("unexpected execution count: %d", summary.ExecutionCount)
+	}
+	if summary.AssertionStats["a"].Passed != 1 || summary.AssertionStats["a"].Failed != 1 {
+		t.Fatalf("unexpected assertion stats: %+v", summary.AssertionStats["a"])
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -3,6 +3,7 @@ package benchmark
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -55,7 +56,28 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 	if summary.ExecutionCount != 2 {
 		t.Fatalf("unexpected execution count: %d", summary.ExecutionCount)
 	}
+	if summary.Avg <= 0 || summary.QPS <= 0 {
+		t.Fatalf("expected avg and qps to be populated: %+v", summary)
+	}
 	if summary.AssertionStats["a"].Passed != 1 || summary.AssertionStats["a"].Failed != 1 {
 		t.Fatalf("unexpected assertion stats: %+v", summary.AssertionStats["a"])
+	}
+}
+
+func TestFormatConsoleSummary(t *testing.T) {
+	result := &RunResult{
+		Generator: GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
+		Executions: []WorkloadRunResult{{
+			Name:       "q1",
+			Duration:   10 * time.Millisecond,
+			Assertions: []AssertionResult{{Name: "a", Passed: true}},
+		}},
+	}
+	formatted := FormatConsoleSummary(result)
+	if formatted == "" {
+		t.Fatalf("expected non-empty console summary")
+	}
+	if !strings.Contains(formatted, "Benchmark Summary") {
+		t.Fatalf("expected benchmark header in summary: %s", formatted)
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -24,16 +24,24 @@ type RunResult struct {
 
 // WorkloadRunResult captures one workload execution result.
 type WorkloadRunResult struct {
-	Name         string        `json:"name"`
-	Category     string        `json:"category"`
-	Distribution Distribution  `json:"distribution"`
-	PageSize     int           `json:"page_size"`
-	PageNumber   int           `json:"page_number"`
-	Offset       int           `json:"offset"`
-	ResultCount  int           `json:"result_count"`
-	TotalRecords int64         `json:"total_records"`
-	Duration     time.Duration `json:"duration"`
-	PlanNotes    []string      `json:"plan_notes,omitempty"`
+	Name         string            `json:"name"`
+	Category     string            `json:"category"`
+	Distribution Distribution      `json:"distribution"`
+	PageSize     int               `json:"page_size"`
+	PageNumber   int               `json:"page_number"`
+	Offset       int               `json:"offset"`
+	ResultCount  int               `json:"result_count"`
+	TotalRecords int64             `json:"total_records"`
+	Duration     time.Duration     `json:"duration"`
+	Assertions   []AssertionResult `json:"assertions,omitempty"`
+	PlanNotes    []string          `json:"plan_notes,omitempty"`
+}
+
+// AssertionResult captures one correctness assertion outcome.
+type AssertionResult struct {
+	Name    string `json:"name"`
+	Passed  bool   `json:"passed"`
+	Message string `json:"message,omitempty"`
 }
 
 // Runner validates benchmark inputs and prepares the phase-1 execution plan.
@@ -141,6 +149,7 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 		return nil, err
 	}
 	executions := make([]WorkloadRunResult, 0, len(r.workloads)*r.config.Iterations)
+	pageRuns := make(map[string]WorkloadRunResult)
 	for _, workload := range r.workloads {
 		if !workload.SupportsDistribution(r.genConfig.Distribution) {
 			continue
@@ -149,6 +158,13 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 			run, err := r.executeWorkload(ctx, h, workload)
 			if err != nil {
 				return nil, fmt.Errorf("execute workload %s: %w", workload.Name, err)
+			}
+			run.Assertions = append(run.Assertions, validateBasicWorkloadAssertions(workload, run)...)
+			if workload.Category == WorkloadCategoryPagination || workload.Category == WorkloadCategoryDeepPage {
+				if previous, ok := pageRuns[workload.TargetSchema]; ok {
+					run.Assertions = append(run.Assertions, validatePaginationTransition(previous, run)...)
+				}
+				pageRuns[workload.TargetSchema] = run
 			}
 			executions = append(executions, run)
 		}
@@ -216,4 +232,36 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 		run.PlanNotes = append([]string(nil), result.Plan.Notes...)
 	}
 	return run, nil
+}
+
+func validateBasicWorkloadAssertions(workload WorkloadDefinition, run WorkloadRunResult) []AssertionResult {
+	assertions := []AssertionResult{
+		{
+			Name:    "non-negative-total-records",
+			Passed:  run.TotalRecords >= 0,
+			Message: fmt.Sprintf("total_records=%d", run.TotalRecords),
+		},
+		{
+			Name:    "page-size-bound",
+			Passed:  run.ResultCount <= run.PageSize,
+			Message: fmt.Sprintf("result_count=%d page_size=%d", run.ResultCount, run.PageSize),
+		},
+	}
+	if workload.Category == WorkloadCategoryDeepPage {
+		assertions = append(assertions, AssertionResult{
+			Name:    "deep-page-empty-when-offset-exceeds-total",
+			Passed:  run.Offset < int(run.TotalRecords) || run.ResultCount == 0,
+			Message: fmt.Sprintf("offset=%d total=%d result_count=%d", run.Offset, run.TotalRecords, run.ResultCount),
+		})
+	}
+	return assertions
+}
+
+func validatePaginationTransition(previous, current WorkloadRunResult) []AssertionResult {
+	assertion := AssertionResult{
+		Name:    "non-decreasing-offsets-across-pagination-runs",
+		Passed:  current.Offset >= previous.Offset,
+		Message: fmt.Sprintf("previous_offset=%d current_offset=%d", previous.Offset, current.Offset),
+	}
+	return []AssertionResult{assertion}
 }

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -209,7 +209,7 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 	if pageSize <= 0 {
 		pageSize = r.config.PageSize
 	}
-	opts := &federated.QueryOptions{Limit: pageSize, Offset: workload.DerivedOffset(r.config.PageSize)}
+	opts := &federated.QueryOptions{Limit: pageSize, Offset: workload.DerivedOffset(r.config.PageSize), SortBy: "tradeTime", SortDesc: true}
 	if workload.UsesSimpleFilter() {
 		opts.Filter = &federated.Filter{Conditions: map[string]any{workload.FilterAttribute: workload.FilterValue}}
 	}

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	forma "github.com/lychee-technology/forma"
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
 )
 
 // RunResult captures the phase-1 scaffold output.
@@ -17,7 +18,22 @@ type RunResult struct {
 	ValidationOnly bool                 `json:"validation_only"`
 	Schemas        []SchemaFixture      `json:"schemas"`
 	Workloads      []WorkloadDefinition `json:"workloads"`
+	Executions     []WorkloadRunResult  `json:"executions,omitempty"`
 	Notes          []string             `json:"notes"`
+}
+
+// WorkloadRunResult captures one workload execution result.
+type WorkloadRunResult struct {
+	Name         string        `json:"name"`
+	Category     string        `json:"category"`
+	Distribution Distribution  `json:"distribution"`
+	PageSize     int           `json:"page_size"`
+	PageNumber   int           `json:"page_number"`
+	Offset       int           `json:"offset"`
+	ResultCount  int           `json:"result_count"`
+	TotalRecords int64         `json:"total_records"`
+	Duration     time.Duration `json:"duration"`
+	PlanNotes    []string      `json:"plan_notes,omitempty"`
 }
 
 // Runner validates benchmark inputs and prepares the phase-1 execution plan.
@@ -97,6 +113,65 @@ func (r *Runner) Run(ctx context.Context) (*RunResult, error) {
 	return result, nil
 }
 
+// RunWithHarness executes supported benchmark workloads against a live federated harness.
+func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestHarness, profile TierMixProfile) (*RunResult, error) {
+	if h == nil {
+		return nil, fmt.Errorf("federated harness cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	startedAt := time.Now()
+	if err := r.validateFixtures(); err != nil {
+		return nil, err
+	}
+	generator, err := NewGenerator(r.genConfig)
+	if err != nil {
+		return nil, err
+	}
+	dataset, err := generator.Generate()
+	if err != nil {
+		return nil, err
+	}
+	tiered, err := SplitIntoTiers(dataset, profile)
+	if err != nil {
+		return nil, err
+	}
+	if err := LoadTieredDataset(ctx, h, tiered); err != nil {
+		return nil, err
+	}
+	executions := make([]WorkloadRunResult, 0, len(r.workloads)*r.config.Iterations)
+	for _, workload := range r.workloads {
+		if !workload.SupportsDistribution(r.genConfig.Distribution) {
+			continue
+		}
+		for iteration := 0; iteration < r.config.Iterations; iteration++ {
+			run, err := r.executeWorkload(ctx, h, workload)
+			if err != nil {
+				return nil, fmt.Errorf("execute workload %s: %w", workload.Name, err)
+			}
+			executions = append(executions, run)
+		}
+	}
+	result := &RunResult{
+		Config:         r.config,
+		Generator:      r.genConfig,
+		StartedAt:      startedAt,
+		CompletedAt:    time.Now(),
+		ValidationOnly: false,
+		Schemas:        append([]SchemaFixture(nil), r.schemas...),
+		Workloads:      append([]WorkloadDefinition(nil), r.workloads...),
+		Executions:     executions,
+		Notes: []string{
+			"loaded TPC-E-inspired schema fixtures",
+			fmt.Sprintf("generated dataset with distribution=%s", r.genConfig.Distribution),
+			fmt.Sprintf("loaded tiered dataset profile=%s", profile.Name),
+			"executed supported federated query workloads",
+		},
+	}
+	return result, nil
+}
+
 func (r *Runner) validateFixtures() error {
 	for _, fixture := range r.schemas {
 		id, _, err := r.registry.GetSchemaAttributeCacheByName(fixture.Name)
@@ -111,4 +186,34 @@ func (r *Runner) validateFixtures() error {
 		}
 	}
 	return nil
+}
+
+func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition) (WorkloadRunResult, error) {
+	pageSize := workload.PageSize
+	if pageSize <= 0 {
+		pageSize = r.config.PageSize
+	}
+	opts := &federated.QueryOptions{Limit: pageSize, Offset: workload.DerivedOffset(r.config.PageSize)}
+	if workload.UsesSimpleFilter() {
+		opts.Filter = &federated.Filter{Conditions: map[string]any{workload.FilterAttribute: workload.FilterValue}}
+	}
+	result, err := h.ExecuteFederatedQuery(ctx, opts)
+	if err != nil {
+		return WorkloadRunResult{}, err
+	}
+	run := WorkloadRunResult{
+		Name:         workload.Name,
+		Category:     string(workload.Category),
+		Distribution: r.genConfig.Distribution,
+		PageSize:     pageSize,
+		PageNumber:   workload.PageNumber,
+		Offset:       opts.Offset,
+		ResultCount:  len(result.Records),
+		TotalRecords: result.TotalRecords,
+		Duration:     result.Duration,
+	}
+	if result.Plan != nil {
+		run.PlanNotes = append([]string(nil), result.Plan.Notes...)
+	}
+	return run, nil
 }

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	forma "github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal"
 	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
 )
 
@@ -33,6 +34,7 @@ type WorkloadRunResult struct {
 	ResultCount  int               `json:"result_count"`
 	TotalRecords int64             `json:"total_records"`
 	Duration     time.Duration     `json:"duration"`
+	RowIDs       []string          `json:"row_ids,omitempty"`
 	Assertions   []AssertionResult `json:"assertions,omitempty"`
 	PlanNotes    []string          `json:"plan_notes,omitempty"`
 }
@@ -155,11 +157,12 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 			continue
 		}
 		for iteration := 0; iteration < r.config.Iterations; iteration++ {
-			run, err := r.executeWorkload(ctx, h, workload)
+			run, records, err := r.executeWorkload(ctx, h, workload)
 			if err != nil {
 				return nil, fmt.Errorf("execute workload %s: %w", workload.Name, err)
 			}
 			run.Assertions = append(run.Assertions, validateBasicWorkloadAssertions(workload, run)...)
+			run.Assertions = append(run.Assertions, validateResultLevelAssertions(workload, run, records)...)
 			if workload.Category == WorkloadCategoryPagination || workload.Category == WorkloadCategoryDeepPage {
 				if previous, ok := pageRuns[workload.TargetSchema]; ok {
 					run.Assertions = append(run.Assertions, validatePaginationTransition(previous, run)...)
@@ -204,7 +207,7 @@ func (r *Runner) validateFixtures() error {
 	return nil
 }
 
-func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition) (WorkloadRunResult, error) {
+func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition) (WorkloadRunResult, []*internal.PersistentRecord, error) {
 	pageSize := workload.PageSize
 	if pageSize <= 0 {
 		pageSize = r.config.PageSize
@@ -215,7 +218,7 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 	}
 	result, err := h.ExecuteFederatedQuery(ctx, opts)
 	if err != nil {
-		return WorkloadRunResult{}, err
+		return WorkloadRunResult{}, nil, err
 	}
 	run := WorkloadRunResult{
 		Name:         workload.Name,
@@ -227,11 +230,12 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 		ResultCount:  len(result.Records),
 		TotalRecords: result.TotalRecords,
 		Duration:     result.Duration,
+		RowIDs:       persistentRecordIDs(result.Records),
 	}
 	if result.Plan != nil {
 		run.PlanNotes = append([]string(nil), result.Plan.Notes...)
 	}
-	return run, nil
+	return run, result.Records, nil
 }
 
 func validateBasicWorkloadAssertions(workload WorkloadDefinition, run WorkloadRunResult) []AssertionResult {
@@ -258,10 +262,103 @@ func validateBasicWorkloadAssertions(workload WorkloadDefinition, run WorkloadRu
 }
 
 func validatePaginationTransition(previous, current WorkloadRunResult) []AssertionResult {
-	assertion := AssertionResult{
+	assertions := []AssertionResult{{
 		Name:    "non-decreasing-offsets-across-pagination-runs",
 		Passed:  current.Offset >= previous.Offset,
 		Message: fmt.Sprintf("previous_offset=%d current_offset=%d", previous.Offset, current.Offset),
+	}}
+	if current.Offset > previous.Offset {
+		overlap := hasRowIDOverlap(previous.RowIDs, current.RowIDs)
+		assertions = append(assertions, AssertionResult{
+			Name:    "no-overlap-across-page-slices",
+			Passed:  !overlap,
+			Message: fmt.Sprintf("previous_rows=%d current_rows=%d", len(previous.RowIDs), len(current.RowIDs)),
+		})
 	}
-	return []AssertionResult{assertion}
+	return assertions
+}
+
+func validateResultLevelAssertions(workload WorkloadDefinition, run WorkloadRunResult, records []*internal.PersistentRecord) []AssertionResult {
+	assertions := []AssertionResult{validateUniqueRows(run)}
+	if workload.UsesSimpleFilter() {
+		assertions = append(assertions, validateFilterMatch(workload, records))
+	}
+	if len(records) > 1 {
+		assertions = append(assertions, validateSortOrder(records, "tradeTime", true))
+	}
+	return assertions
+}
+
+func validateUniqueRows(run WorkloadRunResult) AssertionResult {
+	seen := make(map[string]struct{}, len(run.RowIDs))
+	for _, rowID := range run.RowIDs {
+		if _, ok := seen[rowID]; ok {
+			return AssertionResult{Name: "unique-row-ids-within-page", Passed: false, Message: rowID}
+		}
+		seen[rowID] = struct{}{}
+	}
+	return AssertionResult{Name: "unique-row-ids-within-page", Passed: true, Message: fmt.Sprintf("rows=%d", len(run.RowIDs))}
+}
+
+func validateFilterMatch(workload WorkloadDefinition, records []*internal.PersistentRecord) AssertionResult {
+	for _, record := range records {
+		if !recordMatchesFilter(record, workload.FilterAttribute, workload.FilterValue) {
+			return AssertionResult{Name: "filter-results-match-request", Passed: false, Message: fmt.Sprintf("attribute=%s expected=%s row=%s", workload.FilterAttribute, workload.FilterValue, record.RowID)}
+		}
+	}
+	return AssertionResult{Name: "filter-results-match-request", Passed: true, Message: fmt.Sprintf("attribute=%s expected=%s", workload.FilterAttribute, workload.FilterValue)}
+}
+
+func validateSortOrder(records []*internal.PersistentRecord, attribute string, desc bool) AssertionResult {
+	values := make([]int64, 0, len(records))
+	for _, record := range records {
+		value, ok := record.Int64Items[attribute]
+		if !ok {
+			continue
+		}
+		values = append(values, value)
+	}
+	if len(values) <= 1 {
+		return AssertionResult{Name: "sorted-by-tradeTime-desc", Passed: true, Message: "insufficient comparable rows"}
+	}
+	if desc {
+		for i := 1; i < len(values); i++ {
+			if values[i] > values[i-1] {
+				return AssertionResult{Name: "sorted-by-tradeTime-desc", Passed: false, Message: fmt.Sprintf("index=%d prev=%d curr=%d", i, values[i-1], values[i])}
+			}
+		}
+	}
+	return AssertionResult{Name: "sorted-by-tradeTime-desc", Passed: true, Message: fmt.Sprintf("comparable_rows=%d", len(values))}
+}
+
+func recordMatchesFilter(record *internal.PersistentRecord, attribute, expected string) bool {
+	switch attribute {
+	case "symbol", "exchange", "region", "name":
+		return record.TextItems[attribute] == expected
+	case "tradeType":
+		return fmt.Sprintf("%d", record.Int64Items[attribute]) == expected
+	default:
+		return true
+	}
+}
+
+func persistentRecordIDs(records []*internal.PersistentRecord) []string {
+	ids := make([]string, 0, len(records))
+	for _, record := range records {
+		ids = append(ids, record.RowID.String())
+	}
+	return ids
+}
+
+func hasRowIDOverlap(a, b []string) bool {
+	seen := make(map[string]struct{}, len(a))
+	for _, rowID := range a {
+		seen[rowID] = struct{}{}
+	}
+	for _, rowID := range b {
+		if _, ok := seen[rowID]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/e2e_harness/federated/benchmark/tier.go
+++ b/internal/e2e_harness/federated/benchmark/tier.go
@@ -132,24 +132,27 @@ func LoadTieredDataset(ctx context.Context, loader TierLoader, dataset *TieredDa
 	if err := loader.ClearAllData(ctx); err != nil {
 		return fmt.Errorf("clear existing data: %w", err)
 	}
+	baseBySchema := groupRecordsBySchema(dataset.Base)
+	deltaBySchema := groupRecordsBySchema(dataset.Delta)
+	hotBySchema := groupRecordsBySchema(dataset.Hot)
 	for _, fixture := range DefaultSchemaFixtures() {
 		if err := loader.SetupSchema(fixture.ID, fixture.Name); err != nil {
 			return fmt.Errorf("setup schema %s: %w", fixture.Name, err)
 		}
-	}
-	if len(dataset.Base) > 0 {
-		if err := loader.WriteParquet(ctx, "base", "benchmark_base.parquet", ToTestRecords(dataset.Base)); err != nil {
-			return fmt.Errorf("write base parquet: %w", err)
+		if records := baseBySchema[fixture.ID]; len(records) > 0 {
+			if err := loader.WriteParquet(ctx, "base", fmt.Sprintf("benchmark_base_%s.parquet", fixture.Name), ToTestRecords(records)); err != nil {
+				return fmt.Errorf("write base parquet for %s: %w", fixture.Name, err)
+			}
 		}
-	}
-	if len(dataset.Delta) > 0 {
-		if err := loader.WriteParquet(ctx, "delta", "benchmark_delta.parquet", ToTestRecords(dataset.Delta)); err != nil {
-			return fmt.Errorf("write delta parquet: %w", err)
+		if records := deltaBySchema[fixture.ID]; len(records) > 0 {
+			if err := loader.WriteParquet(ctx, "delta", fmt.Sprintf("benchmark_delta_%s.parquet", fixture.Name), ToTestRecords(records)); err != nil {
+				return fmt.Errorf("write delta parquet for %s: %w", fixture.Name, err)
+			}
 		}
-	}
-	if len(dataset.Hot) > 0 {
-		if err := loader.SeedHotRecordsWithData(ctx, ToTestRecords(dataset.Hot)); err != nil {
-			return fmt.Errorf("seed hot records: %w", err)
+		if records := hotBySchema[fixture.ID]; len(records) > 0 {
+			if err := loader.SeedHotRecordsWithData(ctx, ToTestRecords(records)); err != nil {
+				return fmt.Errorf("seed hot records for %s: %w", fixture.Name, err)
+			}
 		}
 	}
 	return nil
@@ -232,4 +235,12 @@ func benchmarkDisplayName(record GeneratedRecord) string {
 	default:
 		return record.SchemaName
 	}
+}
+
+func groupRecordsBySchema(records []GeneratedRecord) map[int16][]GeneratedRecord {
+	out := make(map[int16][]GeneratedRecord)
+	for _, record := range records {
+		out[record.SchemaID] = append(out[record.SchemaID], cloneGeneratedRecord(record))
+	}
+	return out
 }

--- a/internal/e2e_harness/federated/benchmark/tier_test.go
+++ b/internal/e2e_harness/federated/benchmark/tier_test.go
@@ -67,7 +67,10 @@ func TestLoadTieredDatasetUsesLoader(t *testing.T) {
 		t.Fatalf("expected fixture schemas to be registered")
 	}
 	if len(loader.baseWrites) != 1 || len(loader.deltaWrites) != 1 || len(loader.hotWrites) != 1 {
-		t.Fatalf("expected one write per tier")
+		t.Fatalf("expected one write per tier bucket")
+	}
+	if loader.baseWrites[0][0].SchemaID != SchemaIDCustomer {
+		t.Fatalf("expected base write to stay schema-scoped")
 	}
 }
 

--- a/internal/e2e_harness/federated/benchmark/workload.go
+++ b/internal/e2e_harness/federated/benchmark/workload.go
@@ -1,6 +1,9 @@
 package benchmark
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // WorkloadCategory groups benchmark workloads by intent.
 type WorkloadCategory string
@@ -18,6 +21,8 @@ type WorkloadDefinition struct {
 	Description            string           `json:"description"`
 	Category               WorkloadCategory `json:"category"`
 	TargetSchema           string           `json:"target_schema"`
+	FilterAttribute        string           `json:"filter_attribute,omitempty"`
+	FilterValue            string           `json:"filter_value,omitempty"`
 	PageSize               int              `json:"page_size"`
 	PageNumber             int              `json:"page_number"`
 	SupportsDistributions  []Distribution   `json:"supports_distributions"`
@@ -45,6 +50,8 @@ func DefaultWorkloads() []WorkloadDefinition {
 			Description:            "High-selectivity hot-column filter with pagination on trade rows.",
 			Category:               WorkloadCategoryFilter,
 			TargetSchema:           "trade",
+			FilterAttribute:        "symbol",
+			FilterValue:            "SYM00001",
 			PageSize:               20,
 			PageNumber:             1,
 			SupportsDistributions:  allDistributions(),
@@ -55,6 +62,8 @@ func DefaultWorkloads() []WorkloadDefinition {
 			Description:            "EAV-backed filter with paginated trade results.",
 			Category:               WorkloadCategoryFilter,
 			TargetSchema:           "trade",
+			FilterAttribute:        "exchange",
+			FilterValue:            "NYSE",
 			PageSize:               20,
 			PageNumber:             1,
 			SupportsDistributions:  allDistributions(),
@@ -94,6 +103,34 @@ func DefaultWorkloads() []WorkloadDefinition {
 			Phase1ExecutionStubbed: true,
 		},
 	}
+}
+
+// SupportsDistribution reports whether a workload can run for a distribution.
+func (w WorkloadDefinition) SupportsDistribution(dist Distribution) bool {
+	for _, supported := range w.SupportsDistributions {
+		if supported == dist {
+			return true
+		}
+	}
+	return false
+}
+
+// DerivedOffset returns the offset implied by page size and page number.
+func (w WorkloadDefinition) DerivedOffset(defaultPageSize int) int {
+	pageSize := w.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	pageNumber := w.PageNumber
+	if pageNumber <= 1 {
+		return 0
+	}
+	return (pageNumber - 1) * pageSize
+}
+
+// UsesSimpleFilter reports whether the workload is representable via the current harness filter model.
+func (w WorkloadDefinition) UsesSimpleFilter() bool {
+	return strings.TrimSpace(w.FilterAttribute) != ""
 }
 
 // DefaultWorkloadNames returns the full phase-1 workload set.

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -35,6 +35,7 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 		Workloads: []string{
 			"baseline-page-1",
 			"deep-page-1000",
+			"deep-page-100000",
 		},
 	}.WithDefaults())
 	require.NoError(t, err)
@@ -42,10 +43,14 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	result, err := runner.RunWithHarness(ctx, h, bench.TierMixBalanced)
 	require.NoError(t, err)
 	require.False(t, result.ValidationOnly)
-	require.Len(t, result.Executions, 2)
+	require.Len(t, result.Executions, 3)
 	for _, execution := range result.Executions {
 		require.NotEmpty(t, execution.Name)
 		require.GreaterOrEqual(t, execution.ResultCount, 0)
 		require.GreaterOrEqual(t, execution.TotalRecords, int64(0))
+		require.NotEmpty(t, execution.Assertions)
+		for _, assertion := range execution.Assertions {
+			require.True(t, assertion.Passed, assertion.Name+": "+assertion.Message)
+		}
 	}
 }

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -34,6 +34,7 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 		DeleteRatio:   0.05,
 		Workloads: []string{
 			"baseline-page-1",
+			"hot-selective-page",
 			"deep-page-1000",
 			"deep-page-100000",
 		},
@@ -43,14 +44,19 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	result, err := runner.RunWithHarness(ctx, h, bench.TierMixBalanced)
 	require.NoError(t, err)
 	require.False(t, result.ValidationOnly)
-	require.Len(t, result.Executions, 3)
+	require.Len(t, result.Executions, 4)
+	filteredSeen := false
 	for _, execution := range result.Executions {
 		require.NotEmpty(t, execution.Name)
 		require.GreaterOrEqual(t, execution.ResultCount, 0)
 		require.GreaterOrEqual(t, execution.TotalRecords, int64(0))
 		require.NotEmpty(t, execution.Assertions)
+		if execution.Name == "hot-selective-page" {
+			filteredSeen = true
+		}
 		for _, assertion := range execution.Assertions {
 			require.True(t, assertion.Passed, assertion.Name+": "+assertion.Message)
 		}
 	}
+	require.True(t, filteredSeen)
 }

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -1,0 +1,51 @@
+//go:build e2e
+
+package federated_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
+	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	h, err := federated.NewFederatedTestHarness(ctx)
+	require.NoError(t, err)
+	defer h.Cleanup(ctx)
+
+	runner, err := bench.NewRunner(bench.Config{
+		Mode:          bench.ExecutionModePlan,
+		Scale:         bench.ScaleSmall,
+		Distribution:  bench.DistributionHotspot,
+		Iterations:    1,
+		PageSize:      20,
+		Seed:          42,
+		TradeCount:    120,
+		CustomerCount: 12,
+		SecurityCount: 6,
+		OverlapRatio:  0.10,
+		DeleteRatio:   0.05,
+		Workloads: []string{
+			"baseline-page-1",
+			"deep-page-1000",
+		},
+	}.WithDefaults())
+	require.NoError(t, err)
+
+	result, err := runner.RunWithHarness(ctx, h, bench.TierMixBalanced)
+	require.NoError(t, err)
+	require.False(t, result.ValidationOnly)
+	require.Len(t, result.Executions, 2)
+	for _, execution := range result.Executions {
+		require.NotEmpty(t, execution.Name)
+		require.GreaterOrEqual(t, execution.ResultCount, 0)
+		require.GreaterOrEqual(t, execution.TotalRecords, int64(0))
+	}
+}

--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -15,6 +15,7 @@ import (
 func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *QueryOptions) (*QueryResult, error) {
 	opts = normalizeQueryOptions(opts)
 	start := time.Now()
+	benchmarkProjection := usesBenchmarkProjection(opts)
 
 	// Check which tiers have parquet files
 	hasBaseFiles, hasDeltaFiles, err := h.checkTierFiles(ctx)
@@ -50,7 +51,7 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 	}
 	defer rows.Close()
 
-	records, err := h.scanQueryResults(rows)
+	records, err := h.scanQueryResults(rows, benchmarkProjection)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +92,7 @@ func (h *FederatedTestHarness) checkTierFiles(ctx context.Context) (hasBase, has
 }
 
 // scanQueryResults scans DuckDB query rows into PersistentRecords.
-func (h *FederatedTestHarness) scanQueryResults(rows *sql.Rows) ([]*internal.PersistentRecord, error) {
+func (h *FederatedTestHarness) scanQueryResults(rows *sql.Rows, benchmarkProjection bool) ([]*internal.PersistentRecord, error) {
 	var records []*internal.PersistentRecord
 	for rows.Next() {
 		var rowID string
@@ -102,8 +103,14 @@ func (h *FederatedTestHarness) scanQueryResults(rows *sql.Rows) ([]*internal.Per
 		var symbol, exchange, region sql.NullString
 		var tradeType, tradeTime sql.NullInt64
 
-		if err := rows.Scan(&rowID, &schemaID, &changedAt, &deletedAt, &name, &version, &symbol, &exchange, &region, &tradeType, &tradeTime); err != nil {
-			return nil, fmt.Errorf("scan row: %w", err)
+		if benchmarkProjection {
+			if err := rows.Scan(&rowID, &schemaID, &changedAt, &deletedAt, &name, &version, &symbol, &exchange, &region, &tradeType, &tradeTime); err != nil {
+				return nil, fmt.Errorf("scan row: %w", err)
+			}
+		} else {
+			if err := rows.Scan(&rowID, &schemaID, &changedAt, &deletedAt, &name, &version); err != nil {
+				return nil, fmt.Errorf("scan row: %w", err)
+			}
 		}
 
 		rec := &internal.PersistentRecord{
@@ -120,19 +127,21 @@ func (h *FederatedTestHarness) scanQueryResults(rows *sql.Rows) ([]*internal.Per
 		if name.Valid {
 			rec.TextItems["name"] = name.String
 		}
-		if symbol.Valid {
-			rec.TextItems["symbol"] = symbol.String
-		}
-		if exchange.Valid {
-			rec.TextItems["exchange"] = exchange.String
-		}
-		if region.Valid {
-			rec.TextItems["region"] = region.String
+		if benchmarkProjection {
+			if symbol.Valid {
+				rec.TextItems["symbol"] = symbol.String
+			}
+			if exchange.Valid {
+				rec.TextItems["exchange"] = exchange.String
+			}
+			if region.Valid {
+				rec.TextItems["region"] = region.String
+			}
 		}
 		if version.Valid {
 			rec.Float64Items["version"] = float64(version.Int64)
 		}
-		if tradeType.Valid || tradeTime.Valid {
+		if benchmarkProjection && (tradeType.Valid || tradeTime.Valid) {
 			rec.Int64Items = make(map[string]int64)
 			if tradeType.Valid {
 				rec.Int64Items["tradeType"] = tradeType.Int64
@@ -171,31 +180,50 @@ func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath
 	dirtyExclusion := buildDirtyExclusion(dirtyIDs)
 	rowIDFilter := buildRowIDFilter(opts)
 	attributeFilter := buildAttributeFilterClause(opts)
+	benchmarkProjection := usesBenchmarkProjection(opts)
 	pgConnStr := h.buildPGConnString()
 
 	// Build tier queries dynamically
 	var tierQueries []string
 
 	if hasBase {
-		baseQuery := fmt.Sprintf(`
-			SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, epoch_ms(tradeTime) as tradeTime, 'base' as tier
-			FROM read_parquet('%s')
-			WHERE deleted_at = 0 %s %s %s`,
-			basePath, dirtyExclusion, rowIDFilter, attributeFilter)
+		baseQuery := buildParquetTierQuery(basePath, "base", dirtyExclusion, rowIDFilter, attributeFilter, benchmarkProjection)
 		tierQueries = append(tierQueries, baseQuery)
 	}
 
 	if hasDelta {
-		deltaQuery := fmt.Sprintf(`
-			SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, epoch_ms(tradeTime) as tradeTime, 'delta' as tier
-			FROM read_parquet('%s')
-			WHERE deleted_at = 0 %s %s %s`,
-			deltaPath, dirtyExclusion, rowIDFilter, attributeFilter)
+		deltaQuery := buildParquetTierQuery(deltaPath, "delta", dirtyExclusion, rowIDFilter, attributeFilter, benchmarkProjection)
 		tierQueries = append(tierQueries, deltaQuery)
 	}
 
 	// Always include hot buffer (Postgres)
-	hotQuery := fmt.Sprintf(`
+	hotQuery := buildHotTierQuery(pgConnStr, h.SchemaID, rowIDFilter, attributeFilter, benchmarkProjection)
+	tierQueries = append(tierQueries, hotQuery)
+
+	// Combine all tier queries with UNION ALL
+	combinedQuery := strings.Join(tierQueries, "\n\t\t\tUNION ALL\n")
+
+	query := buildFinalFederatedSelect(combinedQuery, opts, benchmarkProjection)
+
+	return query
+}
+
+func buildParquetTierQuery(path, tier, dirtyExclusion, rowIDFilter, attributeFilter string, benchmarkProjection bool) string {
+	if benchmarkProjection {
+		return fmt.Sprintf(`
+			SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, epoch_ms(tradeTime) as tradeTime, '%s' as tier
+			FROM read_parquet('%s')
+			WHERE deleted_at = 0 %s %s %s`, tier, path, dirtyExclusion, rowIDFilter, attributeFilter)
+	}
+	return fmt.Sprintf(`
+			SELECT row_id, schema_id, changed_at, deleted_at, name, version, '%s' as tier
+			FROM read_parquet('%s')
+			WHERE deleted_at = 0 %s %s`, tier, path, dirtyExclusion, rowIDFilter)
+}
+
+func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeFilter string, benchmarkProjection bool) string {
+	if benchmarkProjection {
+		return fmt.Sprintf(`
 		SELECT 
 			cl.row_id::VARCHAR as row_id,
 			cl.schema_id,
@@ -216,14 +244,27 @@ func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath
 			AND cl.schema_id = %d
 			AND (cl.deleted_at = 0 OR cl.deleted_at IS NULL)
 			%s
-			%s`,
-		pgConnStr, pgConnStr, h.SchemaID, rowIDFilter, attributeFilter)
-	tierQueries = append(tierQueries, hotQuery)
+			%s`, pgConnStr, pgConnStr, schemaID, rowIDFilter, attributeFilter)
+	}
+	return fmt.Sprintf(`
+		SELECT 
+			cl.row_id::VARCHAR as row_id,
+			cl.schema_id,
+			cl.changed_at,
+			cl.deleted_at,
+			'' as name,
+			0 as version,
+			'hot' as tier
+		FROM postgres_scan('%s', 'public', 'change_log') cl
+		WHERE cl.flushed_at = 0 
+			AND cl.schema_id = %d
+			AND (cl.deleted_at = 0 OR cl.deleted_at IS NULL)
+			%s`, pgConnStr, schemaID, rowIDFilter)
+}
 
-	// Combine all tier queries with UNION ALL
-	combinedQuery := strings.Join(tierQueries, "\n\t\t\tUNION ALL\n")
-
-	query := fmt.Sprintf(`
+func buildFinalFederatedSelect(combinedQuery string, opts *QueryOptions, benchmarkProjection bool) string {
+	if benchmarkProjection {
+		return fmt.Sprintf(`
 		WITH combined AS (
 			%s
 		),
@@ -237,8 +278,39 @@ func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath
 		ORDER BY %s
 		LIMIT %d OFFSET %d
 	`, combinedQuery, buildOrderByClause(opts), opts.Limit, opts.Offset)
+	}
+	return fmt.Sprintf(`
+		WITH combined AS (
+			%s
+		),
+		deduplicated AS (
+			SELECT *, ROW_NUMBER() OVER (PARTITION BY row_id ORDER BY changed_at DESC) as rn
+			FROM combined
+		)
+		SELECT row_id, schema_id, changed_at, deleted_at, name, version
+		FROM deduplicated
+		WHERE rn = 1
+		ORDER BY row_id
+		LIMIT %d OFFSET %d
+	`, combinedQuery, opts.Limit, opts.Offset)
+}
 
-	return query
+func usesBenchmarkProjection(opts *QueryOptions) bool {
+	if opts == nil {
+		return false
+	}
+	if opts.SortBy != "" && opts.SortBy != "row_id" {
+		return true
+	}
+	if opts.Filter == nil {
+		return false
+	}
+	for key := range opts.Filter.Conditions {
+		if benchmarkQueryColumn(key) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // buildDirtyExclusion builds the dirty ID exclusion clause.

--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -99,8 +99,10 @@ func (h *FederatedTestHarness) scanQueryResults(rows *sql.Rows) ([]*internal.Per
 		var changedAt, deletedAt int64
 		var name sql.NullString
 		var version sql.NullInt64
+		var symbol, exchange, region sql.NullString
+		var tradeType, tradeTime sql.NullInt64
 
-		if err := rows.Scan(&rowID, &schemaID, &changedAt, &deletedAt, &name, &version); err != nil {
+		if err := rows.Scan(&rowID, &schemaID, &changedAt, &deletedAt, &name, &version, &symbol, &exchange, &region, &tradeType, &tradeTime); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 
@@ -118,8 +120,26 @@ func (h *FederatedTestHarness) scanQueryResults(rows *sql.Rows) ([]*internal.Per
 		if name.Valid {
 			rec.TextItems["name"] = name.String
 		}
+		if symbol.Valid {
+			rec.TextItems["symbol"] = symbol.String
+		}
+		if exchange.Valid {
+			rec.TextItems["exchange"] = exchange.String
+		}
+		if region.Valid {
+			rec.TextItems["region"] = region.String
+		}
 		if version.Valid {
 			rec.Float64Items["version"] = float64(version.Int64)
+		}
+		if tradeType.Valid || tradeTime.Valid {
+			rec.Int64Items = make(map[string]int64)
+			if tradeType.Valid {
+				rec.Int64Items["tradeType"] = tradeType.Int64
+			}
+			if tradeTime.Valid {
+				rec.Int64Items["tradeTime"] = tradeTime.Int64
+			}
 		}
 
 		records = append(records, rec)
@@ -150,6 +170,7 @@ func buildExecutionPlan(dirtyIDCount int, hasBase, hasDelta bool, duration time.
 func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions) string {
 	dirtyExclusion := buildDirtyExclusion(dirtyIDs)
 	rowIDFilter := buildRowIDFilter(opts)
+	attributeFilter := buildAttributeFilterClause(opts)
 	pgConnStr := h.buildPGConnString()
 
 	// Build tier queries dynamically
@@ -157,19 +178,19 @@ func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath
 
 	if hasBase {
 		baseQuery := fmt.Sprintf(`
-			SELECT row_id, schema_id, changed_at, deleted_at, name, version, 'base' as tier
+			SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, epoch_ms(tradeTime) as tradeTime, 'base' as tier
 			FROM read_parquet('%s')
-			WHERE deleted_at = 0 %s %s`,
-			basePath, dirtyExclusion, rowIDFilter)
+			WHERE deleted_at = 0 %s %s %s`,
+			basePath, dirtyExclusion, rowIDFilter, attributeFilter)
 		tierQueries = append(tierQueries, baseQuery)
 	}
 
 	if hasDelta {
 		deltaQuery := fmt.Sprintf(`
-			SELECT row_id, schema_id, changed_at, deleted_at, name, version, 'delta' as tier
+			SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, epoch_ms(tradeTime) as tradeTime, 'delta' as tier
 			FROM read_parquet('%s')
-			WHERE deleted_at = 0 %s %s`,
-			deltaPath, dirtyExclusion, rowIDFilter)
+			WHERE deleted_at = 0 %s %s %s`,
+			deltaPath, dirtyExclusion, rowIDFilter, attributeFilter)
 		tierQueries = append(tierQueries, deltaQuery)
 	}
 
@@ -180,15 +201,23 @@ func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath
 			cl.schema_id,
 			cl.changed_at,
 			cl.deleted_at,
-			'' as name,
+			COALESCE(em.text_01, '') as name,
 			0 as version,
+			COALESCE(em.text_01, '') as symbol,
+			'' as exchange,
+			COALESCE(em.text_02, '') as region,
+			COALESCE(em.smallint_01, 0) as tradeType,
+			COALESCE(em.bigint_02, 0) as tradeTime,
 			'hot' as tier
 		FROM postgres_scan('%s', 'public', 'change_log') cl
+		LEFT JOIN postgres_scan('%s', 'public', 'entity_main') em
+			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id::VARCHAR = cl.row_id::VARCHAR
 		WHERE cl.flushed_at = 0 
 			AND cl.schema_id = %d
 			AND (cl.deleted_at = 0 OR cl.deleted_at IS NULL)
+			%s
 			%s`,
-		pgConnStr, h.SchemaID, rowIDFilter)
+		pgConnStr, pgConnStr, h.SchemaID, rowIDFilter, attributeFilter)
 	tierQueries = append(tierQueries, hotQuery)
 
 	// Combine all tier queries with UNION ALL
@@ -202,12 +231,12 @@ func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath
 			SELECT *, ROW_NUMBER() OVER (PARTITION BY row_id ORDER BY changed_at DESC) as rn
 			FROM combined
 		)
-		SELECT row_id, schema_id, changed_at, deleted_at, name, version
+		SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, tradeTime
 		FROM deduplicated
 		WHERE rn = 1
-		ORDER BY row_id
+		ORDER BY %s
 		LIMIT %d OFFSET %d
-	`, combinedQuery, opts.Limit, opts.Offset)
+	`, combinedQuery, buildOrderByClause(opts), opts.Limit, opts.Offset)
 
 	return query
 }
@@ -230,6 +259,68 @@ func buildRowIDFilter(opts *QueryOptions) string {
 		return fmt.Sprintf("AND row_id = '%s'", opts.Filter.RowID.String())
 	}
 	return ""
+}
+
+func buildAttributeFilterClause(opts *QueryOptions) string {
+	if opts == nil || opts.Filter == nil || len(opts.Filter.Conditions) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(opts.Filter.Conditions))
+	for key, value := range opts.Filter.Conditions {
+		column := benchmarkQueryColumn(key)
+		if column == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("AND %s = %s", column, benchmarkSQLLiteral(value)))
+	}
+	return strings.Join(parts, " ")
+}
+
+func benchmarkQueryColumn(attribute string) string {
+	switch attribute {
+	case "symbol":
+		return "symbol"
+	case "exchange":
+		return "exchange"
+	case "region":
+		return "region"
+	case "tradeType":
+		return "tradeType"
+	case "tradeTime":
+		return "tradeTime"
+	default:
+		return ""
+	}
+}
+
+func benchmarkSQLLiteral(value any) string {
+	switch v := value.(type) {
+	case string:
+		return fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''"))
+	case int:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	case float64:
+		return fmt.Sprintf("%v", v)
+	default:
+		return fmt.Sprintf("'%v'", v)
+	}
+}
+
+func buildOrderByClause(opts *QueryOptions) string {
+	if opts == nil {
+		return "row_id ASC"
+	}
+	column := benchmarkQueryColumn(opts.SortBy)
+	if column == "" {
+		column = "row_id"
+	}
+	direction := "ASC"
+	if opts.SortDesc {
+		direction = "DESC"
+	}
+	return fmt.Sprintf("%s %s, row_id ASC", column, direction)
 }
 
 // buildPGConnString builds the Postgres connection string for DuckDB.

--- a/internal/e2e_harness/federated/seeding.go
+++ b/internal/e2e_harness/federated/seeding.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"hash/fnv"
+	"sort"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -111,13 +114,25 @@ func (h *FederatedTestHarness) insertHotRecord(ctx context.Context, r TestRecord
 
 // insertEntityMain inserts a record into the entity_main table.
 func (h *FederatedTestHarness) insertEntityMain(ctx context.Context, r TestRecord) error {
+	text01, text02, smallint01, bigint01, bigint02, double01, uuid01 := benchmarkMainColumnValues(r)
 	_, err := h.PGDB.ExecContext(ctx, `
-		INSERT INTO entity_main (ltbase_schema_id, ltbase_row_id, ltbase_created_at, ltbase_updated_at, ltbase_deleted_at)
-		VALUES ($1, $2, $3, $4, $5)
+		INSERT INTO entity_main (
+			ltbase_schema_id, ltbase_row_id,
+			text_01, text_02, smallint_01, bigint_01, bigint_02, double_01, uuid_01,
+			ltbase_created_at, ltbase_updated_at, ltbase_deleted_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		ON CONFLICT (ltbase_schema_id, ltbase_row_id) DO UPDATE SET
-			ltbase_updated_at = $4,
-			ltbase_deleted_at = $5
-	`, r.SchemaID, r.RowID, r.ChangedAt, r.ChangedAt, sql.NullInt64{Int64: r.DeletedAt, Valid: r.DeletedAt > 0})
+			text_01 = $3,
+			text_02 = $4,
+			smallint_01 = $5,
+			bigint_01 = $6,
+			bigint_02 = $7,
+			double_01 = $8,
+			uuid_01 = $9,
+			ltbase_updated_at = $11,
+			ltbase_deleted_at = $12
+	`, r.SchemaID, r.RowID, text01, text02, smallint01, bigint01, bigint02, double01, uuid01, r.ChangedAt, r.ChangedAt, sql.NullInt64{Int64: r.DeletedAt, Valid: r.DeletedAt > 0})
 	if err != nil {
 		return fmt.Errorf("insert entity_main: %w", err)
 	}
@@ -126,8 +141,13 @@ func (h *FederatedTestHarness) insertEntityMain(ctx context.Context, r TestRecor
 
 // insertEAVData inserts attribute values into the eav_data table.
 func (h *FederatedTestHarness) insertEAVData(ctx context.Context, r TestRecord) error {
-	attrID := 1
-	for name, value := range r.Attributes {
+	keys := make([]string, 0, len(r.Attributes))
+	for name := range r.Attributes {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+	for _, name := range keys {
+		value := r.Attributes[name]
 		var valueText sql.NullString
 		var valueNumeric sql.NullFloat64
 
@@ -146,13 +166,100 @@ func (h *FederatedTestHarness) insertEAVData(ctx context.Context, r TestRecord) 
 			ON CONFLICT (schema_id, row_id, attr_id) DO UPDATE SET
 				value_text = $4,
 				value_numeric = $5
-		`, r.SchemaID, r.RowID, attrID, valueText, valueNumeric)
+		`, r.SchemaID, r.RowID, DeterministicAttributeID(r.SchemaID, name), valueText, valueNumeric)
 		if err != nil {
 			return fmt.Errorf("insert eav_data for %s: %w", name, err)
 		}
-		attrID++
 	}
 	return nil
+}
+
+// DeterministicAttributeID returns a stable test-only attribute ID for a schema/name pair.
+func DeterministicAttributeID(schemaID int16, name string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(strconv.FormatInt(int64(schemaID), 10)))
+	_, _ = h.Write([]byte{':'})
+	_, _ = h.Write([]byte(name))
+	return int(h.Sum32()%30000) + 1
+}
+
+func benchmarkMainColumnValues(r TestRecord) (sql.NullString, sql.NullString, sql.NullInt16, sql.NullInt64, sql.NullInt64, sql.NullFloat64, sql.NullString) {
+	attrs := r.Attributes
+	text01 := nullableString(firstNonNil(attrs, "taxId", "symbol"))
+	text02 := nullableString(firstNonNil(attrs, "region"))
+	smallint01 := nullableInt16(firstNonNil(attrs, "status", "sector", "tradeType"))
+	bigint01 := nullableInt64(firstNonNil(attrs, "quantity"))
+	bigint02 := nullableUnixMillis(firstNonNil(attrs, "tradeTime"))
+	double01 := nullableFloat64(firstNonNil(attrs, "price"))
+	uuid01 := nullableUUIDString(firstNonNil(attrs, "customerId"))
+	return text01, text02, smallint01, bigint01, bigint02, double01, uuid01
+}
+
+func firstNonNil(attrs map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := attrs[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func nullableString(value any) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: fmt.Sprint(value), Valid: true}
+}
+
+func nullableUUIDString(value any) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	parsed := fmt.Sprint(value)
+	if _, err := uuid.Parse(parsed); err != nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: parsed, Valid: true}
+}
+
+func nullableInt16(value any) sql.NullInt16 {
+	if value == nil {
+		return sql.NullInt16{}
+	}
+	return sql.NullInt16{Int16: int16(toFloat64(value)), Valid: true}
+}
+
+func nullableInt64(value any) sql.NullInt64 {
+	if value == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: int64(toFloat64(value)), Valid: true}
+}
+
+func nullableFloat64(value any) sql.NullFloat64 {
+	if value == nil {
+		return sql.NullFloat64{}
+	}
+	return sql.NullFloat64{Float64: toFloat64(value), Valid: true}
+}
+
+func nullableUnixMillis(value any) sql.NullInt64 {
+	if value == nil {
+		return sql.NullInt64{}
+	}
+	switch v := value.(type) {
+	case string:
+		if parsed, err := time.Parse(time.RFC3339, v); err == nil {
+			return sql.NullInt64{Int64: parsed.UnixMilli(), Valid: true}
+		}
+	case int64:
+		return sql.NullInt64{Int64: v, Valid: true}
+	case int:
+		return sql.NullInt64{Int64: int64(v), Valid: true}
+	case float64:
+		return sql.NullInt64{Int64: int64(v), Valid: true}
+	}
+	return sql.NullInt64{}
 }
 
 // insertChangeLog inserts a record into the change_log table.

--- a/internal/e2e_harness/federated/seeding_test.go
+++ b/internal/e2e_harness/federated/seeding_test.go
@@ -1,0 +1,15 @@
+package federated
+
+import "testing"
+
+func TestDeterministicAttributeIDStable(t *testing.T) {
+	first := DeterministicAttributeID(102, "symbol")
+	second := DeterministicAttributeID(102, "symbol")
+	if first != second {
+		t.Fatalf("expected deterministic attribute IDs to match")
+	}
+	third := DeterministicAttributeID(102, "price")
+	if first == third {
+		t.Fatalf("expected different attributes to hash differently")
+	}
+}


### PR DESCRIPTION
## Summary
- reapply the federated benchmark workload execution/reporting baseline on top of `main`
- add richer benchmark output formatting with console summaries, aggregated latency/QPS metrics, and assertion summaries
- add baseline capture guidance and stable artifact output paths for small and medium benchmark runs
- add a dedicated `benchmark baseline` CLI subcommand for repeatable preset captures

## Why
The benchmark is only useful if engineers can capture stable artifacts, compare runs across time, and quickly understand whether a run regressed on latency or correctness. This PR advances #38 by making the reporting and baseline capture flow easier to run and easier to consume.

## Included In This PR
- benchmark report formatting with `avg` and `qps`
- console summary output for `cmd/benchmark run`
- CLI support for `-json-out`, `-md-out`, and `-baseline-dir`
- `benchmark baseline` subcommand with `small` and `medium` presets
- baseline runbook for `small` and `medium`
- replay of the federated benchmark execution/reporting baseline that had previously only lived on the stacked branch

## Validation
- `go test ./cmd/benchmark ./internal/e2e_harness/federated/benchmark/... -run 'TestWriteReports|TestWriteBaselineCaptureAndSummary|TestFormatConsoleSummary|TestRunBenchmarkMainSmoke|TestRunBenchmarkMainBaseline'`
- `go run ./cmd/benchmark run -mode smoke -baseline-dir <tmpdir>`
- `go run ./cmd/benchmark baseline -preset small -output-dir <tmpdir>`

## Follow-ups
- continue #39 with CI/operator guidance once the reporting flow settles