### PR TITLE
Close out benchmark readiness docs

### DIFF
--- a/docs/federated-query/federated-query-benchmark-autoresearch-issues.md
+++ b/docs/federated-query/federated-query-benchmark-autoresearch-issues.md
@@ -10,20 +10,20 @@ This backlog extends the closed phase-1 benchmark work and reorganizes the remai
 Planned issues:
 
 1. `#55` umbrella issue for the benchmark-to-autoresearch follow-up plan
-2. `#70` backlog alignment for benchmark follow-up work
-3. `#64` remaining workload-matrix expansion before optimization waves
-4. `#63` selective workload oracle generalization
-5. `#65` stability checks and oracle provenance hardening
-6. `#45` baseline capture and CI execution policy
-7. `#69` benchmark readiness gate
-8. `#49` autoresearch perf loop scaffolding
-9. `#53` autoresearch perf targets and gate scripts
-10. `#46` deep-pagination optimization wave
-11. `#51` filter pushdown and EAV optimization wave
-12. `#54` routing and concurrency optimization wave
+2. `#49` autoresearch perf loop scaffolding
+3. `#53` autoresearch perf targets and gate scripts
+4. `#46` deep-pagination optimization wave
+5. `#51` filter pushdown and EAV optimization wave
+6. `#54` routing and concurrency optimization wave
 
 Already closed foundation issues:
 
+- `#70` backlog alignment for benchmark follow-up work
+- `#64` remaining workload-matrix expansion before optimization waves
+- `#63` selective workload oracle generalization
+- `#65` stability checks and oracle provenance hardening
+- `#45` baseline capture and CI execution policy
+- `#69` benchmark readiness gate
 - `#52` executable benchmark runtime backed by the live federated harness
 - `#48` result semantics and correctness hardening
 - `#50` filter fidelity and schema-scoped workload execution

--- a/docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md
+++ b/docs/federated-query/federated-query-benchmark-autoresearch-pr-plan.md
@@ -22,8 +22,10 @@ The repository has already landed the first benchmark foundation wave:
 - live benchmark execution backed by the federated harness
 - stronger correctness and failure semantics in benchmark results
 - workload-level summaries, machine-readable diff support, and baseline capture artifacts
+- repeated-run stability summaries and grouped oracle provenance in reports
+- documented baseline presets, CI-safe benchmark subsets, and a benchmark readiness gate
 
-This means the next phase is no longer about reopening the original runtime and artifact issues. It is about closing the remaining trust gaps before optimization and autoresearch loops depend on benchmark output.
+This means the benchmark readiness phase is complete. The next phase is benchmark-driven automation and optimization work, rather than more readiness hardening.
 
 ## 2. Delivery Principles
 

--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -1,6 +1,6 @@
 # Federated Query Benchmark Baseline Runbook
 
-Last updated: 2026-04-18  
+Last updated: 2026-04-20  
 Repository: `forma`
 
 ## Purpose
@@ -69,6 +69,8 @@ Compare these fields first:
 - `avg`
 - `qps`
 - assertion pass/fail counts
+- top-level `stability`
+- top-level `oracle_provenance`
 
 ## Oracle Mode
 
@@ -142,6 +144,8 @@ Treat any future change that turns `prefer_hot` into a real execution flag as a 
 - read `correctness_failures` and `infra_failures` separately in benchmark summaries; only the latter indicates an execution-environment problem
 - for repeated executions with the same seed, expect `FailureKind`, `total_records`, and page `row_ids` to remain stable for supported workloads
 - read workload `oracle_mode` when interpreting selective filter workloads; `truth-pass` means expected results were validated through the live federated path rather than only loaded-state reconstruction
+- read top-level `stability` before comparing latency deltas; any unstable workload means correctness evidence changed across same-seed runs and should be investigated first
+- read top-level `oracle_provenance` to confirm whether a workload group was judged via `loaded-state` or `truth-pass` without inspecting each workload entry individually
 
 ## Runtime Envelopes
 

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -160,6 +160,45 @@ Use these rules in CI and automation for the current benchmark model.
 
 The repository CI workflow now includes a dedicated `benchmark-smoke` job for the scaffolded benchmark command and the existing federated e2e smoke tests remain the executable coverage path.
 
+## Benchmark Readiness Gate
+
+Treat the benchmark as ready to inform optimization review only when all of the following are true:
+
+- the live benchmark path is available through `go run ./cmd/benchmark run -mode live ...` and the documented baseline presets
+- correctness failures and infrastructure failures are reported separately in benchmark summaries
+- same-seed repeated-run stability is visible through the top-level `stability` summary
+- oracle methodology is visible through workload `oracle_mode` and top-level `oracle_provenance`
+- workload-level summaries and diff artifacts are available for baseline comparison
+- CI-safe and manual-only workload subsets remain separated by policy
+
+If any of those conditions stops being true, treat the benchmark as evidence for debugging only rather than as an optimization gate.
+
+### Protected Workloads
+
+Use these workloads as the default protected set when evaluating benchmark-driven query changes:
+
+- `baseline-page-1`
+- `hot-selective-page`
+- `hot-low-selectivity-page`
+- `eav-selective-page`
+- `mixed-hot-eav-page`
+- `mixed-tier-window`
+- `hot-only-window`
+- `cold-only-window`
+- `deep-page-1000`
+
+Operationally:
+
+- treat correctness regressions in any protected workload as a hard stop
+- treat repeated-run instability in any protected workload as a methodology problem that must be resolved before trusting latency deltas
+- reserve `deep-page-100000` for heavier manual review rather than routine protection in CI-safe flows
+
+### Known Methodology Limits
+
+- `truth-pass` workloads use the live federated path to validate expected results, so oracle mode changes are methodology changes rather than pure performance changes
+- `prefer_hot` is still primarily provenance metadata outside the documented tier-mix execution override case
+- live benchmark runs are intended for repeatable correctness and relative performance review, not for production-grade throughput SLOs
+
 ## Environment Requirements
 
 - Go toolchain matching the repository CI version

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -1,6 +1,6 @@
 # Federated Query Benchmark CI and Operator Guide
 
-Last updated: 2026-04-18  
+Last updated: 2026-04-20  
 Repository: `forma`
 
 ## Purpose
@@ -15,6 +15,7 @@ This guide defines which benchmark subsets are safe for local validation, PR-tim
 - `-mode live` creates the federated harness, prepares tiered benchmark data, and executes supported workloads end to end
 - live benchmark summaries distinguish correctness failures from infrastructure failures, and workload-level expected-result checks are part of the executable path
 - benchmark summaries now expose workload oracle provenance so selective workloads can be distinguished between `loaded-state` and `truth-pass` expected-result modes
+- benchmark summaries now expose repeated-run stability status so reviewers can quickly tell whether same-seed live runs stayed stable
 - harness-backed tests such as `go test ./internal/e2e_harness/federated/... -run TestBenchmarkWorkloadExecution_RunWithHarness` remain the focused executable coverage path for repository tests
 
 This means CI can continue to treat smoke mode as the cheap artifact regression layer, while local or manual runs can use live mode for executable benchmark evidence. It is still not an official throughput gate.
@@ -183,6 +184,8 @@ Check these fields first in `benchmark-summary.json` or the Markdown summary:
 - `qps`
 - per-assertion pass/fail counts
 - workload `oracle_mode`
+- top-level `stability`
+- top-level `oracle_provenance`
 
 Interpretation guidance:
 
@@ -192,6 +195,8 @@ Interpretation guidance:
 - a drop in `qps` without matching row-count changes is a regression candidate worth manual review
 - planning-only output should stay structurally stable across runs for the same seed and workload selection
 - supported live workloads should also keep repeated-run `FailureKind`, `total_records`, and page `row_ids` stable for the same seed and workload selection
+- if `stability.enabled=true`, review `unstable_workloads`, `failure_kind_failures`, `total_record_failures`, and `page_row_id_failures` before trusting latency changes
+- use `oracle_provenance` to see which workloads were judged via `loaded-state` versus `truth-pass` without reading every workload row individually
 
 ## Common Failure Modes
 

--- a/docs/federated-query/issues/08-benchmark-autoresearch-umbrella.md
+++ b/docs/federated-query/issues/08-benchmark-autoresearch-umbrella.md
@@ -31,9 +31,9 @@ The current benchmark foundation is useful for validation and early workload exe
 - [x] #70 Align benchmark follow-up backlog with shipped runtime and remaining gaps
 - [x] #64 Expand the benchmark workload matrix with low-selectivity, mixed-filter, and tier-targeted window cases
 - [x] #63 Generalize selective-workload benchmark oracles beyond workload-specific truth passes
-- [ ] #65 Harden benchmark stability checks and expose oracle provenance in reports
-- [ ] #45 Capture benchmark baselines and codify CI execution policy
-- [ ] #69 Define a benchmark readiness gate before optimization and autoresearch decisions
+- [x] #65 Harden benchmark stability checks and expose oracle provenance in reports
+- [x] #45 Capture benchmark baselines and codify CI execution policy
+- [x] #69 Define a benchmark readiness gate before optimization and autoresearch decisions
 
 ## Benchmark-Driven Automation
 

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -36,6 +36,8 @@ type EnvironmentMetadata struct {
 type SummaryReport struct {
 	Metadata            ArtifactMetadata         `json:"metadata"`
 	OracleModes         map[string]string        `json:"oracle_modes,omitempty"`
+	OracleProvenance    []OracleProvenance       `json:"oracle_provenance,omitempty"`
+	Stability           StabilitySummary         `json:"stability"`
 	ExecutionCount      int                      `json:"execution_count"`
 	Passed              bool                     `json:"passed"`
 	FailureCount        int                      `json:"failure_count,omitempty"`
@@ -57,6 +59,22 @@ type SummaryReport struct {
 type AssertionStat struct {
 	Passed int `json:"passed"`
 	Failed int `json:"failed"`
+}
+
+// OracleProvenance groups workloads by expected-result oracle mode.
+type OracleProvenance struct {
+	Mode      string   `json:"mode"`
+	Workloads []string `json:"workloads,omitempty"`
+}
+
+// StabilitySummary captures repeated-run stability signals for same-seed runs.
+type StabilitySummary struct {
+	Enabled              bool     `json:"enabled"`
+	WorkloadsChecked     int      `json:"workloads_checked,omitempty"`
+	UnstableWorkloads    []string `json:"unstable_workloads,omitempty"`
+	FailureKindFailures  int      `json:"failure_kind_failures,omitempty"`
+	TotalRecordsFailures int      `json:"total_records_failures,omitempty"`
+	PageRowIDFailures    int      `json:"page_row_id_failures,omitempty"`
 }
 
 // WorkloadSummary captures stable workload-level metrics and metadata.
@@ -162,6 +180,16 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 	b.WriteString(fmt.Sprintf("- P95: %s\n", summary.P95))
 	b.WriteString(fmt.Sprintf("- P99: %s\n", summary.P99))
 	b.WriteString(fmt.Sprintf("- Max: %s\n", summary.Max))
+	b.WriteString(fmt.Sprintf("- Repeated-run checks enabled: %t\n", summary.Stability.Enabled))
+	if summary.Stability.Enabled {
+		b.WriteString(fmt.Sprintf("- Repeated-run workloads checked: %d\n", summary.Stability.WorkloadsChecked))
+		b.WriteString(fmt.Sprintf("- Repeated-run failure-kind failures: %d\n", summary.Stability.FailureKindFailures))
+		b.WriteString(fmt.Sprintf("- Repeated-run total-record failures: %d\n", summary.Stability.TotalRecordsFailures))
+		b.WriteString(fmt.Sprintf("- Repeated-run page-row-id failures: %d\n", summary.Stability.PageRowIDFailures))
+	}
+	if len(summary.Stability.UnstableWorkloads) > 0 {
+		b.WriteString(fmt.Sprintf("- Unstable workloads: `%s`\n", strings.Join(summary.Stability.UnstableWorkloads, "`, `")))
+	}
 	if len(result.Executions) > 0 {
 		b.WriteString("\n## Executions\n\n")
 		for _, execution := range result.Executions {
@@ -187,6 +215,12 @@ func WriteMarkdownReport(path string, result *RunResult) error {
 		b.WriteString("\n## Workload Summaries\n\n")
 		for _, workload := range summary.Workloads {
 			b.WriteString(fmt.Sprintf("- `%s`: schema=%s oracle_mode=%s prefer_hot=%t executions=%d passed=%t qps=%.2f p95=%s avg=%s avg_result_count=%.2f avg_total_records=%.2f\n", workload.Name, workload.TargetSchema, workload.OracleMode, workload.PreferHot, workload.ExecutionCount, workload.Passed, workload.QPS, workload.P95, workload.Avg, workload.AvgResultCount, workload.AvgTotalRecords))
+		}
+	}
+	if len(summary.OracleProvenance) > 0 {
+		b.WriteString("\n## Oracle Provenance\n\n")
+		for _, provenance := range summary.OracleProvenance {
+			b.WriteString(fmt.Sprintf("- `%s`: `%s`\n", provenance.Mode, strings.Join(provenance.Workloads, "`, `")))
 		}
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
@@ -234,15 +268,18 @@ func SummarizeRunResult(result *RunResult) SummaryReport {
 	}
 	summary.Metadata = metadataForResult(result)
 	summary.OracleModes = cloneStringMap(result.OracleModes)
+	summary.OracleProvenance = summarizeOracleProvenance(result)
 	if len(result.Executions) == 0 {
 		summary.Passed = result != nil && result.Passed
 		summary.FailureCount = resultFailureCount(result)
 		summary.Workloads = summarizeWorkloads(result)
+		summary.Stability = summarizeStability(summary.Workloads)
 		return summary
 	}
 	summary.Passed = result.Passed
 	summary.FailureCount = resultFailureCount(result)
 	summary.Workloads = summarizeWorkloads(result)
+	summary.Stability = summarizeStability(summary.Workloads)
 	durations := make([]time.Duration, 0, len(result.Executions))
 	for _, execution := range result.Executions {
 		durations = append(durations, execution.Duration)
@@ -316,6 +353,14 @@ func FormatConsoleSummary(result *RunResult) string {
 	b.WriteString("Benchmark Summary\n")
 	b.WriteString(fmt.Sprintf("benchmark_id=%s scale=%s distribution=%s executions=%d passed=%t failures=%d correctness_failures=%d infra_failures=%d\n", summary.Metadata.BenchmarkID, result.Generator.Scale, result.Generator.Distribution, summary.ExecutionCount, summary.Passed, summary.FailureCount, summary.CorrectnessFailures, summary.InfraFailures))
 	b.WriteString(fmt.Sprintf("latency min=%s p50=%s p95=%s p99=%s max=%s avg=%s total=%s qps=%.2f\n", summary.Min, summary.P50, summary.P95, summary.P99, summary.Max, summary.Avg, summary.TotalDuration, summary.QPS))
+	b.WriteString(fmt.Sprintf("stability enabled=%t workloads_checked=%d unstable_workloads=%d failure_kind_failures=%d total_record_failures=%d page_row_id_failures=%d\n", summary.Stability.Enabled, summary.Stability.WorkloadsChecked, len(summary.Stability.UnstableWorkloads), summary.Stability.FailureKindFailures, summary.Stability.TotalRecordsFailures, summary.Stability.PageRowIDFailures))
+	if len(summary.OracleProvenance) > 0 {
+		parts := make([]string, 0, len(summary.OracleProvenance))
+		for _, provenance := range summary.OracleProvenance {
+			parts = append(parts, fmt.Sprintf("%s=%s", provenance.Mode, strings.Join(provenance.Workloads, ",")))
+		}
+		b.WriteString(fmt.Sprintf("oracle_provenance %s\n", strings.Join(parts, " ")))
+	}
 	if len(summary.AssertionStats) > 0 {
 		keys := make([]string, 0, len(summary.AssertionStats))
 		for key := range summary.AssertionStats {
@@ -547,6 +592,68 @@ func summarizeWorkloads(result *RunResult) []WorkloadSummary {
 		workloads = append(workloads, workload)
 	}
 	return workloads
+}
+
+func summarizeOracleProvenance(result *RunResult) []OracleProvenance {
+	if result == nil {
+		return nil
+	}
+	byMode := make(map[string][]string)
+	if len(result.Workloads) > 0 {
+		for _, workload := range result.Workloads {
+			mode := string(workload.ResolvedOracleMode())
+			byMode[mode] = append(byMode[mode], workload.Name)
+		}
+	} else {
+		for _, execution := range result.Executions {
+			if execution.OracleMode == "" {
+				continue
+			}
+			byMode[execution.OracleMode] = append(byMode[execution.OracleMode], execution.Name)
+		}
+	}
+	if len(byMode) == 0 {
+		return nil
+	}
+	modes := make([]string, 0, len(byMode))
+	for mode := range byMode {
+		modes = append(modes, mode)
+	}
+	sort.Strings(modes)
+	provenance := make([]OracleProvenance, 0, len(modes))
+	for _, mode := range modes {
+		workloads := append([]string(nil), byMode[mode]...)
+		sort.Strings(workloads)
+		provenance = append(provenance, OracleProvenance{Mode: mode, Workloads: workloads})
+	}
+	return provenance
+}
+
+func summarizeStability(workloads []WorkloadSummary) StabilitySummary {
+	var summary StabilitySummary
+	seenUnstable := make(map[string]struct{})
+	for _, workload := range workloads {
+		failureKind := workload.AssertionStats["repeated-run-failure-kind-stable"]
+		totalRecords := workload.AssertionStats["repeated-run-total-records-stable"]
+		pageRowIDs := workload.AssertionStats["repeated-run-page-row-ids-stable"]
+		checked := failureKind.Passed+failureKind.Failed > 0 || totalRecords.Passed+totalRecords.Failed > 0 || pageRowIDs.Passed+pageRowIDs.Failed > 0
+		if !checked {
+			continue
+		}
+		summary.Enabled = true
+		summary.WorkloadsChecked++
+		summary.FailureKindFailures += failureKind.Failed
+		summary.TotalRecordsFailures += totalRecords.Failed
+		summary.PageRowIDFailures += pageRowIDs.Failed
+		if failureKind.Failed > 0 || totalRecords.Failed > 0 || pageRowIDs.Failed > 0 {
+			if _, ok := seenUnstable[workload.Name]; !ok {
+				seenUnstable[workload.Name] = struct{}{}
+				summary.UnstableWorkloads = append(summary.UnstableWorkloads, workload.Name)
+			}
+		}
+	}
+	sort.Strings(summary.UnstableWorkloads)
+	return summary
 }
 
 func compareWorkloadSummaries(baseline, candidate []WorkloadSummary) []WorkloadDiff {

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -48,10 +48,14 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 		Passed:       false,
 		FailureCount: 2,
 		Generator:    GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
-		OracleModes:  map[string]string{"q1": string(OracleModeLoadedState), "q2": string(OracleModeTruthPass)},
+		Workloads: []WorkloadDefinition{
+			{Name: "q1", Category: WorkloadCategoryPagination, TargetSchema: "trade", OracleMode: OracleModeLoadedState},
+			{Name: "q2", Category: WorkloadCategoryFilter, TargetSchema: "trade", OracleMode: OracleModeTruthPass, PreferHot: true},
+		},
+		OracleModes: map[string]string{"q1": string(OracleModeLoadedState), "q2": string(OracleModeTruthPass)},
 		Executions: []WorkloadRunResult{
 			{Name: "q1", Passed: true, OracleMode: string(OracleModeLoadedState), Duration: 10 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: true}}},
-			{Name: "q2", Passed: false, PreferHot: true, OracleMode: string(OracleModeTruthPass), FailureKind: FailureKindCorrectness, FailureCount: 1, Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}}},
+			{Name: "q2", Passed: false, PreferHot: true, OracleMode: string(OracleModeTruthPass), FailureKind: FailureKindCorrectness, FailureCount: 1, Duration: 30 * time.Millisecond, Assertions: []AssertionResult{{Name: "a", Passed: false}, {Name: "repeated-run-total-records-stable", Passed: false}}},
 		},
 	}
 	if err := WriteBaselineCapture(dir, result); err != nil {
@@ -86,6 +90,21 @@ func TestWriteBaselineCaptureAndSummary(t *testing.T) {
 	}
 	if summary.OracleModes["q2"] != string(OracleModeTruthPass) {
 		t.Fatalf("expected summary to expose oracle modes, got %+v", summary.OracleModes)
+	}
+	if !summary.Stability.Enabled {
+		t.Fatalf("expected summary to expose repeated-run stability state")
+	}
+	if summary.Stability.WorkloadsChecked != 1 {
+		t.Fatalf("expected one workload with repeated-run checks, got %+v", summary.Stability)
+	}
+	if summary.Stability.TotalRecordsFailures != 1 {
+		t.Fatalf("expected one repeated-run total-record failure, got %+v", summary.Stability)
+	}
+	if len(summary.Stability.UnstableWorkloads) != 1 || summary.Stability.UnstableWorkloads[0] != "q2" {
+		t.Fatalf("expected q2 to be marked unstable, got %+v", summary.Stability)
+	}
+	if len(summary.OracleProvenance) != 2 {
+		t.Fatalf("expected grouped oracle provenance, got %+v", summary.OracleProvenance)
 	}
 	if !summary.Workloads[1].PreferHot {
 		t.Fatalf("expected workload summary to expose prefer_hot intent, got %+v", summary.Workloads[1])
@@ -126,6 +145,12 @@ func TestFormatConsoleSummary(t *testing.T) {
 	if !strings.Contains(formatted, "correctness_failures=1") {
 		t.Fatalf("expected correctness failures in summary: %s", formatted)
 	}
+	if !strings.Contains(formatted, "stability enabled=") {
+		t.Fatalf("expected stability line in summary: %s", formatted)
+	}
+	if !strings.Contains(formatted, "oracle_provenance") {
+		t.Fatalf("expected oracle provenance line in summary: %s", formatted)
+	}
 }
 
 func TestSummarizeWorkloadsCarriesOracleMode(t *testing.T) {
@@ -136,6 +161,44 @@ func TestSummarizeWorkloadsCarriesOracleMode(t *testing.T) {
 	}
 	if !workloads[0].PreferHot {
 		t.Fatalf("expected workload summary to carry prefer_hot, got %+v", workloads)
+	}
+}
+
+func TestSummarizeRunResultBuildsOracleProvenanceAndStability(t *testing.T) {
+	result := &RunResult{
+		Workloads: []WorkloadDefinition{
+			{Name: "baseline-page-1", Category: WorkloadCategoryPagination, TargetSchema: "trade", OracleMode: OracleModeLoadedState},
+			{Name: "hot-selective-page", Category: WorkloadCategoryFilter, TargetSchema: "trade", OracleMode: OracleModeTruthPass},
+		},
+		Executions: []WorkloadRunResult{
+			{
+				Name:       "baseline-page-1",
+				Passed:     true,
+				Duration:   10 * time.Millisecond,
+				OracleMode: string(OracleModeLoadedState),
+				Assertions: []AssertionResult{{Name: "repeated-run-failure-kind-stable", Passed: true}},
+			},
+			{
+				Name:       "hot-selective-page",
+				Passed:     false,
+				Duration:   15 * time.Millisecond,
+				OracleMode: string(OracleModeTruthPass),
+				Assertions: []AssertionResult{{Name: "repeated-run-page-row-ids-stable", Passed: false}},
+			},
+		},
+	}
+	summary := SummarizeRunResult(result)
+	if len(summary.OracleProvenance) != 2 {
+		t.Fatalf("expected two oracle provenance groups, got %+v", summary.OracleProvenance)
+	}
+	if !summary.Stability.Enabled || summary.Stability.WorkloadsChecked != 2 {
+		t.Fatalf("expected stability to be enabled for both workloads, got %+v", summary.Stability)
+	}
+	if len(summary.Stability.UnstableWorkloads) != 1 || summary.Stability.UnstableWorkloads[0] != "hot-selective-page" {
+		t.Fatalf("expected unstable workload to be tracked, got %+v", summary.Stability)
+	}
+	if summary.Stability.PageRowIDFailures != 1 {
+		t.Fatalf("expected one page-row-id stability failure, got %+v", summary.Stability)
 	}
 }
 


### PR DESCRIPTION
## Summary
- mark the benchmark readiness phase complete in the roadmap and issue breakdown docs
- add the explicit benchmark readiness gate, protected workloads, and known methodology limits to the operator guide
- sync the local umbrella doc with the readiness issues that have now been closed

## Testing
- go test ./internal/e2e_harness/federated/benchmark

## Notes
- this PR is documentation-only and reflects the readiness issues already closed in GitHub (`#45`, `#55`, `#69`)
- no benchmark execution semantics changed in this PR
