### PR TITLE
add live benchmark runtime

### DIFF
--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -12,7 +12,37 @@ import (
 	"strings"
 	"syscall"
 
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
 	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
+)
+
+var (
+	newBenchmarkRunner = bench.NewRunner
+	runValidationMode  = func(ctx context.Context, runner *bench.Runner) (*bench.RunResult, error) {
+		return runner.Run(ctx)
+	}
+	runLiveMode = func(ctx context.Context, runner *bench.Runner, cfg bench.Config) (*bench.RunResult, error) {
+		profile, err := bench.ResolveTierMixProfile(cfg.TierProfile)
+		if err != nil {
+			return nil, err
+		}
+		h, err := federated.NewFederatedTestHarness(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("create federated harness: %w", err)
+		}
+		result, runErr := runner.RunWithHarness(ctx, h, profile)
+		cleanupErr := h.Cleanup(ctx)
+		if runErr != nil {
+			if cleanupErr != nil {
+				return nil, fmt.Errorf("%w; cleanup federated harness: %v", runErr, cleanupErr)
+			}
+			return nil, runErr
+		}
+		if cleanupErr != nil {
+			return nil, fmt.Errorf("cleanup federated harness: %w", cleanupErr)
+		}
+		return result, nil
+	}
 )
 
 func main() {
@@ -46,7 +76,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "Commands:")
 	fmt.Fprintln(out, "  describe   Print benchmark schemas, workloads, and defaults")
 	fmt.Fprintln(out, "  baseline   Capture a baseline artifact set for a preset")
-	fmt.Fprintln(out, "  run        Execute the scaffolded benchmark runner")
+	fmt.Fprintln(out, "  run        Execute benchmark validation or live runtime")
 }
 
 func runDescribe(out io.Writer) int {
@@ -105,12 +135,13 @@ type runOutputs struct {
 func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, int) {
 	flags := flag.NewFlagSet("run", flag.ContinueOnError)
 	flags.SetOutput(errOut)
-	mode := flags.String("mode", string(bench.ExecutionModeSmoke), "Execution mode: smoke or plan")
+	mode := flags.String("mode", string(bench.ExecutionModeSmoke), "Execution mode: smoke, plan, or live")
 	scale := flags.String("scale", string(bench.ScaleSmall), "Dataset scale: small, medium, or large")
 	distribution := flags.String("distribution", string(bench.DistributionUniform), "Data distribution preset")
 	iterations := flags.Int("iterations", 1, "Number of iterations to schedule")
 	concurrency := flags.Int("concurrency", 1, "Number of concurrent workers to schedule")
 	pageSize := flags.Int("page-size", 20, "Default page size for workload planning")
+	tierProfile := flags.String("tier-profile", bench.DefaultTierMixProfile().Name, "Tier mix profile: balanced, high-hot, long-history, or explicit profile name")
 	seed := flags.Int64("seed", 42, "Deterministic benchmark seed")
 	tradeCount := flags.Int("trade-count", 0, "Override generated trade row count")
 	customerCount := flags.Int("customer-count", 0, "Override generated customer row count")
@@ -132,6 +163,7 @@ func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, 
 		Concurrency:   *concurrency,
 		PageSize:      *pageSize,
 		Seed:          *seed,
+		TierProfile:   *tierProfile,
 		TradeCount:    *tradeCount,
 		CustomerCount: *customerCount,
 		SecurityCount: *securityCount,
@@ -144,12 +176,18 @@ func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, 
 }
 
 func executeBenchmarkRun(ctx context.Context, cfg bench.Config, outputs runOutputs, out, errOut io.Writer) int {
-	runner, err := bench.NewRunner(cfg)
+	runner, err := newBenchmarkRunner(cfg)
 	if err != nil {
 		fmt.Fprintf(errOut, "benchmark setup failed: %v\n", err)
 		return 1
 	}
-	result, err := runner.Run(ctx)
+	var result *bench.RunResult
+	switch cfg.Mode {
+	case bench.ExecutionModeLive:
+		result, err = runLiveMode(ctx, runner, cfg)
+	default:
+		result, err = runValidationMode(ctx, runner)
+	}
 	if err != nil {
 		fmt.Fprintf(errOut, "benchmark run failed: %v\n", err)
 		return 1

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
 )
 
 func TestRunBenchmarkMainDescribe(t *testing.T) {
@@ -51,5 +53,51 @@ func TestRunBenchmarkMainBaseline(t *testing.T) {
 		if _, err := os.Stat(matches[0]); err != nil {
 			t.Fatalf("expected baseline artifact %s to exist: %v", name, err)
 		}
+	}
+}
+
+func TestRunBenchmarkMainLiveUsesLiveExecutor(t *testing.T) {
+	originalLiveMode := runLiveMode
+	originalValidationMode := runValidationMode
+	defer func() {
+		runLiveMode = originalLiveMode
+		runValidationMode = originalValidationMode
+	}()
+
+	var liveCalled bool
+	runValidationMode = func(context.Context, *bench.Runner) (*bench.RunResult, error) {
+		t.Fatalf("validation mode should not be called for live execution")
+		return nil, nil
+	}
+	runLiveMode = func(_ context.Context, _ *bench.Runner, cfg bench.Config) (*bench.RunResult, error) {
+		liveCalled = true
+		if cfg.Mode != bench.ExecutionModeLive {
+			t.Fatalf("expected live mode config, got %q", cfg.Mode)
+		}
+		if cfg.TierProfile != "high-hot" {
+			t.Fatalf("expected tier profile override to be preserved, got %q", cfg.TierProfile)
+		}
+		return &bench.RunResult{
+			Config:         cfg,
+			Generator:      bench.GeneratorConfig{Scale: cfg.Scale, Distribution: cfg.Distribution},
+			ValidationOnly: false,
+			Notes:          []string{"stub live execution"},
+		}, nil
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"run", "-mode", "live", "-tier-profile", "high-hot", "-workloads", "baseline-page-1"}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("live run returned exit code %d: %s", exitCode, errOut.String())
+	}
+	if !liveCalled {
+		t.Fatalf("expected live executor to be called")
+	}
+	if out.Len() == 0 {
+		t.Fatalf("live run should emit JSON output")
+	}
+	if errOut.Len() == 0 {
+		t.Fatalf("live run should emit console summary to stderr")
 	}
 }

--- a/cmd/tools/compactor.go
+++ b/cmd/tools/compactor.go
@@ -100,10 +100,27 @@ func runCompactor(ctx context.Context, args []string) error {
 		zap.Int16("schema_id", compactCfg.SchemaID),
 		zap.String("bucket", s3Config.bucket))
 
-	if err := c.RunOnce(ctx); err != nil {
+	result, err := c.RunOnce(ctx)
+	if err != nil {
 		return fmt.Errorf("compaction failed: %w", err)
 	}
 
-	logger.Info("compaction completed")
+	switch result.Outcome {
+	case compaction.PromotionApplied:
+		logger.Info("compaction completed",
+			zap.Int16("schema_id", result.SchemaID),
+			zap.Int64("version", result.Version),
+			zap.Float64("dirty_ratio", result.DirtyRatio))
+	case compaction.RewritePending:
+		logger.Warn("compaction deferred: rewrite pending",
+			zap.Int16("schema_id", result.SchemaID),
+			zap.Float64("dirty_ratio", result.DirtyRatio),
+			zap.Int64("base_mb", result.BaseMB),
+			zap.Int64("delta_mb", result.DeltaMB))
+	default:
+		logger.Info("compaction completed",
+			zap.Int16("schema_id", result.SchemaID),
+			zap.String("outcome", string(result.Outcome)))
+	}
 	return nil
 }

--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -66,6 +66,7 @@ Compare these fields first:
 
 ## Current Limitations
 
-- current CLI `run` still uses the scaffolded execution path unless the runtime is wired to a live harness
+- baseline presets currently favor `smoke` and `plan` modes for artifact stability over live execution cost
+- use `go run ./cmd/benchmark run -mode live ...` when you need executable benchmark evidence instead of planning-only artifacts
 - baseline capture is designed for artifact stability first, not for production-like throughput measurement
 - CI integration and operator workflow guidance are documented in `docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md`

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -9,12 +9,13 @@ This guide defines which benchmark subsets are safe for local validation, PR-tim
 
 ## Current Execution Model
 
-- `go run ./cmd/benchmark run ...` is currently a scaffolded validation path
+- `go run ./cmd/benchmark run ...` supports both validation and live execution paths
 - `-mode smoke` validates config, fixtures, and workload resolution only
 - `-mode plan` validates config and emits the planned workload shape only
-- live federated-query execution currently happens through the harness-backed test path such as `go test ./internal/e2e_harness/federated/... -run TestBenchmarkWorkloadExecution_RunWithHarness`
+- `-mode live` creates the federated harness, prepares tiered benchmark data, and executes supported workloads end to end
+- harness-backed tests such as `go test ./internal/e2e_harness/federated/... -run TestBenchmarkWorkloadExecution_RunWithHarness` remain the focused executable coverage path for repository tests
 
-This means phase-1 benchmark CI should be treated as configuration, fixture, and artifact regression coverage first. It is not yet an official throughput gate.
+This means CI can continue to treat smoke mode as the cheap artifact regression layer, while local or manual runs can use live mode for executable benchmark evidence. It is still not an official throughput gate.
 
 ## Workload Groups
 
@@ -40,7 +41,7 @@ Use for pre-merge review, local baseline capture, and scheduled CI.
 
 - workloads: `baseline-page-1`, `hot-selective-page`, `eav-selective-page`, `mixed-tier-window`
 - scale: `small` or `medium`
-- mode: `plan` for CLI-only checks, harness-backed test for executable query coverage
+- mode: `plan` for cheap CLI-only checks, `live` for executable query coverage
 - goal: verify workload set shape, artifacts, and supported federated execution paths without using the heaviest deep-page cases
 - expected runtime: 1 to 5 minutes depending on runner size and whether harness-backed tests are included
 
@@ -84,12 +85,12 @@ go run ./cmd/benchmark run \
 
 ```bash
 go run ./cmd/benchmark run \
-  -mode plan \
-  -scale medium \
-  -distribution zipf \
-  -iterations 5 \
-  -workloads baseline-page-1,hot-selective-page,eav-selective-page,mixed-tier-window \
-  -baseline-dir .artifacts/benchmark/regression-medium
+  -mode live \
+  -scale small \
+  -distribution hotspot-overlap \
+  -tier-profile balanced \
+  -workloads baseline-page-1,hot-selective-page \
+  -baseline-dir .artifacts/benchmark/live-small
 ```
 
 ### Harness-Backed Execution Check
@@ -98,6 +99,18 @@ go run ./cmd/benchmark run \
 go test -v ./internal/e2e_harness/federated/... \
   -run TestBenchmarkWorkloadExecution_RunWithHarness \
   -timeout=10m
+```
+
+### Local Regression Planning
+
+```bash
+go run ./cmd/benchmark run \
+  -mode plan \
+  -scale medium \
+  -distribution zipf \
+  -iterations 5 \
+  -workloads baseline-page-1,hot-selective-page,eav-selective-page,mixed-tier-window \
+  -baseline-dir .artifacts/benchmark/regression-medium
 ```
 
 ## CI Guidance
@@ -118,7 +131,7 @@ The repository CI workflow now includes a dedicated `benchmark-smoke` job for th
 - Go toolchain matching the repository CI version
 - writable workspace for `.artifacts/benchmark` output
 - for CLI smoke/plan runs: no external services beyond normal test prerequisites
-- for harness-backed execution: the same environment required by federated e2e tests, including Docker-backed services when applicable
+- for CLI `-mode live` and harness-backed execution: the same environment required by federated e2e tests, including Docker-backed services when applicable
 
 Operational expectations:
 
@@ -158,7 +171,6 @@ These items remain intentionally out of scope for the current phase-1 operating 
 
 - official CI performance gating on large-scale thresholds
 - benchmark trend dashboards and longitudinal regression tracking
-- CLI wiring for live harness-backed execution instead of validation-only `run`
 - keyset pagination comparison workloads
 - distributed benchmark agents
 

--- a/internal/compaction/compactor.go
+++ b/internal/compaction/compactor.go
@@ -22,6 +22,25 @@ var ErrConcurrentModification = errors.New("manifest concurrently modified")
 // but did not advance manifest metadata as required by FileProvider contract.
 var ErrManifestMetadataContractViolation = errors.New("manifest metadata contract violated")
 
+// CompactionOutcome describes the result of a compaction pass for a single schema.
+type CompactionOutcome string
+
+const (
+	Noop             CompactionOutcome = "noop"
+	PromotionApplied CompactionOutcome = "promotion_applied"
+	RewritePending   CompactionOutcome = "rewrite_pending"
+)
+
+// CompactionResult carries the outcome and metadata from a compaction pass.
+type CompactionResult struct {
+	Outcome    CompactionOutcome
+	SchemaID   int16
+	Version    int64
+	DirtyRatio float64
+	BaseMB     int64
+	DeltaMB    int64
+}
+
 // FileProvider fetches manifest and lists actual files (optionally cross-check).
 type FileProvider interface {
 	LoadManifest(ctx context.Context, schemaID int16) (*manifest.Manifest, string, error)
@@ -51,45 +70,34 @@ type Compactor struct {
 	Resolver   manifest.PathResolver
 }
 
-// RunOnce executes compaction for a schema (or all if Config.SchemaID==0).
-func (c *Compactor) RunOnce(ctx context.Context) error {
+// RunOnce executes compaction for a schema and returns a typed result.
+func (c *Compactor) RunOnce(ctx context.Context) (CompactionResult, error) {
 	if c.Provider == nil {
-		return fmt.Errorf("file provider is nil")
+		return CompactionResult{}, fmt.Errorf("file provider is nil")
 	}
-	schemas := []int16{c.Config.SchemaID}
 	if c.Config.SchemaID == 0 {
-		// For MVP, require explicit schema; all-schema sweep can be added later.
-		return fmt.Errorf("schema_id required for compaction in MVP")
+		return CompactionResult{}, fmt.Errorf("schema_id required for compaction in MVP")
 	}
 
 	cfg := c.Config.WithDefaults()
-	for _, sid := range schemas {
-		if sid == 0 {
-			continue
-		}
-		if err := c.compactSchemaWithRetry(ctx, sid, cfg); err != nil {
-			return err
-		}
-	}
-	return nil
+	return c.compactSchemaWithRetry(ctx, c.Config.SchemaID, cfg)
 }
 
 // compactSchemaWithRetry wraps compactSchema with exponential backoff for transient errors.
-func (c *Compactor) compactSchemaWithRetry(ctx context.Context, schemaID int16, cfg cdc.CompactionConfig) error {
+func (c *Compactor) compactSchemaWithRetry(ctx context.Context, schemaID int16, cfg cdc.CompactionConfig) (CompactionResult, error) {
 	var lastErr error
 	for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
-		err := c.compactSchema(ctx, schemaID, cfg)
+		result, err := c.compactSchema(ctx, schemaID, cfg)
 		if err == nil {
-			return nil
+			return result, nil
 		}
 		lastErr = err
 
-		// Don't retry if context cancelled or non-retryable
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return CompactionResult{}, ctx.Err()
 		}
 		if !isRetryable(err) {
-			return err
+			return CompactionResult{}, err
 		}
 
 		if attempt < cfg.MaxRetries {
@@ -102,12 +110,12 @@ func (c *Compactor) compactSchemaWithRetry(ctx context.Context, schemaID int16, 
 
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return CompactionResult{}, ctx.Err()
 			case <-time.After(backoff):
 			}
 		}
 	}
-	return fmt.Errorf("compaction failed after %d retries: %w", cfg.MaxRetries, lastErr)
+	return CompactionResult{}, fmt.Errorf("compaction failed after %d retries: %w", cfg.MaxRetries, lastErr)
 }
 
 // computeBackoff returns exponential backoff with jitter.
@@ -129,18 +137,16 @@ func isRetryable(err error) bool {
 	return false
 }
 
-func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.CompactionConfig) error {
+func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.CompactionConfig) (CompactionResult, error) {
 	m, etag, err := c.Provider.LoadManifest(ctx, schemaID)
 	if err != nil {
-		return fmt.Errorf("load manifest: %w", err)
+		return CompactionResult{}, fmt.Errorf("load manifest: %w", err)
 	}
 	if m == nil {
-		// No manifest yet means no data to compact
 		c.Logger.Debug("no manifest for schema, skipping", zap.Int16("schema_id", schemaID))
-		return nil
+		return CompactionResult{Outcome: Noop, SchemaID: schemaID}, nil
 	}
 
-	// Separate base and delta files
 	baseFiles := manifest.FilterByTier(m, "base")
 	deltaFiles := manifest.FilterByTier(m, "delta")
 
@@ -152,7 +158,6 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 		zap.Int("base_files", len(baseFiles)),
 		zap.Int("delta_files", len(deltaFiles)))
 
-	// Calculate total sizes
 	var baseTotalBytes, deltaTotalBytes int64
 	for _, f := range baseFiles {
 		baseTotalBytes += f.SizeBytes
@@ -166,8 +171,6 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 	dirtyRatio := c.computeDirtyRatio(baseFiles, deltaFiles)
 	telemetry.EmitCompactionDirtyRatio(ctx, schemaID, dirtyRatio)
 
-	// Decision: promote deltas to base if delta total > target base size
-	// or rewrite base if dirty ratio exceeded
 	needsPromotion := deltaTotalMB >= int64(cfg.TargetBaseSizeMB)
 	needsRewrite := len(baseFiles) > 0 && dirtyRatio > float64(cfg.DirtyRatioPct)/100.0
 
@@ -176,18 +179,15 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 			zap.Int16("schema_id", schemaID),
 			zap.Int64("base_mb", baseTotalMB),
 			zap.Int64("delta_mb", deltaTotalMB))
-		return nil
+		return CompactionResult{Outcome: Noop, SchemaID: schemaID, DirtyRatio: dirtyRatio, BaseMB: baseTotalMB, DeltaMB: deltaTotalMB}, nil
 	}
 
-	// For MVP: simple promotion - move delta files to base tier
-	// Full rewrite (reading + merging parquet) deferred to later iteration
 	applied := false
 	if needsPromotion {
 		c.Logger.Info("promoting deltas to base tier",
 			zap.Int16("schema_id", schemaID),
 			zap.Int64("delta_mb", deltaTotalMB))
 
-		// Update file entries: change tier from delta to base
 		for i := range m.Files {
 			if strings.EqualFold(m.Files[i].Tier, "delta") {
 				m.Files[i].Tier = "base"
@@ -204,7 +204,13 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 			zap.Int("dirty_ratio_pct", cfg.DirtyRatioPct),
 			zap.Int64("base_mb", baseTotalMB),
 			zap.Int64("delta_mb", deltaTotalMB))
-		return nil
+		return CompactionResult{
+			Outcome:    RewritePending,
+			SchemaID:   schemaID,
+			DirtyRatio: dirtyRatio,
+			BaseMB:     baseTotalMB,
+			DeltaMB:    deltaTotalMB,
+		}, nil
 	}
 
 	if !applied {
@@ -212,7 +218,7 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 			zap.Int16("schema_id", schemaID),
 			zap.Bool("needs_promotion", needsPromotion),
 			zap.Bool("needs_rewrite", needsRewrite))
-		return nil
+		return CompactionResult{Outcome: Noop, SchemaID: schemaID, DirtyRatio: dirtyRatio, BaseMB: baseTotalMB, DeltaMB: deltaTotalMB}, nil
 	}
 
 	prevVersion := m.Version
@@ -220,11 +226,10 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 
 	newEtag, err := c.Provider.SaveManifest(ctx, schemaID, m, etag)
 	if err != nil {
-		// Check if this is a concurrent modification (etag mismatch)
 		if newEtag == "" && etag != "" {
-			return fmt.Errorf("%w: etag mismatch", ErrConcurrentModification)
+			return CompactionResult{}, fmt.Errorf("%w: etag mismatch", ErrConcurrentModification)
 		}
-		return fmt.Errorf("save manifest: %w", err)
+		return CompactionResult{}, fmt.Errorf("save manifest: %w", err)
 	}
 
 	if m.Version <= prevVersion || m.UpdatedAtMs <= prevUpdatedAtMs {
@@ -236,7 +241,7 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 			zap.Int64("prev_updated_at_ms", prevUpdatedAtMs),
 			zap.Int64("new_updated_at_ms", m.UpdatedAtMs),
 			zap.String("etag", newEtag))
-		return fmt.Errorf("%w: provider must mutate manifest in-place; prev(version=%d, updated_at_ms=%d), new(version=%d, updated_at_ms=%d)",
+		return CompactionResult{}, fmt.Errorf("%w: provider must mutate manifest in-place; prev(version=%d, updated_at_ms=%d), new(version=%d, updated_at_ms=%d)",
 			ErrManifestMetadataContractViolation,
 			prevVersion,
 			prevUpdatedAtMs,
@@ -250,7 +255,14 @@ func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.C
 		zap.Int64("version", m.Version),
 		zap.String("etag", newEtag))
 
-	return nil
+	return CompactionResult{
+		Outcome:    PromotionApplied,
+		SchemaID:   schemaID,
+		Version:    m.Version,
+		DirtyRatio: dirtyRatio,
+		BaseMB:     baseTotalMB,
+		DeltaMB:    deltaTotalMB,
+	}, nil
 }
 
 // computeDirtyRatio estimates the ratio of updated/deleted rows to total base rows.

--- a/internal/compaction/compactor_test.go
+++ b/internal/compaction/compactor_test.go
@@ -70,9 +70,10 @@ func TestCompactor_RunOnce_RequiresSchemaID(t *testing.T) {
 		Provider: &mockProvider{},
 	}
 
-	err := c.RunOnce(context.Background())
+	result, err := c.RunOnce(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "schema_id required")
+	require.Empty(t, result.Outcome)
 }
 
 func TestCompactor_RunOnce_RequiresProvider(t *testing.T) {
@@ -82,9 +83,10 @@ func TestCompactor_RunOnce_RequiresProvider(t *testing.T) {
 		Config: cdc.CompactionConfig{SchemaID: 1},
 	}
 
-	err := c.RunOnce(context.Background())
+	result, err := c.RunOnce(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "file provider is nil")
+	require.Empty(t, result.Outcome)
 }
 
 func TestCompactor_RunOnce_NoManifest(t *testing.T) {
@@ -95,8 +97,9 @@ func TestCompactor_RunOnce_NoManifest(t *testing.T) {
 		Provider: &mockProvider{manifest: nil},
 	}
 
-	err := c.RunOnce(context.Background())
-	require.NoError(t, err) // no manifest = nothing to compact
+	result, err := c.RunOnce(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, Noop, result.Outcome)
 }
 
 func TestCompactor_RunOnce_NoFilesToCompact(t *testing.T) {
@@ -115,8 +118,9 @@ func TestCompactor_RunOnce_NoFilesToCompact(t *testing.T) {
 		Provider: provider,
 	}
 
-	err := c.RunOnce(context.Background())
+	result, err := c.RunOnce(context.Background())
 	require.NoError(t, err)
+	require.Equal(t, Noop, result.Outcome)
 }
 
 func TestCompactor_RunOnce_PromotsDeltas(t *testing.T) {
@@ -143,10 +147,10 @@ func TestCompactor_RunOnce_PromotsDeltas(t *testing.T) {
 		Provider: provider,
 	}
 
-	err := c.RunOnce(context.Background())
+	result, err := c.RunOnce(context.Background())
 	require.NoError(t, err)
+	require.Equal(t, PromotionApplied, result.Outcome)
 
-	// Check that files were promoted to base tier
 	for _, f := range provider.manifest.Files {
 		require.Equal(t, "base", f.Tier)
 	}
@@ -176,10 +180,9 @@ func TestCompactor_RunOnce_PromotesDeltasCaseInsensitiveTier(t *testing.T) {
 		Provider: provider,
 	}
 
-	err := c.RunOnce(context.Background())
+	result, err := c.RunOnce(context.Background())
 	require.NoError(t, err)
-
-	require.Equal(t, "base", provider.manifest.Files[0].Tier)
+	require.Equal(t, PromotionApplied, result.Outcome)
 	require.Equal(t, "new-etag", provider.savedEtag)
 	require.Equal(t, int64(2), provider.manifest.Version)
 }
@@ -209,10 +212,11 @@ func TestCompactor_RunOnce_SaveManifestMissingVersionAdvance(t *testing.T) {
 		Provider: provider,
 	}
 
-	err := c.RunOnce(context.Background())
+	result, err := c.RunOnce(context.Background())
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrManifestMetadataContractViolation)
 	require.Contains(t, err.Error(), "version")
+	require.Empty(t, result.Outcome)
 }
 
 func TestCompactor_RunOnce_SaveManifestMissingUpdatedAtAdvance(t *testing.T) {
@@ -240,10 +244,11 @@ func TestCompactor_RunOnce_SaveManifestMissingUpdatedAtAdvance(t *testing.T) {
 		Provider: provider,
 	}
 
-	err := c.RunOnce(context.Background())
+	result, err := c.RunOnce(context.Background())
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrManifestMetadataContractViolation)
 	require.Contains(t, err.Error(), "updated_at_ms")
+	require.Empty(t, result.Outcome)
 }
 
 func TestCompactor_RunOnce_SaveManifestContractViolationEmitsTelemetry(t *testing.T) {
@@ -281,7 +286,7 @@ func TestCompactor_RunOnce_SaveManifestContractViolationEmitsTelemetry(t *testin
 		Provider: provider,
 	}
 
-	err := c.RunOnce(context.Background())
+	_, err := c.RunOnce(context.Background())
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrManifestMetadataContractViolation)
 	require.Equal(t, "compaction_manifest_contract_violation_total", gotName)
@@ -321,14 +326,13 @@ func TestCompactor_RunOnce_NeedsRewriteWithoutPromotion_SkipsManifestUpdate(t *t
 		Provider: provider,
 	}
 
-	err := c.RunOnce(context.Background())
+	result, err := c.RunOnce(context.Background())
 	require.NoError(t, err)
+	require.Equal(t, RewritePending, result.Outcome)
 
-	// Rewrite is not implemented yet, so manifest should not be persisted.
 	require.Equal(t, "", provider.savedEtag)
 	require.Equal(t, int64(1), provider.manifest.Version)
 
-	// No rewrite/promotion happened in current implementation.
 	require.Equal(t, "base", provider.manifest.Files[0].Tier)
 	require.Equal(t, "delta", provider.manifest.Files[1].Tier)
 
@@ -351,7 +355,7 @@ func TestCompactor_RunOnce_LoadManifestError(t *testing.T) {
 		Provider: provider,
 	}
 
-	err := c.RunOnce(context.Background())
+	_, err := c.RunOnce(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "load manifest")
 }

--- a/internal/e2e_harness/federated/benchmark/config.go
+++ b/internal/e2e_harness/federated/benchmark/config.go
@@ -28,6 +28,7 @@ type ExecutionMode string
 const (
 	ExecutionModeSmoke ExecutionMode = "smoke"
 	ExecutionModePlan  ExecutionMode = "plan"
+	ExecutionModeLive  ExecutionMode = "live"
 )
 
 // Config describes a benchmark run.
@@ -44,6 +45,7 @@ type Config struct {
 	SecurityCount int           `json:"security_count,omitempty"`
 	OverlapRatio  float64       `json:"overlap_ratio,omitempty"`
 	DeleteRatio   float64       `json:"delete_ratio,omitempty"`
+	TierProfile   string        `json:"tier_profile,omitempty"`
 	Workloads     []string      `json:"workloads"`
 }
 
@@ -57,6 +59,7 @@ func DefaultConfig() Config {
 		Concurrency:  1,
 		PageSize:     20,
 		Seed:         42,
+		TierProfile:  DefaultTierMixProfile().Name,
 		Workloads:    DefaultWorkloadNames(),
 	}
 }
@@ -85,6 +88,9 @@ func (c Config) WithDefaults() Config {
 	if c.Seed == 0 {
 		c.Seed = defaults.Seed
 	}
+	if c.TierProfile == "" {
+		c.TierProfile = defaults.TierProfile
+	}
 	if len(c.Workloads) == 0 {
 		c.Workloads = defaults.Workloads
 	}
@@ -111,6 +117,11 @@ func (c Config) Validate() error {
 	if c.PageSize <= 0 {
 		return fmt.Errorf("page size must be greater than zero")
 	}
+	if c.TierProfile != "" {
+		if _, err := ResolveTierMixProfile(c.TierProfile); err != nil {
+			return err
+		}
+	}
 	if _, err := ResolveWorkloads(c.Workloads); err != nil {
 		return err
 	}
@@ -119,7 +130,7 @@ func (c Config) Validate() error {
 
 func isValidMode(mode ExecutionMode) bool {
 	switch mode {
-	case ExecutionModeSmoke, ExecutionModePlan:
+	case ExecutionModeSmoke, ExecutionModePlan, ExecutionModeLive:
 		return true
 	default:
 		return false

--- a/internal/e2e_harness/federated/benchmark/config_test.go
+++ b/internal/e2e_harness/federated/benchmark/config_test.go
@@ -16,3 +16,19 @@ func TestConfigValidateRejectsUnknownWorkload(t *testing.T) {
 		t.Fatalf("Validate should reject unknown workloads")
 	}
 }
+
+func TestConfigValidateAcceptsLiveMode(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Mode = ExecutionModeLive
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate should accept live mode: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsUnknownTierProfile(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.TierProfile = "does-not-exist"
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate should reject unknown tier profile")
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/tier.go
+++ b/internal/e2e_harness/federated/benchmark/tier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/google/uuid"
 	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
@@ -52,6 +53,26 @@ var (
 // DefaultTierMixProfiles returns the supported tier layouts.
 func DefaultTierMixProfiles() []TierMixProfile {
 	return []TierMixProfile{TierMixBalanced, TierMixHighHot, TierMixLongHistory}
+}
+
+// DefaultTierMixProfile returns the default tier layout for benchmark execution.
+func DefaultTierMixProfile() TierMixProfile {
+	return TierMixBalanced
+}
+
+// ResolveTierMixProfile resolves a CLI or config profile name to a supported tier mix.
+func ResolveTierMixProfile(name string) (TierMixProfile, error) {
+	normalized := strings.TrimSpace(strings.ToLower(name))
+	switch normalized {
+	case "", strings.ToLower(TierMixBalanced.Name), "balanced":
+		return TierMixBalanced, nil
+	case strings.ToLower(TierMixHighHot.Name), "high-hot":
+		return TierMixHighHot, nil
+	case strings.ToLower(TierMixLongHistory.Name), "long-history":
+		return TierMixLongHistory, nil
+	default:
+		return TierMixProfile{}, fmt.Errorf("unknown tier profile %q", name)
+	}
 }
 
 // SplitIntoTiers partitions the generated dataset into base, delta, and hot tiers.

--- a/internal/e2e_harness/federated/benchmark/tier_test.go
+++ b/internal/e2e_harness/federated/benchmark/tier_test.go
@@ -74,6 +74,19 @@ func TestLoadTieredDatasetUsesLoader(t *testing.T) {
 	}
 }
 
+func TestResolveTierMixProfile(t *testing.T) {
+	profile, err := ResolveTierMixProfile("high-hot")
+	if err != nil {
+		t.Fatalf("ResolveTierMixProfile failed: %v", err)
+	}
+	if profile.Name != TierMixHighHot.Name {
+		t.Fatalf("unexpected profile: %+v", profile)
+	}
+	if _, err := ResolveTierMixProfile("unknown"); err == nil {
+		t.Fatalf("expected unknown tier profile to fail")
+	}
+}
+
 type captureTierLoader struct {
 	cleared     bool
 	schemas     []SchemaFixture


### PR DESCRIPTION
## Summary
- wire `cmd/benchmark run` to support a live harness-backed execution mode in addition to `smoke` and `plan`
- add tier-profile config and validation for live benchmark runs
- update benchmark CLI tests and operator docs to describe validation versus live execution

## Testing
- go test ./cmd/benchmark
- go test ./internal/e2e_harness/federated/benchmark

Closes #52