### PR TITLE
add benchmark autoresearch roadmap docs

### DIFF
--- a/docs/federated-query/federated-query-benchmark-autoresearch-issues.md
+++ b/docs/federated-query/federated-query-benchmark-autoresearch-issues.md
@@ -1,0 +1,43 @@
+# Federated Query Benchmark Autoresearch Issue Breakdown
+
+Last updated: 2026-04-18  
+Repository: `forma`
+
+## Issue Set
+
+This backlog extends the closed phase-1 benchmark work and reorganizes the next phase around one goal: make the benchmark trustworthy enough for autoresearch-guided performance tuning.
+
+Planned issues:
+
+1. `#55` umbrella issue for the benchmark-to-autoresearch follow-up plan
+2. `#52` executable benchmark runtime backed by the live federated harness
+3. `#48` result semantics and correctness hardening
+4. `#50` filter fidelity and schema-scoped workload execution
+5. `#47` metrics expansion, artifact schema, and baseline diff support
+6. `#45` baseline capture and CI execution policy
+7. `#49` autoresearch perf loop scaffolding
+8. `#53` autoresearch perf targets and gate scripts
+9. `#46` deep-pagination optimization wave
+10. `#51` filter pushdown and EAV optimization wave
+11. `#54` routing and concurrency optimization wave
+
+## PR Mapping
+
+| PR | Primary Goal |
+|---|---|
+| PR 1 | `#52` Promote the benchmark to a supported live-execution runtime |
+| PR 2 | `#48` Make benchmark outputs trustworthy for optimization decisions |
+| PR 3 | `#50` Align executed workloads with the benchmark data model |
+| PR 4 | `#47` Produce machine-comparable metrics and baseline diffs |
+| PR 5 | `#45` Codify baseline capture and CI-safe benchmark subsets |
+| PR 6 | `#49` Add a benchmark-driven autoresearch performance loop |
+| PR 7 | `#53` Add performance target briefs and benchmark gate scripts |
+| PR 8 | `#46` Improve deep-pagination performance using the benchmark |
+| PR 9 | `#51` Improve filter pushdown and EAV behavior using the benchmark |
+| PR 10 | `#54` Improve routing heuristics and concurrency behavior |
+
+## Notes
+
+- PRs 1 through 5 are readiness work and should land before benchmark-driven autoresearch optimization begins.
+- PRs 6 and 7 integrate the benchmark with autoresearch without changing the current BDD testing loop.
+- PRs 8 through 10 should be evaluated with the benchmark guardrails created earlier in the sequence.

--- a/docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md
+++ b/docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md
@@ -1,0 +1,204 @@
+# Federated Query Benchmark Autoresearch PR Plan
+
+Last updated: 2026-04-18  
+Repository: `forma`
+
+## 1. Objective
+
+The next benchmark phase is not about widening TPC-E coverage. It is about turning the existing TPC-E-inspired benchmark into a stable optimization judge for federated-query tuning and future autoresearch loops.
+
+The benchmark is ready for autoresearch-guided optimization only when it can do all of the following reliably:
+
+- execute live benchmark workloads end to end without relying on ad hoc test-only entrypoints
+- reject correctness regressions before reporting latency wins
+- emit stable, workload-level evidence that can be compared to a saved baseline
+- support fast and repeatable benchmark subsets suitable for automated keep/discard decisions
+
+## 2. Delivery Principles
+
+- correctness before speed: any failed correctness assertion blocks optimization claims
+- `trade` remains the primary benchmark schema until the execution path is trustworthy
+- benchmark artifacts must be machine-comparable, not just human-readable
+- small reproducible runs come before larger and noisier runs
+- autoresearch should consume benchmark evidence only after the benchmark becomes a trustworthy gate
+
+## 3. PR Sequence
+
+### PR 1: Executable Benchmark Runtime
+
+Goal: promote the benchmark from scaffolded CLI validation to a supported live-execution path.
+
+Scope:
+
+- add an executable benchmark mode backed by the live federated harness
+- preserve existing `smoke` and `plan` modes for cheap validation
+- make benchmark run outputs identify whether execution was validation-only or live
+- cover the live path with focused tests and operator commands
+
+Exit criteria:
+
+- `cmd/benchmark` can execute supported workloads against the harness
+- local execution does not require reaching into test-only helper code by hand
+- the benchmark has a single documented runtime story for validation and live execution
+
+### PR 2: Result Semantics and Correctness Hardening
+
+Goal: make benchmark results safe to use as optimization evidence.
+
+Scope:
+
+- fix `total_records` and deep-page result semantics
+- strengthen assertions for dedup, ordering stability, delete shadowing, and last-write-wins
+- add explicit workload failure signals for correctness regressions
+- tighten benchmark result structures so that downstream automation can trust them
+
+Exit criteria:
+
+- workload results distinguish empty pages from broken query behavior
+- repeated runs with the same seed produce stable correctness verdicts
+- benchmark failures clearly separate correctness failures from infrastructure failures
+
+### PR 3: Filter Fidelity and Schema-Scoped Workloads
+
+Goal: make the executed workloads match the benchmark model instead of only the current happy path.
+
+Scope:
+
+- complete hot, EAV, and mixed filter execution fidelity
+- make schema targeting explicit in execution instead of declarative-only metadata
+- keep `trade` as the primary executed schema while retaining fixture sanity coverage for `customer` and `security`
+- expand workload assertions around schema-scoped and filter-scoped behavior
+
+Exit criteria:
+
+- hot and EAV workloads execute with consistent semantics across tiers
+- benchmark execution honors workload schema intent
+- mixed-tier and deep-page workloads are representative enough for tuning work
+
+### PR 4: Metrics, Artifact Schema, and Baseline Diff
+
+Goal: make benchmark artifacts directly usable for automated comparison.
+
+Scope:
+
+- extend summary metrics beyond latency percentiles and QPS
+- capture workload-level metadata, environment data, and benchmark identifiers
+- add machine-readable diff support against a saved baseline
+- keep output formats stable across runs with the same seed and workload set
+
+Exit criteria:
+
+- benchmark output can answer which workloads improved, regressed, or stayed flat
+- saved baselines are structurally stable and safe for automation
+- artifact fields are sufficient for later autoresearch decision rules
+
+### PR 5: Baseline Capture and CI Policy
+
+Goal: codify which benchmark subsets are safe for local automation, CI, and manual tuning review.
+
+Scope:
+
+- capture initial `small` and `medium` benchmark baselines
+- define fast, medium, and heavy benchmark subsets
+- document acceptable runtime envelopes and environment expectations
+- align CI commands with the benchmark's live and validation modes
+
+Exit criteria:
+
+- the repository has documented baseline artifacts and comparison guidance
+- CI-safe subsets are clearly separated from heavier manual runs
+- benchmark commands used by later autoresearch loops are stable and documented
+
+### PR 6: Autoresearch Perf Loop Scaffold
+
+Goal: add a performance-oriented autoresearch loop that consumes benchmark evidence instead of only test coverage.
+
+Scope:
+
+- introduce a performance autoresearch mode alongside the existing testing mode
+- define decision artifact fields for latency, regressions, and correctness gates
+- add controller support for benchmark baseline, candidate run, and keep/discard evaluation
+- keep the same commit-per-keep operational model
+
+Exit criteria:
+
+- a single performance iteration can run, compare benchmark evidence, and emit a decision artifact
+- keep/discard logic can block candidates that regress correctness or protected workloads
+- the new flow does not weaken the current test-oriented autoresearch safeguards
+
+### PR 7: Autoresearch Perf Targets and Gates
+
+Goal: make the performance loop actionable for real tuning targets.
+
+Scope:
+
+- add performance target briefs for the first federated-query hotspots
+- define fast, medium, and heavy benchmark gates for those targets
+- make target guidance explicit about protected workloads and known risk areas
+- document how performance targets differ from BDD testing targets
+
+Exit criteria:
+
+- target authors can run the perf loop against a known module and workload subset
+- gate scripts are deterministic enough for iterative local use
+- target briefs point at benchmark evidence rather than vague speed goals
+
+### PR 8: Optimization Wave 1, Deep Pagination
+
+Goal: use the benchmark to improve the highest-risk pagination path first.
+
+Scope:
+
+- investigate deep-page cost in merge-before-pagination flows
+- optimize query planning or execution where page depth dominates latency
+- validate improvements with the benchmark fast and medium gates
+- record observed wins and remaining bottlenecks in the artifact trail
+
+Exit criteria:
+
+- target deep-page workloads improve without correctness regressions
+- the benchmark can prove the win at workload level rather than anecdotal logs
+
+### PR 9: Optimization Wave 2, Filter Pushdown and EAV
+
+Goal: improve selective filter performance after the pagination path is measurable and trustworthy.
+
+Scope:
+
+- investigate hot filter, EAV filter, and mixed filter routing costs
+- optimize pushdown and tier merge behavior where possible
+- use benchmark deltas to guard against regressions in non-target workloads
+
+Exit criteria:
+
+- targeted filter workloads improve under benchmark comparison
+- deep-page and baseline workloads remain within guardrail thresholds
+
+### PR 10: Optimization Wave 3, Routing and Concurrency
+
+Goal: improve strategy selection and tail behavior under repeated runs.
+
+Scope:
+
+- investigate routing heuristics between Postgres and DuckDB paths
+- add or refine fixed-concurrency benchmark execution
+- tune workload groups where tail latency or routing instability dominates
+- protect correctness and prior wins with the same benchmark guardrails
+
+Exit criteria:
+
+- routing-sensitive workloads show measurable improvement or clearer guardrails
+- concurrency-aware benchmark runs remain reproducible enough for repeated comparison
+
+## 4. Ready-For-Autoresearch Gate
+
+The repository should not treat the benchmark as a performance autoresearch gate until PRs 1 through 5 are complete.
+
+At that point, the minimum bar is:
+
+- live benchmark execution exists as a supported command path
+- correctness assertions are strong enough to reject bad optimizations
+- workload-level baselines and diffs are machine-readable
+- the benchmark has CI-safe and local-safe execution subsets
+
+PRs 6 and 7 then turn that benchmark into an optimization controller input. PRs 8 through 10 are the first optimization campaigns that should rely on it.

--- a/docs/federated-query/issues/08-benchmark-autoresearch-umbrella.md
+++ b/docs/federated-query/issues/08-benchmark-autoresearch-umbrella.md
@@ -1,0 +1,39 @@
+## Summary
+
+Track the follow-up work required to turn the federated query benchmark into a reliable foundation for autoresearch-guided performance tuning.
+
+## Why
+
+The current benchmark foundation is useful for validation and early workload execution, but it is not yet strong enough to act as an optimization judge. The repository needs a single coordination issue for the work that makes benchmark evidence trustworthy and automatable.
+
+## Scope
+
+- define the follow-up benchmark phases after the closed phase-1 issue set
+- link the PR-sliced execution plan for benchmark and autoresearch work
+- track the execution issues needed before optimization waves begin
+- establish the readiness bar for using benchmark artifacts in autoresearch keep or discard decisions
+
+## Acceptance Criteria
+
+- the roadmap links the benchmark readiness work and optimization waves
+- execution issues are listed explicitly and grouped in delivery order
+- the issue can be used as the single coordination entrypoint for benchmark-to-autoresearch work
+
+## Execution Issues
+
+- [ ] #52 Add executable benchmark runtime backed by the live federated harness
+- [ ] #48 Harden benchmark result semantics and correctness assertions
+- [ ] #50 Complete filter fidelity and schema-scoped benchmark workloads
+- [ ] #47 Expand benchmark metrics, artifact schema, and baseline diff support
+- [ ] #45 Capture benchmark baselines and codify CI execution policy
+- [ ] #49 Scaffold a performance-oriented autoresearch loop around benchmark evidence
+- [ ] #53 Add autoresearch performance targets and benchmark gate scripts
+- [ ] #46 Optimize the federated deep-pagination path using benchmark evidence
+- [ ] #51 Optimize federated filter pushdown and EAV behavior using benchmark evidence
+- [ ] #54 Optimize federated routing and concurrency behavior using benchmark evidence
+
+## References
+
+- `docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md`
+- `docs/federated-query/federated-query-benchmark-autoresearch-issues.md`
+- `docs/federated-query/federated-query-benchmark-hld-en.md`

--- a/docs/federated-query/issues/09-executable-benchmark-runtime.md
+++ b/docs/federated-query/issues/09-executable-benchmark-runtime.md
@@ -1,0 +1,26 @@
+## Summary
+
+Add an executable benchmark runtime backed by the live federated harness.
+
+## Why
+
+The current benchmark CLI is still primarily a scaffolded validation path. Before the benchmark can guide optimization or autoresearch decisions, it needs a supported live-execution mode that runs the benchmark flow end to end through the harness.
+
+## Scope
+
+- add a live-execution benchmark mode in `cmd/benchmark`
+- wire benchmark runtime setup to the federated harness instead of only validation-only runner paths
+- preserve `smoke` and `plan` modes for cheap validation and artifact checks
+- document the runtime contract for validation-only versus live benchmark execution
+
+## Acceptance Criteria
+
+- the benchmark CLI can execute supported workloads against a live harness-backed environment
+- local and CI operators no longer need to rely on ad hoc test entrypoints for the primary executable benchmark path
+- benchmark results clearly identify whether the run was validation-only or live
+
+## References
+
+- `cmd/benchmark/main.go`
+- `internal/e2e_harness/federated/benchmark/runner.go`
+- `docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md`

--- a/docs/federated-query/issues/10-benchmark-result-semantics-and-correctness.md
+++ b/docs/federated-query/issues/10-benchmark-result-semantics-and-correctness.md
@@ -1,0 +1,26 @@
+## Summary
+
+Harden benchmark result semantics and correctness assertions.
+
+## Why
+
+Optimization work is only trustworthy if the benchmark can reject incorrect behavior. The current result model and assertions are useful, but they are still too shallow for automated keep or discard decisions.
+
+## Scope
+
+- fix benchmark result semantics for total records, deep-page behavior, and workload failure reporting
+- strengthen assertions for deduplication, stable ordering, delete shadowing, and last-write-wins behavior
+- separate correctness failures from infrastructure or environment failures
+- make the result model explicit enough for downstream automation and artifact diffing
+
+## Acceptance Criteria
+
+- workload results distinguish empty pages from broken execution behavior
+- repeated benchmark runs with the same seed produce stable correctness verdicts
+- correctness regressions fail the benchmark in a way that later automation can consume directly
+
+## References
+
+- `internal/e2e_harness/federated/benchmark/runner.go`
+- `internal/e2e_harness/federated/query.go`
+- `docs/federated-query/issues/05-workload-matrix-and-deep-pagination.md`

--- a/docs/federated-query/issues/11-filter-fidelity-and-schema-scoped-workloads.md
+++ b/docs/federated-query/issues/11-filter-fidelity-and-schema-scoped-workloads.md
@@ -1,0 +1,27 @@
+## Summary
+
+Complete filter fidelity and schema-scoped workload execution for the federated benchmark.
+
+## Why
+
+The benchmark model already describes hot, EAV, mixed-tier, and schema-scoped workloads, but the executed path still leans heavily on the current `trade` happy path. That gap makes it hard to trust performance results for filter-heavy tuning work.
+
+## Scope
+
+- align executed workloads with declared hot, EAV, and mixed filter semantics
+- make workload schema targeting explicit in execution instead of declarative-only metadata
+- keep `trade` as the primary executed schema while preserving sanity coverage for `customer` and `security`
+- add assertions that prove schema-scoped and filter-scoped behavior is working as intended
+
+## Acceptance Criteria
+
+- supported hot and EAV workloads execute with consistent semantics across base, delta, and hot tiers
+- benchmark execution honors workload schema intent instead of relying on implicit harness state
+- filter-heavy benchmark cases are representative enough to guide later pushdown optimization work
+
+## References
+
+- `internal/e2e_harness/federated/benchmark/workload.go`
+- `internal/e2e_harness/federated/benchmark/runner.go`
+- `internal/e2e_harness/federated/query.go`
+- `docs/federated-query/federated-query-benchmark-hld-en.md`

--- a/docs/federated-query/issues/12-metrics-artifacts-and-baseline-diff.md
+++ b/docs/federated-query/issues/12-metrics-artifacts-and-baseline-diff.md
@@ -1,0 +1,26 @@
+## Summary
+
+Expand benchmark metrics, artifact schema, and baseline diff support.
+
+## Why
+
+The benchmark is only useful for iterative tuning if its outputs can be compared automatically at workload level. Today the repository has report generation, but it still lacks the richer metrics and structured comparisons needed for automated performance decisions.
+
+## Scope
+
+- expand benchmark metrics beyond latency percentiles and QPS
+- capture workload-level metadata, environment metadata, and benchmark identifiers in artifacts
+- add a machine-readable diff flow against a saved baseline
+- keep JSON, Markdown, and console outputs stable enough for automation
+
+## Acceptance Criteria
+
+- artifacts can identify workload-level improvements and regressions across runs
+- the benchmark records enough metadata to support later autoresearch decision rules
+- baseline comparison output is machine-readable and stable across repeated runs with the same seed and workload set
+
+## References
+
+- `internal/e2e_harness/federated/benchmark/report.go`
+- `docs/federated-query/issues/06-reporting-and-baseline-capture.md`
+- `docs/federated-query/federated-query-benchmark-baseline-runbook.md`

--- a/docs/federated-query/issues/13-baseline-capture-and-ci-policy.md
+++ b/docs/federated-query/issues/13-baseline-capture-and-ci-policy.md
@@ -1,0 +1,27 @@
+## Summary
+
+Capture benchmark baselines and codify CI execution policy for optimization work.
+
+## Why
+
+Autoresearch and manual tuning both need a clear answer to which benchmark subsets are safe for routine execution and which ones should be reserved for slower review environments. The repository also needs saved baseline guidance that matches the live benchmark path.
+
+## Scope
+
+- capture initial `small` and `medium` benchmark baselines with the richer artifact model
+- define fast, medium, and heavy benchmark subsets for local, CI, and manual use
+- document runtime envelopes and environment expectations for each subset
+- align repository automation with the benchmark's live and validation execution modes
+
+## Acceptance Criteria
+
+- the repository documents stable baseline capture procedures for `small` and `medium`
+- CI-safe and manual-only benchmark subsets are clearly separated
+- benchmark commands used later by autoresearch are documented and stable enough for repeated use
+
+## References
+
+- `docs/federated-query/federated-query-benchmark-baseline-runbook.md`
+- `docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md`
+- `Makefile`
+- `.github/workflows/ci.yml`

--- a/docs/federated-query/issues/14-autoresearch-perf-loop-scaffold.md
+++ b/docs/federated-query/issues/14-autoresearch-perf-loop-scaffold.md
@@ -1,0 +1,26 @@
+## Summary
+
+Scaffold a performance-oriented autoresearch loop around benchmark evidence.
+
+## Why
+
+The repository already has a local autoresearch loop for BDD-style test generation, but performance tuning needs a different controller contract. It needs benchmark baseline capture, workload-level comparison, and decision rules that reject regressions even when some workloads get faster.
+
+## Scope
+
+- add a performance autoresearch mode alongside the existing testing mode
+- define decision artifact fields for correctness status, workload regressions, and protected benchmark deltas
+- add controller support for baseline, candidate run, and keep or discard evaluation
+- preserve the same commit-per-keep and controller-owned git safety model
+
+## Acceptance Criteria
+
+- one performance autoresearch iteration can run a benchmark subset and emit a keep or discard decision
+- the controller can reject a candidate when correctness fails or protected workloads regress
+- the new performance loop does not weaken the current test-oriented autoresearch safety model
+
+## References
+
+- `tools/autoresearch/testing/README.md`
+- `tools/autoresearch/testing/scripts/autoloop.sh`
+- `docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md`

--- a/docs/federated-query/issues/15-autoresearch-perf-targets-and-gates.md
+++ b/docs/federated-query/issues/15-autoresearch-perf-targets-and-gates.md
@@ -1,0 +1,27 @@
+## Summary
+
+Add autoresearch performance targets and benchmark gate scripts for federated-query tuning.
+
+## Why
+
+Once the performance loop exists, it still needs target briefs and deterministic benchmark gate scripts before engineers can use it productively. Those targets should point at real hotspots and define which workloads are protected or expected to improve.
+
+## Scope
+
+- add initial performance target briefs for federated-query hotspots such as query planning, federated execution, and service-layer routing
+- define fast, medium, and heavy benchmark gates for those targets
+- document protected workloads, expected win areas, and known risk areas in each target brief
+- explain how benchmark-driven perf targets differ from the existing BDD testing targets
+
+## Acceptance Criteria
+
+- target authors can run a performance autoresearch iteration against a known module and benchmark subset
+- gate scripts are deterministic enough for repeated local use
+- target briefs tie decisions to benchmark evidence instead of generic speed claims
+
+## References
+
+- `tools/autoresearch/testing/targets/postgres_duckdb_query.md`
+- `tools/autoresearch/testing/targets/entity_query_service.md`
+- `internal/e2e_harness/federated/query.go`
+- `internal/postgres_duckdb_query.go`

--- a/docs/federated-query/issues/16-deep-pagination-optimization-wave.md
+++ b/docs/federated-query/issues/16-deep-pagination-optimization-wave.md
@@ -1,0 +1,26 @@
+## Summary
+
+Optimize the federated deep-pagination path using benchmark evidence.
+
+## Why
+
+Deep pagination remains one of the highest-risk federated-query paths because it amplifies merge, sort, and count costs as offsets grow. It is the best first optimization wave once the benchmark becomes a trustworthy judge.
+
+## Scope
+
+- investigate deep-page latency in the merge-before-pagination path
+- optimize planning or execution where large offsets dominate latency
+- validate improvements with benchmark fast and medium gates
+- record wins, regressions, and remaining bottlenecks through benchmark artifacts
+
+## Acceptance Criteria
+
+- target deep-page workloads improve under benchmark comparison without correctness regressions
+- benchmark artifacts make the improvement visible at workload level, not just in anecdotal logs
+- remaining bottlenecks are documented for later optimization waves
+
+## References
+
+- `docs/federated-query/issues/05-workload-matrix-and-deep-pagination.md`
+- `internal/e2e_harness/federated/query.go`
+- `internal/postgres_duckdb_query.go`

--- a/docs/federated-query/issues/17-filter-pushdown-and-eav-optimization-wave.md
+++ b/docs/federated-query/issues/17-filter-pushdown-and-eav-optimization-wave.md
@@ -1,0 +1,26 @@
+## Summary
+
+Optimize federated filter pushdown and EAV behavior using benchmark evidence.
+
+## Why
+
+After deep pagination is measurable and guarded, the next major opportunity is selective filtering across hot fields, EAV fields, and mixed predicates. This is where benchmark fidelity work should start paying off directly.
+
+## Scope
+
+- investigate hot-filter, EAV-filter, and mixed-filter workload costs
+- optimize pushdown and tier-merge behavior where possible
+- validate improvements with workload-level benchmark diffs and protected workload guardrails
+- record trade-offs between target wins and non-target workload movement
+
+## Acceptance Criteria
+
+- targeted filter workloads improve under benchmark comparison
+- deep-page and baseline workloads stay within agreed guardrails
+- benchmark artifacts clearly show where the win came from and what risks remain
+
+## References
+
+- `internal/e2e_harness/federated/query.go`
+- `internal/postgres_duckdb_query.go`
+- `docs/federated-query/federated-query-benchmark-hld-en.md`

--- a/docs/federated-query/issues/18-routing-and-concurrency-optimization-wave.md
+++ b/docs/federated-query/issues/18-routing-and-concurrency-optimization-wave.md
@@ -1,0 +1,26 @@
+## Summary
+
+Optimize federated routing and concurrency behavior using benchmark evidence.
+
+## Why
+
+After the main pagination and filter paths are benchmarked and hardened, the next tuning step is to improve strategy selection and tail behavior. That includes routing heuristics between Postgres and DuckDB paths and fixed-concurrency benchmark behavior.
+
+## Scope
+
+- investigate routing-sensitive workloads and strategy-selection heuristics
+- add or refine fixed-concurrency benchmark execution where needed
+- tune workloads where tail latency or route instability dominates
+- protect correctness and earlier optimization wins with the established benchmark guardrails
+
+## Acceptance Criteria
+
+- routing-sensitive workloads show measurable improvement or better guardrails under benchmark comparison
+- concurrency-aware benchmark runs are reproducible enough for repeated evaluation
+- benchmark artifacts clearly separate target wins from tail-latency regressions elsewhere
+
+## References
+
+- `internal/e2e_harness/federated/query.go`
+- `internal/entity_query_service.go`
+- `docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md`


### PR DESCRIPTION
## Summary
- add a PR-sliced roadmap for turning the federated query benchmark into the basis for autoresearch-guided performance tuning
- add local documentation copies of the follow-up benchmark and optimization issue breakdown
- add issue-draft documents that map the execution sequence from benchmark readiness through the first optimization waves

## Testing
- not run (documentation-only changes)

Refs #55