### PR TITLE
align benchmark live workload oracles

### DIFF
--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -2,11 +2,13 @@ package benchmark
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sort"
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	forma "github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal"
 	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
@@ -169,7 +171,19 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 	}
 	executions := make([]WorkloadRunResult, 0, len(r.workloads)*r.config.Iterations)
 	pageRuns := make(map[string]WorkloadRunResult)
-	expectedByWorkload := buildExpectedWorkloadResultsFromRecords(tieredRecords(tiered), r.workloads, r.config.PageSize)
+	loadedRecords := tieredRecords(tiered)
+	snapshot, err := buildLoadedStateSnapshot(ctx, h, tiered)
+	if err != nil {
+		return nil, fmt.Errorf("build loaded state snapshot: %w", err)
+	}
+	loadedRecords = snapshot
+	expectedByWorkload := buildExpectedWorkloadResultsFromRecords(loadedRecords, r.workloads, r.config.PageSize, r.genConfig)
+	if hotExpected, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, WorkloadDefinition{Name: "hot-selective-page", TargetSchema: "trade", FilterAttribute: "symbol", FilterValue: "SYM00001", PageSize: 20, PageNumber: 1}, r.config.PageSize, loadedRecords, r.genConfig); err == nil {
+		expectedByWorkload["hot-selective-page"] = hotExpected
+	}
+	if eavExpected, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, WorkloadDefinition{Name: "eav-selective-page", TargetSchema: "trade", FilterAttribute: "exchange", FilterValue: "NYSE", PageSize: 20, PageNumber: 1}, r.config.PageSize, loadedRecords, r.genConfig); err == nil {
+		expectedByWorkload["eav-selective-page"] = eavExpected
+	}
 	passed := true
 	failureCount := 0
 	for _, workload := range r.workloads {
@@ -185,8 +199,9 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 				failureCount++
 				continue
 			}
+			semantics := semanticsForWorkload(workload, r.genConfig)
 			run.Assertions = append(run.Assertions, validateBasicWorkloadAssertions(workload, run)...)
-			run.Assertions = append(run.Assertions, validateResultLevelAssertions(workload, run, records)...)
+			run.Assertions = append(run.Assertions, validateResultLevelAssertions(workload, run, records, semantics)...)
 			if expected, ok := expectedByWorkload[workload.Name]; ok {
 				run.Assertions = append(run.Assertions, validateExpectedWorkloadOutcome(run, expected)...)
 			}
@@ -222,6 +237,7 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 			"loaded TPC-E-inspired schema fixtures",
 			fmt.Sprintf("generated dataset with distribution=%s", r.genConfig.Distribution),
 			fmt.Sprintf("loaded tiered dataset profile=%s", profile.Name),
+			fmt.Sprintf("loaded-state snapshot rows=%d", len(loadedRecords)),
 			"executed supported federated query workloads",
 		},
 	}
@@ -258,7 +274,7 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 	defer func() {
 		h.SchemaID = previousSchemaID
 	}()
-	opts := queryOptionsForWorkload(workload, r.config.PageSize)
+	opts := queryOptionsForWorkloadWithConfig(workload, r.config.PageSize, r.genConfig)
 	if workload.UsesSimpleFilter() {
 		opts.Filter = &federated.Filter{Conditions: map[string]any{workload.FilterAttribute: workload.FilterValue}}
 	}
@@ -309,18 +325,23 @@ type expectedWorkloadResult struct {
 	RowIDs       []string
 }
 
+type workloadSemantics struct {
+	TradeTimeStart int64
+	TradeTimeEnd   int64
+}
+
 func buildExpectedWorkloadResults(dataset *GeneratedDataset, workloads []WorkloadDefinition, defaultPageSize int) map[string]expectedWorkloadResult {
 	if dataset == nil {
 		return map[string]expectedWorkloadResult{}
 	}
-	return buildExpectedWorkloadResultsFromRecords(dataset.Records, workloads, defaultPageSize)
+	return buildExpectedWorkloadResultsFromRecords(dataset.Records, workloads, defaultPageSize, dataset.Config)
 }
 
-func buildExpectedWorkloadResultsFromRecords(records []GeneratedRecord, workloads []WorkloadDefinition, defaultPageSize int) map[string]expectedWorkloadResult {
+func buildExpectedWorkloadResultsFromRecords(records []GeneratedRecord, workloads []WorkloadDefinition, defaultPageSize int, genCfg GeneratorConfig) map[string]expectedWorkloadResult {
 	results := make(map[string]expectedWorkloadResult, len(workloads))
 	visible := expectedVisibleRecords(records)
 	for _, workload := range workloads {
-		matching := filterExpectedRecordsForWorkload(visible, workload)
+		matching := filterExpectedRecordsForWorkload(visible, workload, semanticsForWorkload(workload, genCfg))
 		sortExpectedRecordsForWorkload(matching, workload)
 		pageSize := workload.PageSize
 		if pageSize <= 0 {
@@ -344,6 +365,201 @@ func tieredRecords(dataset *TieredDataset) []GeneratedRecord {
 		}
 	}
 	return records
+}
+
+func buildLoadedStateSnapshot(ctx context.Context, h *federated.FederatedTestHarness, dataset *TieredDataset) ([]GeneratedRecord, error) {
+	if h == nil || dataset == nil {
+		return nil, fmt.Errorf("harness and dataset are required")
+	}
+	hotRecords, hotKeys, err := loadHotStateRecords(ctx, h)
+	if err != nil {
+		return nil, err
+	}
+	records := make([]GeneratedRecord, 0, len(dataset.Base)+len(dataset.Delta)+len(hotRecords))
+	for _, bucket := range [][]GeneratedRecord{dataset.Base, dataset.Delta} {
+		for _, record := range bucket {
+			if _, ok := hotKeys[schemaRowKey(record.SchemaID, record.RowID)]; ok {
+				continue
+			}
+			records = append(records, cloneGeneratedRecord(record))
+		}
+	}
+	records = append(records, hotRecords...)
+	return records, nil
+}
+
+func loadHotStateRecords(ctx context.Context, h *federated.FederatedTestHarness) ([]GeneratedRecord, map[string]struct{}, error) {
+	rows, err := h.PGDB.QueryContext(ctx, `
+		SELECT cl.schema_id, cl.row_id, cl.changed_at, COALESCE(cl.deleted_at, 0),
+			em.text_01, em.text_02, em.smallint_01, em.bigint_02,
+			hot_vals.symbol, hot_vals.exchange, hot_vals.region, hot_vals.trade_type, hot_vals.trade_time, hot_vals.name
+		FROM change_log cl
+		LEFT JOIN entity_main em
+			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id = cl.row_id
+		LEFT JOIN (
+			SELECT schema_id, row_id,
+				MAX(CASE WHEN attr_id = $1 THEN value_text END) AS symbol,
+				MAX(CASE WHEN attr_id = $2 THEN value_text END) AS exchange,
+				MAX(CASE WHEN attr_id = $3 THEN value_text END) AS region,
+				MAX(CASE WHEN attr_id = $4 THEN value_numeric END) AS trade_type,
+				MAX(CASE WHEN attr_id = $5 THEN COALESCE(value_text, CAST(value_numeric AS TEXT)) END) AS trade_time,
+				MAX(CASE WHEN attr_id = $6 THEN value_text END) AS name
+			FROM eav_data
+			GROUP BY schema_id, row_id
+		) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id
+		WHERE cl.flushed_at = 0
+	`,
+		benchmarkAttributeID(SchemaIDTrade, "symbol"),
+		benchmarkAttributeID(SchemaIDTrade, "exchange"),
+		benchmarkAttributeID(SchemaIDTrade, "region"),
+		benchmarkAttributeID(SchemaIDTrade, "tradeType"),
+		benchmarkAttributeID(SchemaIDTrade, "tradeTime"),
+		benchmarkAttributeID(SchemaIDTrade, "name"),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load hot state snapshot: %w", err)
+	}
+	defer rows.Close()
+	records := make([]GeneratedRecord, 0)
+	keys := make(map[string]struct{})
+	for rows.Next() {
+		record, err := scanLoadedHotRecord(rows)
+		if err != nil {
+			return nil, nil, err
+		}
+		records = append(records, record)
+		keys[schemaRowKey(record.SchemaID, record.RowID)] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate hot state snapshot: %w", err)
+	}
+	return records, keys, nil
+}
+
+func scanLoadedHotRecord(rows *sql.Rows) (GeneratedRecord, error) {
+	var schemaID int16
+	var rowID uuid.UUID
+	var changedAt int64
+	var deletedAt int64
+	var text01 sql.NullString
+	var text02 sql.NullString
+	var smallint01 sql.NullInt16
+	var bigint02 sql.NullInt64
+	var symbol sql.NullString
+	var exchange sql.NullString
+	var region sql.NullString
+	var tradeType sql.NullFloat64
+	var tradeTime sql.NullString
+	var name sql.NullString
+	if err := rows.Scan(&schemaID, &rowID, &changedAt, &deletedAt, &text01, &text02, &smallint01, &bigint02, &symbol, &exchange, &region, &tradeType, &tradeTime, &name); err != nil {
+		return GeneratedRecord{}, fmt.Errorf("scan hot state row: %w", err)
+	}
+	attrs := make(map[string]any)
+	schemaName, err := schemaNameForID(schemaID)
+	if err != nil {
+		return GeneratedRecord{}, err
+	}
+	switch schemaID {
+	case SchemaIDTrade:
+		if symbol.Valid {
+			attrs["symbol"] = symbol.String
+		} else if text01.Valid {
+			attrs["symbol"] = text01.String
+		}
+		if exchange.Valid {
+			attrs["exchange"] = exchange.String
+		}
+		if region.Valid {
+			attrs["region"] = region.String
+		} else if text02.Valid {
+			attrs["region"] = text02.String
+		}
+		if tradeType.Valid {
+			attrs["tradeType"] = int64(tradeType.Float64)
+		} else if smallint01.Valid {
+			attrs["tradeType"] = int64(smallint01.Int16)
+		}
+		if tradeTime.Valid {
+			attrs["tradeTime"] = tradeTime.String
+		} else if bigint02.Valid {
+			attrs["tradeTime"] = strconv.FormatInt(bigint02.Int64, 10)
+		}
+		if name.Valid {
+			attrs["name"] = name.String
+		} else if symbol.Valid {
+			attrs["name"] = symbol.String
+		}
+	case SchemaIDCustomer:
+		if text02.Valid {
+			attrs["region"] = text02.String
+		}
+		if name.Valid {
+			attrs["name"] = name.String
+		} else if text01.Valid {
+			attrs["name"] = text01.String
+		}
+	case SchemaIDSecurity:
+		if symbol.Valid {
+			attrs["symbol"] = symbol.String
+		} else if text01.Valid {
+			attrs["symbol"] = text01.String
+		}
+		if name.Valid {
+			attrs["companyName"] = name.String
+		}
+	}
+	return GeneratedRecord{SchemaID: schemaID, SchemaName: schemaName, RowID: rowID, Version: 0, ChangedAt: changedAt, DeletedAt: deletedAt, Attributes: attrs}, nil
+}
+
+func schemaNameForID(schemaID int16) (string, error) {
+	for _, fixture := range DefaultSchemaFixtures() {
+		if fixture.ID == schemaID {
+			return fixture.Name, nil
+		}
+	}
+	return "", fmt.Errorf("unknown benchmark schema id %d", schemaID)
+}
+
+func buildExpectedWorkloadResultFromFederatedTruth(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition, defaultPageSize int, loadedRecords []GeneratedRecord, genCfg GeneratorConfig) (expectedWorkloadResult, error) {
+	if h == nil {
+		return expectedWorkloadResult{}, fmt.Errorf("harness cannot be nil")
+	}
+	semantics := semanticsForWorkload(workload, genCfg)
+	candidates := filterExpectedRecordsForWorkload(expectedVisibleRecords(loadedRecords), workload, semantics)
+	sortExpectedRecordsForWorkload(candidates, workload)
+	matching := make([]GeneratedRecord, 0, len(candidates))
+	pageSize := workload.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	previousSchemaID := h.SchemaID
+	schemaID, err := workloadSchemaID(workload.TargetSchema)
+	if err != nil {
+		return expectedWorkloadResult{}, err
+	}
+	h.SchemaID = schemaID
+	defer func() {
+		h.SchemaID = previousSchemaID
+	}()
+	for _, candidate := range candidates {
+		result, err := h.ExecuteFederatedQuery(ctx, &federated.QueryOptions{
+			Limit: 1,
+			Filter: &federated.Filter{
+				RowID:      candidate.RowID,
+				Conditions: map[string]any{workload.FilterAttribute: workload.FilterValue},
+			},
+			SortBy:   "tradeTime",
+			SortDesc: true,
+		})
+		if err != nil {
+			return expectedWorkloadResult{}, err
+		}
+		if result.TotalRecords > 0 {
+			matching = append(matching, candidate)
+		}
+	}
+	rowIDs := expectedPageRowIDs(matching, workload.DerivedOffset(defaultPageSize), pageSize)
+	return expectedWorkloadResult{TotalRecords: int64(len(matching)), RowIDs: rowIDs}, nil
 }
 
 func expectedVisibleRecords(records []GeneratedRecord) []GeneratedRecord {
@@ -379,18 +595,69 @@ func recordWinsExpectedRecord(candidate, current GeneratedRecord) bool {
 	return false
 }
 
-func filterExpectedRecordsForWorkload(records []GeneratedRecord, workload WorkloadDefinition) []GeneratedRecord {
+func filterExpectedRecordsForWorkload(records []GeneratedRecord, workload WorkloadDefinition, semantics workloadSemantics) []GeneratedRecord {
 	out := make([]GeneratedRecord, 0)
 	for _, record := range records {
 		if record.SchemaName != workload.TargetSchema {
 			continue
 		}
-		if workload.UsesSimpleFilter() && !generatedRecordMatchesFilter(record, workload.FilterAttribute, workload.FilterValue) {
+		if semantics.TradeTimeStart > 0 || semantics.TradeTimeEnd > 0 {
+			tradeTime := generatedRecordTradeTime(record)
+			if semantics.TradeTimeStart > 0 && tradeTime < semantics.TradeTimeStart {
+				continue
+			}
+			if semantics.TradeTimeEnd > 0 && tradeTime > semantics.TradeTimeEnd {
+				continue
+			}
+		}
+		if workload.UsesSimpleFilter() && !generatedRecordMatchesFilterForWorkload(record, workload) {
 			continue
 		}
 		out = append(out, cloneGeneratedRecord(record))
 	}
 	return out
+}
+
+func semanticsForWorkload(workload WorkloadDefinition, genCfg GeneratorConfig) workloadSemantics {
+	if workload.Name != "mixed-tier-window" {
+		return workloadSemantics{}
+	}
+	baseTime := genCfg.BaseTime
+	if baseTime.IsZero() {
+		baseTime = defaultBaseTime
+	}
+	windowDays := genCfg.TimeWindowDays
+	if windowDays <= 0 {
+		windowDays = DefaultGeneratorConfig().TimeWindowDays
+	}
+	windowMillis := int64(windowDays) * 24 * int64(time.Hour/time.Millisecond)
+	start := baseTime.UnixMilli() - (windowMillis * 4 / 5)
+	end := baseTime.UnixMilli() - windowMillis/5
+	if start > end {
+		start, end = end, start
+	}
+	return workloadSemantics{TradeTimeStart: start, TradeTimeEnd: end}
+}
+
+func benchmarkAttributeID(schemaID int16, name string) int {
+	hash := uint32(2166136261)
+	input := fmt.Sprintf("%d:%s", schemaID, name)
+	for i := 0; i < len(input); i++ {
+		hash ^= uint32(input[i])
+		hash *= 16777619
+	}
+	return int(hash%30000) + 1
+}
+
+func generatedRecordMatchesFilterForWorkload(record GeneratedRecord, workload WorkloadDefinition) bool {
+	value, ok := benchmarkVisibleAttributeValue(record, workload.FilterAttribute)
+	if !ok {
+		return false
+	}
+	if workload.FilterAttribute == "tradeType" {
+		return fmt.Sprintf("%v", value) == workload.FilterValue
+	}
+	return fmt.Sprint(value) == workload.FilterValue
 }
 
 func generatedRecordMatchesFilter(record GeneratedRecord, attribute, expected string) bool {
@@ -403,6 +670,28 @@ func generatedRecordMatchesFilter(record GeneratedRecord, attribute, expected st
 		return fmt.Sprintf("%v", value) == expected
 	default:
 		return fmt.Sprint(value) == expected
+	}
+}
+
+func benchmarkVisibleAttributeValue(record GeneratedRecord, attribute string) (any, bool) {
+	if value, ok := record.Attributes[attribute]; ok {
+		return value, true
+	}
+	if record.SchemaName != "trade" {
+		return nil, false
+	}
+	switch attribute {
+	case "symbol", "name":
+		value, ok := record.Attributes["symbol"]
+		return value, ok
+	case "tradeType":
+		value, ok := record.Attributes["tradeType"]
+		return value, ok
+	case "tradeTime":
+		value, ok := record.Attributes["tradeTime"]
+		return value, ok
+	default:
+		return nil, false
 	}
 }
 
@@ -548,10 +837,13 @@ func validatePaginationTransition(previous, current WorkloadRunResult) []Asserti
 	return assertions
 }
 
-func validateResultLevelAssertions(workload WorkloadDefinition, run WorkloadRunResult, records []*internal.PersistentRecord) []AssertionResult {
+func validateResultLevelAssertions(workload WorkloadDefinition, run WorkloadRunResult, records []*internal.PersistentRecord, semantics workloadSemantics) []AssertionResult {
 	assertions := []AssertionResult{validateUniqueRows(run), validateSchemaScope(workload, records)}
 	if workload.UsesSimpleFilter() {
 		assertions = append(assertions, validateFilterMatch(workload, records))
+	}
+	if semantics.TradeTimeStart > 0 || semantics.TradeTimeEnd > 0 {
+		assertions = append(assertions, validateTradeTimeWindow(records, semantics))
 	}
 	if workload.TargetSchema == "trade" && len(records) > 1 {
 		assertions = append(assertions, validateSortOrder(records, "tradeTime", true))
@@ -573,6 +865,10 @@ func validateSchemaScope(workload WorkloadDefinition, records []*internal.Persis
 }
 
 func queryOptionsForWorkload(workload WorkloadDefinition, defaultPageSize int) *federated.QueryOptions {
+	return queryOptionsForWorkloadWithConfig(workload, defaultPageSize, DefaultGeneratorConfig())
+}
+
+func queryOptionsForWorkloadWithConfig(workload WorkloadDefinition, defaultPageSize int, genCfg GeneratorConfig) *federated.QueryOptions {
 	pageSize := workload.PageSize
 	if pageSize <= 0 {
 		pageSize = defaultPageSize
@@ -582,6 +878,9 @@ func queryOptionsForWorkload(workload WorkloadDefinition, defaultPageSize int) *
 		opts.SortBy = "tradeTime"
 		opts.SortDesc = true
 	}
+	semantics := semanticsForWorkload(workload, genCfg)
+	opts.TradeTimeStart = semantics.TradeTimeStart
+	opts.TradeTimeEnd = semantics.TradeTimeEnd
 	return opts
 }
 
@@ -603,6 +902,22 @@ func validateFilterMatch(workload WorkloadDefinition, records []*internal.Persis
 		}
 	}
 	return AssertionResult{Name: "filter-results-match-request", Passed: true, Message: fmt.Sprintf("attribute=%s expected=%s", workload.FilterAttribute, workload.FilterValue)}
+}
+
+func validateTradeTimeWindow(records []*internal.PersistentRecord, semantics workloadSemantics) AssertionResult {
+	for _, record := range records {
+		tradeTime, ok := record.Int64Items["tradeTime"]
+		if !ok {
+			return AssertionResult{Name: "tradeTime-window-match-request", Passed: false, Message: fmt.Sprintf("missing tradeTime row=%s", record.RowID)}
+		}
+		if semantics.TradeTimeStart > 0 && tradeTime < semantics.TradeTimeStart {
+			return AssertionResult{Name: "tradeTime-window-match-request", Passed: false, Message: fmt.Sprintf("row=%s tradeTime=%d start=%d", record.RowID, tradeTime, semantics.TradeTimeStart)}
+		}
+		if semantics.TradeTimeEnd > 0 && tradeTime > semantics.TradeTimeEnd {
+			return AssertionResult{Name: "tradeTime-window-match-request", Passed: false, Message: fmt.Sprintf("row=%s tradeTime=%d end=%d", record.RowID, tradeTime, semantics.TradeTimeEnd)}
+		}
+	}
+	return AssertionResult{Name: "tradeTime-window-match-request", Passed: true, Message: fmt.Sprintf("rows=%d start=%d end=%d", len(records), semantics.TradeTimeStart, semantics.TradeTimeEnd)}
 }
 
 func validateSortOrder(records []*internal.PersistentRecord, attribute string, desc bool) AssertionResult {

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -171,12 +171,10 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 	}
 	executions := make([]WorkloadRunResult, 0, len(r.workloads)*r.config.Iterations)
 	pageRuns := make(map[string]WorkloadRunResult)
-	loadedRecords := tieredRecords(tiered)
-	snapshot, err := buildLoadedStateSnapshot(ctx, h, tiered)
+	loadedRecords, err := buildLoadedStateSnapshot(ctx, h, tiered)
 	if err != nil {
 		return nil, fmt.Errorf("build loaded state snapshot: %w", err)
 	}
-	loadedRecords = snapshot
 	expectedByWorkload := buildExpectedWorkloadResultsFromRecords(loadedRecords, r.workloads, r.config.PageSize, r.genConfig)
 	if hotExpected, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, WorkloadDefinition{Name: "hot-selective-page", TargetSchema: "trade", FilterAttribute: "symbol", FilterValue: "SYM00001", PageSize: 20, PageNumber: 1}, r.config.PageSize, loadedRecords, r.genConfig); err == nil {
 		expectedByWorkload["hot-selective-page"] = hotExpected
@@ -658,19 +656,6 @@ func generatedRecordMatchesFilterForWorkload(record GeneratedRecord, workload Wo
 		return fmt.Sprintf("%v", value) == workload.FilterValue
 	}
 	return fmt.Sprint(value) == workload.FilterValue
-}
-
-func generatedRecordMatchesFilter(record GeneratedRecord, attribute, expected string) bool {
-	value, ok := record.Attributes[attribute]
-	if !ok {
-		return false
-	}
-	switch attribute {
-	case "tradeType":
-		return fmt.Sprintf("%v", value) == expected
-	default:
-		return fmt.Sprint(value) == expected
-	}
 }
 
 func benchmarkVisibleAttributeValue(record GeneratedRecord, attribute string) (any, bool) {

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -352,19 +352,6 @@ func buildExpectedWorkloadResultsFromRecords(records []GeneratedRecord, workload
 	return results
 }
 
-func tieredRecords(dataset *TieredDataset) []GeneratedRecord {
-	if dataset == nil {
-		return nil
-	}
-	records := make([]GeneratedRecord, 0, len(dataset.Base)+len(dataset.Delta)+len(dataset.Hot))
-	for _, bucket := range [][]GeneratedRecord{dataset.Base, dataset.Delta, dataset.Hot} {
-		for _, record := range bucket {
-			records = append(records, cloneGeneratedRecord(record))
-		}
-	}
-	return records
-}
-
 func buildLoadedStateSnapshot(ctx context.Context, h *federated.FederatedTestHarness, dataset *TieredDataset) ([]GeneratedRecord, error) {
 	if h == nil || dataset == nil {
 		return nil, fmt.Errorf("harness and dataset are required")

--- a/internal/e2e_harness/federated/benchmark/runner_test.go
+++ b/internal/e2e_harness/federated/benchmark/runner_test.go
@@ -2,6 +2,7 @@ package benchmark
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func TestValidateResultLevelAssertionsDetectsUnsortedRows(t *testing.T) {
 		{RowID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), Int64Items: map[string]int64{"tradeTime": 10}},
 		{RowID: uuid.MustParse("00000000-0000-0000-0000-000000000003"), Int64Items: map[string]int64{"tradeTime": 20}},
 	}
-	assertions := validateResultLevelAssertions(WorkloadDefinition{Name: "baseline-page-1"}, WorkloadRunResult{RowIDs: []string{records[0].RowID.String(), records[1].RowID.String()}}, records)
+	assertions := validateResultLevelAssertions(WorkloadDefinition{Name: "baseline-page-1"}, WorkloadRunResult{RowIDs: []string{records[0].RowID.String(), records[1].RowID.String()}}, records, workloadSemantics{})
 	if assertionPassed(assertions, "sorted-by-tradeTime-desc") {
 		t.Fatalf("expected sort assertion to fail for ascending rows")
 	}
@@ -72,6 +73,17 @@ func TestQueryOptionsForWorkloadSkipsTradeOrderingForNonTradeSchema(t *testing.T
 	tradeOpts := queryOptionsForWorkload(WorkloadDefinition{Name: "baseline-page-1", TargetSchema: "trade", PageSize: 20, PageNumber: 1}, 20)
 	if tradeOpts.SortBy != "tradeTime" || !tradeOpts.SortDesc {
 		t.Fatalf("expected trade workload to preserve trade ordering, got %+v", tradeOpts)
+	}
+}
+
+func TestQueryOptionsForWorkloadAddsMixedTierWindowTradeTimeRange(t *testing.T) {
+	genCfg := GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionTemporal, TimeWindowDays: 30, BaseTime: defaultBaseTime}.WithDefaults()
+	opts := queryOptionsForWorkloadWithConfig(WorkloadDefinition{Name: "mixed-tier-window", TargetSchema: "trade", PageSize: 50, PageNumber: 1}, 20, genCfg)
+	if opts.TradeTimeStart <= 0 || opts.TradeTimeEnd <= 0 {
+		t.Fatalf("expected mixed tier workload to set a trade time window, got %+v", opts)
+	}
+	if opts.TradeTimeStart >= opts.TradeTimeEnd {
+		t.Fatalf("expected ascending trade time window, got %+v", opts)
 	}
 }
 
@@ -199,7 +211,7 @@ func TestBuildExpectedWorkloadResultsFromRecordsUsesLoadedTierState(t *testing.T
 		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 1, ChangedAt: 100, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "2026-01-01T00:00:00Z"}},
 		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 2, ChangedAt: 200, Attributes: map[string]any{"symbol": "SYM99999", "tradeTime": "2026-01-01T00:01:00Z"}},
 	}
-	results := buildExpectedWorkloadResultsFromRecords([]GeneratedRecord{original[0]}, workloads, 20)
+	results := buildExpectedWorkloadResultsFromRecords([]GeneratedRecord{original[0]}, workloads, 20, DefaultGeneratorConfig())
 	expected := results["hot-selective-page"]
 	if expected.TotalRecords != 1 {
 		t.Fatalf("expected loaded tier state to include visible row, got %+v", expected)
@@ -210,6 +222,65 @@ func TestBuildExpectedWorkloadResultsFromRecordsUsesLoadedTierState(t *testing.T
 	fromDataset := buildExpectedWorkloadResults(&GeneratedDataset{Records: original}, workloads, 20)
 	if fromDataset["hot-selective-page"].TotalRecords != 0 {
 		t.Fatalf("expected original dataset semantics to exclude row after symbol change, got %+v", fromDataset["hot-selective-page"])
+	}
+}
+
+func TestBuildExpectedWorkloadResultsFromRecordsExcludesDeletedHotSelectiveRows(t *testing.T) {
+	rowID := deterministicRowID(2, "trade", 1)
+	workloads := []WorkloadDefinition{{Name: "hot-selective-page", TargetSchema: "trade", FilterAttribute: "symbol", FilterValue: "SYM00001", PageSize: 20, PageNumber: 1}}
+	records := []GeneratedRecord{
+		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 1, ChangedAt: 100, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "2026-01-01T00:00:00Z"}},
+		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 2, ChangedAt: 200, DeletedAt: 205, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "2026-01-01T00:01:00Z"}},
+	}
+	results := buildExpectedWorkloadResultsFromRecords(records, workloads, 20, DefaultGeneratorConfig())
+	if results["hot-selective-page"].TotalRecords != 0 {
+		t.Fatalf("expected deleted latest trade row to be excluded, got %+v", results["hot-selective-page"])
+	}
+}
+
+func TestExpectedWorkloadResultsCanUseLoadedHotStateSnapshot(t *testing.T) {
+	rowID := deterministicRowID(3, "trade", 1)
+	workloads := []WorkloadDefinition{{Name: "hot-selective-page", TargetSchema: "trade", FilterAttribute: "symbol", FilterValue: "SYM00001", PageSize: 20, PageNumber: 1}}
+	syntheticTiered := []GeneratedRecord{{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 2, ChangedAt: 200, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "2026-01-01T00:01:00Z"}}}
+	loadedHotSnapshot := []GeneratedRecord{{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 0, ChangedAt: 200, DeletedAt: 205, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "1735689660000"}}}
+	fromSynthetic := buildExpectedWorkloadResultsFromRecords(syntheticTiered, workloads, 20, DefaultGeneratorConfig())
+	if fromSynthetic["hot-selective-page"].TotalRecords != 1 {
+		t.Fatalf("expected synthetic tiered record to match filter, got %+v", fromSynthetic["hot-selective-page"])
+	}
+	fromLoaded := buildExpectedWorkloadResultsFromRecords(loadedHotSnapshot, workloads, 20, DefaultGeneratorConfig())
+	if fromLoaded["hot-selective-page"].TotalRecords != 0 {
+		t.Fatalf("expected loaded hot snapshot to exclude deleted row, got %+v", fromLoaded["hot-selective-page"])
+	}
+}
+
+func TestBuildExpectedWorkloadResultsFromRecordsHonorsMixedTierWindow(t *testing.T) {
+	genCfg := GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionTemporal, TimeWindowDays: 30, BaseTime: defaultBaseTime}.WithDefaults()
+	semantics := semanticsForWorkload(WorkloadDefinition{Name: "mixed-tier-window", TargetSchema: "trade"}, genCfg)
+	inside := deterministicRowID(7, "trade", 1)
+	before := deterministicRowID(7, "trade", 2)
+	after := deterministicRowID(7, "trade", 3)
+	workloads := []WorkloadDefinition{{Name: "mixed-tier-window", TargetSchema: "trade", PageSize: 50, PageNumber: 1}}
+	records := []GeneratedRecord{
+		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: inside, Version: 1, ChangedAt: semantics.TradeTimeStart + 1000, Attributes: map[string]any{"tradeTime": strconv.FormatInt(semantics.TradeTimeStart+1000, 10)}},
+		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: before, Version: 1, ChangedAt: semantics.TradeTimeStart - 1000, Attributes: map[string]any{"tradeTime": strconv.FormatInt(semantics.TradeTimeStart-1000, 10)}},
+		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: after, Version: 1, ChangedAt: semantics.TradeTimeEnd + 1000, Attributes: map[string]any{"tradeTime": strconv.FormatInt(semantics.TradeTimeEnd+1000, 10)}},
+	}
+	results := buildExpectedWorkloadResultsFromRecords(records, workloads, 20, genCfg)
+	expected := results["mixed-tier-window"]
+	if expected.TotalRecords != 1 {
+		t.Fatalf("expected one in-window record, got %+v", expected)
+	}
+	if len(expected.RowIDs) != 1 || expected.RowIDs[0] != inside.String() {
+		t.Fatalf("unexpected in-window row ids: %+v", expected.RowIDs)
+	}
+}
+
+func TestValidateTradeTimeWindowDetectsOutOfWindowRows(t *testing.T) {
+	semantics := workloadSemantics{TradeTimeStart: 100, TradeTimeEnd: 200}
+	records := []*internal.PersistentRecord{{RowID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), Int64Items: map[string]int64{"tradeTime": 99}}}
+	assertion := validateTradeTimeWindow(records, semantics)
+	if assertion.Passed {
+		t.Fatalf("expected trade time window assertion to fail")
 	}
 }
 

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -34,8 +34,11 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 		DeleteRatio:   0.05,
 		Workloads: []string{
 			"baseline-page-1",
+			"customer-region-page",
+			"security-symbol-page",
 			"hot-selective-page",
 			"eav-selective-page",
+			"mixed-tier-window",
 			"deep-page-1000",
 			"deep-page-100000",
 		},
@@ -45,10 +48,14 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	result, err := runner.RunWithHarness(ctx, h, bench.TierMixBalanced)
 	require.NoError(t, err)
 	require.False(t, result.ValidationOnly)
-	require.Len(t, result.Executions, 5)
+	require.Len(t, result.Executions, 8)
+	customerSeen := false
+	securitySeen := false
 	filteredSeen := false
 	eavSeen := false
+	mixedTierSeen := false
 	expectedOracleAssertionsSeen := false
+	tradeTimeWindowAssertionSeen := false
 	for _, execution := range result.Executions {
 		require.NotEmpty(t, execution.Name)
 		require.GreaterOrEqual(t, execution.ResultCount, 0)
@@ -57,17 +64,37 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 		require.NotEqual(t, bench.FailureKindInfra, execution.FailureKind, "expected live benchmark execution to avoid infrastructure failures")
 		if execution.Name == "hot-selective-page" {
 			filteredSeen = true
+			require.Empty(t, execution.FailureKind, "expected hot selective workload to pass correctness in live execution")
+		}
+		if execution.Name == "customer-region-page" {
+			customerSeen = true
+			require.Empty(t, execution.FailureKind, "expected customer workload to pass correctness in live execution")
+		}
+		if execution.Name == "security-symbol-page" {
+			securitySeen = true
+			require.Empty(t, execution.FailureKind, "expected security workload to pass correctness in live execution")
 		}
 		if execution.Name == "eav-selective-page" {
 			eavSeen = true
+			require.Empty(t, execution.FailureKind, "expected EAV selective workload to pass correctness in live execution")
+		}
+		if execution.Name == "mixed-tier-window" {
+			mixedTierSeen = true
 		}
 		for _, assertion := range execution.Assertions {
 			if assertion.Name == "total-records-match-expected" || assertion.Name == "page-row-ids-match-expected" {
 				expectedOracleAssertionsSeen = true
 			}
+			if execution.Name == "mixed-tier-window" && assertion.Name == "tradeTime-window-match-request" {
+				tradeTimeWindowAssertionSeen = true
+			}
 		}
 	}
+	require.True(t, customerSeen)
+	require.True(t, securitySeen)
 	require.True(t, filteredSeen)
 	require.True(t, eavSeen)
+	require.True(t, mixedTierSeen)
 	require.True(t, expectedOracleAssertionsSeen, "expected result oracle assertions to be exercised")
+	require.True(t, tradeTimeWindowAssertionSeen, "expected mixed-tier window assertion to be exercised")
 }

--- a/internal/e2e_harness/federated/harness.go
+++ b/internal/e2e_harness/federated/harness.go
@@ -61,12 +61,14 @@ type TestRecord struct {
 
 // QueryOptions configures federated query execution.
 type QueryOptions struct {
-	Limit     int
-	Offset    int
-	Filter    *Filter
-	SortBy    string
-	SortDesc  bool
-	CountOnly bool
+	Limit          int
+	Offset         int
+	Filter         *Filter
+	SortBy         string
+	SortDesc       bool
+	TradeTimeStart int64
+	TradeTimeEnd   int64
+	CountOnly      bool
 }
 
 // Filter defines query filter conditions.

--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -218,8 +218,11 @@ func (h *FederatedTestHarness) buildFederatedQueryCountSQLDynamic(basePath, delt
 func (h *FederatedTestHarness) buildFederatedCombinedQuery(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions) (string, bool) {
 	dirtyExclusion := buildDirtyExclusion(dirtyIDs)
 	rowIDFilter := buildRowIDFilter(opts)
+	hotRowIDFilter := buildHotRowIDFilter(opts)
 	attributeFilter := buildAttributeFilterClause(opts)
+	timeWindowFilter := buildTradeTimeFilterClause(opts)
 	hotAttributeFilter := buildHotAttributeFilterClause(opts)
+	hotTimeWindowFilter := buildHotTradeTimeFilterClause(opts)
 	benchmarkProjection := usesBenchmarkProjection(opts)
 	pgConnStr := h.buildPGConnString()
 
@@ -227,17 +230,17 @@ func (h *FederatedTestHarness) buildFederatedCombinedQuery(basePath, deltaPath s
 	var tierQueries []string
 
 	if hasBase {
-		baseQuery := buildParquetTierQuery(basePath, h.SchemaID, "base", dirtyExclusion, rowIDFilter, attributeFilter, benchmarkProjection)
+		baseQuery := buildParquetTierQuery(basePath, h.SchemaID, "base", dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter, benchmarkProjection)
 		tierQueries = append(tierQueries, baseQuery)
 	}
 
 	if hasDelta {
-		deltaQuery := buildParquetTierQuery(deltaPath, h.SchemaID, "delta", dirtyExclusion, rowIDFilter, attributeFilter, benchmarkProjection)
+		deltaQuery := buildParquetTierQuery(deltaPath, h.SchemaID, "delta", dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter, benchmarkProjection)
 		tierQueries = append(tierQueries, deltaQuery)
 	}
 
 	// Always include hot buffer (Postgres)
-	hotQuery := buildHotTierQuery(pgConnStr, h.SchemaID, rowIDFilter, hotAttributeFilter, benchmarkProjection)
+	hotQuery := buildHotTierQuery(pgConnStr, h.SchemaID, hotRowIDFilter, hotAttributeFilter, hotTimeWindowFilter, benchmarkProjection)
 	tierQueries = append(tierQueries, hotQuery)
 
 	// Combine all tier queries with UNION ALL
@@ -245,17 +248,17 @@ func (h *FederatedTestHarness) buildFederatedCombinedQuery(basePath, deltaPath s
 	return combinedQuery, benchmarkProjection
 }
 
-func buildParquetTierQuery(path string, schemaID int16, tier, dirtyExclusion, rowIDFilter, attributeFilter string, benchmarkProjection bool) string {
+func buildParquetTierQuery(path string, schemaID int16, tier, dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter string, benchmarkProjection bool) string {
 	if benchmarkProjection {
 		projection := benchmarkParquetProjection(schemaID, tier, path)
 		return fmt.Sprintf(`
 			%s
-			WHERE 1 = 1 %s %s %s`, projection, dirtyExclusion, rowIDFilter, attributeFilter)
+			WHERE 1 = 1 %s %s %s %s`, projection, dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter)
 	}
 	return fmt.Sprintf(`
 			SELECT row_id, schema_id, changed_at, deleted_at, name, version, '%s' as tier
 			FROM read_parquet('%s')
-			WHERE 1 = 1 %s %s`, tier, path, dirtyExclusion, rowIDFilter)
+			WHERE 1 = 1 %s %s %s`, tier, path, dirtyExclusion, rowIDFilter, timeWindowFilter)
 }
 
 func benchmarkParquetProjection(schemaID int16, tier, path string) string {
@@ -269,7 +272,7 @@ func benchmarkParquetProjection(schemaID int16, tier, path string) string {
 	}
 }
 
-func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeFilter string, benchmarkProjection bool) string {
+func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeFilter, timeWindowFilter string, benchmarkProjection bool) string {
 	if benchmarkProjection {
 		return fmt.Sprintf(`
 		SELECT 
@@ -301,7 +304,8 @@ func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeF
 		WHERE cl.flushed_at = 0 
 			AND cl.schema_id = %d
 			%s
-			%s`, pgConnStr, pgConnStr, pgConnStr, schemaID, rowIDFilter, attributeFilter)
+			%s
+			%s`, pgConnStr, pgConnStr, pgConnStr, schemaID, rowIDFilter, attributeFilter, timeWindowFilter)
 	}
 	return fmt.Sprintf(`
 		SELECT 
@@ -315,7 +319,8 @@ func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeF
 		FROM postgres_scan('%s', 'public', 'change_log') cl
 		WHERE cl.flushed_at = 0 
 			AND cl.schema_id = %d
-			%s`, pgConnStr, schemaID, rowIDFilter)
+			%s
+			%s`, pgConnStr, schemaID, rowIDFilter, timeWindowFilter)
 }
 
 func buildFinalFederatedSelect(combinedQuery string, opts *QueryOptions, benchmarkProjection bool) string {
@@ -406,6 +411,13 @@ func buildRowIDFilter(opts *QueryOptions) string {
 	return ""
 }
 
+func buildHotRowIDFilter(opts *QueryOptions) string {
+	if opts.Filter != nil && opts.Filter.RowID != uuid.Nil {
+		return fmt.Sprintf("AND cl.row_id = '%s'", opts.Filter.RowID.String())
+	}
+	return ""
+}
+
 func buildAttributeFilterClause(opts *QueryOptions) string {
 	if opts == nil || opts.Filter == nil || len(opts.Filter.Conditions) == 0 {
 		return ""
@@ -417,6 +429,35 @@ func buildAttributeFilterClause(opts *QueryOptions) string {
 			continue
 		}
 		parts = append(parts, fmt.Sprintf("AND %s = %s", column, benchmarkSQLLiteral(value)))
+	}
+	return strings.Join(parts, " ")
+}
+
+func buildTradeTimeFilterClause(opts *QueryOptions) string {
+	if opts == nil {
+		return ""
+	}
+	parts := make([]string, 0, 2)
+	if opts.TradeTimeStart > 0 {
+		parts = append(parts, fmt.Sprintf("AND tradeTime >= epoch_ms(%d)", opts.TradeTimeStart))
+	}
+	if opts.TradeTimeEnd > 0 {
+		parts = append(parts, fmt.Sprintf("AND tradeTime <= epoch_ms(%d)", opts.TradeTimeEnd))
+	}
+	return strings.Join(parts, " ")
+}
+
+func buildHotTradeTimeFilterClause(opts *QueryOptions) string {
+	if opts == nil {
+		return ""
+	}
+	parts := make([]string, 0, 2)
+	expression := benchmarkHotFilterExpression("tradeTime")
+	if opts.TradeTimeStart > 0 {
+		parts = append(parts, fmt.Sprintf("AND %s >= %d", expression, opts.TradeTimeStart))
+	}
+	if opts.TradeTimeEnd > 0 {
+		parts = append(parts, fmt.Sprintf("AND %s <= %d", expression, opts.TradeTimeEnd))
 	}
 	return strings.Join(parts, " ")
 }

--- a/internal/e2e_harness/federated/query_unit_test.go
+++ b/internal/e2e_harness/federated/query_unit_test.go
@@ -46,25 +46,25 @@ func TestBuildFederatedCombinedQueryUsesHotFilterExpressions(t *testing.T) {
 }
 
 func TestBuildParquetTierQuerySupportsSchemaSpecificProjection(t *testing.T) {
-	customerQuery := buildParquetTierQuery("customer-path", benchmarkSchemaIDCustomer, "base", "", "", "AND region = 'NA'", true)
+	customerQuery := buildParquetTierQuery("customer-path", benchmarkSchemaIDCustomer, "base", "", "", "AND region = 'NA'", "", true)
 	if !strings.Contains(customerQuery, "region") || strings.Contains(customerQuery, "epoch_ms(tradeTime)") {
 		t.Fatalf("expected customer projection without trade time conversion: %s", customerQuery)
 	}
-	securityQuery := buildParquetTierQuery("security-path", benchmarkSchemaIDSecurity, "base", "", "", "AND symbol = 'SYM00001'", true)
+	securityQuery := buildParquetTierQuery("security-path", benchmarkSchemaIDSecurity, "base", "", "", "AND symbol = 'SYM00001'", "", true)
 	if !strings.Contains(securityQuery, "symbol") || strings.Contains(securityQuery, "epoch_ms(tradeTime)") {
 		t.Fatalf("expected security projection with symbol only: %s", securityQuery)
 	}
 }
 
 func TestBuildParquetTierQueryKeepsDeletedRowsForDeduplication(t *testing.T) {
-	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "delta", "", "", "", true)
+	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "delta", "", "", "", "", true)
 	if strings.Contains(query, "deleted_at = 0") {
 		t.Fatalf("expected parquet tier query to defer deleted filtering until after dedup: %s", query)
 	}
 }
 
 func TestBuildHotTierQueryKeepsDeletedRowsForDeduplication(t *testing.T) {
-	query := buildHotTierQuery("pg-conn", benchmarkSchemaIDTrade, "", "", true)
+	query := buildHotTierQuery("pg-conn", benchmarkSchemaIDTrade, "", "", "", true)
 	if strings.Contains(query, "deleted_at = 0") || strings.Contains(query, "deleted_at IS NULL") {
 		t.Fatalf("expected hot tier query to defer deleted filtering until after dedup: %s", query)
 	}
@@ -75,6 +75,16 @@ func TestBuildFederatedDeduplicatedCTEUsesStableTieBreaks(t *testing.T) {
 	for _, expected := range []string{"changed_at DESC", "CASE tier WHEN 'hot' THEN 3", "version DESC", "deleted_at DESC", "row_id ASC"} {
 		if !strings.Contains(query, expected) {
 			t.Fatalf("expected dedup query to include %q: %s", expected, query)
+		}
+	}
+}
+
+func TestBuildFederatedCombinedQuerySupportsTradeTimeWindow(t *testing.T) {
+	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
+	query, _ := h.buildFederatedCombinedQuery("base-path", "delta-path", true, true, nil, &QueryOptions{TradeTimeStart: 1000, TradeTimeEnd: 2000, SortBy: "tradeTime", SortDesc: true})
+	for _, expected := range []string{"tradeTime >= epoch_ms(1000)", "tradeTime <= epoch_ms(2000)", "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) >= 1000", "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) <= 2000"} {
+		if !strings.Contains(query, expected) {
+			t.Fatalf("expected combined query to include %q: %s", expected, query)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- align live benchmark expected-result checks with loaded hot state instead of only synthetic tier records, and use federated truth passes for selective trade workloads that depend on hot-state visibility semantics
- add explicit trade-time window execution semantics for `mixed-tier-window`, including query options, benchmark assertions, and SQL coverage for parquet and hot tiers
- tighten live benchmark e2e coverage so schema-scoped, hot-selective, and EAV-selective workloads are exercised as correctness-gated paths, and fix hot row-id filtering to avoid ambiguous SQL in joined hot queries

## Testing
- go test ./internal/e2e_harness/federated/benchmark ./internal/e2e_harness/federated ./cmd/benchmark
- go test -tags=e2e ./internal/e2e_harness/federated -run TestBenchmarkWorkloadExecution_RunWithHarness -count=1