### PR TITLE
expand benchmark workload readiness

### DIFF
--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -64,11 +64,14 @@ Compare these fields first:
 - treat assertion failures as correctness regressions even if latency improves
 - treat large `max` growth separately from percentile movement; it is often a sign of tier skew or unstable deep pagination
 - read `correctness_failures` and `infra_failures` separately in benchmark summaries; only the latter indicates an execution-environment problem
+- for repeated executions with the same seed, expect `FailureKind`, `total_records`, and page `row_ids` to remain stable for supported workloads
+- read workload `oracle_mode` when interpreting selective filter workloads; `truth-pass` means expected results were validated through the live federated path rather than only loaded-state reconstruction
 
 ## Current Limitations
 
 - baseline presets currently favor `smoke` and `plan` modes for artifact stability over live execution cost
 - use `go run ./cmd/benchmark run -mode live ...` when you need executable benchmark evidence instead of planning-only artifacts
 - live benchmark correctness checks compare query results against the benchmark's loaded tier state rather than only the pre-split generated dataset
+- selective hot/EAV workloads may use a truth-pass-backed oracle mode to align expected results with the executable federated filter semantics
 - baseline capture is designed for artifact stability first, not for production-like throughput measurement
 - CI integration and operator workflow guidance are documented in `docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md`

--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -57,6 +57,54 @@ Compare these fields first:
 - `qps`
 - assertion pass/fail counts
 
+## Oracle Mode
+
+`oracle_mode` describes how the benchmark derived the expected result set for a workload before comparing it with the actual federated query output.
+
+This is important because the benchmark is not only measuring latency. It is also making a correctness judgment. That judgment depends on what the benchmark believes the correct answer should be, so reviewers need to know where that expected answer came from.
+
+### `loaded-state`
+
+Use this interpretation when `oracle_mode` is `loaded-state`.
+
+- the benchmark reconstructs the expected visible rows from the benchmark's loaded tier state
+- base and delta rows come from the generated benchmark records after tier splitting
+- hot rows come from the loaded Postgres state snapshot used by the live harness path
+- delete shadowing, last-write-wins, page slicing, and time-window filtering are then applied to that reconstructed state
+
+This is the default oracle mode and is appropriate when the benchmark can explain the visible result set directly from the loaded benchmark data model.
+
+Typical examples:
+
+- `baseline-page-1`
+- schema-scoped workloads such as `customer-region-page` and `security-symbol-page`
+- window workloads such as `mixed-tier-window`, `hot-only-window`, and `cold-only-window`
+- deep page workloads
+
+### `truth-pass`
+
+Use this interpretation when `oracle_mode` is `truth-pass`.
+
+- the benchmark still starts from the loaded tier state
+- but for candidate rows that match the workload shape, it validates expected visibility by running a targeted federated query through the live harness path
+- the resulting expected set is therefore backed by executable federated semantics rather than only by synthetic reconstruction
+
+This mode is used when reproducing the final visible filter semantics directly from benchmark records is not yet trustworthy enough. In practice this is most useful for selective workloads that depend on hot-state visibility rules, EAV-backed filters, or combinations of both.
+
+Typical examples:
+
+- `hot-selective-page`
+- `hot-low-selectivity-page`
+- `eav-selective-page`
+- `mixed-hot-eav-page`
+
+### How To Interpret It
+
+- if `oracle_mode` is `loaded-state`, a correctness failure usually means the query result diverged from the benchmark's reconstructed loaded state
+- if `oracle_mode` is `truth-pass`, a correctness failure means the benchmark's final expected answer was confirmed through the live federated path itself
+- `truth-pass` is usually more expensive than `loaded-state`, so do not assume all workloads should use it by default
+- if a workload changes oracle mode between baselines, treat that as a benchmark methodology change, not a pure performance change
+
 ## Interpretation Guidance
 
 - use `small` to catch obvious correctness or latency regressions quickly

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -14,6 +14,7 @@ This guide defines which benchmark subsets are safe for local validation, PR-tim
 - `-mode plan` validates config and emits the planned workload shape only
 - `-mode live` creates the federated harness, prepares tiered benchmark data, and executes supported workloads end to end
 - live benchmark summaries distinguish correctness failures from infrastructure failures, and workload-level expected-result checks are part of the executable path
+- benchmark summaries now expose workload oracle provenance so selective workloads can be distinguished between `loaded-state` and `truth-pass` expected-result modes
 - harness-backed tests such as `go test ./internal/e2e_harness/federated/... -run TestBenchmarkWorkloadExecution_RunWithHarness` remain the focused executable coverage path for repository tests
 
 This means CI can continue to treat smoke mode as the cheap artifact regression layer, while local or manual runs can use live mode for executable benchmark evidence. It is still not an official throughput gate.
@@ -150,6 +151,7 @@ Check these fields first in `benchmark-summary.json` or the Markdown summary:
 - `avg`
 - `qps`
 - per-assertion pass/fail counts
+- workload `oracle_mode`
 
 Interpretation guidance:
 
@@ -158,6 +160,7 @@ Interpretation guidance:
 - isolated `max` spikes often point to skew, tier imbalance, or unstable deep-page behavior
 - a drop in `qps` without matching row-count changes is a regression candidate worth manual review
 - planning-only output should stay structurally stable across runs for the same seed and workload selection
+- supported live workloads should also keep repeated-run `FailureKind`, `total_records`, and page `row_ids` stable for the same seed and workload selection
 
 ## Common Failure Modes
 

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -19,6 +19,34 @@ This guide defines which benchmark subsets are safe for local validation, PR-tim
 
 This means CI can continue to treat smoke mode as the cheap artifact regression layer, while local or manual runs can use live mode for executable benchmark evidence. It is still not an official throughput gate.
 
+## Oracle Modes
+
+The benchmark reports a workload `oracle_mode` because correctness verdicts depend on how expected results were derived.
+
+### Why this exists
+
+The benchmark compares actual federated query output against an expected result set. For some workloads, the expected result can be reconstructed directly from the benchmark's loaded tier state. For other workloads, especially selective hot or EAV-heavy cases, the safest expected-result path is to confirm visibility through targeted federated truth passes.
+
+Without this distinction, two correctness failures could look identical even though they were derived from different benchmark methods.
+
+### `loaded-state`
+
+- expected rows are reconstructed from the benchmark's loaded tier state
+- this is the normal mode for workloads whose visibility semantics are already well modeled by the benchmark runner
+- it is cheaper and should remain the default where it is trustworthy
+
+### `truth-pass`
+
+- expected rows are confirmed through the live federated path for targeted candidate rows
+- this is used for workloads where final visible filter semantics are better validated through execution than through synthetic reconstruction alone
+- it is intentionally narrower and more expensive than `loaded-state`
+
+### Operational guidance
+
+- do not treat a switch between `loaded-state` and `truth-pass` as a pure performance change; it also changes how correctness is judged
+- when a selective workload fails under `truth-pass`, assume the benchmark has already validated the expected answer through the executable path
+- when comparing benchmark summaries, use `oracle_mode` alongside `correctness_failures` so reviewers understand whether failures came from loaded-state reconstruction or truth-pass-backed verification
+
 ## Workload Groups
 
 ### Smoke

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -35,6 +35,7 @@ type EnvironmentMetadata struct {
 // SummaryReport captures aggregated execution metrics.
 type SummaryReport struct {
 	Metadata            ArtifactMetadata         `json:"metadata"`
+	OracleModes         map[string]string        `json:"oracle_modes,omitempty"`
 	ExecutionCount      int                      `json:"execution_count"`
 	Passed              bool                     `json:"passed"`
 	FailureCount        int                      `json:"failure_count,omitempty"`
@@ -63,6 +64,7 @@ type WorkloadSummary struct {
 	Name                string                   `json:"name"`
 	Category            string                   `json:"category"`
 	TargetSchema        string                   `json:"target_schema,omitempty"`
+	OracleMode          string                   `json:"oracle_mode,omitempty"`
 	Distribution        Distribution             `json:"distribution"`
 	ExecutionCount      int                      `json:"execution_count"`
 	Passed              bool                     `json:"passed"`
@@ -230,6 +232,7 @@ func SummarizeRunResult(result *RunResult) SummaryReport {
 		return summary
 	}
 	summary.Metadata = metadataForResult(result)
+	summary.OracleModes = cloneStringMap(result.OracleModes)
 	if len(result.Executions) == 0 {
 		summary.Passed = result != nil && result.Passed
 		summary.FailureCount = resultFailureCount(result)
@@ -289,6 +292,17 @@ func percentileDuration(values []time.Duration, percentile float64) time.Duratio
 		idx = len(values) - 1
 	}
 	return values[idx]
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }
 
 // FormatConsoleSummary returns a stable text summary for terminal output.
@@ -469,6 +483,7 @@ func summarizeWorkloads(result *RunResult) []WorkloadSummary {
 		if def, ok := workloadDefs[name]; ok {
 			workload.Category = string(def.Category)
 			workload.TargetSchema = def.TargetSchema
+			workload.OracleMode = string(def.ResolvedOracleMode())
 			workload.Distribution = runs[0].Distribution
 			workload.PageSize = def.PageSize
 		}
@@ -497,6 +512,9 @@ func summarizeWorkloads(result *RunResult) []WorkloadSummary {
 			}
 			if run.Offset > workload.MaxOffset {
 				workload.MaxOffset = run.Offset
+			}
+			if workload.OracleMode == "" && run.OracleMode != "" {
+				workload.OracleMode = run.OracleMode
 			}
 			for _, assertion := range run.Assertions {
 				stat := workload.AssertionStats[assertion.Name]

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -48,9 +48,10 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 		Passed:       false,
 		FailureCount: 2,
 		Generator:    GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
+		OracleModes:  map[string]string{"q1": string(OracleModeLoadedState), "q2": string(OracleModeTruthPass)},
 		Executions: []WorkloadRunResult{
-			{Name: "q1", Passed: true, Duration: 10 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: true}}},
-			{Name: "q2", Passed: false, FailureKind: FailureKindCorrectness, FailureCount: 1, Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}}},
+			{Name: "q1", Passed: true, OracleMode: string(OracleModeLoadedState), Duration: 10 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: true}}},
+			{Name: "q2", Passed: false, OracleMode: string(OracleModeTruthPass), FailureKind: FailureKindCorrectness, FailureCount: 1, Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}}},
 		},
 	}
 	if err := WriteBaselineCapture(dir, result); err != nil {
@@ -83,6 +84,9 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 	if summary.Metadata.BenchmarkID == "" {
 		t.Fatalf("expected summary metadata to include benchmark ID")
 	}
+	if summary.OracleModes["q2"] != string(OracleModeTruthPass) {
+		t.Fatalf("expected summary to expose oracle modes, got %+v", summary.OracleModes)
+	}
 	if len(summary.Workloads) != 2 {
 		t.Fatalf("expected two workload summaries, got %d", len(summary.Workloads))
 	}
@@ -96,6 +100,7 @@ func TestFormatConsoleSummary(t *testing.T) {
 		Executions: []WorkloadRunResult{{
 			Name:         "q1",
 			Passed:       false,
+			OracleMode:   string(OracleModeTruthPass),
 			FailureKind:  FailureKindCorrectness,
 			FailureCount: 1,
 			Duration:     10 * time.Millisecond,
@@ -117,6 +122,14 @@ func TestFormatConsoleSummary(t *testing.T) {
 	}
 	if !strings.Contains(formatted, "correctness_failures=1") {
 		t.Fatalf("expected correctness failures in summary: %s", formatted)
+	}
+}
+
+func TestSummarizeWorkloadsCarriesOracleMode(t *testing.T) {
+	result := &RunResult{Executions: []WorkloadRunResult{{Name: "q1", OracleMode: string(OracleModeTruthPass), Duration: 10 * time.Millisecond, Passed: true}}}
+	workloads := summarizeWorkloads(result)
+	if len(workloads) != 1 || workloads[0].OracleMode != string(OracleModeTruthPass) {
+		t.Fatalf("expected workload summary to carry oracle mode, got %+v", workloads)
 	}
 }
 

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -29,6 +29,7 @@ type RunResult struct {
 	Workloads      []WorkloadDefinition `json:"workloads"`
 	Executions     []WorkloadRunResult  `json:"executions,omitempty"`
 	Notes          []string             `json:"notes"`
+	OracleModes    map[string]string    `json:"oracle_modes,omitempty"`
 }
 
 // WorkloadRunResult captures one workload execution result.
@@ -44,6 +45,7 @@ type WorkloadRunResult struct {
 	Duration     time.Duration     `json:"duration"`
 	Passed       bool              `json:"passed"`
 	FailureKind  string            `json:"failure_kind,omitempty"`
+	OracleMode   string            `json:"oracle_mode,omitempty"`
 	FailureCount int               `json:"failure_count,omitempty"`
 	InfraError   string            `json:"infra_error,omitempty"`
 	RowIDs       []string          `json:"row_ids,omitempty"`
@@ -171,16 +173,14 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 	}
 	executions := make([]WorkloadRunResult, 0, len(r.workloads)*r.config.Iterations)
 	pageRuns := make(map[string]WorkloadRunResult)
+	previousRuns := make(map[string]WorkloadRunResult)
 	loadedRecords, err := buildLoadedStateSnapshot(ctx, h, tiered)
 	if err != nil {
 		return nil, fmt.Errorf("build loaded state snapshot: %w", err)
 	}
-	expectedByWorkload := buildExpectedWorkloadResultsFromRecords(loadedRecords, r.workloads, r.config.PageSize, r.genConfig)
-	if hotExpected, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, WorkloadDefinition{Name: "hot-selective-page", TargetSchema: "trade", FilterAttribute: "symbol", FilterValue: "SYM00001", PageSize: 20, PageNumber: 1}, r.config.PageSize, loadedRecords, r.genConfig); err == nil {
-		expectedByWorkload["hot-selective-page"] = hotExpected
-	}
-	if eavExpected, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, WorkloadDefinition{Name: "eav-selective-page", TargetSchema: "trade", FilterAttribute: "exchange", FilterValue: "NYSE", PageSize: 20, PageNumber: 1}, r.config.PageSize, loadedRecords, r.genConfig); err == nil {
-		expectedByWorkload["eav-selective-page"] = eavExpected
+	expectedByWorkload, oracleModes, oracleNotes, err := r.buildExpectedResults(ctx, h, loadedRecords)
+	if err != nil {
+		return nil, err
 	}
 	passed := true
 	failureCount := 0
@@ -200,6 +200,7 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 			semantics := semanticsForWorkload(workload, r.genConfig)
 			run.Assertions = append(run.Assertions, validateBasicWorkloadAssertions(workload, run)...)
 			run.Assertions = append(run.Assertions, validateResultLevelAssertions(workload, run, records, semantics)...)
+			run.OracleMode = string(workload.ResolvedOracleMode())
 			if expected, ok := expectedByWorkload[workload.Name]; ok {
 				run.Assertions = append(run.Assertions, validateExpectedWorkloadOutcome(run, expected)...)
 			}
@@ -209,6 +210,10 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 				}
 				pageRuns[workload.TargetSchema] = run
 			}
+			if previous, ok := previousRuns[workload.Name]; ok {
+				run.Assertions = append(run.Assertions, validateRepeatedRunStability(previous, run)...)
+			}
+			previousRuns[workload.Name] = run
 			run.FailureCount = countFailedAssertions(run.Assertions)
 			run.FailureKind = failureKindForRun(run)
 			run.Passed = run.FailureCount == 0 && run.InfraError == ""
@@ -231,15 +236,40 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 		Schemas:        append([]SchemaFixture(nil), r.schemas...),
 		Workloads:      append([]WorkloadDefinition(nil), r.workloads...),
 		Executions:     executions,
+		OracleModes:    oracleModes,
 		Notes: []string{
 			"loaded TPC-E-inspired schema fixtures",
 			fmt.Sprintf("generated dataset with distribution=%s", r.genConfig.Distribution),
 			fmt.Sprintf("loaded tiered dataset profile=%s", profile.Name),
 			fmt.Sprintf("loaded-state snapshot rows=%d", len(loadedRecords)),
+			oracleNotes,
 			"executed supported federated query workloads",
 		},
 	}
 	return result, nil
+}
+
+func (r *Runner) buildExpectedResults(ctx context.Context, h *federated.FederatedTestHarness, loadedRecords []GeneratedRecord) (map[string]expectedWorkloadResult, map[string]string, string, error) {
+	results := buildExpectedWorkloadResultsFromRecords(loadedRecords, r.workloads, r.config.PageSize, r.genConfig)
+	oracleModes := make(map[string]string, len(r.workloads))
+	loadedStateCount := 0
+	truthPassCount := 0
+	for _, workload := range r.workloads {
+		mode := string(workload.ResolvedOracleMode())
+		oracleModes[workload.Name] = mode
+		switch workload.ResolvedOracleMode() {
+		case OracleModeTruthPass:
+			expected, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, workload, r.config.PageSize, loadedRecords, r.genConfig)
+			if err != nil {
+				return nil, nil, "", fmt.Errorf("build truth-pass expected result for %s: %w", workload.Name, err)
+			}
+			results[workload.Name] = expected
+			truthPassCount++
+		default:
+			loadedStateCount++
+		}
+	}
+	return results, oracleModes, fmt.Sprintf("oracle_modes loaded_state=%d truth_pass=%d", loadedStateCount, truthPassCount), nil
 }
 
 func (r *Runner) validateFixtures() error {
@@ -273,8 +303,8 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 		h.SchemaID = previousSchemaID
 	}()
 	opts := queryOptionsForWorkloadWithConfig(workload, r.config.PageSize, r.genConfig)
-	if workload.UsesSimpleFilter() {
-		opts.Filter = &federated.Filter{Conditions: map[string]any{workload.FilterAttribute: workload.FilterValue}}
+	if conditions := workload.ResolvedFilterConditions(); len(conditions) > 0 {
+		opts.Filter = &federated.Filter{Conditions: conditions}
 	}
 	result, err := h.ExecuteFederatedQuery(ctx, opts)
 	if err != nil {
@@ -527,11 +557,12 @@ func buildExpectedWorkloadResultFromFederatedTruth(ctx context.Context, h *feder
 		h.SchemaID = previousSchemaID
 	}()
 	for _, candidate := range candidates {
+		conditions := workload.ResolvedFilterConditions()
 		result, err := h.ExecuteFederatedQuery(ctx, &federated.QueryOptions{
 			Limit: 1,
 			Filter: &federated.Filter{
 				RowID:      candidate.RowID,
-				Conditions: map[string]any{workload.FilterAttribute: workload.FilterValue},
+				Conditions: conditions,
 			},
 			SortBy:   "tradeTime",
 			SortDesc: true,
@@ -595,7 +626,7 @@ func filterExpectedRecordsForWorkload(records []GeneratedRecord, workload Worklo
 				continue
 			}
 		}
-		if workload.UsesSimpleFilter() && !generatedRecordMatchesFilterForWorkload(record, workload) {
+		if len(workload.ResolvedFilterConditions()) > 0 && !generatedRecordMatchesFilterForWorkload(record, workload) {
 			continue
 		}
 		out = append(out, cloneGeneratedRecord(record))
@@ -604,7 +635,7 @@ func filterExpectedRecordsForWorkload(records []GeneratedRecord, workload Worklo
 }
 
 func semanticsForWorkload(workload WorkloadDefinition, genCfg GeneratorConfig) workloadSemantics {
-	if workload.Name != "mixed-tier-window" {
+	if workload.TargetSchema != "trade" {
 		return workloadSemantics{}
 	}
 	baseTime := genCfg.BaseTime
@@ -616,8 +647,20 @@ func semanticsForWorkload(workload WorkloadDefinition, genCfg GeneratorConfig) w
 		windowDays = DefaultGeneratorConfig().TimeWindowDays
 	}
 	windowMillis := int64(windowDays) * 24 * int64(time.Hour/time.Millisecond)
-	start := baseTime.UnixMilli() - (windowMillis * 4 / 5)
-	end := baseTime.UnixMilli() - windowMillis/5
+	var start, end int64
+	switch workload.Name {
+	case "mixed-tier-window":
+		start = baseTime.UnixMilli() - (windowMillis * 4 / 5)
+		end = baseTime.UnixMilli() - windowMillis/5
+	case "hot-only-window":
+		start = baseTime.UnixMilli() - windowMillis/5
+		end = baseTime.UnixMilli()
+	case "cold-only-window":
+		start = baseTime.UnixMilli() - windowMillis
+		end = baseTime.UnixMilli() - (windowMillis * 4 / 5)
+	default:
+		return workloadSemantics{}
+	}
 	if start > end {
 		start, end = end, start
 	}
@@ -635,14 +678,22 @@ func benchmarkAttributeID(schemaID int16, name string) int {
 }
 
 func generatedRecordMatchesFilterForWorkload(record GeneratedRecord, workload WorkloadDefinition) bool {
-	value, ok := benchmarkVisibleAttributeValue(record, workload.FilterAttribute)
-	if !ok {
-		return false
+	for key, expected := range workload.ResolvedFilterConditions() {
+		value, ok := benchmarkVisibleAttributeValue(record, key)
+		if !ok {
+			return false
+		}
+		if key == "tradeType" {
+			if fmt.Sprintf("%v", value) != fmt.Sprintf("%v", expected) {
+				return false
+			}
+			continue
+		}
+		if fmt.Sprint(value) != fmt.Sprint(expected) {
+			return false
+		}
 	}
-	if workload.FilterAttribute == "tradeType" {
-		return fmt.Sprintf("%v", value) == workload.FilterValue
-	}
-	return fmt.Sprint(value) == workload.FilterValue
+	return true
 }
 
 func benchmarkVisibleAttributeValue(record GeneratedRecord, attribute string) (any, bool) {
@@ -809,9 +860,28 @@ func validatePaginationTransition(previous, current WorkloadRunResult) []Asserti
 	return assertions
 }
 
+func validateRepeatedRunStability(previous, current WorkloadRunResult) []AssertionResult {
+	assertions := []AssertionResult{{
+		Name:    "repeated-run-failure-kind-stable",
+		Passed:  previous.FailureKind == current.FailureKind,
+		Message: fmt.Sprintf("previous=%s current=%s", previous.FailureKind, current.FailureKind),
+	}}
+	assertions = append(assertions, AssertionResult{
+		Name:    "repeated-run-total-records-stable",
+		Passed:  previous.TotalRecords == current.TotalRecords,
+		Message: fmt.Sprintf("previous=%d current=%d", previous.TotalRecords, current.TotalRecords),
+	})
+	assertions = append(assertions, AssertionResult{
+		Name:    "repeated-run-page-row-ids-stable",
+		Passed:  stringSlicesEqual(previous.RowIDs, current.RowIDs),
+		Message: fmt.Sprintf("previous=%v current=%v", previous.RowIDs, current.RowIDs),
+	})
+	return assertions
+}
+
 func validateResultLevelAssertions(workload WorkloadDefinition, run WorkloadRunResult, records []*internal.PersistentRecord, semantics workloadSemantics) []AssertionResult {
 	assertions := []AssertionResult{validateUniqueRows(run), validateSchemaScope(workload, records)}
-	if workload.UsesSimpleFilter() {
+	if len(workload.ResolvedFilterConditions()) > 0 {
 		assertions = append(assertions, validateFilterMatch(workload, records))
 	}
 	if semantics.TradeTimeStart > 0 || semantics.TradeTimeEnd > 0 {
@@ -869,11 +939,13 @@ func validateUniqueRows(run WorkloadRunResult) AssertionResult {
 
 func validateFilterMatch(workload WorkloadDefinition, records []*internal.PersistentRecord) AssertionResult {
 	for _, record := range records {
-		if !recordMatchesFilter(record, workload.FilterAttribute, workload.FilterValue) {
-			return AssertionResult{Name: "filter-results-match-request", Passed: false, Message: fmt.Sprintf("attribute=%s expected=%s row=%s", workload.FilterAttribute, workload.FilterValue, record.RowID)}
+		for key, expected := range workload.ResolvedFilterConditions() {
+			if !recordMatchesFilter(record, key, fmt.Sprint(expected)) {
+				return AssertionResult{Name: "filter-results-match-request", Passed: false, Message: fmt.Sprintf("attribute=%s expected=%v row=%s", key, expected, record.RowID)}
+			}
 		}
 	}
-	return AssertionResult{Name: "filter-results-match-request", Passed: true, Message: fmt.Sprintf("attribute=%s expected=%s", workload.FilterAttribute, workload.FilterValue)}
+	return AssertionResult{Name: "filter-results-match-request", Passed: true, Message: fmt.Sprintf("conditions=%v", workload.ResolvedFilterConditions())}
 }
 
 func validateTradeTimeWindow(records []*internal.PersistentRecord, semantics workloadSemantics) AssertionResult {

--- a/internal/e2e_harness/federated/benchmark/runner_test.go
+++ b/internal/e2e_harness/federated/benchmark/runner_test.go
@@ -87,6 +87,21 @@ func TestQueryOptionsForWorkloadAddsMixedTierWindowTradeTimeRange(t *testing.T) 
 	}
 }
 
+func TestQueryOptionsForWorkloadAddsHotAndColdWindowRanges(t *testing.T) {
+	genCfg := GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionTemporal, TimeWindowDays: 30, BaseTime: defaultBaseTime}.WithDefaults()
+	hotOpts := queryOptionsForWorkloadWithConfig(WorkloadDefinition{Name: "hot-only-window", TargetSchema: "trade", PageSize: 50, PageNumber: 1}, 20, genCfg)
+	coldOpts := queryOptionsForWorkloadWithConfig(WorkloadDefinition{Name: "cold-only-window", TargetSchema: "trade", PageSize: 50, PageNumber: 1}, 20, genCfg)
+	if hotOpts.TradeTimeStart <= 0 || hotOpts.TradeTimeEnd <= hotOpts.TradeTimeStart {
+		t.Fatalf("expected hot-only window to set a valid range, got %+v", hotOpts)
+	}
+	if coldOpts.TradeTimeStart <= 0 || coldOpts.TradeTimeEnd <= coldOpts.TradeTimeStart {
+		t.Fatalf("expected cold-only window to set a valid range, got %+v", coldOpts)
+	}
+	if coldOpts.TradeTimeEnd > hotOpts.TradeTimeStart {
+		t.Fatalf("expected cold-only window to end before hot-only window starts, cold=%+v hot=%+v", coldOpts, hotOpts)
+	}
+}
+
 func TestValidateSchemaScopeDetectsCrossSchemaRows(t *testing.T) {
 	records := []*internal.PersistentRecord{{RowID: uuid.MustParse("00000000-0000-0000-0000-000000000010"), SchemaID: SchemaIDTrade}}
 	assertion := validateSchemaScope(WorkloadDefinition{Name: "customer-region-page", TargetSchema: "customer"}, records)
@@ -275,6 +290,30 @@ func TestBuildExpectedWorkloadResultsFromRecordsHonorsMixedTierWindow(t *testing
 	}
 }
 
+func TestGeneratedRecordMatchesFilterForWorkloadSupportsMultipleConditions(t *testing.T) {
+	workload := WorkloadDefinition{FilterConditions: map[string]any{"symbol": "SYM00001", "exchange": "NYSE"}}
+	record := GeneratedRecord{SchemaName: "trade", Attributes: map[string]any{"symbol": "SYM00001", "exchange": "NYSE"}}
+	if !generatedRecordMatchesFilterForWorkload(record, workload) {
+		t.Fatalf("expected record to satisfy all filter conditions")
+	}
+	record.Attributes["exchange"] = "NASDAQ"
+	if generatedRecordMatchesFilterForWorkload(record, workload) {
+		t.Fatalf("expected record to fail when one filter condition does not match")
+	}
+}
+
+func TestValidateFilterMatchSupportsMultipleConditions(t *testing.T) {
+	workload := WorkloadDefinition{FilterConditions: map[string]any{"symbol": "SYM00001", "exchange": "NYSE"}}
+	passing := []*internal.PersistentRecord{{TextItems: map[string]string{"symbol": "SYM00001", "exchange": "NYSE"}}}
+	if assertion := validateFilterMatch(workload, passing); !assertion.Passed {
+		t.Fatalf("expected multi-condition filter assertion to pass: %+v", assertion)
+	}
+	failing := []*internal.PersistentRecord{{TextItems: map[string]string{"symbol": "SYM00001", "exchange": "NASDAQ"}}}
+	if assertion := validateFilterMatch(workload, failing); assertion.Passed {
+		t.Fatalf("expected multi-condition filter assertion to fail")
+	}
+}
+
 func TestValidateTradeTimeWindowDetectsOutOfWindowRows(t *testing.T) {
 	semantics := workloadSemantics{TradeTimeStart: 100, TradeTimeEnd: 200}
 	records := []*internal.PersistentRecord{{RowID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), Int64Items: map[string]int64{"tradeTime": 99}}}
@@ -293,5 +332,65 @@ func TestFailureKindForRunDistinguishesInfraAndCorrectness(t *testing.T) {
 	}
 	if kind := failureKindForRun(WorkloadRunResult{Assertions: []AssertionResult{{Name: "a", Passed: true}}}); kind != "" {
 		t.Fatalf("expected empty failure kind for successful run, got %q", kind)
+	}
+}
+
+func TestValidateRepeatedRunStabilityDetectsChangingRows(t *testing.T) {
+	previous := WorkloadRunResult{FailureKind: "", TotalRecords: 5, RowIDs: []string{"a", "b"}}
+	current := WorkloadRunResult{FailureKind: "", TotalRecords: 5, RowIDs: []string{"a", "c"}}
+	assertions := validateRepeatedRunStability(previous, current)
+	if assertionPassed(assertions, "repeated-run-page-row-ids-stable") {
+		t.Fatalf("expected repeated-run-page-row-ids-stable to fail")
+	}
+	if !assertionPassed(assertions, "repeated-run-total-records-stable") {
+		t.Fatalf("expected repeated-run-total-records-stable to pass")
+	}
+}
+
+func TestWorkloadResolvedOracleModeDefaultsToLoadedState(t *testing.T) {
+	if mode := (WorkloadDefinition{Name: "baseline-page-1"}).ResolvedOracleMode(); mode != OracleModeLoadedState {
+		t.Fatalf("expected default oracle mode to be loaded-state, got %q", mode)
+	}
+	if mode := (WorkloadDefinition{Name: "hot-selective-page", OracleMode: OracleModeTruthPass}).ResolvedOracleMode(); mode != OracleModeTruthPass {
+		t.Fatalf("expected explicit truth-pass oracle mode, got %q", mode)
+	}
+}
+
+func TestDefaultWorkloadsMarkSelectiveWorkloadsAsTruthPass(t *testing.T) {
+	resolved, err := ResolveWorkloads([]string{"hot-selective-page", "hot-low-selectivity-page", "eav-selective-page", "mixed-hot-eav-page", "baseline-page-1"})
+	if err != nil {
+		t.Fatalf("ResolveWorkloads failed: %v", err)
+	}
+	modes := map[string]OracleMode{}
+	for _, workload := range resolved {
+		modes[workload.Name] = workload.ResolvedOracleMode()
+	}
+	if modes["hot-selective-page"] != OracleModeTruthPass {
+		t.Fatalf("expected hot-selective-page to use truth-pass oracle, got %q", modes["hot-selective-page"])
+	}
+	if modes["eav-selective-page"] != OracleModeTruthPass {
+		t.Fatalf("expected eav-selective-page to use truth-pass oracle, got %q", modes["eav-selective-page"])
+	}
+	if modes["hot-low-selectivity-page"] != OracleModeTruthPass {
+		t.Fatalf("expected hot-low-selectivity-page to use truth-pass oracle, got %q", modes["hot-low-selectivity-page"])
+	}
+	if modes["mixed-hot-eav-page"] != OracleModeTruthPass {
+		t.Fatalf("expected mixed-hot-eav-page to use truth-pass oracle, got %q", modes["mixed-hot-eav-page"])
+	}
+	if modes["baseline-page-1"] != OracleModeLoadedState {
+		t.Fatalf("expected baseline-page-1 to use loaded-state oracle, got %q", modes["baseline-page-1"])
+	}
+}
+
+func TestWorkloadResolvedFilterConditionsPrefersExplicitMap(t *testing.T) {
+	workload := WorkloadDefinition{FilterAttribute: "symbol", FilterValue: "SYM00001", FilterConditions: map[string]any{"symbol": "SYM00002", "exchange": "NYSE"}}
+	conditions := workload.ResolvedFilterConditions()
+	if len(conditions) != 2 || conditions["symbol"] != "SYM00002" || conditions["exchange"] != "NYSE" {
+		t.Fatalf("expected explicit filter conditions to win, got %+v", conditions)
+	}
+	simple := WorkloadDefinition{FilterAttribute: "symbol", FilterValue: "SYM00001"}
+	conditions = simple.ResolvedFilterConditions()
+	if len(conditions) != 1 || conditions["symbol"] != "SYM00001" {
+		t.Fatalf("expected simple filter fallback, got %+v", conditions)
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/workload.go
+++ b/internal/e2e_harness/federated/benchmark/workload.go
@@ -8,11 +8,17 @@ import (
 // WorkloadCategory groups benchmark workloads by intent.
 type WorkloadCategory string
 
+// OracleMode declares how expected benchmark results are derived.
+type OracleMode string
+
 const (
 	WorkloadCategoryPagination WorkloadCategory = "pagination"
 	WorkloadCategoryFilter     WorkloadCategory = "filter"
 	WorkloadCategoryDeepPage   WorkloadCategory = "deep-pagination"
 	WorkloadCategoryTierMix    WorkloadCategory = "tier-mix"
+
+	OracleModeLoadedState OracleMode = "loaded-state"
+	OracleModeTruthPass   OracleMode = "truth-pass"
 )
 
 // WorkloadDefinition declares a benchmark workload.
@@ -23,12 +29,14 @@ type WorkloadDefinition struct {
 	TargetSchema          string           `json:"target_schema"`
 	FilterAttribute       string           `json:"filter_attribute,omitempty"`
 	FilterValue           string           `json:"filter_value,omitempty"`
+	FilterConditions      map[string]any   `json:"filter_conditions,omitempty"`
 	PageSize              int              `json:"page_size"`
 	PageNumber            int              `json:"page_number"`
 	SupportsDistributions []Distribution   `json:"supports_distributions"`
 	PreferHot             bool             `json:"prefer_hot,omitempty"`
 	UsesEAVFilter         bool             `json:"uses_eav_filter,omitempty"`
 	LargePageJump         bool             `json:"large_page_jump,omitempty"`
+	OracleMode            OracleMode       `json:"oracle_mode,omitempty"`
 }
 
 // DefaultWorkloads returns the initial declarative workload matrix.
@@ -42,6 +50,7 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageSize:              20,
 			PageNumber:            1,
 			SupportsDistributions: allDistributions(),
+			OracleMode:            OracleModeLoadedState,
 		},
 		{
 			Name:                  "customer-region-page",
@@ -53,6 +62,7 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageSize:              20,
 			PageNumber:            1,
 			SupportsDistributions: allDistributions(),
+			OracleMode:            OracleModeLoadedState,
 		},
 		{
 			Name:                  "security-symbol-page",
@@ -64,6 +74,7 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageSize:              20,
 			PageNumber:            1,
 			SupportsDistributions: allDistributions(),
+			OracleMode:            OracleModeLoadedState,
 		},
 		{
 			Name:                  "hot-selective-page",
@@ -72,9 +83,25 @@ func DefaultWorkloads() []WorkloadDefinition {
 			TargetSchema:          "trade",
 			FilterAttribute:       "symbol",
 			FilterValue:           "SYM00001",
+			FilterConditions:      map[string]any{"symbol": "SYM00001"},
 			PageSize:              20,
 			PageNumber:            1,
 			SupportsDistributions: allDistributions(),
+			OracleMode:            OracleModeTruthPass,
+		},
+		{
+			Name:                  "hot-low-selectivity-page",
+			Description:           "Lower-selectivity hot-column filter with pagination on trade rows.",
+			Category:              WorkloadCategoryFilter,
+			TargetSchema:          "trade",
+			FilterAttribute:       "tradeType",
+			FilterValue:           "0",
+			FilterConditions:      map[string]any{"tradeType": 0},
+			PageSize:              20,
+			PageNumber:            1,
+			SupportsDistributions: allDistributions(),
+			PreferHot:             true,
+			OracleMode:            OracleModeTruthPass,
 		},
 		{
 			Name:                  "eav-selective-page",
@@ -83,10 +110,27 @@ func DefaultWorkloads() []WorkloadDefinition {
 			TargetSchema:          "trade",
 			FilterAttribute:       "exchange",
 			FilterValue:           "NYSE",
+			FilterConditions:      map[string]any{"exchange": "NYSE"},
 			PageSize:              20,
 			PageNumber:            1,
 			SupportsDistributions: allDistributions(),
 			UsesEAVFilter:         true,
+			OracleMode:            OracleModeTruthPass,
+		},
+		{
+			Name:                  "mixed-hot-eav-page",
+			Description:           "Mixed hot and EAV filter workload with paginated trade results.",
+			Category:              WorkloadCategoryFilter,
+			TargetSchema:          "trade",
+			FilterAttribute:       "symbol",
+			FilterValue:           "SYM00001",
+			FilterConditions:      map[string]any{"symbol": "SYM00001", "exchange": "NYSE"},
+			PageSize:              20,
+			PageNumber:            1,
+			SupportsDistributions: allDistributions(),
+			PreferHot:             true,
+			UsesEAVFilter:         true,
+			OracleMode:            OracleModeTruthPass,
 		},
 		{
 			Name:                  "mixed-tier-window",
@@ -96,6 +140,28 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageSize:              50,
 			PageNumber:            1,
 			SupportsDistributions: []Distribution{DistributionTemporal, DistributionHotspot, DistributionUniform},
+			OracleMode:            OracleModeLoadedState,
+		},
+		{
+			Name:                  "hot-only-window",
+			Description:           "Recent time-window query expected to stay within hot rows.",
+			Category:              WorkloadCategoryTierMix,
+			TargetSchema:          "trade",
+			PageSize:              50,
+			PageNumber:            1,
+			SupportsDistributions: []Distribution{DistributionTemporal, DistributionHotspot, DistributionUniform},
+			PreferHot:             true,
+			OracleMode:            OracleModeLoadedState,
+		},
+		{
+			Name:                  "cold-only-window",
+			Description:           "Historical time-window query expected to stay within cold tiers.",
+			Category:              WorkloadCategoryTierMix,
+			TargetSchema:          "trade",
+			PageSize:              50,
+			PageNumber:            1,
+			SupportsDistributions: []Distribution{DistributionTemporal, DistributionHotspot, DistributionUniform},
+			OracleMode:            OracleModeLoadedState,
 		},
 		{
 			Name:                  "deep-page-1000",
@@ -106,6 +172,7 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageNumber:            1000,
 			SupportsDistributions: allDistributions(),
 			LargePageJump:         true,
+			OracleMode:            OracleModeLoadedState,
 		},
 		{
 			Name:                  "deep-page-100000",
@@ -116,6 +183,7 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageNumber:            100000,
 			SupportsDistributions: allDistributions(),
 			LargePageJump:         true,
+			OracleMode:            OracleModeLoadedState,
 		},
 	}
 }
@@ -146,6 +214,29 @@ func (w WorkloadDefinition) DerivedOffset(defaultPageSize int) int {
 // UsesSimpleFilter reports whether the workload is representable via the current harness filter model.
 func (w WorkloadDefinition) UsesSimpleFilter() bool {
 	return strings.TrimSpace(w.FilterAttribute) != ""
+}
+
+// ResolvedFilterConditions returns the filter map used by executable workloads.
+func (w WorkloadDefinition) ResolvedFilterConditions() map[string]any {
+	if len(w.FilterConditions) > 0 {
+		conditions := make(map[string]any, len(w.FilterConditions))
+		for key, value := range w.FilterConditions {
+			conditions[key] = value
+		}
+		return conditions
+	}
+	if strings.TrimSpace(w.FilterAttribute) == "" {
+		return nil
+	}
+	return map[string]any{w.FilterAttribute: w.FilterValue}
+}
+
+// ResolvedOracleMode returns the default oracle mode when not explicitly set.
+func (w WorkloadDefinition) ResolvedOracleMode() OracleMode {
+	if w.OracleMode == "" {
+		return OracleModeLoadedState
+	}
+	return w.OracleMode
 }
 
 // DefaultWorkloadNames returns the full default workload set.

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -24,7 +24,7 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 		Mode:          bench.ExecutionModePlan,
 		Scale:         bench.ScaleSmall,
 		Distribution:  bench.DistributionHotspot,
-		Iterations:    1,
+		Iterations:    2,
 		PageSize:      20,
 		Seed:          42,
 		TradeCount:    120,
@@ -37,8 +37,12 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 			"customer-region-page",
 			"security-symbol-page",
 			"hot-selective-page",
+			"hot-low-selectivity-page",
 			"eav-selective-page",
+			"mixed-hot-eav-page",
 			"mixed-tier-window",
+			"hot-only-window",
+			"cold-only-window",
 			"deep-page-1000",
 			"deep-page-100000",
 		},
@@ -48,14 +52,20 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	result, err := runner.RunWithHarness(ctx, h, bench.TierMixBalanced)
 	require.NoError(t, err)
 	require.False(t, result.ValidationOnly)
-	require.Len(t, result.Executions, 8)
+	require.Len(t, result.Executions, 24)
+	require.Contains(t, result.Notes, "oracle_modes loaded_state=8 truth_pass=4")
 	customerSeen := false
 	securitySeen := false
 	filteredSeen := false
+	lowSelectiveSeen := false
 	eavSeen := false
+	mixedFilterSeen := false
 	mixedTierSeen := false
+	hotOnlySeen := false
+	coldOnlySeen := false
 	expectedOracleAssertionsSeen := false
 	tradeTimeWindowAssertionSeen := false
+	repeatedRunStabilitySeen := false
 	for _, execution := range result.Executions {
 		require.NotEmpty(t, execution.Name)
 		require.GreaterOrEqual(t, execution.ResultCount, 0)
@@ -78,14 +88,31 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 			eavSeen = true
 			require.Empty(t, execution.FailureKind, "expected EAV selective workload to pass correctness in live execution")
 		}
+		if execution.Name == "hot-low-selectivity-page" {
+			lowSelectiveSeen = true
+			require.Empty(t, execution.FailureKind, "expected low-selectivity workload to pass correctness in live execution")
+		}
+		if execution.Name == "mixed-hot-eav-page" {
+			mixedFilterSeen = true
+			require.Empty(t, execution.FailureKind, "expected mixed hot+EAV workload to pass correctness in live execution")
+		}
 		if execution.Name == "mixed-tier-window" {
 			mixedTierSeen = true
+		}
+		if execution.Name == "hot-only-window" {
+			hotOnlySeen = true
+		}
+		if execution.Name == "cold-only-window" {
+			coldOnlySeen = true
 		}
 		for _, assertion := range execution.Assertions {
 			if assertion.Name == "total-records-match-expected" || assertion.Name == "page-row-ids-match-expected" {
 				expectedOracleAssertionsSeen = true
 			}
-			if execution.Name == "mixed-tier-window" && assertion.Name == "tradeTime-window-match-request" {
+			if assertion.Name == "repeated-run-failure-kind-stable" || assertion.Name == "repeated-run-total-records-stable" || assertion.Name == "repeated-run-page-row-ids-stable" {
+				repeatedRunStabilitySeen = true
+			}
+			if (execution.Name == "mixed-tier-window" || execution.Name == "hot-only-window" || execution.Name == "cold-only-window") && assertion.Name == "tradeTime-window-match-request" {
 				tradeTimeWindowAssertionSeen = true
 			}
 		}
@@ -93,8 +120,13 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	require.True(t, customerSeen)
 	require.True(t, securitySeen)
 	require.True(t, filteredSeen)
+	require.True(t, lowSelectiveSeen)
 	require.True(t, eavSeen)
+	require.True(t, mixedFilterSeen)
 	require.True(t, mixedTierSeen)
+	require.True(t, hotOnlySeen)
+	require.True(t, coldOnlySeen)
 	require.True(t, expectedOracleAssertionsSeen, "expected result oracle assertions to be exercised")
+	require.True(t, repeatedRunStabilitySeen, "expected repeated-run stability assertions to be exercised")
 	require.True(t, tradeTimeWindowAssertionSeen, "expected mixed-tier window assertion to be exercised")
 }


### PR DESCRIPTION
## Summary
- expand the live benchmark workload matrix with low-selectivity, mixed hot+EAV, and hot-only/cold-only window workloads, including executable filter semantics and time-window handling
- make benchmark oracle provenance explicit through workload oracle modes in run results and summaries, while keeping selective workloads backed by reusable truth-pass oracles
- add repeated-run stability assertions for the supported live subset so correctness signals include failure-kind, total-record, and page-row stability across identical seeds

## Testing
- go test ./internal/e2e_harness/federated/benchmark ./internal/e2e_harness/federated ./cmd/benchmark
- go test -tags=e2e ./internal/e2e_harness/federated -run TestBenchmarkWorkloadExecution_RunWithHarness -count=1