### PR TITLE
harden benchmark result semantics

### DIFF
--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -211,7 +211,14 @@ func executeBenchmarkRun(ctx context.Context, cfg bench.Config, outputs runOutpu
 		}
 	}
 	fmt.Fprintln(errOut, bench.FormatConsoleSummary(result))
-	return writeJSON(out, result)
+	exitCode := writeJSON(out, result)
+	if exitCode != 0 {
+		return exitCode
+	}
+	if !result.Passed {
+		return 1
+	}
+	return 0
 }
 
 func baselinePresetConfig(rawPreset string, distribution bench.Distribution) (bench.Config, string, error) {

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -81,6 +81,7 @@ func TestRunBenchmarkMainLiveUsesLiveExecutor(t *testing.T) {
 			Config:         cfg,
 			Generator:      bench.GeneratorConfig{Scale: cfg.Scale, Distribution: cfg.Distribution},
 			ValidationOnly: false,
+			Passed:         true,
 			Notes:          []string{"stub live execution"},
 		}, nil
 	}
@@ -99,5 +100,31 @@ func TestRunBenchmarkMainLiveUsesLiveExecutor(t *testing.T) {
 	}
 	if errOut.Len() == 0 {
 		t.Fatalf("live run should emit console summary to stderr")
+	}
+}
+
+func TestRunBenchmarkMainReturnsNonZeroForFailedBenchmarkResult(t *testing.T) {
+	originalValidationMode := runValidationMode
+	defer func() {
+		runValidationMode = originalValidationMode
+	}()
+	runValidationMode = func(context.Context, *bench.Runner) (*bench.RunResult, error) {
+		return &bench.RunResult{
+			Passed:         false,
+			FailureCount:   1,
+			ValidationOnly: true,
+			Generator:      bench.GeneratorConfig{Scale: bench.ScaleSmall, Distribution: bench.DistributionUniform},
+			Notes:          []string{"failed benchmark result"},
+		}, nil
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"run", "-mode", "smoke"}, &out, &errOut)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for failed benchmark result")
+	}
+	if out.Len() == 0 {
+		t.Fatalf("expected JSON output even on failed benchmark result")
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -14,6 +14,9 @@ import (
 // SummaryReport captures aggregated execution metrics.
 type SummaryReport struct {
 	ExecutionCount int                      `json:"execution_count"`
+	Passed         bool                     `json:"passed"`
+	FailureCount   int                      `json:"failure_count,omitempty"`
+	InfraFailures  int                      `json:"infra_failures,omitempty"`
 	P50            time.Duration            `json:"p50"`
 	P95            time.Duration            `json:"p95"`
 	P99            time.Duration            `json:"p99"`
@@ -50,6 +53,8 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 	var b strings.Builder
 	b.WriteString("# Federated Query Benchmark Report\n\n")
 	b.WriteString(fmt.Sprintf("- Validation only: %t\n", result.ValidationOnly))
+	b.WriteString(fmt.Sprintf("- Passed: %t\n", result.Passed))
+	b.WriteString(fmt.Sprintf("- Failure count: %d\n", result.FailureCount))
 	b.WriteString(fmt.Sprintf("- Distribution: %s\n", result.Generator.Distribution))
 	b.WriteString(fmt.Sprintf("- Scale: %s\n", result.Generator.Scale))
 	b.WriteString(fmt.Sprintf("- Executions: %d\n", len(result.Executions)))
@@ -60,7 +65,10 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 	if len(result.Executions) > 0 {
 		b.WriteString("\n## Executions\n\n")
 		for _, execution := range result.Executions {
-			b.WriteString(fmt.Sprintf("- `%s`: count=%d total=%d duration=%s offset=%d\n", execution.Name, execution.ResultCount, execution.TotalRecords, execution.Duration, execution.Offset))
+			b.WriteString(fmt.Sprintf("- `%s`: passed=%t failures=%d count=%d total=%d duration=%s offset=%d\n", execution.Name, execution.Passed, execution.FailureCount, execution.ResultCount, execution.TotalRecords, execution.Duration, execution.Offset))
+			if execution.InfraError != "" {
+				b.WriteString(fmt.Sprintf("  infra_error=%s\n", execution.InfraError))
+			}
 		}
 	}
 	if len(summary.AssertionStats) > 0 {
@@ -104,11 +112,18 @@ func WriteBaselineCapture(dir string, result *RunResult) error {
 func SummarizeRunResult(result *RunResult) SummaryReport {
 	summary := SummaryReport{AssertionStats: make(map[string]AssertionStat)}
 	if result == nil || len(result.Executions) == 0 {
+		summary.Passed = result != nil && result.Passed
+		summary.FailureCount = resultFailureCount(result)
 		return summary
 	}
+	summary.Passed = result.Passed
+	summary.FailureCount = resultFailureCount(result)
 	durations := make([]time.Duration, 0, len(result.Executions))
 	for _, execution := range result.Executions {
 		durations = append(durations, execution.Duration)
+		if execution.InfraError != "" {
+			summary.InfraFailures++
+		}
 		for _, assertion := range execution.Assertions {
 			stat := summary.AssertionStats[assertion.Name]
 			if assertion.Passed {
@@ -158,7 +173,7 @@ func FormatConsoleSummary(result *RunResult) string {
 	summary := SummarizeRunResult(result)
 	var b strings.Builder
 	b.WriteString("Benchmark Summary\n")
-	b.WriteString(fmt.Sprintf("scale=%s distribution=%s executions=%d\n", result.Generator.Scale, result.Generator.Distribution, summary.ExecutionCount))
+	b.WriteString(fmt.Sprintf("scale=%s distribution=%s executions=%d passed=%t failures=%d infra_failures=%d\n", result.Generator.Scale, result.Generator.Distribution, summary.ExecutionCount, summary.Passed, summary.FailureCount, summary.InfraFailures))
 	b.WriteString(fmt.Sprintf("latency p50=%s p95=%s p99=%s max=%s avg=%s qps=%.2f\n", summary.P50, summary.P95, summary.P99, summary.Max, summary.Avg, summary.QPS))
 	if len(summary.AssertionStats) > 0 {
 		keys := make([]string, 0, len(summary.AssertionStats))
@@ -172,4 +187,18 @@ func FormatConsoleSummary(result *RunResult) string {
 		}
 	}
 	return b.String()
+}
+
+func resultFailureCount(result *RunResult) int {
+	if result == nil {
+		return 0
+	}
+	if result.FailureCount > 0 {
+		return result.FailureCount
+	}
+	failed := 0
+	for _, execution := range result.Executions {
+		failed += maxInt(execution.FailureCount, countFailedAssertions(execution.Assertions))
+	}
+	return failed
 }

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -13,9 +13,11 @@ func TestWriteReports(t *testing.T) {
 	jsonPath := filepath.Join(dir, "report.json")
 	mdPath := filepath.Join(dir, "report.md")
 	result := &RunResult{
+		Passed:    true,
 		Generator: GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
 		Executions: []WorkloadRunResult{{
 			Name:         "baseline-page-1",
+			Passed:       true,
 			ResultCount:  20,
 			TotalRecords: 100,
 			Duration:     10 * time.Millisecond,
@@ -38,10 +40,12 @@ func TestWriteReports(t *testing.T) {
 func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 	dir := t.TempDir()
 	result := &RunResult{
-		Generator: GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
+		Passed:       false,
+		FailureCount: 2,
+		Generator:    GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
 		Executions: []WorkloadRunResult{
-			{Name: "q1", Duration: 10 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: true}}},
-			{Name: "q2", Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}}},
+			{Name: "q1", Passed: true, Duration: 10 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: true}}},
+			{Name: "q2", Passed: false, FailureCount: 1, Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}}},
 		},
 	}
 	if err := WriteBaselineCapture(dir, result); err != nil {
@@ -62,15 +66,25 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 	if summary.AssertionStats["a"].Passed != 1 || summary.AssertionStats["a"].Failed != 1 {
 		t.Fatalf("unexpected assertion stats: %+v", summary.AssertionStats["a"])
 	}
+	if summary.Passed {
+		t.Fatalf("expected summary to be marked failed")
+	}
+	if summary.FailureCount != 2 {
+		t.Fatalf("expected summary failure count 2, got %d", summary.FailureCount)
+	}
 }
 
 func TestFormatConsoleSummary(t *testing.T) {
 	result := &RunResult{
-		Generator: GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
+		Passed:       false,
+		FailureCount: 1,
+		Generator:    GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
 		Executions: []WorkloadRunResult{{
-			Name:       "q1",
-			Duration:   10 * time.Millisecond,
-			Assertions: []AssertionResult{{Name: "a", Passed: true}},
+			Name:         "q1",
+			Passed:       false,
+			FailureCount: 1,
+			Duration:     10 * time.Millisecond,
+			Assertions:   []AssertionResult{{Name: "a", Passed: true}},
 		}},
 	}
 	formatted := FormatConsoleSummary(result)
@@ -79,5 +93,8 @@ func TestFormatConsoleSummary(t *testing.T) {
 	}
 	if !strings.Contains(formatted, "Benchmark Summary") {
 		t.Fatalf("expected benchmark header in summary: %s", formatted)
+	}
+	if !strings.Contains(formatted, "passed=false") {
+		t.Fatalf("expected pass state in summary: %s", formatted)
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -17,6 +17,9 @@ type RunResult struct {
 	StartedAt      time.Time            `json:"started_at"`
 	CompletedAt    time.Time            `json:"completed_at"`
 	ValidationOnly bool                 `json:"validation_only"`
+	Passed         bool                 `json:"passed"`
+	FailureCount   int                  `json:"failure_count,omitempty"`
+	InfraError     string               `json:"infra_error,omitempty"`
 	Schemas        []SchemaFixture      `json:"schemas"`
 	Workloads      []WorkloadDefinition `json:"workloads"`
 	Executions     []WorkloadRunResult  `json:"executions,omitempty"`
@@ -34,6 +37,9 @@ type WorkloadRunResult struct {
 	ResultCount  int               `json:"result_count"`
 	TotalRecords int64             `json:"total_records"`
 	Duration     time.Duration     `json:"duration"`
+	Passed       bool              `json:"passed"`
+	FailureCount int               `json:"failure_count,omitempty"`
+	InfraError   string            `json:"infra_error,omitempty"`
 	RowIDs       []string          `json:"row_ids,omitempty"`
 	Assertions   []AssertionResult `json:"assertions,omitempty"`
 	PlanNotes    []string          `json:"plan_notes,omitempty"`
@@ -97,6 +103,7 @@ func (r *Runner) Run(ctx context.Context) (*RunResult, error) {
 		Generator:      r.genConfig,
 		StartedAt:      startedAt,
 		ValidationOnly: true,
+		Passed:         true,
 		Schemas:        append([]SchemaFixture(nil), r.schemas...),
 		Workloads:      append([]WorkloadDefinition(nil), r.workloads...),
 	}
@@ -152,6 +159,8 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 	}
 	executions := make([]WorkloadRunResult, 0, len(r.workloads)*r.config.Iterations)
 	pageRuns := make(map[string]WorkloadRunResult)
+	passed := true
+	failureCount := 0
 	for _, workload := range r.workloads {
 		if !workload.SupportsDistribution(r.genConfig.Distribution) {
 			continue
@@ -159,7 +168,11 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 		for iteration := 0; iteration < r.config.Iterations; iteration++ {
 			run, records, err := r.executeWorkload(ctx, h, workload)
 			if err != nil {
-				return nil, fmt.Errorf("execute workload %s: %w", workload.Name, err)
+				run = failedWorkloadRunResult(workload, r.genConfig.Distribution, r.config.PageSize, fmt.Sprintf("execute workload: %v", err))
+				executions = append(executions, run)
+				passed = false
+				failureCount++
+				continue
 			}
 			run.Assertions = append(run.Assertions, validateBasicWorkloadAssertions(workload, run)...)
 			run.Assertions = append(run.Assertions, validateResultLevelAssertions(workload, run, records)...)
@@ -168,6 +181,12 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 					run.Assertions = append(run.Assertions, validatePaginationTransition(previous, run)...)
 				}
 				pageRuns[workload.TargetSchema] = run
+			}
+			run.FailureCount = countFailedAssertions(run.Assertions)
+			run.Passed = run.FailureCount == 0 && run.InfraError == ""
+			if !run.Passed {
+				passed = false
+				failureCount += maxInt(1, run.FailureCount)
 			}
 			executions = append(executions, run)
 		}
@@ -178,6 +197,8 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 		StartedAt:      startedAt,
 		CompletedAt:    time.Now(),
 		ValidationOnly: false,
+		Passed:         passed,
+		FailureCount:   failureCount,
 		Schemas:        append([]SchemaFixture(nil), r.schemas...),
 		Workloads:      append([]WorkloadDefinition(nil), r.workloads...),
 		Executions:     executions,
@@ -230,12 +251,31 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 		ResultCount:  len(result.Records),
 		TotalRecords: result.TotalRecords,
 		Duration:     result.Duration,
+		Passed:       true,
 		RowIDs:       persistentRecordIDs(result.Records),
 	}
 	if result.Plan != nil {
 		run.PlanNotes = append([]string(nil), result.Plan.Notes...)
 	}
 	return run, result.Records, nil
+}
+
+func failedWorkloadRunResult(workload WorkloadDefinition, distribution Distribution, defaultPageSize int, infraError string) WorkloadRunResult {
+	pageSize := workload.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	return WorkloadRunResult{
+		Name:         workload.Name,
+		Category:     string(workload.Category),
+		Distribution: distribution,
+		PageSize:     pageSize,
+		PageNumber:   workload.PageNumber,
+		Offset:       workload.DerivedOffset(defaultPageSize),
+		Passed:       false,
+		FailureCount: 1,
+		InfraError:   infraError,
+	}
 }
 
 func validateBasicWorkloadAssertions(workload WorkloadDefinition, run WorkloadRunResult) []AssertionResult {
@@ -249,6 +289,16 @@ func validateBasicWorkloadAssertions(workload WorkloadDefinition, run WorkloadRu
 			Name:    "page-size-bound",
 			Passed:  run.ResultCount <= run.PageSize,
 			Message: fmt.Sprintf("result_count=%d page_size=%d", run.ResultCount, run.PageSize),
+		},
+		{
+			Name:    "result-count-within-total-records",
+			Passed:  int64(run.ResultCount) <= run.TotalRecords,
+			Message: fmt.Sprintf("result_count=%d total_records=%d", run.ResultCount, run.TotalRecords),
+		},
+		{
+			Name:    "empty-page-only-when-offset-reaches-total",
+			Passed:  run.ResultCount > 0 || run.Offset >= int(run.TotalRecords) || run.TotalRecords == 0,
+			Message: fmt.Sprintf("offset=%d total=%d result_count=%d", run.Offset, run.TotalRecords, run.ResultCount),
 		},
 	}
 	if workload.Category == WorkloadCategoryDeepPage {
@@ -361,4 +411,21 @@ func hasRowIDOverlap(a, b []string) bool {
 		}
 	}
 	return false
+}
+
+func countFailedAssertions(assertions []AssertionResult) int {
+	failed := 0
+	for _, assertion := range assertions {
+		if !assertion.Passed {
+			failed++
+		}
+	}
+	return failed
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/internal/e2e_harness/federated/benchmark/runner_test.go
+++ b/internal/e2e_harness/federated/benchmark/runner_test.go
@@ -3,6 +3,10 @@ package benchmark
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma/internal"
 )
 
 func TestRunnerRunSmoke(t *testing.T) {
@@ -22,5 +26,92 @@ func TestRunnerRunSmoke(t *testing.T) {
 	}
 	if len(result.Schemas) == 0 {
 		t.Fatalf("expected loaded schemas")
+	}
+	if !result.Passed {
+		t.Fatalf("expected smoke result to pass")
+	}
+}
+
+func TestValidateBasicWorkloadAssertionsDetectsUnexpectedEmptyPage(t *testing.T) {
+	workload := WorkloadDefinition{Name: "baseline-page-100", Category: WorkloadCategoryPagination, PageNumber: 100, PageSize: 20}
+	run := WorkloadRunResult{PageSize: 20, Offset: 40, ResultCount: 0, TotalRecords: 100}
+	assertions := validateBasicWorkloadAssertions(workload, run)
+	if assertionPassed(assertions, "empty-page-only-when-offset-reaches-total") {
+		t.Fatalf("expected empty-page-only-when-offset-reaches-total to fail")
+	}
+}
+
+func TestValidateBasicWorkloadAssertionsAllowsEmptyDeepPagePastTotal(t *testing.T) {
+	workload := WorkloadDefinition{Name: "deep-page-1000", Category: WorkloadCategoryDeepPage, PageNumber: 1000, PageSize: 20}
+	run := WorkloadRunResult{PageSize: 20, Offset: 20000, ResultCount: 0, TotalRecords: 50}
+	assertions := validateBasicWorkloadAssertions(workload, run)
+	if !assertionPassed(assertions, "deep-page-empty-when-offset-exceeds-total") {
+		t.Fatalf("expected deep page assertion to pass when offset exceeds total")
+	}
+	if !assertionPassed(assertions, "empty-page-only-when-offset-reaches-total") {
+		t.Fatalf("expected generic empty page assertion to pass when offset exceeds total")
+	}
+}
+
+func TestValidateResultLevelAssertionsDetectsUnsortedRows(t *testing.T) {
+	records := []*internal.PersistentRecord{
+		{RowID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), Int64Items: map[string]int64{"tradeTime": 10}},
+		{RowID: uuid.MustParse("00000000-0000-0000-0000-000000000003"), Int64Items: map[string]int64{"tradeTime": 20}},
+	}
+	assertions := validateResultLevelAssertions(WorkloadDefinition{Name: "baseline-page-1"}, WorkloadRunResult{RowIDs: []string{records[0].RowID.String(), records[1].RowID.String()}}, records)
+	if assertionPassed(assertions, "sorted-by-tradeTime-desc") {
+		t.Fatalf("expected sort assertion to fail for ascending rows")
+	}
+}
+
+func TestFailedWorkloadRunResultMarksInfraFailure(t *testing.T) {
+	run := failedWorkloadRunResult(WorkloadDefinition{Name: "baseline-page-1", Category: WorkloadCategoryPagination, PageNumber: 1}, DistributionUniform, 20, "boom")
+	if run.Passed {
+		t.Fatalf("expected failed workload run to be marked failed")
+	}
+	if run.InfraError == "" {
+		t.Fatalf("expected infra error to be recorded")
+	}
+	if run.FailureCount != 1 {
+		t.Fatalf("expected failure count 1, got %d", run.FailureCount)
+	}
+}
+
+func TestCountFailedAssertions(t *testing.T) {
+	failed := countFailedAssertions([]AssertionResult{{Name: "a", Passed: true}, {Name: "b", Passed: false}, {Name: "c", Passed: false}})
+	if failed != 2 {
+		t.Fatalf("expected 2 failed assertions, got %d", failed)
+	}
+}
+
+func assertionPassed(assertions []AssertionResult, name string) bool {
+	for _, assertion := range assertions {
+		if assertion.Name == name {
+			return assertion.Passed
+		}
+	}
+	return false
+}
+
+func TestSummarizedWorkloadResultCarriesPassState(t *testing.T) {
+	result := &RunResult{
+		Passed: false,
+		Executions: []WorkloadRunResult{{
+			Name:       "q1",
+			Passed:     false,
+			Duration:   10 * time.Millisecond,
+			InfraError: "broken",
+			Assertions: []AssertionResult{{Name: "a", Passed: false}},
+		}},
+	}
+	summary := SummarizeRunResult(result)
+	if summary.Passed {
+		t.Fatalf("expected summary to reflect failed run")
+	}
+	if summary.InfraFailures != 1 {
+		t.Fatalf("expected one infra failure, got %d", summary.InfraFailures)
+	}
+	if summary.FailureCount != 1 {
+		t.Fatalf("expected one total failure, got %d", summary.FailureCount)
 	}
 }

--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -40,11 +40,22 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 
 	// Build and execute the federated query
 	query := h.buildFederatedQuerySQLDynamic(basePath, deltaPath, hasBaseFiles, hasDeltaFiles, dirtyIDs, opts)
+	countQuery := h.buildFederatedQueryCountSQLDynamic(basePath, deltaPath, hasBaseFiles, hasDeltaFiles, dirtyIDs, opts)
+
+	var totalRecords int64
+	if err := h.Duck.DB.QueryRowContext(ctx, countQuery).Scan(&totalRecords); err != nil {
+		if isFederatedTierFileError(err) {
+			return h.ExecutePostgresQuery(ctx, opts)
+		}
+		return nil, fmt.Errorf("count query: %w", err)
+	}
+	if opts.CountOnly {
+		return &QueryResult{TotalRecords: totalRecords, Duration: time.Since(start), Plan: buildExecutionPlan(len(dirtyIDs), hasBaseFiles, hasDeltaFiles, time.Since(start))}, nil
+	}
 
 	rows, err := h.Duck.DB.QueryContext(ctx, query)
 	if err != nil {
-		// Check if it's a file not found error
-		if strings.Contains(err.Error(), "No files found") || strings.Contains(err.Error(), "does not exist") {
+		if isFederatedTierFileError(err) {
 			return h.ExecutePostgresQuery(ctx, opts)
 		}
 		return nil, fmt.Errorf("execute query: %w", err)
@@ -61,7 +72,7 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 
 	return &QueryResult{
 		Records:      records,
-		TotalRecords: int64(len(records)),
+		TotalRecords: totalRecords,
 		Duration:     duration,
 		Plan:         plan,
 	}, nil
@@ -175,8 +186,25 @@ func buildExecutionPlan(dirtyIDCount int, hasBase, hasDelta bool, duration time.
 	}
 }
 
+func isFederatedTierFileError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "No files found") || strings.Contains(err.Error(), "does not exist")
+}
+
 // buildFederatedQuerySQLDynamic builds the federated query SQL, only including tiers that have files.
 func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions) string {
+	combinedQuery, benchmarkProjection := h.buildFederatedCombinedQuery(basePath, deltaPath, hasBase, hasDelta, dirtyIDs, opts)
+	return buildFinalFederatedSelect(combinedQuery, opts, benchmarkProjection)
+}
+
+func (h *FederatedTestHarness) buildFederatedQueryCountSQLDynamic(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions) string {
+	combinedQuery, _ := h.buildFederatedCombinedQuery(basePath, deltaPath, hasBase, hasDelta, dirtyIDs, opts)
+	return buildFinalFederatedCount(combinedQuery)
+}
+
+func (h *FederatedTestHarness) buildFederatedCombinedQuery(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions) (string, bool) {
 	dirtyExclusion := buildDirtyExclusion(dirtyIDs)
 	rowIDFilter := buildRowIDFilter(opts)
 	attributeFilter := buildAttributeFilterClause(opts)
@@ -202,10 +230,7 @@ func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath
 
 	// Combine all tier queries with UNION ALL
 	combinedQuery := strings.Join(tierQueries, "\n\t\t\tUNION ALL\n")
-
-	query := buildFinalFederatedSelect(combinedQuery, opts, benchmarkProjection)
-
-	return query
+	return combinedQuery, benchmarkProjection
 }
 
 func buildParquetTierQuery(path, tier, dirtyExclusion, rowIDFilter, attributeFilter string, benchmarkProjection bool) string {
@@ -263,22 +288,37 @@ func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeF
 }
 
 func buildFinalFederatedSelect(combinedQuery string, opts *QueryOptions, benchmarkProjection bool) string {
+	cte := buildFederatedDeduplicatedCTE(combinedQuery)
 	if benchmarkProjection {
 		return fmt.Sprintf(`
-		WITH combined AS (
-			%s
-		),
-		deduplicated AS (
-			SELECT *, ROW_NUMBER() OVER (PARTITION BY row_id ORDER BY changed_at DESC) as rn
-			FROM combined
-		)
+		%s
 		SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, tradeTime
 		FROM deduplicated
 		WHERE rn = 1
 		ORDER BY %s
 		LIMIT %d OFFSET %d
-	`, combinedQuery, buildOrderByClause(opts), opts.Limit, opts.Offset)
+	`, cte, buildOrderByClause(opts), opts.Limit, opts.Offset)
 	}
+	return fmt.Sprintf(`
+		%s
+		SELECT row_id, schema_id, changed_at, deleted_at, name, version
+		FROM deduplicated
+		WHERE rn = 1
+		ORDER BY row_id
+		LIMIT %d OFFSET %d
+	`, cte, opts.Limit, opts.Offset)
+}
+
+func buildFinalFederatedCount(combinedQuery string) string {
+	return fmt.Sprintf(`
+		%s
+		SELECT COUNT(*)
+		FROM deduplicated
+		WHERE rn = 1
+	`, buildFederatedDeduplicatedCTE(combinedQuery))
+}
+
+func buildFederatedDeduplicatedCTE(combinedQuery string) string {
 	return fmt.Sprintf(`
 		WITH combined AS (
 			%s
@@ -287,12 +327,7 @@ func buildFinalFederatedSelect(combinedQuery string, opts *QueryOptions, benchma
 			SELECT *, ROW_NUMBER() OVER (PARTITION BY row_id ORDER BY changed_at DESC) as rn
 			FROM combined
 		)
-		SELECT row_id, schema_id, changed_at, deleted_at, name, version
-		FROM deduplicated
-		WHERE rn = 1
-		ORDER BY row_id
-		LIMIT %d OFFSET %d
-	`, combinedQuery, opts.Limit, opts.Offset)
+	`, combinedQuery)
 }
 
 func usesBenchmarkProjection(opts *QueryOptions) bool {
@@ -427,6 +462,16 @@ func (h *FederatedTestHarness) getDirtyIDs(ctx context.Context) ([]uuid.UUID, er
 func (h *FederatedTestHarness) ExecutePostgresQuery(ctx context.Context, opts *QueryOptions) (*QueryResult, error) {
 	opts = normalizeQueryOptions(opts)
 	start := time.Now()
+	if opts.CountOnly {
+		var total int64
+		if err := h.PGDB.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM entity_main 
+			WHERE ltbase_schema_id = $1 AND (ltbase_deleted_at IS NULL OR ltbase_deleted_at = 0)
+		`, h.SchemaID).Scan(&total); err != nil {
+			return nil, err
+		}
+		return &QueryResult{TotalRecords: total, Duration: time.Since(start)}, nil
+	}
 
 	query := `
 		SELECT 

--- a/internal/e2e_harness/federated/query_unit_test.go
+++ b/internal/e2e_harness/federated/query_unit_test.go
@@ -1,0 +1,35 @@
+package federated
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestBuildFinalFederatedCount(t *testing.T) {
+	query := buildFinalFederatedCount("SELECT row_id, changed_at FROM combined_source")
+	if !strings.Contains(query, "SELECT COUNT(*)") {
+		t.Fatalf("expected count query, got: %s", query)
+	}
+	if !strings.Contains(query, "WHERE rn = 1") {
+		t.Fatalf("expected deduplicated filter, got: %s", query)
+	}
+}
+
+func TestBuildFederatedQueryCountSQLDynamic(t *testing.T) {
+	h := &FederatedTestHarness{SchemaID: 1, PGHost: "localhost", PGPort: "5432"}
+	query := h.buildFederatedQueryCountSQLDynamic("base-path", "delta-path", true, true, []uuid.UUID{uuid.MustParse("00000000-0000-0000-0000-000000000001")}, &QueryOptions{Limit: 20, Offset: 40, SortBy: "tradeTime", SortDesc: true})
+	if !strings.Contains(query, "SELECT COUNT(*)") {
+		t.Fatalf("expected count projection, got: %s", query)
+	}
+	if strings.Contains(query, "LIMIT 20 OFFSET 40") {
+		t.Fatalf("count query should not preserve pagination slice: %s", query)
+	}
+	if !strings.Contains(query, "row_id NOT IN") {
+		t.Fatalf("expected dirty-id exclusion in count query: %s", query)
+	}
+	if !strings.Contains(query, "postgres_scan") {
+		t.Fatalf("expected hot tier in count query: %s", query)
+	}
+}


### PR DESCRIPTION
## Summary
- fix federated benchmark total-record semantics by adding a deduplicated count query instead of treating page length as the total
- add structured pass/fail and infra-failure fields to benchmark run results so correctness failures are machine-readable
- make benchmark CLI return a non-zero exit code when the benchmark result fails while still emitting reports and summaries

## Testing
- go test ./cmd/benchmark
- go test ./internal/e2e_harness/federated/benchmark
- go test ./internal/e2e_harness/federated

Closes #48