### PR TITLE
Generalize benchmark oracle defaults

### DIFF
--- a/docs/federated-query/federated-query-benchmark-autoresearch-issues.md
+++ b/docs/federated-query/federated-query-benchmark-autoresearch-issues.md
@@ -1,35 +1,44 @@
 # Federated Query Benchmark Autoresearch Issue Breakdown
 
-Last updated: 2026-04-18  
+Last updated: 2026-04-20  
 Repository: `forma`
 
 ## Issue Set
 
-This backlog extends the closed phase-1 benchmark work and reorganizes the next phase around one goal: make the benchmark trustworthy enough for autoresearch-guided performance tuning.
+This backlog extends the closed phase-1 benchmark work and reorganizes the remaining work around one goal: make the benchmark trustworthy enough for autoresearch-guided performance tuning.
 
 Planned issues:
 
 1. `#55` umbrella issue for the benchmark-to-autoresearch follow-up plan
-2. `#52` executable benchmark runtime backed by the live federated harness
-3. `#48` result semantics and correctness hardening
-4. `#50` filter fidelity and schema-scoped workload execution
-5. `#47` metrics expansion, artifact schema, and baseline diff support
+2. `#70` backlog alignment for benchmark follow-up work
+3. `#64` remaining workload-matrix expansion before optimization waves
+4. `#63` selective workload oracle generalization
+5. `#65` stability checks and oracle provenance hardening
 6. `#45` baseline capture and CI execution policy
-7. `#49` autoresearch perf loop scaffolding
-8. `#53` autoresearch perf targets and gate scripts
-9. `#46` deep-pagination optimization wave
-10. `#51` filter pushdown and EAV optimization wave
-11. `#54` routing and concurrency optimization wave
+7. `#69` benchmark readiness gate
+8. `#49` autoresearch perf loop scaffolding
+9. `#53` autoresearch perf targets and gate scripts
+10. `#46` deep-pagination optimization wave
+11. `#51` filter pushdown and EAV optimization wave
+12. `#54` routing and concurrency optimization wave
+
+Already closed foundation issues:
+
+- `#52` executable benchmark runtime backed by the live federated harness
+- `#48` result semantics and correctness hardening
+- `#50` filter fidelity and schema-scoped workload execution
+- `#47` metrics expansion, artifact schema, and baseline diff support
 
 ## PR Mapping
 
 | PR | Primary Goal |
 |---|---|
-| PR 1 | `#52` Promote the benchmark to a supported live-execution runtime |
-| PR 2 | `#48` Make benchmark outputs trustworthy for optimization decisions |
-| PR 3 | `#50` Align executed workloads with the benchmark data model |
-| PR 4 | `#47` Produce machine-comparable metrics and baseline diffs |
-| PR 5 | `#45` Codify baseline capture and CI-safe benchmark subsets |
+| PR 0 | `#70` Align the roadmap with shipped benchmark foundations and remaining gaps |
+| PR 1 | `#64` Complete the pre-optimization workload matrix |
+| PR 2 | `#63` Generalize selective workload oracle handling |
+| PR 3 | `#65` Harden repeated-run stability checks and oracle provenance |
+| PR 4 | `#45` Codify baseline capture and CI-safe benchmark subsets |
+| PR 5 | `#69` Define the readiness gate before benchmark-driven optimization decisions |
 | PR 6 | `#49` Add a benchmark-driven autoresearch performance loop |
 | PR 7 | `#53` Add performance target briefs and benchmark gate scripts |
 | PR 8 | `#46` Improve deep-pagination performance using the benchmark |
@@ -38,6 +47,6 @@ Planned issues:
 
 ## Notes
 
-- PRs 1 through 5 are readiness work and should land before benchmark-driven autoresearch optimization begins.
+- PRs 0 through 5 are readiness work and should land before benchmark-driven autoresearch optimization begins.
 - PRs 6 and 7 integrate the benchmark with autoresearch without changing the current BDD testing loop.
 - PRs 8 through 10 should be evaluated with the benchmark guardrails created earlier in the sequence.

--- a/docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md
+++ b/docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md
@@ -1,6 +1,6 @@
 # Federated Query Benchmark Autoresearch PR Plan
 
-Last updated: 2026-04-18  
+Last updated: 2026-04-20  
 Repository: `forma`
 
 ## 1. Objective
@@ -14,6 +14,17 @@ The benchmark is ready for autoresearch-guided optimization only when it can do 
 - emit stable, workload-level evidence that can be compared to a saved baseline
 - support fast and repeatable benchmark subsets suitable for automated keep/discard decisions
 
+## 1.1 Current State
+
+The repository has already landed the first benchmark foundation wave:
+
+- a supported CLI with `smoke`, `plan`, and `live` benchmark modes
+- live benchmark execution backed by the federated harness
+- stronger correctness and failure semantics in benchmark results
+- workload-level summaries, machine-readable diff support, and baseline capture artifacts
+
+This means the next phase is no longer about reopening the original runtime and artifact issues. It is about closing the remaining trust gaps before optimization and autoresearch loops depend on benchmark output.
+
 ## 2. Delivery Principles
 
 - correctness before speed: any failed correctness assertion blocks optimization claims
@@ -24,75 +35,71 @@ The benchmark is ready for autoresearch-guided optimization only when it can do 
 
 ## 3. PR Sequence
 
-### PR 1: Executable Benchmark Runtime
+### PR 0: Backlog Alignment
 
-Goal: promote the benchmark from scaffolded CLI validation to a supported live-execution path.
-
-Scope:
-
-- add an executable benchmark mode backed by the live federated harness
-- preserve existing `smoke` and `plan` modes for cheap validation
-- make benchmark run outputs identify whether execution was validation-only or live
-- cover the live path with focused tests and operator commands
-
-Exit criteria:
-
-- `cmd/benchmark` can execute supported workloads against the harness
-- local execution does not require reaching into test-only helper code by hand
-- the benchmark has a single documented runtime story for validation and live execution
-
-### PR 2: Result Semantics and Correctness Hardening
-
-Goal: make benchmark results safe to use as optimization evidence.
+Goal: align the benchmark roadmap with the shipped runtime and the remaining open gaps.
 
 Scope:
 
-- fix `total_records` and deep-page result semantics
-- strengthen assertions for dedup, ordering stability, delete shadowing, and last-write-wins
-- add explicit workload failure signals for correctness regressions
-- tighten benchmark result structures so that downstream automation can trust them
+- audit the current benchmark issue set against the shipped CLI, runtime, workload matrix, reports, and docs
+- distinguish closed foundation work from still-open readiness work
+- update the umbrella roadmap so later optimization issues point at current prerequisites
 
 Exit criteria:
 
-- workload results distinguish empty pages from broken query behavior
-- repeated runs with the same seed produce stable correctness verdicts
-- benchmark failures clearly separate correctness failures from infrastructure failures
+- the umbrella issue reflects the current repository state instead of the original phase-1 split
+- remaining readiness issues are ordered and non-duplicative
+- newer follow-up issues clearly refine rather than repeat earlier closed work
 
-### PR 3: Filter Fidelity and Schema-Scoped Workloads
+### PR 1: Workload Matrix Completion
 
-Goal: make the executed workloads match the benchmark model instead of only the current happy path.
+Goal: finish the remaining representative workload coverage needed before optimization waves begin.
 
 Scope:
 
-- complete hot, EAV, and mixed filter execution fidelity
-- make schema targeting explicit in execution instead of declarative-only metadata
-- keep `trade` as the primary executed schema while retaining fixture sanity coverage for `customer` and `security`
-- expand workload assertions around schema-scoped and filter-scoped behavior
+- add the remaining low-selectivity, mixed-filter, and tier-targeted window cases to the workload matrix
+- ensure the new workload set executes through the live path with explicit expected-result semantics
+- cover the expanded matrix with benchmark runner and harness-backed tests
 
 Exit criteria:
 
-- hot and EAV workloads execute with consistent semantics across tiers
-- benchmark execution honors workload schema intent
-- mixed-tier and deep-page workloads are representative enough for tuning work
+- the benchmark covers the agreed pre-optimization workload matrix
+- newly added workloads are executable rather than declarative-only
+- later deep-page, filter, and routing issues have the intended benchmark targets available
 
-### PR 4: Metrics, Artifact Schema, and Baseline Diff
+### PR 2: Selective Oracle Generalization
 
-Goal: make benchmark artifacts directly usable for automated comparison.
+Goal: remove workload-name-specific truth-pass behavior from selective benchmark correctness checks.
 
 Scope:
 
-- extend summary metrics beyond latency percentiles and QPS
-- capture workload-level metadata, environment data, and benchmark identifiers
-- add machine-readable diff support against a saved baseline
-- keep output formats stable across runs with the same seed and workload set
+- extract selective workload truth-pass logic into a reusable oracle mechanism
+- define when `loaded-state` is sufficient and when `truth-pass` is required
+- keep oracle provenance visible in benchmark results
 
 Exit criteria:
 
-- benchmark output can answer which workloads improved, regressed, or stayed flat
-- saved baselines are structurally stable and safe for automation
-- artifact fields are sufficient for later autoresearch decision rules
+- adding a new selective workload does not require bespoke oracle wiring in the runner
+- selective workload correctness remains explainable and reproducible
+- oracle provenance stays explicit in reports and summaries
 
-### PR 5: Baseline Capture and CI Policy
+### PR 3: Stability And Oracle Provenance Hardening
+
+Goal: make repeated-run benchmark trust signals explicit before the benchmark is treated as an optimization judge.
+
+Scope:
+
+- add same-seed repeated-run stability checks for supported live workloads
+- expose oracle provenance clearly in reports and operator guidance
+- document how reviewers should interpret loaded-state and truth-pass benchmark verdicts
+
+Exit criteria:
+
+- repeated runs with the same seed produce stable correctness verdicts for the supported live subset
+- benchmark reports show enough oracle provenance for selective workloads
+- CI and review guidance explain how to interpret these signals
+
+### PR 4: Baseline Capture and CI Policy
 
 Goal: codify which benchmark subsets are safe for local automation, CI, and manual tuning review.
 
@@ -108,6 +115,22 @@ Exit criteria:
 - the repository has documented baseline artifacts and comparison guidance
 - CI-safe subsets are clearly separated from heavier manual runs
 - benchmark commands used by later autoresearch loops are stable and documented
+
+### PR 5: Benchmark Readiness Gate
+
+Goal: define the explicit bar the benchmark must clear before optimization and autoresearch decisions depend on it.
+
+Scope:
+
+- define the readiness checklist for benchmark-driven optimization work
+- identify protected workloads and known methodology limitations
+- document the exit criteria for enabling benchmark-driven keep/discard automation
+
+Exit criteria:
+
+- the repository has a documented readiness gate with explicit pass criteria
+- methodology limitations and protected workloads are visible to reviewers and automation
+- later optimization and autoresearch issues can cite a stable benchmark gate
 
 ### PR 6: Autoresearch Perf Loop Scaffold
 
@@ -192,12 +215,14 @@ Exit criteria:
 
 ## 4. Ready-For-Autoresearch Gate
 
-The repository should not treat the benchmark as a performance autoresearch gate until PRs 1 through 5 are complete.
+The repository should not treat the benchmark as a performance autoresearch gate until PRs 0 through 5 are complete.
 
 At that point, the minimum bar is:
 
-- live benchmark execution exists as a supported command path
-- correctness assertions are strong enough to reject bad optimizations
+- the benchmark backlog is aligned with shipped behavior and remaining dependencies
+- the benchmark covers the intended pre-optimization workload matrix
+- selective workload correctness no longer depends on workload-name-specific oracle branching
+- repeated-run stability and oracle provenance are visible and documented
 - workload-level baselines and diffs are machine-readable
 - the benchmark has CI-safe and local-safe execution subsets
 

--- a/docs/federated-query/issues/08-benchmark-autoresearch-umbrella.md
+++ b/docs/federated-query/issues/08-benchmark-autoresearch-umbrella.md
@@ -8,9 +8,9 @@ The current benchmark foundation is useful for validation and early workload exe
 
 ## Scope
 
-- define the follow-up benchmark phases after the closed phase-1 issue set
+- track the remaining benchmark readiness work after the shipped runtime and phase-1 hardening work
 - link the PR-sliced execution plan for benchmark and autoresearch work
-- track the execution issues needed before optimization waves begin
+- distinguish closed benchmark foundations from still-open follow-up gaps
 - establish the readiness bar for using benchmark artifacts in autoresearch keep or discard decisions
 
 ## Acceptance Criteria
@@ -19,15 +19,29 @@ The current benchmark foundation is useful for validation and early workload exe
 - execution issues are listed explicitly and grouped in delivery order
 - the issue can be used as the single coordination entrypoint for benchmark-to-autoresearch work
 
-## Execution Issues
+## Shipped Foundations
 
-- [ ] #52 Add executable benchmark runtime backed by the live federated harness
-- [ ] #48 Harden benchmark result semantics and correctness assertions
-- [ ] #50 Complete filter fidelity and schema-scoped benchmark workloads
-- [ ] #47 Expand benchmark metrics, artifact schema, and baseline diff support
+- [x] #52 Add executable benchmark runtime backed by the live federated harness
+- [x] #48 Harden benchmark result semantics and correctness assertions
+- [x] #50 Complete filter fidelity and schema-scoped benchmark workloads
+- [x] #47 Expand benchmark metrics, artifact schema, and baseline diff support
+
+## Remaining Readiness Work
+
+- [x] #70 Align benchmark follow-up backlog with shipped runtime and remaining gaps
+- [x] #64 Expand the benchmark workload matrix with low-selectivity, mixed-filter, and tier-targeted window cases
+- [x] #63 Generalize selective-workload benchmark oracles beyond workload-specific truth passes
+- [ ] #65 Harden benchmark stability checks and expose oracle provenance in reports
 - [ ] #45 Capture benchmark baselines and codify CI execution policy
+- [ ] #69 Define a benchmark readiness gate before optimization and autoresearch decisions
+
+## Benchmark-Driven Automation
+
 - [ ] #49 Scaffold a performance-oriented autoresearch loop around benchmark evidence
 - [ ] #53 Add autoresearch performance targets and benchmark gate scripts
+
+## Optimization Waves
+
 - [ ] #46 Optimize the federated deep-pagination path using benchmark evidence
 - [ ] #51 Optimize federated filter pushdown and EAV behavior using benchmark evidence
 - [ ] #54 Optimize federated routing and concurrency behavior using benchmark evidence

--- a/internal/e2e_harness/federated/benchmark/runner_test.go
+++ b/internal/e2e_harness/federated/benchmark/runner_test.go
@@ -351,6 +351,12 @@ func TestWorkloadResolvedOracleModeDefaultsToLoadedState(t *testing.T) {
 	if mode := (WorkloadDefinition{Name: "baseline-page-1"}).ResolvedOracleMode(); mode != OracleModeLoadedState {
 		t.Fatalf("expected default oracle mode to be loaded-state, got %q", mode)
 	}
+	if mode := (WorkloadDefinition{Name: "generic-trade-filter", Category: WorkloadCategoryFilter, TargetSchema: "trade"}).ResolvedOracleMode(); mode != OracleModeTruthPass {
+		t.Fatalf("expected trade filter workload to default to truth-pass oracle, got %q", mode)
+	}
+	if mode := (WorkloadDefinition{Name: "generic-customer-filter", Category: WorkloadCategoryFilter, TargetSchema: "customer"}).ResolvedOracleMode(); mode != OracleModeLoadedState {
+		t.Fatalf("expected non-trade filter workload to default to loaded-state oracle, got %q", mode)
+	}
 	if mode := (WorkloadDefinition{Name: "hot-selective-page", OracleMode: OracleModeTruthPass}).ResolvedOracleMode(); mode != OracleModeTruthPass {
 		t.Fatalf("expected explicit truth-pass oracle mode, got %q", mode)
 	}
@@ -379,6 +385,55 @@ func TestDefaultWorkloadsMarkSelectiveWorkloadsAsTruthPass(t *testing.T) {
 	}
 	if modes["baseline-page-1"] != OracleModeLoadedState {
 		t.Fatalf("expected baseline-page-1 to use loaded-state oracle, got %q", modes["baseline-page-1"])
+	}
+}
+
+func TestDefaultSelectiveWorkloadsRelyOnInferredOracleMode(t *testing.T) {
+	resolved, err := ResolveWorkloads([]string{"hot-selective-page", "hot-low-selectivity-page", "eav-selective-page", "mixed-hot-eav-page"})
+	if err != nil {
+		t.Fatalf("ResolveWorkloads failed: %v", err)
+	}
+	for _, workload := range resolved {
+		if workload.OracleMode != "" {
+			t.Fatalf("expected workload %s to rely on inferred oracle mode, got explicit mode %q", workload.Name, workload.OracleMode)
+		}
+		if mode := workload.ResolvedOracleMode(); mode != OracleModeTruthPass {
+			t.Fatalf("expected workload %s to resolve to truth-pass, got %q", workload.Name, mode)
+		}
+	}
+}
+
+func TestInferredOracleModeUsesWorkloadClassInsteadOfName(t *testing.T) {
+	cases := []struct {
+		name     string
+		workload WorkloadDefinition
+		expect   OracleMode
+	}{
+		{
+			name:     "trade filter defaults to truth pass",
+			workload: WorkloadDefinition{Name: "future-trade-filter", Category: WorkloadCategoryFilter, TargetSchema: "trade", FilterConditions: map[string]any{"symbol": "SYM12345"}},
+			expect:   OracleModeTruthPass,
+		},
+		{
+			name:     "trade pagination defaults to loaded state",
+			workload: WorkloadDefinition{Name: "future-trade-page", Category: WorkloadCategoryPagination, TargetSchema: "trade"},
+			expect:   OracleModeLoadedState,
+		},
+		{
+			name:     "non trade filter defaults to loaded state",
+			workload: WorkloadDefinition{Name: "future-security-filter", Category: WorkloadCategoryFilter, TargetSchema: "security", FilterConditions: map[string]any{"symbol": "SYM12345"}},
+			expect:   OracleModeLoadedState,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if mode := tc.workload.InferredOracleMode(); mode != tc.expect {
+				t.Fatalf("expected inferred oracle mode %q, got %q", tc.expect, mode)
+			}
+			if mode := tc.workload.ResolvedOracleMode(); mode != tc.expect {
+				t.Fatalf("expected resolved oracle mode %q, got %q", tc.expect, mode)
+			}
+		})
 	}
 }
 

--- a/internal/e2e_harness/federated/benchmark/workload.go
+++ b/internal/e2e_harness/federated/benchmark/workload.go
@@ -87,7 +87,6 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageSize:              20,
 			PageNumber:            1,
 			SupportsDistributions: allDistributions(),
-			OracleMode:            OracleModeTruthPass,
 		},
 		{
 			Name:                  "hot-low-selectivity-page",
@@ -101,7 +100,6 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageNumber:            1,
 			SupportsDistributions: allDistributions(),
 			PreferHot:             true,
-			OracleMode:            OracleModeTruthPass,
 		},
 		{
 			Name:                  "eav-selective-page",
@@ -115,7 +113,6 @@ func DefaultWorkloads() []WorkloadDefinition {
 			PageNumber:            1,
 			SupportsDistributions: allDistributions(),
 			UsesEAVFilter:         true,
-			OracleMode:            OracleModeTruthPass,
 		},
 		{
 			Name:                  "mixed-hot-eav-page",
@@ -130,7 +127,6 @@ func DefaultWorkloads() []WorkloadDefinition {
 			SupportsDistributions: allDistributions(),
 			PreferHot:             true,
 			UsesEAVFilter:         true,
-			OracleMode:            OracleModeTruthPass,
 		},
 		{
 			Name:                  "mixed-tier-window",
@@ -231,10 +227,20 @@ func (w WorkloadDefinition) ResolvedFilterConditions() map[string]any {
 	return map[string]any{w.FilterAttribute: w.FilterValue}
 }
 
-// ResolvedOracleMode returns the default oracle mode when not explicitly set.
+// InferredOracleMode returns the workload-class default oracle mode.
+func (w WorkloadDefinition) InferredOracleMode() OracleMode {
+	// Trade filter workloads use a truth-pass oracle because loaded-state-only
+	// reconstruction can diverge from executable federated filter semantics.
+	if w.Category == WorkloadCategoryFilter && w.TargetSchema == "trade" {
+		return OracleModeTruthPass
+	}
+	return OracleModeLoadedState
+}
+
+// ResolvedOracleMode returns the explicit oracle override or the inferred default.
 func (w WorkloadDefinition) ResolvedOracleMode() OracleMode {
 	if w.OracleMode == "" {
-		return OracleModeLoadedState
+		return w.InferredOracleMode()
 	}
 	return w.OracleMode
 }


### PR DESCRIPTION
## Summary
- infer benchmark oracle defaults from workload class so future trade filter workloads resolve to `truth-pass` without bespoke wiring
- remove explicit truth-pass declarations from the default selective workloads while preserving existing oracle provenance in reports
- align the benchmark readiness roadmap docs with the shipped foundations and the remaining open issues

## Testing
- go test ./internal/e2e_harness/federated/benchmark
- go test ./internal/e2e_harness/federated/...
- go test -tags=e2e -v ./internal/e2e_harness/federated/... -run TestBenchmarkWorkloadExecution_RunWithHarness -timeout=10m

## Notes
- this PR intentionally includes only the benchmark oracle and roadmap files; unrelated local federated harness changes were left out of the commit
- closes #63
