### PR TITLE
codify benchmark baseline presets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,17 +61,17 @@ coverage: create-build-dir
 benchmark-smoke: create-build-dir
 	@echo "Running benchmark smoke validation..."
 	@mkdir -p .artifacts/benchmark/smoke
-	@$(GOENV) go run ./cmd/benchmark run -mode smoke -scale small -distribution uniform -workloads baseline-page-1,hot-selective-page -baseline-dir .artifacts/benchmark/smoke
+	@$(GOENV) go run ./cmd/benchmark baseline -preset ci-smoke -output-dir .artifacts/benchmark/smoke
 
 benchmark-regression: create-build-dir
-	@echo "Running benchmark regression planning..."
+	@echo "Running benchmark regression live subset..."
 	@mkdir -p .artifacts/benchmark/regression
-	@$(GOENV) go run ./cmd/benchmark run -mode plan -scale medium -distribution zipf -iterations 5 -workloads baseline-page-1,hot-selective-page,eav-selective-page,mixed-tier-window -baseline-dir .artifacts/benchmark/regression
+	@$(GOENV) go run ./cmd/benchmark baseline -preset small-live -output-dir .artifacts/benchmark/regression
 
 benchmark-heavy: create-build-dir
 	@echo "Running benchmark heavy planning set..."
 	@mkdir -p .artifacts/benchmark/heavy
-	@$(GOENV) go run ./cmd/benchmark run -mode plan -scale large -distribution hotspot-overlap -iterations 3 -workloads baseline-page-1,hot-selective-page,eav-selective-page,mixed-tier-window,deep-page-1000,deep-page-100000 -baseline-dir .artifacts/benchmark/heavy
+	@$(GOENV) go run ./cmd/benchmark baseline -preset heavy-plan -output-dir .artifacts/benchmark/heavy
 
 # Build server for current platform
 build-server: create-build-dir

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -16,6 +16,16 @@ import (
 	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
 )
 
+type benchmarkPreset struct {
+	Name          string       `json:"name"`
+	Description   string       `json:"description"`
+	RuntimeClass  string       `json:"runtime_class"`
+	BaselineDir   string       `json:"baseline_dir"`
+	CISafe        bool         `json:"ci_safe"`
+	ExpectedUsage string       `json:"expected_usage"`
+	Config        bench.Config `json:"config"`
+}
+
 var (
 	newBenchmarkRunner = bench.NewRunner
 	runValidationMode  = func(ctx context.Context, runner *bench.Runner) (*bench.RunResult, error) {
@@ -87,6 +97,7 @@ func runDescribe(out io.Writer) int {
 		SchemaDir    string                     `json:"schema_dir"`
 		Defaults     bench.Config               `json:"defaults"`
 		Generator    bench.GeneratorConfig      `json:"generator_defaults"`
+		Presets      []benchmarkPreset          `json:"presets"`
 		ScalePresets []bench.ScalePreset        `json:"scale_presets"`
 		TierProfiles []bench.TierMixProfile     `json:"tier_profiles"`
 		Schemas      []bench.SchemaFixture      `json:"schemas"`
@@ -95,6 +106,7 @@ func runDescribe(out io.Writer) int {
 		SchemaDir:    bench.FixturesDir(),
 		Defaults:     bench.DefaultConfig(),
 		Generator:    bench.DefaultGeneratorConfig(),
+		Presets:      defaultBenchmarkPresets(),
 		ScalePresets: bench.DefaultScalePresets(),
 		TierProfiles: bench.DefaultTierMixProfiles(),
 		Schemas:      bench.DefaultSchemaFixtures(),
@@ -114,7 +126,7 @@ func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int
 func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int {
 	flags := flag.NewFlagSet("run", flag.ContinueOnError)
 	flags.SetOutput(errOut)
-	preset := flags.String("preset", "small", "Baseline preset: small or medium")
+	preset := flags.String("preset", "small", "Baseline preset: ci-smoke, small, small-live, medium, medium-live, or heavy-plan")
 	outputDir := flags.String("output-dir", ".artifacts/benchmark", "Directory to store baseline captures")
 	distribution := flags.String("distribution", string(bench.DistributionUniform), "Data distribution preset")
 	compareTo := flags.String("compare-to", "", "Optional path to an existing benchmark-summary.json for diff output")
@@ -275,18 +287,74 @@ func executeBenchmarkRun(ctx context.Context, cfg bench.Config, outputs runOutpu
 }
 
 func baselinePresetConfig(rawPreset string, distribution bench.Distribution) (bench.Config, string, error) {
-	preset := strings.ToLower(strings.TrimSpace(rawPreset))
-	if distribution == "" {
-		distribution = bench.DistributionUniform
+	preset, err := resolveBenchmarkPreset(rawPreset, distribution)
+	if err != nil {
+		return bench.Config{}, "", err
 	}
-	switch preset {
-	case "small":
-		return bench.Config{Mode: bench.ExecutionModeSmoke, Scale: bench.ScaleSmall, Distribution: distribution, Iterations: 5, PageSize: 20, Seed: 42}.WithDefaults(), fmt.Sprintf("small-%s", distribution), nil
-	case "medium":
-		return bench.Config{Mode: bench.ExecutionModePlan, Scale: bench.ScaleMedium, Distribution: distribution, Iterations: 10, PageSize: 20, Seed: 42}.WithDefaults(), fmt.Sprintf("medium-%s", distribution), nil
-	default:
-		return bench.Config{}, "", fmt.Errorf("unknown baseline preset %q", rawPreset)
+	return preset.Config, preset.BaselineDir, nil
+}
+
+func defaultBenchmarkPresets() []benchmarkPreset {
+	return []benchmarkPreset{
+		{
+			Name:          "ci-smoke",
+			Description:   "Cheap CI-safe smoke validation with artifact capture.",
+			RuntimeClass:  "fast",
+			BaselineDir:   "ci-smoke-uniform",
+			CISafe:        true,
+			ExpectedUsage: "pull requests and quick local validation",
+			Config:        bench.Config{Mode: bench.ExecutionModeSmoke, Scale: bench.ScaleSmall, Distribution: bench.DistributionUniform, Iterations: 1, PageSize: 20, Seed: 42, Workloads: []string{"baseline-page-1", "hot-selective-page"}}.WithDefaults(),
+		},
+		{
+			Name:          "small-live",
+			Description:   "Live small-scale baseline subset for routine benchmark evidence.",
+			RuntimeClass:  "medium",
+			BaselineDir:   "small-live-hotspot-overlap",
+			CISafe:        false,
+			ExpectedUsage: "local or controlled review baseline capture",
+			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleSmall, Distribution: bench.DistributionHotspot, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: []string{"baseline-page-1", "customer-region-page", "security-symbol-page", "hot-selective-page", "eav-selective-page", "mixed-tier-window", "hot-only-window"}}.WithDefaults(),
+		},
+		{
+			Name:          "medium-live",
+			Description:   "Controlled medium-scale live baseline subset for regression review.",
+			RuntimeClass:  "medium",
+			BaselineDir:   "medium-live-zipf",
+			CISafe:        false,
+			ExpectedUsage: "manual or scheduled baseline capture",
+			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleMedium, Distribution: bench.DistributionZipf, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: []string{"baseline-page-1", "hot-selective-page", "eav-selective-page", "mixed-tier-window", "hot-only-window", "cold-only-window", "deep-page-1000"}}.WithDefaults(),
+		},
+		{
+			Name:          "heavy-plan",
+			Description:   "Heavy planning-only workload set for manual or nightly review.",
+			RuntimeClass:  "heavy",
+			BaselineDir:   "heavy-plan-hotspot-overlap",
+			CISafe:        false,
+			ExpectedUsage: "manual or nightly planning review only",
+			Config:        bench.Config{Mode: bench.ExecutionModePlan, Scale: bench.ScaleLarge, Distribution: bench.DistributionHotspot, Iterations: 3, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: bench.DefaultWorkloadNames()}.WithDefaults(),
+		},
 	}
+}
+
+func resolveBenchmarkPreset(rawPreset string, distribution bench.Distribution) (benchmarkPreset, error) {
+	presetName := strings.ToLower(strings.TrimSpace(rawPreset))
+	if presetName == "small" {
+		presetName = "small-live"
+	}
+	if presetName == "medium" {
+		presetName = "medium-live"
+	}
+	for _, preset := range defaultBenchmarkPresets() {
+		if preset.Name != presetName {
+			continue
+		}
+		resolved := preset
+		if distribution != "" {
+			resolved.Config.Distribution = distribution
+			resolved.BaselineDir = fmt.Sprintf("%s-%s", resolved.Name, distribution)
+		}
+		return resolved, nil
+	}
+	return benchmarkPreset{}, fmt.Errorf("unknown baseline preset %q", rawPreset)
 }
 
 func parseWorkloads(raw string) []string {

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -42,18 +42,47 @@ func TestRunBenchmarkMainBaseline(t *testing.T) {
 	dir := t.TempDir()
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	exitCode := runBenchmarkMain(context.Background(), []string{"baseline", "-preset", "small", "-output-dir", dir}, &out, &errOut)
+	exitCode := runBenchmarkMain(context.Background(), []string{"baseline", "-preset", "ci-smoke", "-output-dir", dir}, &out, &errOut)
 	if exitCode != 0 {
 		t.Fatalf("baseline returned exit code %d: %s", exitCode, errOut.String())
 	}
 	for _, name := range []string{"benchmark-result.json", "benchmark-result.md", "benchmark-summary.json"} {
-		matches, err := filepath.Glob(filepath.Join(dir, "small-*", name))
+		matches, err := filepath.Glob(filepath.Join(dir, "ci-smoke*", name))
 		if err != nil || len(matches) == 0 {
 			t.Fatalf("expected baseline artifact %s to exist", name)
 		}
 		if _, err := os.Stat(matches[0]); err != nil {
 			t.Fatalf("expected baseline artifact %s to exist: %v", name, err)
 		}
+	}
+}
+
+func TestResolveBenchmarkPresetSupportsAliasesAndPresets(t *testing.T) {
+	small, err := resolveBenchmarkPreset("small", bench.DistributionUniform)
+	if err != nil {
+		t.Fatalf("resolveBenchmarkPreset small failed: %v", err)
+	}
+	if small.Name != "small-live" || small.Config.Mode != bench.ExecutionModeLive {
+		t.Fatalf("expected small alias to resolve to small-live live preset, got %+v", small)
+	}
+	ci, err := resolveBenchmarkPreset("ci-smoke", bench.DistributionUniform)
+	if err != nil {
+		t.Fatalf("resolveBenchmarkPreset ci-smoke failed: %v", err)
+	}
+	if !ci.CISafe || ci.Config.Mode != bench.ExecutionModeSmoke {
+		t.Fatalf("expected ci-smoke preset to be CI-safe smoke, got %+v", ci)
+	}
+}
+
+func TestRunBenchmarkMainDescribeIncludesPresets(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"describe"}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("describe returned exit code %d: %s", exitCode, errOut.String())
+	}
+	if !bytes.Contains(out.Bytes(), []byte(`"presets"`)) {
+		t.Fatalf("expected describe output to include presets: %s", out.String())
 	}
 }
 

--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -7,33 +7,39 @@ Repository: `forma`
 
 This runbook defines a repeatable baseline capture flow for the federated query benchmark at `small` and `medium` scale.
 
-## Recommended Baseline Scales
+## Recommended Baseline Presets
 
-- `small`: local development and PR validation
-- `medium`: controlled baseline comparison and regression review
+- `ci-smoke`: cheapest artifact-generating preset for pull requests and quick local checks
+- `small-live`: default live baseline subset for local or controlled review runs
+- `medium-live`: medium-scale live subset for manual regression review
+- `heavy-plan`: planning-only heavyweight set for manual or nightly use
+
+Use `go run ./cmd/benchmark describe` to inspect the current preset definitions and workload matrix. The CLI also accepts the legacy aliases `small` -> `small-live` and `medium` -> `medium-live` when running `benchmark baseline`.
 
 ## Recommended Commands
 
-### Small Baseline
+### CI Smoke Baseline
 
 ```bash
-go run ./cmd/benchmark run \
-  -mode smoke \
-  -scale small \
-  -distribution uniform \
-  -iterations 5 \
-  -baseline-dir .artifacts/benchmark/small-uniform
+go run ./cmd/benchmark baseline \
+  -preset ci-smoke \
+  -output-dir .artifacts/benchmark
 ```
 
-### Medium Baseline
+### Small Live Baseline
 
 ```bash
-go run ./cmd/benchmark run \
-  -mode plan \
-  -scale medium \
-  -distribution zipf \
-  -iterations 10 \
-  -baseline-dir .artifacts/benchmark/medium-zipf
+go run ./cmd/benchmark baseline \
+  -preset small-live \
+  -output-dir .artifacts/benchmark
+```
+
+### Medium Live Baseline
+
+```bash
+go run ./cmd/benchmark baseline \
+  -preset medium-live \
+  -output-dir .artifacts/benchmark
 ```
 
 ## Output Files
@@ -43,6 +49,13 @@ Each baseline directory should contain:
 - `benchmark-result.json`
 - `benchmark-result.md`
 - `benchmark-summary.json`
+
+The default baseline directory naming now follows the benchmark preset name, for example:
+
+- `.artifacts/benchmark/ci-smoke-uniform`
+- `.artifacts/benchmark/small-live-hotspot-overlap`
+- `.artifacts/benchmark/medium-live-zipf`
+- `.artifacts/benchmark/heavy-plan-hotspot-overlap`
 
 ## How To Compare Runs
 
@@ -121,17 +134,26 @@ Treat any future change that turns `prefer_hot` into a real execution flag as a 
 ## Interpretation Guidance
 
 - use `small` to catch obvious correctness or latency regressions quickly
-- use `medium` to compare behavior across distributions and page-depth workloads
+- use `small-live` to collect executable baseline evidence without the full heavy workload set
+- use `medium-live` to compare behavior across distributions and page-depth workloads
+- use `heavy-plan` only when you need planning coverage for the full workload matrix
 - treat assertion failures as correctness regressions even if latency improves
 - treat large `max` growth separately from percentile movement; it is often a sign of tier skew or unstable deep pagination
 - read `correctness_failures` and `infra_failures` separately in benchmark summaries; only the latter indicates an execution-environment problem
 - for repeated executions with the same seed, expect `FailureKind`, `total_records`, and page `row_ids` to remain stable for supported workloads
 - read workload `oracle_mode` when interpreting selective filter workloads; `truth-pass` means expected results were validated through the live federated path rather than only loaded-state reconstruction
 
+## Runtime Envelopes
+
+- `ci-smoke`: usually under 1 minute on CI runners
+- `small-live`: roughly 1 to 5 minutes depending on machine size and Docker startup overhead
+- `medium-live`: noticeably slower; use in controlled review environments rather than PR-time CI
+- `heavy-plan`: planning-only and suitable for manual or nightly review, not routine pre-merge execution
+
 ## Current Limitations
 
-- baseline presets currently favor `smoke` and `plan` modes for artifact stability over live execution cost
-- use `go run ./cmd/benchmark run -mode live ...` when you need executable benchmark evidence instead of planning-only artifacts
+- live baseline capture now exists through `small-live` and `medium-live`, but CI should still default to the cheaper `ci-smoke` preset
+- use `go run ./cmd/benchmark run -mode live ...` when you need a custom executable workload mix instead of the documented presets
 - live benchmark correctness checks compare query results against the benchmark's loaded tier state rather than only the pre-split generated dataset
 - selective hot/EAV workloads may use a truth-pass-backed oracle mode to align expected results with the executable federated filter semantics
 - baseline capture is designed for artifact stability first, not for production-like throughput measurement

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -81,9 +81,10 @@ make benchmark-smoke
 
 Use for pre-merge review, local baseline capture, and scheduled CI.
 
-- workloads: `baseline-page-1`, `hot-selective-page`, `eav-selective-page`, `mixed-tier-window`
-- scale: `small` or `medium`
-- mode: `plan` for cheap CLI-only checks, `live` for executable query coverage
+- preset: `small-live`
+- workloads: baseline pagination, schema-scoped lookups, selective filters, and tier-window coverage
+- scale: `small`
+- mode: `live`
 - goal: verify workload set shape, artifacts, and supported federated execution paths without using the heaviest deep-page cases
 - expected runtime: 1 to 5 minutes depending on runner size and whether harness-backed tests are included
 
@@ -98,9 +99,10 @@ go test -v ./internal/e2e_harness/federated/... -run TestBenchmarkWorkloadExecut
 
 Use for manual performance review or nightly jobs only.
 
+- preset: `heavy-plan`
 - workloads: full workload set including `deep-page-1000` and `deep-page-100000`
-- scale: `medium` or `large`
-- mode: `plan` today, harness-backed execution only when the environment can tolerate larger seeded datasets
+- scale: `large`
+- mode: `plan`
 - goal: compare deep-pagination planning shape and prepare for later real benchmark gating
 - expected runtime: several minutes for planning, significantly longer once large executable runs are wired into the CLI
 
@@ -115,24 +117,17 @@ make benchmark-heavy
 ### Local Smoke
 
 ```bash
-go run ./cmd/benchmark run \
-  -mode smoke \
-  -scale small \
-  -distribution uniform \
-  -workloads baseline-page-1,hot-selective-page \
-  -baseline-dir .artifacts/benchmark/smoke
+go run ./cmd/benchmark baseline \
+  -preset ci-smoke \
+  -output-dir .artifacts/benchmark
 ```
 
-### Local Regression Planning
+### Local Regression Live Subset
 
 ```bash
-go run ./cmd/benchmark run \
-  -mode live \
-  -scale small \
-  -distribution hotspot-overlap \
-  -tier-profile balanced \
-  -workloads baseline-page-1,hot-selective-page \
-  -baseline-dir .artifacts/benchmark/live-small
+go run ./cmd/benchmark baseline \
+  -preset small-live \
+  -output-dir .artifacts/benchmark
 ```
 
 ### Harness-Backed Execution Check
@@ -143,26 +138,22 @@ go test -v ./internal/e2e_harness/federated/... \
   -timeout=10m
 ```
 
-### Local Regression Planning
+### Medium Live Baseline
 
 ```bash
-go run ./cmd/benchmark run \
-  -mode plan \
-  -scale medium \
-  -distribution zipf \
-  -iterations 5 \
-  -workloads baseline-page-1,hot-selective-page,eav-selective-page,mixed-tier-window \
-  -baseline-dir .artifacts/benchmark/regression-medium
+go run ./cmd/benchmark baseline \
+  -preset medium-live \
+  -output-dir .artifacts/benchmark
 ```
 
 ## CI Guidance
 
-Use these rules in CI until the benchmark CLI is wired to live execution.
+Use these rules in CI and automation for the current benchmark model.
 
 - run `make benchmark-smoke` on pull requests
-- keep CI benchmark runs on `small` scale only
+- keep PR-time benchmark automation on the `ci-smoke` preset only
 - do not run `deep-page-100000` in PR-time CI
-- use scheduled jobs for `benchmark-regression`
+- use scheduled jobs or manual review environments for `make benchmark-regression`
 - reserve `benchmark-heavy` for manual or nightly jobs
 - treat harness-backed execution tests as smoke coverage, not as stable performance thresholds
 


### PR DESCRIPTION
## Summary
- define reusable benchmark baseline presets for `ci-smoke`, `small-live`, `medium-live`, and `heavy-plan`, and expose them through `benchmark describe` and `benchmark baseline`
- align the Makefile benchmark targets with those presets so the documented smoke, regression, and heavy entrypoints all use the same CLI policy
- update the baseline runbook and CI/operator guide with concrete preset names, runtime envelopes, and PR-time versus manual execution guidance

## Testing
- go test ./cmd/benchmark ./internal/e2e_harness/federated/benchmark
- go test ./internal/e2e_harness/federated ./cmd/benchmark ./internal/e2e_harness/federated/benchmark