### PR TITLE
surface prefer-hot benchmark semantics

### DIFF
--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -105,6 +105,19 @@ Typical examples:
 - `truth-pass` is usually more expensive than `loaded-state`, so do not assume all workloads should use it by default
 - if a workload changes oracle mode between baselines, treat that as a benchmark methodology change, not a pure performance change
 
+## PreferHot
+
+`prefer_hot` currently records workload intent and benchmark provenance. It tells reviewers that a workload is expected to bias toward hot data freshness or hot-tier-heavy access patterns.
+
+At the current stage, `prefer_hot` should mostly be interpreted as metadata. The benchmark now uses a real hot-preferred execution override only for tier-mix workloads where a Postgres-only hot-path comparison is intentional.
+
+- it appears in workload definitions, run results, summaries, and plan notes
+- it helps reviewers distinguish hot-biased workloads from neutral workloads when comparing baselines
+- for filter-heavy workloads it does not yet mean the benchmark has applied a hard routing override that excludes cold or mixed execution paths
+- for tier-mix workloads such as `hot-only-window`, the benchmark may record that a hot-preferred execution override was applied
+
+Treat any future change that turns `prefer_hot` into a real execution flag as a benchmark methodology change and compare baselines accordingly.
+
 ## Interpretation Guidance
 
 - use `small` to catch obvious correctness or latency regressions quickly

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -47,6 +47,18 @@ Without this distinction, two correctness failures could look identical even tho
 - when a selective workload fails under `truth-pass`, assume the benchmark has already validated the expected answer through the executable path
 - when comparing benchmark summaries, use `oracle_mode` alongside `correctness_failures` so reviewers understand whether failures came from loaded-state reconstruction or truth-pass-backed verification
 
+## PreferHot
+
+The benchmark also carries `prefer_hot` as workload intent metadata.
+
+At this stage, `prefer_hot` means the workload is intended to emphasize hot-tier freshness or hot-biased access patterns. For most workloads it is still intent metadata only. The current exception is tier-mix workloads where the benchmark may apply a hot-preferred Postgres-only override to make that execution choice explicit.
+
+Operationally, that means:
+
+- use `prefer_hot` to group or explain workloads in reviews and benchmark summaries
+- do not interpret `prefer_hot=true` as proof that cold tiers were excluded from execution unless the run also records a hot-preferred execution override in plan notes
+- if a later change turns `prefer_hot` into a real routing or planning flag, treat that as a benchmark methodology change rather than a simple benchmark expansion
+
 ## Workload Groups
 
 ### Smoke

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -65,6 +65,7 @@ type WorkloadSummary struct {
 	Category            string                   `json:"category"`
 	TargetSchema        string                   `json:"target_schema,omitempty"`
 	OracleMode          string                   `json:"oracle_mode,omitempty"`
+	PreferHot           bool                     `json:"prefer_hot,omitempty"`
 	Distribution        Distribution             `json:"distribution"`
 	ExecutionCount      int                      `json:"execution_count"`
 	Passed              bool                     `json:"passed"`
@@ -164,7 +165,7 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 	if len(result.Executions) > 0 {
 		b.WriteString("\n## Executions\n\n")
 		for _, execution := range result.Executions {
-			b.WriteString(fmt.Sprintf("- `%s`: passed=%t failure_kind=%s failures=%d count=%d total=%d duration=%s offset=%d\n", execution.Name, execution.Passed, execution.FailureKind, execution.FailureCount, execution.ResultCount, execution.TotalRecords, execution.Duration, execution.Offset))
+			b.WriteString(fmt.Sprintf("- `%s`: passed=%t failure_kind=%s oracle_mode=%s prefer_hot=%t failures=%d count=%d total=%d duration=%s offset=%d\n", execution.Name, execution.Passed, execution.FailureKind, execution.OracleMode, execution.PreferHot, execution.FailureCount, execution.ResultCount, execution.TotalRecords, execution.Duration, execution.Offset))
 			if execution.InfraError != "" {
 				b.WriteString(fmt.Sprintf("  infra_error=%s\n", execution.InfraError))
 			}
@@ -185,7 +186,7 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 	if len(summary.Workloads) > 0 {
 		b.WriteString("\n## Workload Summaries\n\n")
 		for _, workload := range summary.Workloads {
-			b.WriteString(fmt.Sprintf("- `%s`: schema=%s executions=%d passed=%t qps=%.2f p95=%s avg=%s avg_result_count=%.2f avg_total_records=%.2f\n", workload.Name, workload.TargetSchema, workload.ExecutionCount, workload.Passed, workload.QPS, workload.P95, workload.Avg, workload.AvgResultCount, workload.AvgTotalRecords))
+			b.WriteString(fmt.Sprintf("- `%s`: schema=%s oracle_mode=%s prefer_hot=%t executions=%d passed=%t qps=%.2f p95=%s avg=%s avg_result_count=%.2f avg_total_records=%.2f\n", workload.Name, workload.TargetSchema, workload.OracleMode, workload.PreferHot, workload.ExecutionCount, workload.Passed, workload.QPS, workload.P95, workload.Avg, workload.AvgResultCount, workload.AvgTotalRecords))
 		}
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
@@ -484,6 +485,7 @@ func summarizeWorkloads(result *RunResult) []WorkloadSummary {
 			workload.Category = string(def.Category)
 			workload.TargetSchema = def.TargetSchema
 			workload.OracleMode = string(def.ResolvedOracleMode())
+			workload.PreferHot = def.PreferHot
 			workload.Distribution = runs[0].Distribution
 			workload.PageSize = def.PageSize
 		}
@@ -515,6 +517,9 @@ func summarizeWorkloads(result *RunResult) []WorkloadSummary {
 			}
 			if workload.OracleMode == "" && run.OracleMode != "" {
 				workload.OracleMode = run.OracleMode
+			}
+			if run.PreferHot {
+				workload.PreferHot = true
 			}
 			for _, assertion := range run.Assertions {
 				stat := workload.AssertionStats[assertion.Name]

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -51,7 +51,7 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 		OracleModes:  map[string]string{"q1": string(OracleModeLoadedState), "q2": string(OracleModeTruthPass)},
 		Executions: []WorkloadRunResult{
 			{Name: "q1", Passed: true, OracleMode: string(OracleModeLoadedState), Duration: 10 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: true}}},
-			{Name: "q2", Passed: false, OracleMode: string(OracleModeTruthPass), FailureKind: FailureKindCorrectness, FailureCount: 1, Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}}},
+			{Name: "q2", Passed: false, PreferHot: true, OracleMode: string(OracleModeTruthPass), FailureKind: FailureKindCorrectness, FailureCount: 1, Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}}},
 		},
 	}
 	if err := WriteBaselineCapture(dir, result); err != nil {
@@ -86,6 +86,9 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 	}
 	if summary.OracleModes["q2"] != string(OracleModeTruthPass) {
 		t.Fatalf("expected summary to expose oracle modes, got %+v", summary.OracleModes)
+	}
+	if !summary.Workloads[1].PreferHot {
+		t.Fatalf("expected workload summary to expose prefer_hot intent, got %+v", summary.Workloads[1])
 	}
 	if len(summary.Workloads) != 2 {
 		t.Fatalf("expected two workload summaries, got %d", len(summary.Workloads))
@@ -126,10 +129,13 @@ func TestFormatConsoleSummary(t *testing.T) {
 }
 
 func TestSummarizeWorkloadsCarriesOracleMode(t *testing.T) {
-	result := &RunResult{Executions: []WorkloadRunResult{{Name: "q1", OracleMode: string(OracleModeTruthPass), Duration: 10 * time.Millisecond, Passed: true}}}
+	result := &RunResult{Executions: []WorkloadRunResult{{Name: "q1", PreferHot: true, OracleMode: string(OracleModeTruthPass), Duration: 10 * time.Millisecond, Passed: true}}}
 	workloads := summarizeWorkloads(result)
 	if len(workloads) != 1 || workloads[0].OracleMode != string(OracleModeTruthPass) {
 		t.Fatalf("expected workload summary to carry oracle mode, got %+v", workloads)
+	}
+	if !workloads[0].PreferHot {
+		t.Fatalf("expected workload summary to carry prefer_hot, got %+v", workloads)
 	}
 }
 

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -40,6 +40,7 @@ type WorkloadRunResult struct {
 	PageSize     int               `json:"page_size"`
 	PageNumber   int               `json:"page_number"`
 	Offset       int               `json:"offset"`
+	PreferHot    bool              `json:"prefer_hot,omitempty"`
 	ResultCount  int               `json:"result_count"`
 	TotalRecords int64             `json:"total_records"`
 	Duration     time.Duration     `json:"duration"`
@@ -243,6 +244,7 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 			fmt.Sprintf("loaded tiered dataset profile=%s", profile.Name),
 			fmt.Sprintf("loaded-state snapshot rows=%d", len(loadedRecords)),
 			oracleNotes,
+			"prefer_hot expresses workload intent and report provenance, not hard execution routing",
 			"executed supported federated query workloads",
 		},
 	}
@@ -303,6 +305,7 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 		h.SchemaID = previousSchemaID
 	}()
 	opts := queryOptionsForWorkloadWithConfig(workload, r.config.PageSize, r.genConfig)
+	opts.PreferHot = workload.PreferHot && workload.Category == WorkloadCategoryTierMix
 	if conditions := workload.ResolvedFilterConditions(); len(conditions) > 0 {
 		opts.Filter = &federated.Filter{Conditions: conditions}
 	}
@@ -317,6 +320,7 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 		PageSize:     pageSize,
 		PageNumber:   workload.PageNumber,
 		Offset:       opts.Offset,
+		PreferHot:    workload.PreferHot,
 		ResultCount:  len(result.Records),
 		TotalRecords: result.TotalRecords,
 		Duration:     result.Duration,
@@ -325,6 +329,12 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 	}
 	if result.Plan != nil {
 		run.PlanNotes = append([]string(nil), result.Plan.Notes...)
+	}
+	if workload.PreferHot {
+		run.PlanNotes = append(run.PlanNotes, "prefer_hot=true (intent/provenance only; no hard routing override yet)")
+		if opts.PreferHot {
+			run.PlanNotes = append(run.PlanNotes, "prefer_hot_execution=true (postgres-only override active for tier-mix workload)")
+		}
 	}
 	return run, result.Records, nil
 }
@@ -341,6 +351,7 @@ func failedWorkloadRunResult(workload WorkloadDefinition, distribution Distribut
 		PageSize:     pageSize,
 		PageNumber:   workload.PageNumber,
 		Offset:       workload.DerivedOffset(defaultPageSize),
+		PreferHot:    workload.PreferHot,
 		Passed:       false,
 		FailureKind:  FailureKindInfra,
 		FailureCount: 1,

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -54,6 +54,7 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	require.False(t, result.ValidationOnly)
 	require.Len(t, result.Executions, 24)
 	require.Contains(t, result.Notes, "oracle_modes loaded_state=8 truth_pass=4")
+	require.Contains(t, result.Notes, "prefer_hot expresses workload intent and report provenance, not hard execution routing")
 	customerSeen := false
 	securitySeen := false
 	filteredSeen := false
@@ -90,10 +91,16 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 		}
 		if execution.Name == "hot-low-selectivity-page" {
 			lowSelectiveSeen = true
+			require.True(t, execution.PreferHot)
+			require.Contains(t, execution.PlanNotes, "prefer_hot=true (intent/provenance only; no hard routing override yet)")
+			require.NotContains(t, execution.PlanNotes, "prefer_hot_execution=true (postgres-only override active for tier-mix workload)")
 			require.Empty(t, execution.FailureKind, "expected low-selectivity workload to pass correctness in live execution")
 		}
 		if execution.Name == "mixed-hot-eav-page" {
 			mixedFilterSeen = true
+			require.True(t, execution.PreferHot)
+			require.Contains(t, execution.PlanNotes, "prefer_hot=true (intent/provenance only; no hard routing override yet)")
+			require.NotContains(t, execution.PlanNotes, "prefer_hot_execution=true (postgres-only override active for tier-mix workload)")
 			require.Empty(t, execution.FailureKind, "expected mixed hot+EAV workload to pass correctness in live execution")
 		}
 		if execution.Name == "mixed-tier-window" {
@@ -101,6 +108,9 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 		}
 		if execution.Name == "hot-only-window" {
 			hotOnlySeen = true
+			require.True(t, execution.PreferHot)
+			require.Contains(t, execution.PlanNotes, "prefer_hot=true (intent/provenance only; no hard routing override yet)")
+			require.Contains(t, execution.PlanNotes, "prefer_hot_execution=true (postgres-only override active for tier-mix workload)")
 		}
 		if execution.Name == "cold-only-window" {
 			coldOnlySeen = true

--- a/internal/e2e_harness/federated/harness.go
+++ b/internal/e2e_harness/federated/harness.go
@@ -66,6 +66,7 @@ type QueryOptions struct {
 	Filter         *Filter
 	SortBy         string
 	SortDesc       bool
+	PreferHot      bool
 	TradeTimeStart int64
 	TradeTimeEnd   int64
 	CountOnly      bool

--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -21,6 +21,19 @@ const (
 func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *QueryOptions) (*QueryResult, error) {
 	opts = normalizeQueryOptions(opts)
 	start := time.Now()
+	if opts.PreferHot {
+		result, err := h.ExecutePostgresQuery(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		if result.Plan == nil {
+			result.Plan = &internal.ExecutionPlan{Notes: []string{}, Timings: map[string]int64{}}
+		}
+		result.Plan.Notes = append(result.Plan.Notes, "prefer_hot_override", "postgres_only_execution")
+		result.Plan.Timings["total"] = time.Since(start).Milliseconds()
+		result.Duration = time.Since(start)
+		return result, nil
+	}
 	benchmarkProjection := usesBenchmarkProjection(opts)
 	if benchmarkProjection {
 		if err := prepareBenchmarkDuckDBMacros(ctx, h); err != nil {
@@ -635,72 +648,255 @@ func (h *FederatedTestHarness) getDirtyIDs(ctx context.Context) ([]uuid.UUID, er
 func (h *FederatedTestHarness) ExecutePostgresQuery(ctx context.Context, opts *QueryOptions) (*QueryResult, error) {
 	opts = normalizeQueryOptions(opts)
 	start := time.Now()
+	countQuery, countArgs := h.buildPostgresOnlyCountQuery(opts)
+	var total int64
+	if err := h.PGDB.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total); err != nil {
+		return nil, err
+	}
 	if opts.CountOnly {
-		var total int64
-		if err := h.PGDB.QueryRowContext(ctx, `
-			SELECT COUNT(*) FROM entity_main 
-			WHERE ltbase_schema_id = $1 AND (ltbase_deleted_at IS NULL OR ltbase_deleted_at = 0)
-		`, h.SchemaID).Scan(&total); err != nil {
-			return nil, err
-		}
-		return &QueryResult{TotalRecords: total, Duration: time.Since(start)}, nil
+		return &QueryResult{TotalRecords: total, Duration: time.Since(start), Plan: buildPostgresOnlyExecutionPlan(time.Since(start), opts.PreferHot)}, nil
 	}
 
-	query := `
-		SELECT 
-			em.ltbase_row_id,
-			em.ltbase_schema_id,
-			em.ltbase_created_at,
-			em.ltbase_deleted_at
-		FROM entity_main em
-		WHERE em.ltbase_schema_id = $1
-			AND (em.ltbase_deleted_at IS NULL OR em.ltbase_deleted_at = 0)
-		ORDER BY em.ltbase_created_at DESC
-		LIMIT $2 OFFSET $3
-	`
-
-	rows, err := h.PGDB.QueryContext(ctx, query, h.SchemaID, opts.Limit, opts.Offset)
+	query, args := h.buildPostgresOnlySelectQuery(opts)
+	rows, err := h.PGDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
+	benchmarkProjection := usesBenchmarkProjection(opts)
 	var records []*internal.PersistentRecord
 	for rows.Next() {
-		var rowID uuid.UUID
+		var rowID string
 		var schemaID int16
-		var createdAt int64
-		var deletedAt sql.NullInt64
-
-		if err := rows.Scan(&rowID, &schemaID, &createdAt, &deletedAt); err != nil {
-			return nil, err
+		var changedAt, deletedAt int64
+		var name sql.NullString
+		var version sql.NullInt64
+		var symbol, exchange, region sql.NullString
+		var tradeType, tradeTime sql.NullInt64
+		if benchmarkProjection {
+			if err := rows.Scan(&rowID, &schemaID, &changedAt, &deletedAt, &name, &version, &symbol, &exchange, &region, &tradeType, &tradeTime); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := rows.Scan(&rowID, &schemaID, &changedAt, &deletedAt, &name, &version); err != nil {
+				return nil, err
+			}
 		}
-
-		rec := &internal.PersistentRecord{
-			RowID:     rowID,
-			SchemaID:  schemaID,
-			CreatedAt: createdAt,
-			UpdatedAt: createdAt,
+		rec := &internal.PersistentRecord{RowID: uuid.MustParse(rowID), SchemaID: schemaID, CreatedAt: changedAt, UpdatedAt: changedAt, TextItems: map[string]string{}, Float64Items: map[string]float64{}}
+		if deletedAt > 0 {
+			rec.DeletedAt = &deletedAt
 		}
-		if deletedAt.Valid && deletedAt.Int64 > 0 {
-			rec.DeletedAt = &deletedAt.Int64
+		if name.Valid {
+			rec.TextItems["name"] = name.String
 		}
-
+		if benchmarkProjection {
+			if symbol.Valid {
+				rec.TextItems["symbol"] = symbol.String
+			}
+			if exchange.Valid {
+				rec.TextItems["exchange"] = exchange.String
+			}
+			if region.Valid {
+				rec.TextItems["region"] = region.String
+			}
+		}
+		if version.Valid {
+			rec.Float64Items["version"] = float64(version.Int64)
+		}
+		if benchmarkProjection && (tradeType.Valid || tradeTime.Valid) {
+			rec.Int64Items = make(map[string]int64)
+			if tradeType.Valid {
+				rec.Int64Items["tradeType"] = tradeType.Int64
+			}
+			if tradeTime.Valid {
+				rec.Int64Items["tradeTime"] = tradeTime.Int64
+			}
+		}
 		records = append(records, rec)
 	}
-
-	// Get total count
-	var total int64
-	_ = h.PGDB.QueryRowContext(ctx, `
-		SELECT COUNT(*) FROM entity_main 
-		WHERE ltbase_schema_id = $1 AND (ltbase_deleted_at IS NULL OR ltbase_deleted_at = 0)
-	`, h.SchemaID).Scan(&total)
 
 	return &QueryResult{
 		Records:      records,
 		TotalRecords: total,
 		Duration:     time.Since(start),
+		Plan:         buildPostgresOnlyExecutionPlan(time.Since(start), opts.PreferHot),
 	}, nil
+}
+
+func (h *FederatedTestHarness) buildPostgresOnlySelectQuery(opts *QueryOptions) (string, []any) {
+	args := []any{h.SchemaID}
+	attrIDs := benchmarkPostgresAttributeIDs()
+	query := strings.Builder{}
+	query.WriteString(`
+		SELECT
+			cl.row_id::VARCHAR,
+			cl.schema_id,
+			cl.changed_at,
+			COALESCE(cl.deleted_at, 0),
+			COALESCE(hot_vals.name, hot_vals.symbol, '') as name,
+			0 as version`)
+	if usesBenchmarkProjection(opts) {
+		query.WriteString(`,
+			COALESCE(hot_vals.symbol, em.text_01, '') as symbol,
+			COALESCE(hot_vals.exchange, '') as exchange,
+			COALESCE(hot_vals.region, em.text_02, '') as region,
+			COALESCE(hot_vals.trade_type, em.smallint_01::BIGINT, 0) as tradeType,
+			COALESCE(hot_vals.trade_time, em.bigint_02, 0) as tradeTime`)
+	}
+	query.WriteString(fmt.Sprintf(`
+		FROM change_log cl
+		LEFT JOIN entity_main em
+			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id = cl.row_id
+		LEFT JOIN (
+			SELECT schema_id, row_id,
+				MAX(CASE WHEN attr_id = %d THEN value_text END) AS symbol,
+				MAX(CASE WHEN attr_id = %d THEN value_text END) AS exchange,
+				MAX(CASE WHEN attr_id = %d THEN value_text END) AS region,
+				MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS trade_type,
+				MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS trade_time,
+				MAX(CASE WHEN attr_id = %d THEN value_text END) AS name
+			FROM eav_data
+			WHERE attr_id IN (%d, %d, %d, %d, %d, %d)
+			GROUP BY schema_id, row_id
+		) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id
+		WHERE cl.schema_id = $1 AND cl.flushed_at = 0 AND (cl.deleted_at IS NULL OR cl.deleted_at = 0)`,
+		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name,
+		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name))
+	filterSQL, filterArgs := buildPostgresOnlyFilterClauses(opts, 2)
+	query.WriteString(filterSQL)
+	args = append(args, filterArgs...)
+	query.WriteString(fmt.Sprintf(" ORDER BY %s LIMIT $%d OFFSET $%d", buildPostgresOnlyOrderBy(opts), len(args)+1, len(args)+2))
+	args = append(args, opts.Limit, opts.Offset)
+	return query.String(), args
+}
+
+func (h *FederatedTestHarness) buildPostgresOnlyCountQuery(opts *QueryOptions) (string, []any) {
+	args := []any{h.SchemaID}
+	attrIDs := benchmarkPostgresAttributeIDs()
+	query := strings.Builder{}
+	query.WriteString(fmt.Sprintf(`
+		SELECT COUNT(*)
+		FROM change_log cl
+		LEFT JOIN entity_main em
+			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id = cl.row_id
+		LEFT JOIN (
+			SELECT schema_id, row_id,
+				MAX(CASE WHEN attr_id = %d THEN value_text END) AS symbol,
+				MAX(CASE WHEN attr_id = %d THEN value_text END) AS exchange,
+				MAX(CASE WHEN attr_id = %d THEN value_text END) AS region,
+				MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS trade_type,
+				MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS trade_time,
+				MAX(CASE WHEN attr_id = %d THEN value_text END) AS name
+			FROM eav_data
+			WHERE attr_id IN (%d, %d, %d, %d, %d, %d)
+			GROUP BY schema_id, row_id
+		) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id
+		WHERE cl.schema_id = $1 AND cl.flushed_at = 0 AND (cl.deleted_at IS NULL OR cl.deleted_at = 0)`,
+		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name,
+		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name))
+	filterSQL, filterArgs := buildPostgresOnlyFilterClauses(opts, 2)
+	query.WriteString(filterSQL)
+	args = append(args, filterArgs...)
+	return query.String(), args
+}
+
+func buildPostgresOnlyFilterClauses(opts *QueryOptions, placeholderStart int) (string, []any) {
+	if opts == nil {
+		return "", nil
+	}
+	args := make([]any, 0)
+	parts := make([]string, 0)
+	placeholder := placeholderStart
+	if opts.Filter != nil && opts.Filter.RowID != uuid.Nil {
+		parts = append(parts, fmt.Sprintf("AND cl.row_id = $%d", placeholder))
+		args = append(args, opts.Filter.RowID)
+		placeholder++
+	}
+	if opts.Filter != nil {
+		for key, value := range opts.Filter.Conditions {
+			expression := postgresOnlyFilterExpression(key)
+			if expression == "" {
+				continue
+			}
+			parts = append(parts, fmt.Sprintf("AND %s = $%d", expression, placeholder))
+			args = append(args, value)
+			placeholder++
+		}
+	}
+	if opts.TradeTimeStart > 0 {
+		parts = append(parts, fmt.Sprintf("AND %s >= $%d", postgresOnlyFilterExpression("tradeTime"), placeholder))
+		args = append(args, opts.TradeTimeStart)
+		placeholder++
+	}
+	if opts.TradeTimeEnd > 0 {
+		parts = append(parts, fmt.Sprintf("AND %s <= $%d", postgresOnlyFilterExpression("tradeTime"), placeholder))
+		args = append(args, opts.TradeTimeEnd)
+	}
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return " " + strings.Join(parts, " "), args
+}
+
+func buildPostgresOnlyOrderBy(opts *QueryOptions) string {
+	if opts == nil || opts.SortBy == "" {
+		return "cl.row_id ASC"
+	}
+	column := postgresOnlyFilterExpression(opts.SortBy)
+	if column == "" {
+		column = "cl.row_id"
+	}
+	direction := "ASC"
+	if opts.SortDesc {
+		direction = "DESC"
+	}
+	return fmt.Sprintf("%s %s, cl.row_id ASC", column, direction)
+}
+
+type postgresBenchmarkAttributeIDs struct {
+	symbol    int
+	exchange  int
+	region    int
+	tradeType int
+	tradeTime int
+	name      int
+}
+
+func benchmarkPostgresAttributeIDs() postgresBenchmarkAttributeIDs {
+	return postgresBenchmarkAttributeIDs{
+		symbol:    benchmarkAttributeID(benchmarkSchemaIDTrade, "symbol"),
+		exchange:  benchmarkAttributeID(benchmarkSchemaIDTrade, "exchange"),
+		region:    benchmarkAttributeID(benchmarkSchemaIDTrade, "region"),
+		tradeType: benchmarkAttributeID(benchmarkSchemaIDTrade, "tradeType"),
+		tradeTime: benchmarkAttributeID(benchmarkSchemaIDTrade, "tradeTime"),
+		name:      benchmarkAttributeID(benchmarkSchemaIDTrade, "name"),
+	}
+}
+
+func postgresOnlyFilterExpression(attribute string) string {
+	switch attribute {
+	case "symbol":
+		return "COALESCE(hot_vals.symbol, em.text_01, '')"
+	case "exchange":
+		return "COALESCE(hot_vals.exchange, '')"
+	case "region":
+		return "COALESCE(hot_vals.region, em.text_02, '')"
+	case "tradeType":
+		return "COALESCE(hot_vals.trade_type, em.smallint_01::BIGINT, 0)"
+	case "tradeTime":
+		return "COALESCE(hot_vals.trade_time, em.bigint_02, 0)"
+	default:
+		return ""
+	}
+}
+
+func buildPostgresOnlyExecutionPlan(duration time.Duration, preferHot bool) *internal.ExecutionPlan {
+	notes := []string{"hot_buffer_scanned", "postgres_only_execution"}
+	if preferHot {
+		notes = append(notes, "prefer_hot_override")
+	}
+	return &internal.ExecutionPlan{Notes: notes, Timings: map[string]int64{"total": duration.Milliseconds()}}
 }
 
 // StreamFederatedQuery streams query results with a handler callback.

--- a/internal/e2e_harness/federated/query_unit_test.go
+++ b/internal/e2e_harness/federated/query_unit_test.go
@@ -88,3 +88,19 @@ func TestBuildFederatedCombinedQuerySupportsTradeTimeWindow(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildPostgresOnlyQueriesSupportBenchmarkFilters(t *testing.T) {
+	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade}
+	selectQuery, _ := h.buildPostgresOnlySelectQuery(&QueryOptions{PreferHot: true, Filter: &Filter{Conditions: map[string]any{"tradeType": 0, "exchange": "NYSE"}}, TradeTimeStart: 1000, TradeTimeEnd: 2000, SortBy: "tradeTime", SortDesc: true, Limit: 20})
+	countQuery, _ := h.buildPostgresOnlyCountQuery(&QueryOptions{PreferHot: true, Filter: &Filter{Conditions: map[string]any{"tradeType": 0, "exchange": "NYSE"}}, TradeTimeStart: 1000, TradeTimeEnd: 2000})
+	for _, query := range []string{selectQuery, countQuery} {
+		for _, expected := range []string{"COALESCE(hot_vals.trade_type, em.smallint_01::BIGINT, 0)", "COALESCE(hot_vals.exchange, '')", "COALESCE(hot_vals.trade_time, em.bigint_02, 0)", "FROM change_log cl"} {
+			if !strings.Contains(query, expected) {
+				t.Fatalf("expected postgres-only query to include %q: %s", expected, query)
+			}
+		}
+	}
+	if strings.Contains(countQuery, "LIMIT") {
+		t.Fatalf("count query should not include pagination: %s", countQuery)
+	}
+}


### PR DESCRIPTION
## Summary
- expose `prefer_hot` intent in benchmark run results, workload summaries, markdown output, and benchmark documentation so reviewers can distinguish hot-biased workloads from neutral ones
- thread `PreferHot` through benchmark query options and harness execution, and apply a real Postgres-only hot-preferred execution override for tier-mix workloads where that method change is explicit and reviewable
- keep selective filter workloads on intent-only `prefer_hot` semantics for now, while expanding the Postgres-only benchmark query path so benchmark filters, counts, ordering, and time windows still work when the hot-preferred override is active

## Testing
- go test ./internal/e2e_harness/federated/benchmark ./internal/e2e_harness/federated ./cmd/benchmark
- go test -tags=e2e ./internal/e2e_harness/federated -run TestBenchmarkWorkloadExecution_RunWithHarness -count=1