### PR TITLE
expand benchmark artifact diffs

### DIFF
--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -59,6 +59,8 @@ func runBenchmarkMain(ctx context.Context, args []string, out, errOut io.Writer)
 	switch args[0] {
 	case "describe":
 		return runDescribe(out)
+	case "compare":
+		return runCompare(args[1:], out, errOut)
 	case "baseline":
 		return runBaseline(ctx, args[1:], out, errOut)
 	case "run":
@@ -75,6 +77,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "Commands:")
 	fmt.Fprintln(out, "  describe   Print benchmark schemas, workloads, and defaults")
+	fmt.Fprintln(out, "  compare    Compare two benchmark summary artifacts")
 	fmt.Fprintln(out, "  baseline   Capture a baseline artifact set for a preset")
 	fmt.Fprintln(out, "  run        Execute benchmark validation or live runtime")
 }
@@ -114,6 +117,7 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 	preset := flags.String("preset", "small", "Baseline preset: small or medium")
 	outputDir := flags.String("output-dir", ".artifacts/benchmark", "Directory to store baseline captures")
 	distribution := flags.String("distribution", string(bench.DistributionUniform), "Data distribution preset")
+	compareTo := flags.String("compare-to", "", "Optional path to an existing benchmark-summary.json for diff output")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -123,7 +127,56 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 		return 1
 	}
 	outputs := runOutputs{baselineDir: filepath.Join(*outputDir, dirName)}
-	return executeBenchmarkRun(ctx, config, outputs, out, errOut)
+	exitCode := executeBenchmarkRun(ctx, config, outputs, out, errOut)
+	if *compareTo == "" {
+		return exitCode
+	}
+	if outputs.baselineDir == "" {
+		return exitCode
+	}
+	diffExitCode := compareSummaryFiles(*compareTo, filepath.Join(outputs.baselineDir, "benchmark-summary.json"), out, errOut)
+	if diffExitCode != 0 {
+		return diffExitCode
+	}
+	return exitCode
+}
+
+func runCompare(args []string, out, errOut io.Writer) int {
+	flags := flag.NewFlagSet("compare", flag.ContinueOnError)
+	flags.SetOutput(errOut)
+	baseline := flags.String("baseline", "", "Path to the baseline benchmark-summary.json")
+	candidate := flags.String("candidate", "", "Path to the candidate benchmark-summary.json")
+	diffOut := flags.String("diff-out", "", "Optional path for machine-readable diff output")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if strings.TrimSpace(*baseline) == "" || strings.TrimSpace(*candidate) == "" {
+		fmt.Fprintln(errOut, "compare requires -baseline and -candidate")
+		return 1
+	}
+	return compareSummaryFiles(*baseline, *candidate, out, errOut, *diffOut)
+}
+
+func compareSummaryFiles(baselinePath, candidatePath string, out, errOut io.Writer, diffOut ...string) int {
+	baseline, err := bench.ReadSummaryReport(baselinePath)
+	if err != nil {
+		fmt.Fprintf(errOut, "failed to read baseline summary: %v\n", err)
+		return 1
+	}
+	candidate, err := bench.ReadSummaryReport(candidatePath)
+	if err != nil {
+		fmt.Fprintf(errOut, "failed to read candidate summary: %v\n", err)
+		return 1
+	}
+	diff := bench.CompareSummaryReports(baseline, candidate)
+	if len(diffOut) > 0 && strings.TrimSpace(diffOut[0]) != "" {
+		if err := bench.WriteDiffReport(diffOut[0], &diff); err != nil {
+			fmt.Fprintf(errOut, "failed to write diff report: %v\n", err)
+			return 1
+		}
+	}
+	fmt.Fprintln(errOut, bench.FormatDiffSummary(diff))
+	return writeJSON(out, diff)
 }
 
 type runOutputs struct {

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -126,5 +127,43 @@ func TestRunBenchmarkMainReturnsNonZeroForFailedBenchmarkResult(t *testing.T) {
 	}
 	if out.Len() == 0 {
 		t.Fatalf("expected JSON output even on failed benchmark result")
+	}
+}
+
+func TestRunBenchmarkMainCompare(t *testing.T) {
+	dir := t.TempDir()
+	baseline := bench.SummaryReport{Metadata: bench.ArtifactMetadata{BenchmarkID: "bench-a"}, Passed: true, QPS: 10, Avg: 10}
+	candidate := bench.SummaryReport{Metadata: bench.ArtifactMetadata{BenchmarkID: "bench-b"}, Passed: false, FailureCount: 1, QPS: 8, Avg: 15}
+	baselinePath := filepath.Join(dir, "baseline-summary.json")
+	candidatePath := filepath.Join(dir, "candidate-summary.json")
+	diffPath := filepath.Join(dir, "diff.json")
+	writeSummaryFixture(t, baselinePath, baseline)
+	writeSummaryFixture(t, candidatePath, candidate)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"compare", "-baseline", baselinePath, "-candidate", candidatePath, "-diff-out", diffPath}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("compare returned exit code %d: %s", exitCode, errOut.String())
+	}
+	if out.Len() == 0 {
+		t.Fatalf("compare should emit JSON output")
+	}
+	if _, err := os.Stat(diffPath); err != nil {
+		t.Fatalf("expected diff output to exist: %v", err)
+	}
+	if errOut.Len() == 0 {
+		t.Fatalf("compare should emit console diff summary")
+	}
+}
+
+func writeSummaryFixture(t *testing.T, path string, summary bench.SummaryReport) {
+	t.Helper()
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal summary fixture: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write summary fixture: %v", err)
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -3,33 +3,121 @@ package benchmark
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
 )
 
+const benchmarkArtifactFormatVersion = "v1"
+
+// ArtifactMetadata captures stable identifiers and environment details for a benchmark artifact.
+type ArtifactMetadata struct {
+	FormatVersion string              `json:"format_version"`
+	BenchmarkID   string              `json:"benchmark_id"`
+	WorkloadNames []string            `json:"workload_names,omitempty"`
+	Environment   EnvironmentMetadata `json:"environment"`
+}
+
+// EnvironmentMetadata records machine metadata relevant to benchmark artifacts.
+type EnvironmentMetadata struct {
+	GoVersion string `json:"go_version"`
+	GOOS      string `json:"goos"`
+	GOARCH    string `json:"goarch"`
+	NumCPU    int    `json:"num_cpu"`
+	Hostname  string `json:"hostname,omitempty"`
+}
+
 // SummaryReport captures aggregated execution metrics.
 type SummaryReport struct {
+	Metadata       ArtifactMetadata         `json:"metadata"`
 	ExecutionCount int                      `json:"execution_count"`
 	Passed         bool                     `json:"passed"`
 	FailureCount   int                      `json:"failure_count,omitempty"`
 	InfraFailures  int                      `json:"infra_failures,omitempty"`
+	Min            time.Duration            `json:"min"`
 	P50            time.Duration            `json:"p50"`
 	P95            time.Duration            `json:"p95"`
 	P99            time.Duration            `json:"p99"`
 	Max            time.Duration            `json:"max"`
 	Avg            time.Duration            `json:"avg"`
+	TotalDuration  time.Duration            `json:"total_duration"`
 	QPS            float64                  `json:"qps"`
 	AssertionStats map[string]AssertionStat `json:"assertion_stats"`
+	Workloads      []WorkloadSummary        `json:"workloads,omitempty"`
 }
 
 // AssertionStat captures aggregate assertion pass/fail counts.
 type AssertionStat struct {
 	Passed int `json:"passed"`
 	Failed int `json:"failed"`
+}
+
+// WorkloadSummary captures stable workload-level metrics and metadata.
+type WorkloadSummary struct {
+	Name            string                   `json:"name"`
+	Category        string                   `json:"category"`
+	TargetSchema    string                   `json:"target_schema,omitempty"`
+	Distribution    Distribution             `json:"distribution"`
+	ExecutionCount  int                      `json:"execution_count"`
+	Passed          bool                     `json:"passed"`
+	FailureCount    int                      `json:"failure_count,omitempty"`
+	InfraFailures   int                      `json:"infra_failures,omitempty"`
+	PageSize        int                      `json:"page_size,omitempty"`
+	MaxOffset       int                      `json:"max_offset,omitempty"`
+	AvgResultCount  float64                  `json:"avg_result_count,omitempty"`
+	AvgTotalRecords float64                  `json:"avg_total_records,omitempty"`
+	Min             time.Duration            `json:"min"`
+	P50             time.Duration            `json:"p50"`
+	P95             time.Duration            `json:"p95"`
+	P99             time.Duration            `json:"p99"`
+	Max             time.Duration            `json:"max"`
+	Avg             time.Duration            `json:"avg"`
+	TotalDuration   time.Duration            `json:"total_duration"`
+	QPS             float64                  `json:"qps"`
+	AssertionStats  map[string]AssertionStat `json:"assertion_stats,omitempty"`
+}
+
+// DiffReport captures machine-readable baseline deltas.
+type DiffReport struct {
+	BaselineMetadata  ArtifactMetadata `json:"baseline_metadata"`
+	CandidateMetadata ArtifactMetadata `json:"candidate_metadata"`
+	Summary           SummaryDiff      `json:"summary"`
+	Workloads         []WorkloadDiff   `json:"workloads,omitempty"`
+}
+
+// SummaryDiff captures aggregate benchmark deltas.
+type SummaryDiff struct {
+	PassedChanged       bool          `json:"passed_changed"`
+	FailureCountDelta   int           `json:"failure_count_delta"`
+	InfraFailuresDelta  int           `json:"infra_failures_delta"`
+	ExecutionCountDelta int           `json:"execution_count_delta"`
+	QPSDelta            float64       `json:"qps_delta"`
+	AvgLatencyDelta     time.Duration `json:"avg_latency_delta"`
+	P95LatencyDelta     time.Duration `json:"p95_latency_delta"`
+	P99LatencyDelta     time.Duration `json:"p99_latency_delta"`
+	TotalDurationDelta  time.Duration `json:"total_duration_delta"`
+}
+
+// WorkloadDiff captures workload-level metric deltas.
+type WorkloadDiff struct {
+	Name                 string        `json:"name"`
+	TargetSchema         string        `json:"target_schema,omitempty"`
+	MissingInBaseline    bool          `json:"missing_in_baseline,omitempty"`
+	MissingInCandidate   bool          `json:"missing_in_candidate,omitempty"`
+	PassedChanged        bool          `json:"passed_changed"`
+	FailureCountDelta    int           `json:"failure_count_delta"`
+	InfraFailuresDelta   int           `json:"infra_failures_delta"`
+	ExecutionCountDelta  int           `json:"execution_count_delta"`
+	QPSDelta             float64       `json:"qps_delta"`
+	AvgLatencyDelta      time.Duration `json:"avg_latency_delta"`
+	P95LatencyDelta      time.Duration `json:"p95_latency_delta"`
+	AvgResultCountDelta  float64       `json:"avg_result_count_delta"`
+	AvgTotalRecordsDelta float64       `json:"avg_total_records_delta"`
 }
 
 // WriteJSONReport writes a benchmark run result to JSON.
@@ -52,12 +140,16 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 	summary := SummarizeRunResult(result)
 	var b strings.Builder
 	b.WriteString("# Federated Query Benchmark Report\n\n")
+	b.WriteString(fmt.Sprintf("- Benchmark ID: `%s`\n", summary.Metadata.BenchmarkID))
+	b.WriteString(fmt.Sprintf("- Format version: `%s`\n", summary.Metadata.FormatVersion))
 	b.WriteString(fmt.Sprintf("- Validation only: %t\n", result.ValidationOnly))
 	b.WriteString(fmt.Sprintf("- Passed: %t\n", result.Passed))
 	b.WriteString(fmt.Sprintf("- Failure count: %d\n", result.FailureCount))
 	b.WriteString(fmt.Sprintf("- Distribution: %s\n", result.Generator.Distribution))
 	b.WriteString(fmt.Sprintf("- Scale: %s\n", result.Generator.Scale))
 	b.WriteString(fmt.Sprintf("- Executions: %d\n", len(result.Executions)))
+	b.WriteString(fmt.Sprintf("- Total duration: %s\n", summary.TotalDuration))
+	b.WriteString(fmt.Sprintf("- Min: %s\n", summary.Min))
 	b.WriteString(fmt.Sprintf("- P50: %s\n", summary.P50))
 	b.WriteString(fmt.Sprintf("- P95: %s\n", summary.P95))
 	b.WriteString(fmt.Sprintf("- P99: %s\n", summary.P99))
@@ -81,6 +173,12 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 		for _, key := range keys {
 			stat := summary.AssertionStats[key]
 			b.WriteString(fmt.Sprintf("- `%s`: passed=%d failed=%d\n", key, stat.Passed, stat.Failed))
+		}
+	}
+	if len(summary.Workloads) > 0 {
+		b.WriteString("\n## Workload Summaries\n\n")
+		for _, workload := range summary.Workloads {
+			b.WriteString(fmt.Sprintf("- `%s`: schema=%s executions=%d passed=%t qps=%.2f p95=%s avg=%s avg_result_count=%.2f avg_total_records=%.2f\n", workload.Name, workload.TargetSchema, workload.ExecutionCount, workload.Passed, workload.QPS, workload.P95, workload.Avg, workload.AvgResultCount, workload.AvgTotalRecords))
 		}
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
@@ -108,16 +206,34 @@ func WriteBaselineCapture(dir string, result *RunResult) error {
 	return os.WriteFile(filepath.Join(dir, "benchmark-summary.json"), data, 0o644)
 }
 
+// WriteDiffReport writes a diff report to JSON.
+func WriteDiffReport(path string, diff *DiffReport) error {
+	if diff == nil {
+		return fmt.Errorf("diff report cannot be nil")
+	}
+	data, err := json.MarshalIndent(diff, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal diff report: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
 // SummarizeRunResult aggregates durations and assertion outcomes.
 func SummarizeRunResult(result *RunResult) SummaryReport {
 	summary := SummaryReport{AssertionStats: make(map[string]AssertionStat)}
-	if result == nil || len(result.Executions) == 0 {
+	if result == nil {
+		return summary
+	}
+	summary.Metadata = metadataForResult(result)
+	if len(result.Executions) == 0 {
 		summary.Passed = result != nil && result.Passed
 		summary.FailureCount = resultFailureCount(result)
+		summary.Workloads = summarizeWorkloads(result)
 		return summary
 	}
 	summary.Passed = result.Passed
 	summary.FailureCount = resultFailureCount(result)
+	summary.Workloads = summarizeWorkloads(result)
 	durations := make([]time.Duration, 0, len(result.Executions))
 	for _, execution := range result.Executions {
 		durations = append(durations, execution.Duration)
@@ -136,6 +252,7 @@ func SummarizeRunResult(result *RunResult) SummaryReport {
 	}
 	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
 	summary.ExecutionCount = len(durations)
+	summary.Min = durations[0]
 	summary.P50 = percentileDuration(durations, 0.50)
 	summary.P95 = percentileDuration(durations, 0.95)
 	summary.P99 = percentileDuration(durations, 0.99)
@@ -144,6 +261,7 @@ func SummarizeRunResult(result *RunResult) SummaryReport {
 	for _, duration := range durations {
 		total += duration
 	}
+	summary.TotalDuration = total
 	summary.Avg = total / time.Duration(len(durations))
 	if total > 0 {
 		summary.QPS = float64(len(durations)) / total.Seconds()
@@ -173,8 +291,8 @@ func FormatConsoleSummary(result *RunResult) string {
 	summary := SummarizeRunResult(result)
 	var b strings.Builder
 	b.WriteString("Benchmark Summary\n")
-	b.WriteString(fmt.Sprintf("scale=%s distribution=%s executions=%d passed=%t failures=%d infra_failures=%d\n", result.Generator.Scale, result.Generator.Distribution, summary.ExecutionCount, summary.Passed, summary.FailureCount, summary.InfraFailures))
-	b.WriteString(fmt.Sprintf("latency p50=%s p95=%s p99=%s max=%s avg=%s qps=%.2f\n", summary.P50, summary.P95, summary.P99, summary.Max, summary.Avg, summary.QPS))
+	b.WriteString(fmt.Sprintf("benchmark_id=%s scale=%s distribution=%s executions=%d passed=%t failures=%d infra_failures=%d\n", summary.Metadata.BenchmarkID, result.Generator.Scale, result.Generator.Distribution, summary.ExecutionCount, summary.Passed, summary.FailureCount, summary.InfraFailures))
+	b.WriteString(fmt.Sprintf("latency min=%s p50=%s p95=%s p99=%s max=%s avg=%s total=%s qps=%.2f\n", summary.Min, summary.P50, summary.P95, summary.P99, summary.Max, summary.Avg, summary.TotalDuration, summary.QPS))
 	if len(summary.AssertionStats) > 0 {
 		keys := make([]string, 0, len(summary.AssertionStats))
 		for key := range summary.AssertionStats {
@@ -184,6 +302,11 @@ func FormatConsoleSummary(result *RunResult) string {
 		for _, key := range keys {
 			stat := summary.AssertionStats[key]
 			b.WriteString(fmt.Sprintf("assertion %s passed=%d failed=%d\n", key, stat.Passed, stat.Failed))
+		}
+	}
+	if len(summary.Workloads) > 0 {
+		for _, workload := range summary.Workloads {
+			b.WriteString(fmt.Sprintf("workload %s schema=%s executions=%d passed=%t qps=%.2f p95=%s avg=%s avg_result_count=%.2f avg_total_records=%.2f\n", workload.Name, workload.TargetSchema, workload.ExecutionCount, workload.Passed, workload.QPS, workload.P95, workload.Avg, workload.AvgResultCount, workload.AvgTotalRecords))
 		}
 	}
 	return b.String()
@@ -201,4 +324,234 @@ func resultFailureCount(result *RunResult) int {
 		failed += maxInt(execution.FailureCount, countFailedAssertions(execution.Assertions))
 	}
 	return failed
+}
+
+// BuildArtifactMetadata returns stable metadata for benchmark artifacts.
+func BuildArtifactMetadata(cfg Config, genCfg GeneratorConfig, workloads []WorkloadDefinition) ArtifactMetadata {
+	hostname, _ := os.Hostname()
+	names := make([]string, 0, len(workloads))
+	for _, workload := range workloads {
+		names = append(names, workload.Name)
+	}
+	payload := struct {
+		Config    Config          `json:"config"`
+		Generator GeneratorConfig `json:"generator"`
+		Workloads []string        `json:"workloads"`
+	}{Config: cfg, Generator: genCfg, Workloads: names}
+	encoded, _ := json.Marshal(payload)
+	hash := fnv.New64a()
+	_, _ = hash.Write(encoded)
+	return ArtifactMetadata{
+		FormatVersion: benchmarkArtifactFormatVersion,
+		BenchmarkID:   fmt.Sprintf("bench-%x", hash.Sum64()),
+		WorkloadNames: names,
+		Environment: EnvironmentMetadata{
+			GoVersion: runtime.Version(),
+			GOOS:      runtime.GOOS,
+			GOARCH:    runtime.GOARCH,
+			NumCPU:    runtime.NumCPU(),
+			Hostname:  hostname,
+		},
+	}
+}
+
+func metadataForResult(result *RunResult) ArtifactMetadata {
+	if result == nil {
+		return ArtifactMetadata{}
+	}
+	if result.Metadata.BenchmarkID != "" {
+		return result.Metadata
+	}
+	return BuildArtifactMetadata(result.Config, result.Generator, result.Workloads)
+}
+
+// CompareSummaryReports builds a machine-readable diff between two summaries.
+func CompareSummaryReports(baseline, candidate SummaryReport) DiffReport {
+	return DiffReport{
+		BaselineMetadata:  baseline.Metadata,
+		CandidateMetadata: candidate.Metadata,
+		Summary: SummaryDiff{
+			PassedChanged:       baseline.Passed != candidate.Passed,
+			FailureCountDelta:   candidate.FailureCount - baseline.FailureCount,
+			InfraFailuresDelta:  candidate.InfraFailures - baseline.InfraFailures,
+			ExecutionCountDelta: candidate.ExecutionCount - baseline.ExecutionCount,
+			QPSDelta:            candidate.QPS - baseline.QPS,
+			AvgLatencyDelta:     candidate.Avg - baseline.Avg,
+			P95LatencyDelta:     candidate.P95 - baseline.P95,
+			P99LatencyDelta:     candidate.P99 - baseline.P99,
+			TotalDurationDelta:  candidate.TotalDuration - baseline.TotalDuration,
+		},
+		Workloads: compareWorkloadSummaries(baseline.Workloads, candidate.Workloads),
+	}
+}
+
+// CompareRunResults summarizes and compares two run results.
+func CompareRunResults(baseline, candidate *RunResult) DiffReport {
+	return CompareSummaryReports(SummarizeRunResult(baseline), SummarizeRunResult(candidate))
+}
+
+// ReadSummaryReport reads a summary report JSON file.
+func ReadSummaryReport(path string) (SummaryReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return SummaryReport{}, err
+	}
+	var summary SummaryReport
+	if err := json.Unmarshal(data, &summary); err != nil {
+		return SummaryReport{}, fmt.Errorf("decode summary report: %w", err)
+	}
+	return summary, nil
+}
+
+// FormatDiffSummary returns a stable console diff summary.
+func FormatDiffSummary(diff DiffReport) string {
+	var b strings.Builder
+	b.WriteString("Benchmark Diff Summary\n")
+	b.WriteString(fmt.Sprintf("baseline=%s candidate=%s passed_changed=%t failure_delta=%d infra_delta=%d qps_delta=%.2f avg_latency_delta=%s p95_latency_delta=%s\n",
+		diff.BaselineMetadata.BenchmarkID,
+		diff.CandidateMetadata.BenchmarkID,
+		diff.Summary.PassedChanged,
+		diff.Summary.FailureCountDelta,
+		diff.Summary.InfraFailuresDelta,
+		diff.Summary.QPSDelta,
+		diff.Summary.AvgLatencyDelta,
+		diff.Summary.P95LatencyDelta,
+	))
+	for _, workload := range diff.Workloads {
+		b.WriteString(fmt.Sprintf("workload %s schema=%s missing_baseline=%t missing_candidate=%t passed_changed=%t qps_delta=%.2f avg_latency_delta=%s p95_latency_delta=%s avg_result_delta=%.2f avg_total_delta=%.2f\n",
+			workload.Name,
+			workload.TargetSchema,
+			workload.MissingInBaseline,
+			workload.MissingInCandidate,
+			workload.PassedChanged,
+			workload.QPSDelta,
+			workload.AvgLatencyDelta,
+			workload.P95LatencyDelta,
+			workload.AvgResultCountDelta,
+			workload.AvgTotalRecordsDelta,
+		))
+	}
+	return b.String()
+}
+
+func summarizeWorkloads(result *RunResult) []WorkloadSummary {
+	if result == nil || len(result.Executions) == 0 {
+		return nil
+	}
+	workloadDefs := make(map[string]WorkloadDefinition, len(result.Workloads))
+	for _, workload := range result.Workloads {
+		workloadDefs[workload.Name] = workload
+	}
+	grouped := make(map[string][]WorkloadRunResult)
+	for _, execution := range result.Executions {
+		grouped[execution.Name] = append(grouped[execution.Name], execution)
+	}
+	names := make([]string, 0, len(grouped))
+	for name := range grouped {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	workloads := make([]WorkloadSummary, 0, len(names))
+	for _, name := range names {
+		runs := grouped[name]
+		workload := WorkloadSummary{Name: name, Passed: true, AssertionStats: make(map[string]AssertionStat)}
+		if def, ok := workloadDefs[name]; ok {
+			workload.Category = string(def.Category)
+			workload.TargetSchema = def.TargetSchema
+			workload.Distribution = runs[0].Distribution
+			workload.PageSize = def.PageSize
+		}
+		durations := make([]time.Duration, 0, len(runs))
+		var totalDuration time.Duration
+		var totalResultCount int
+		var totalRecords int64
+		for _, run := range runs {
+			durations = append(durations, run.Duration)
+			totalDuration += run.Duration
+			totalResultCount += run.ResultCount
+			totalRecords += run.TotalRecords
+			workload.ExecutionCount++
+			workload.FailureCount += maxInt(run.FailureCount, countFailedAssertions(run.Assertions))
+			if run.InfraError != "" {
+				workload.InfraFailures++
+			}
+			if !run.Passed {
+				workload.Passed = false
+			}
+			if run.PageSize > 0 && workload.PageSize == 0 {
+				workload.PageSize = run.PageSize
+			}
+			if run.Offset > workload.MaxOffset {
+				workload.MaxOffset = run.Offset
+			}
+			for _, assertion := range run.Assertions {
+				stat := workload.AssertionStats[assertion.Name]
+				if assertion.Passed {
+					stat.Passed++
+				} else {
+					stat.Failed++
+				}
+				workload.AssertionStats[assertion.Name] = stat
+			}
+		}
+		sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+		workload.Min = durations[0]
+		workload.P50 = percentileDuration(durations, 0.50)
+		workload.P95 = percentileDuration(durations, 0.95)
+		workload.P99 = percentileDuration(durations, 0.99)
+		workload.Max = durations[len(durations)-1]
+		workload.TotalDuration = totalDuration
+		workload.Avg = totalDuration / time.Duration(len(durations))
+		if totalDuration > 0 {
+			workload.QPS = float64(len(durations)) / totalDuration.Seconds()
+		}
+		workload.AvgResultCount = float64(totalResultCount) / float64(len(runs))
+		workload.AvgTotalRecords = float64(totalRecords) / float64(len(runs))
+		workloads = append(workloads, workload)
+	}
+	return workloads
+}
+
+func compareWorkloadSummaries(baseline, candidate []WorkloadSummary) []WorkloadDiff {
+	baselineByName := make(map[string]WorkloadSummary, len(baseline))
+	candidateByName := make(map[string]WorkloadSummary, len(candidate))
+	nameSet := make(map[string]struct{}, len(baseline)+len(candidate))
+	for _, workload := range baseline {
+		baselineByName[workload.Name] = workload
+		nameSet[workload.Name] = struct{}{}
+	}
+	for _, workload := range candidate {
+		candidateByName[workload.Name] = workload
+		nameSet[workload.Name] = struct{}{}
+	}
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	diffs := make([]WorkloadDiff, 0, len(names))
+	for _, name := range names {
+		base, baseOK := baselineByName[name]
+		cand, candOK := candidateByName[name]
+		targetSchema := base.TargetSchema
+		if targetSchema == "" {
+			targetSchema = cand.TargetSchema
+		}
+		diffs = append(diffs, WorkloadDiff{
+			Name:                 name,
+			TargetSchema:         targetSchema,
+			MissingInBaseline:    !baseOK,
+			MissingInCandidate:   !candOK,
+			PassedChanged:        base.Passed != cand.Passed,
+			FailureCountDelta:    cand.FailureCount - base.FailureCount,
+			InfraFailuresDelta:   cand.InfraFailures - base.InfraFailures,
+			ExecutionCountDelta:  cand.ExecutionCount - base.ExecutionCount,
+			QPSDelta:             cand.QPS - base.QPS,
+			AvgLatencyDelta:      cand.Avg - base.Avg,
+			P95LatencyDelta:      cand.P95 - base.P95,
+			AvgResultCountDelta:  cand.AvgResultCount - base.AvgResultCount,
+			AvgTotalRecordsDelta: cand.AvgTotalRecords - base.AvgTotalRecords,
+		})
+	}
+	return diffs
 }

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +35,10 @@ func TestWriteReports(t *testing.T) {
 	}
 	if _, err := os.Stat(mdPath); err != nil {
 		t.Fatalf("expected markdown report to exist: %v", err)
+	}
+	summary := SummarizeRunResult(result)
+	if summary.Metadata.BenchmarkID == "" {
+		t.Fatalf("expected summary to carry metadata")
 	}
 }
 
@@ -72,6 +77,12 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 	if summary.FailureCount != 2 {
 		t.Fatalf("expected summary failure count 2, got %d", summary.FailureCount)
 	}
+	if summary.Metadata.BenchmarkID == "" {
+		t.Fatalf("expected summary metadata to include benchmark ID")
+	}
+	if len(summary.Workloads) != 2 {
+		t.Fatalf("expected two workload summaries, got %d", len(summary.Workloads))
+	}
 }
 
 func TestFormatConsoleSummary(t *testing.T) {
@@ -96,5 +107,97 @@ func TestFormatConsoleSummary(t *testing.T) {
 	}
 	if !strings.Contains(formatted, "passed=false") {
 		t.Fatalf("expected pass state in summary: %s", formatted)
+	}
+	if !strings.Contains(formatted, "benchmark_id=") {
+		t.Fatalf("expected benchmark id in summary: %s", formatted)
+	}
+}
+
+func TestCompareSummaryReports(t *testing.T) {
+	baseline := SummaryReport{
+		Metadata:       ArtifactMetadata{BenchmarkID: "bench-a"},
+		Passed:         true,
+		ExecutionCount: 2,
+		QPS:            10,
+		Avg:            10 * time.Millisecond,
+		P95:            20 * time.Millisecond,
+		Workloads: []WorkloadSummary{{
+			Name:            "q1",
+			TargetSchema:    "trade",
+			Passed:          true,
+			ExecutionCount:  2,
+			QPS:             5,
+			Avg:             10 * time.Millisecond,
+			P95:             20 * time.Millisecond,
+			AvgResultCount:  20,
+			AvgTotalRecords: 100,
+		}},
+	}
+	candidate := SummaryReport{
+		Metadata:       ArtifactMetadata{BenchmarkID: "bench-b"},
+		Passed:         false,
+		FailureCount:   1,
+		ExecutionCount: 2,
+		QPS:            8,
+		Avg:            12 * time.Millisecond,
+		P95:            25 * time.Millisecond,
+		Workloads: []WorkloadSummary{{
+			Name:            "q1",
+			TargetSchema:    "trade",
+			Passed:          false,
+			FailureCount:    1,
+			ExecutionCount:  2,
+			QPS:             4,
+			Avg:             12 * time.Millisecond,
+			P95:             25 * time.Millisecond,
+			AvgResultCount:  18,
+			AvgTotalRecords: 95,
+		}},
+	}
+	diff := CompareSummaryReports(baseline, candidate)
+	if !diff.Summary.PassedChanged {
+		t.Fatalf("expected passed state change in diff")
+	}
+	if len(diff.Workloads) != 1 {
+		t.Fatalf("expected one workload diff, got %d", len(diff.Workloads))
+	}
+	if diff.Workloads[0].AvgResultCountDelta >= 0 {
+		t.Fatalf("expected avg result count delta to be negative: %+v", diff.Workloads[0])
+	}
+	formatted := FormatDiffSummary(diff)
+	if !strings.Contains(formatted, "Benchmark Diff Summary") {
+		t.Fatalf("expected diff summary header: %s", formatted)
+	}
+}
+
+func TestWriteAndReadDiffReport(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "diff.json")
+	summaryPath := filepath.Join(dir, "summary.json")
+	diff := &DiffReport{
+		BaselineMetadata:  ArtifactMetadata{BenchmarkID: "bench-a"},
+		CandidateMetadata: ArtifactMetadata{BenchmarkID: "bench-b"},
+		Summary:           SummaryDiff{QPSDelta: -2},
+	}
+	if err := WriteDiffReport(path, diff); err != nil {
+		t.Fatalf("WriteDiffReport failed: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected diff report to exist: %v", err)
+	}
+	summary := SummaryReport{Metadata: ArtifactMetadata{BenchmarkID: "bench-summary"}, Passed: true}
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal summary fixture failed: %v", err)
+	}
+	if err := os.WriteFile(summaryPath, data, 0o644); err != nil {
+		t.Fatalf("write summary fixture failed: %v", err)
+	}
+	readSummary, err := ReadSummaryReport(summaryPath)
+	if err != nil {
+		t.Fatalf("ReadSummaryReport failed: %v", err)
+	}
+	if readSummary.Metadata.BenchmarkID != summary.Metadata.BenchmarkID {
+		t.Fatalf("unexpected summary metadata: %+v", readSummary.Metadata)
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -14,6 +14,7 @@ import (
 type RunResult struct {
 	Config         Config               `json:"config"`
 	Generator      GeneratorConfig      `json:"generator"`
+	Metadata       ArtifactMetadata     `json:"metadata"`
 	StartedAt      time.Time            `json:"started_at"`
 	CompletedAt    time.Time            `json:"completed_at"`
 	ValidationOnly bool                 `json:"validation_only"`
@@ -101,6 +102,7 @@ func (r *Runner) Run(ctx context.Context) (*RunResult, error) {
 	result := &RunResult{
 		Config:         r.config,
 		Generator:      r.genConfig,
+		Metadata:       BuildArtifactMetadata(r.config, r.genConfig, r.workloads),
 		StartedAt:      startedAt,
 		ValidationOnly: true,
 		Passed:         true,
@@ -194,6 +196,7 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 	result := &RunResult{
 		Config:         r.config,
 		Generator:      r.genConfig,
+		Metadata:       BuildArtifactMetadata(r.config, r.genConfig, r.workloads),
 		StartedAt:      startedAt,
 		CompletedAt:    time.Now(),
 		ValidationOnly: false,


### PR DESCRIPTION
## Summary
- add stable benchmark artifact metadata and workload-level summaries to benchmark reports and baseline captures
- add machine-readable summary diff support plus console formatting for comparing benchmark baselines and candidate runs
- add a `benchmark compare` CLI command and baseline compare flow for producing diff artifacts from summary JSON files

## Testing
- go test ./internal/e2e_harness/federated/benchmark
- go test ./cmd/benchmark
- go test ./internal/e2e_harness/federated

Closes #47