### PR TITLE
Scaffold benchmark autoresearch loop

### DIFF
--- a/tools/autoresearch/benchmark/README.md
+++ b/tools/autoresearch/benchmark/README.md
@@ -1,0 +1,63 @@
+# Local Benchmark Autoresearch
+
+A performance-oriented autoresearch scaffold for federated benchmark tuning in Forma.
+
+## Purpose
+
+This loop is separate from `tools/autoresearch/testing/`.
+
+- `testing/` is for BDD-style test generation and uses test gates.
+- `benchmark/` is for performance tuning and uses benchmark baseline, candidate, diff, and decision artifacts.
+
+The benchmark controller owns the keep/discard decision. The model does not run git commands and does not decide whether a candidate is committed.
+
+## Layout
+
+- `prompts/`
+  - `opencode-single-candidate.md`: single-candidate optimization prompt
+- `scripts/`
+  - `autoloop.sh`: controller loop for one-candidate-per-iteration benchmark tuning
+  - `opencode_autoresearch.sh`: prompt launcher for OpenCode
+  - `baseline.sh`: captures a baseline benchmark artifact set for a preset
+  - `run_candidate.sh`: runs the candidate benchmark and writes a diff artifact
+  - `evaluate_benchmark_run.py`: produces a machine-readable keep/discard decision
+  - `test_evaluate_benchmark_run.sh`: evaluator regression test
+
+## Decision Artifact
+
+Each candidate iteration produces a JSON decision artifact with:
+
+- overall `status`: `keep` or `discard`
+- `reason`
+- baseline/candidate summary paths
+- diff path
+- correctness and infrastructure deltas
+- protected workload regressions
+- improved and regressed workloads
+
+The controller commits only when the decision artifact says `keep`.
+
+## Quick Start
+
+```bash
+./tools/autoresearch/benchmark/scripts/autoloop.sh \
+  --model github-copilot/gpt-5 \
+  --preset small-live \
+  --goal "Improve deep pagination without regressing protected workloads" \
+  --baseline \
+  --iterations 5
+```
+
+## Safety Model
+
+- refuses to run on `main` unless `--force` is used
+- creates a dedicated benchmark worktree under `.worktrees/`
+- keeps benchmark evidence and decision artifacts under the git common dir, not in tracked files
+- controller, not the model, decides commit vs discard
+- discard uses controller-owned restore/clean inside the benchmark worktree only
+
+## Notes
+
+- this scaffold intentionally uses benchmark presets instead of per-target performance briefs; target briefs and deterministic gate tiers land in `#53`
+- benchmark evidence currently comes from `cmd/benchmark` baseline and compare commands
+- protected workloads default to the readiness-gate set from the benchmark operator guide

--- a/tools/autoresearch/benchmark/prompts/opencode-single-candidate.md
+++ b/tools/autoresearch/benchmark/prompts/opencode-single-candidate.md
@@ -1,0 +1,40 @@
+# Forma Benchmark Single-Candidate Prompt
+
+You are running in **single-candidate benchmark optimization mode**.
+The controller will manage git state, run benchmark gates, and decide keep vs discard.
+You must **not** run any git commands.
+
+## Context
+
+- benchmark preset: `{{PRESET}}`
+- protected workloads: `{{PROTECTED_WORKLOADS}}`
+- optimization goal: `{{GOAL}}`
+- worktree root: `{{WORKTREE_DIR}}`
+
+## Your Job
+
+Produce exactly **one** focused optimization candidate for the goal above, then stop.
+
+## Rules
+
+1. Do not run any git command.
+2. Do not edit `tools/autoresearch/testing/`.
+3. Do not edit `tools/autoresearch/benchmark/` unless the task is blocked by the scaffold itself.
+4. Keep the diff focused on the current optimization goal.
+5. Prefer the smallest production change that could materially improve the benchmark target.
+6. Preserve correctness. Do not remove assertions, validation, or safety checks to make benchmarks look faster.
+7. Do not invent new benchmark presets or protected workloads in this iteration.
+8. You may update tests if the production change needs coverage, but avoid unrelated cleanup.
+9. Stop after one candidate. The controller will run the benchmark and decide whether to keep it.
+
+## Goal Guidance
+
+- optimize for the benchmark evidence, not for anecdotal claims
+- avoid changes that are likely to speed up one workload by breaking routing, pagination, or correctness semantics elsewhere
+- if the goal seems blocked by missing benchmark target briefs or thresholds, still make one small candidate aligned with the stated goal instead of broad refactoring
+
+## Important
+
+- the controller will evaluate correctness failures, infrastructure failures, and protected workload regressions from benchmark artifacts
+- the controller will discard the candidate if benchmark evidence regresses the protected set
+- do not try multiple alternatives in one iteration

--- a/tools/autoresearch/benchmark/scripts/autoloop.sh
+++ b/tools/autoresearch/benchmark/scripts/autoloop.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/autoresearch/benchmark/scripts/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./tools/autoresearch/benchmark/scripts/autoloop.sh [options]
+
+Options:
+  -m, --model MODEL            OpenCode model in provider/model form
+      --agent AGENT            Optional OpenCode agent name
+      --preset NAME            Benchmark preset (default: small-live)
+      --goal TEXT              Optimization goal text
+      --goal-file PATH         File containing optimization goal text
+      --protected-workloads CSV
+                               Comma-separated protected workloads
+      --iterations N           Number of iterations (default: 5)
+      --baseline               Capture a fresh baseline before the loop starts
+      --skip-local-infra       Do not auto-start Postgres and RustFS
+      --attach URL             Attach to an existing OpenCode server
+      --session ID             Continue a specific OpenCode session across runs
+  -c, --continue               Continue the last OpenCode session across runs
+      --fork                   Fork when continuing a session
+      --dangerously-skip-permissions
+                               Pass through to OpenCode run
+      --sleep-seconds N        Sleep between runs (default: 5)
+      --dry-run                Show commands without executing
+      --force                  Skip branch and cleanliness checks
+  -h, --help                   Show this help
+EOF
+}
+
+MODEL="github-copilot/gpt-5-mini"
+AGENT=""
+PRESET="small-live"
+GOAL_TEXT=""
+GOAL_FILE=""
+PROTECTED_WORKLOADS="$(default_protected_workloads_csv)"
+ITERATIONS=5
+RUN_BASELINE=0
+SKIP_LOCAL_INFRA=0
+ATTACH_URL=""
+SESSION_ID=""
+CONTINUE_LAST=0
+FORK_SESSION=0
+SKIP_PERMISSIONS=0
+SLEEP_SECONDS=5
+DRY_RUN=0
+FORCE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m|--model)
+      MODEL="${2:-}"
+      shift 2
+      ;;
+    --agent)
+      AGENT="${2:-}"
+      shift 2
+      ;;
+    --preset)
+      PRESET="${2:-}"
+      shift 2
+      ;;
+    --goal)
+      GOAL_TEXT="${2:-}"
+      shift 2
+      ;;
+    --goal-file)
+      GOAL_FILE="${2:-}"
+      shift 2
+      ;;
+    --protected-workloads)
+      PROTECTED_WORKLOADS="${2:-}"
+      shift 2
+      ;;
+    --iterations)
+      ITERATIONS="${2:-}"
+      shift 2
+      ;;
+    --baseline)
+      RUN_BASELINE=1
+      shift
+      ;;
+    --skip-local-infra)
+      SKIP_LOCAL_INFRA=1
+      shift
+      ;;
+    --attach)
+      ATTACH_URL="${2:-}"
+      shift 2
+      ;;
+    --session)
+      SESSION_ID="${2:-}"
+      shift 2
+      ;;
+    -c|--continue)
+      CONTINUE_LAST=1
+      shift
+      ;;
+    --fork)
+      FORK_SESSION=1
+      shift
+      ;;
+    --dangerously-skip-permissions)
+      SKIP_PERMISSIONS=1
+      shift
+      ;;
+    --sleep-seconds)
+      SLEEP_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$GOAL_FILE" ]]; then
+  GOAL_TEXT="$(<"$GOAL_FILE")"
+fi
+
+if [[ -z "${GOAL_TEXT// }" ]]; then
+  printf 'an optimization goal is required via --goal or --goal-file\n' >&2
+  exit 1
+fi
+
+if [[ -n "$SESSION_ID" && "$CONTINUE_LAST" -eq 1 ]]; then
+  printf 'use either --continue or --session, not both\n' >&2
+  exit 1
+fi
+
+for value_name in ITERATIONS SLEEP_SECONDS; do
+  value="${!value_name}"
+  if ! [[ "$value" =~ ^[0-9]+$ ]] || [[ "$value" -lt 0 ]]; then
+    printf '%s must be a non-negative integer\n' "$value_name" >&2
+    exit 1
+  fi
+done
+
+PRESET_SAFE="$(sanitize_name "$PRESET")"
+BRANCH_DATE="$(date '+%Y%m%d')"
+RESEARCH_BRANCH="autoresearch/benchmark-${PRESET_SAFE}-${BRANCH_DATE}"
+WORKTREE_DIR="$ROOT_DIR/.worktrees/autoresearch-benchmark-${PRESET_SAFE}"
+LOOP_LOG="$(log_path "benchmark-${PRESET_SAFE}")"
+BASELINE_RUN_NAME="${PRESET_SAFE}-baseline"
+BASELINE_DIR="$REPORT_DIR/baseline/$BASELINE_RUN_NAME"
+BASELINE_SUMMARY="$BASELINE_DIR"/*/benchmark-summary.json
+
+append_loop_log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" | tee -a "$LOOP_LOG"
+}
+
+is_registered_worktree() {
+  git -C "$ROOT_DIR" worktree list --porcelain | rg -Fxq "worktree $WORKTREE_DIR"
+}
+
+ensure_main_clean() {
+  local status
+  status="$(git -C "$ROOT_DIR" status --porcelain)"
+  if [[ -n "$status" && "$FORCE" -ne 1 ]]; then
+    printf 'main branch has uncommitted changes; use --force to override\n' >&2
+    git -C "$ROOT_DIR" status --short >&2
+    return 1
+  fi
+}
+
+init_worktree() {
+  if [[ -d "$WORKTREE_DIR" ]]; then
+    if ! is_registered_worktree; then
+      git -C "$ROOT_DIR" worktree prune >/dev/null 2>&1 || true
+    fi
+    if ! is_registered_worktree; then
+      printf 'worktree directory %s exists but is not registered\n' "$WORKTREE_DIR" >&2
+      return 1
+    fi
+    return 0
+  fi
+  mkdir -p "$(dirname "$WORKTREE_DIR")"
+  if ! git -C "$ROOT_DIR" rev-parse --verify "$RESEARCH_BRANCH" >/dev/null 2>&1; then
+    git -C "$ROOT_DIR" branch "$RESEARCH_BRANCH" origin/main
+  fi
+  git -C "$ROOT_DIR" worktree add "$WORKTREE_DIR" "$RESEARCH_BRANCH"
+}
+
+ensure_worktree_clean() {
+  local status
+  status="$(git -C "$WORKTREE_DIR" status --porcelain)"
+  if [[ -n "$status" ]]; then
+    printf 'worktree %s is not clean\n' "$WORKTREE_DIR" >&2
+    git -C "$WORKTREE_DIR" status --short >&2
+    return 1
+  fi
+}
+
+build_opencode_command() {
+  local -n out_ref=$1
+  local prompt
+  local prompt_cmd=("$SCRIPT_DIR/opencode_autoresearch.sh" --model "$MODEL" --preset "$PRESET" --goal "$GOAL_TEXT" --protected-workloads "$PROTECTED_WORKLOADS" --print-prompt)
+  if [[ -n "$AGENT" ]]; then
+    prompt_cmd+=(--agent "$AGENT")
+  fi
+  prompt="$(WORKTREE_DIR="$WORKTREE_DIR" "${prompt_cmd[@]}" 2>/dev/null)"
+
+  out_ref=(opencode run)
+  if [[ -n "$MODEL" ]]; then
+    out_ref+=(--model "$MODEL")
+  fi
+  if [[ -n "$AGENT" ]]; then
+    out_ref+=(--agent "$AGENT")
+  fi
+  if [[ -n "$ATTACH_URL" ]]; then
+    out_ref+=(--attach "$ATTACH_URL")
+  fi
+  if [[ "$SKIP_PERMISSIONS" -eq 1 ]]; then
+    out_ref+=(--dangerously-skip-permissions)
+  fi
+  if [[ -n "$SESSION_ID" ]]; then
+    out_ref+=(--session "$SESSION_ID")
+  elif [[ "$CONTINUE_LAST" -eq 1 ]]; then
+    out_ref+=(--continue)
+  fi
+  if [[ "$FORK_SESSION" -eq 1 ]]; then
+    out_ref+=(--fork)
+  fi
+  out_ref+=(--title "autoresearch-benchmark:${PRESET}" --dir "$WORKTREE_DIR" -- "$prompt")
+}
+
+commit_candidate() {
+  local run_index="$1"
+  git -C "$WORKTREE_DIR" add -A
+  local changes
+  changes="$(git -C "$WORKTREE_DIR" diff --cached --name-only)"
+  if [[ -z "$changes" ]]; then
+    append_loop_log "iteration $run_index produced no staged changes"
+    return 0
+  fi
+  git -C "$WORKTREE_DIR" commit -m "perf(autoresearch): ${PRESET} run ${run_index}" -m "$GOAL_TEXT"
+}
+
+discard_candidate() {
+  git -C "$WORKTREE_DIR" restore --worktree .
+  git -C "$WORKTREE_DIR" clean -fd
+}
+
+capture_baseline() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf 'baseline command: (cd %q && ./tools/autoresearch/benchmark/scripts/baseline.sh %q %q)\n' "$WORKTREE_DIR" "$PRESET" "$BASELINE_RUN_NAME"
+    return 0
+  fi
+  (
+    cd "$WORKTREE_DIR"
+    ./tools/autoresearch/benchmark/scripts/baseline.sh "$PRESET" "$BASELINE_RUN_NAME"
+  )
+}
+
+run_iteration() {
+  local run_index="$1"
+  local run_name="${PRESET_SAFE}-run-${run_index}"
+  local decision_file="$REPORT_DIR/decisions/${run_name}.json"
+  local stdout_log
+  local cmd=()
+  stdout_log="$(log_path "benchmark-${PRESET_SAFE}-run-${run_index}")"
+
+  build_opencode_command cmd
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf 'run %d command:' "$run_index"
+    printf ' %q' "${cmd[@]}"
+    printf '\n'
+    printf 'candidate gate: (cd %q && ./tools/autoresearch/benchmark/scripts/run_candidate.sh %q %q %q)\n' "$WORKTREE_DIR" "$PRESET" "$BASELINE_SUMMARY_PATH" "$run_name"
+    printf 'decision evaluator: python3 %q --baseline-summary %q --candidate-summary <candidate> --diff <diff> --decision-out %q --protected-workloads %q\n' "$SCRIPT_DIR/evaluate_benchmark_run.py" "$BASELINE_SUMMARY_PATH" "$decision_file" "$PROTECTED_WORKLOADS"
+    append_loop_log "iteration $run_index dry-run complete"
+    return 0
+  fi
+
+  rm -f "$stdout_log"
+  {
+    printf '=== benchmark iteration %d start ===\n' "$run_index"
+    printf 'command:'
+    printf ' %q' "${cmd[@]}"
+    printf '\n'
+    "${cmd[@]}"
+  } 2>&1 | tee "$stdout_log"
+
+  local candidate_output candidate_summary diff_path
+  candidate_output="$(cd "$WORKTREE_DIR" && ./tools/autoresearch/benchmark/scripts/run_candidate.sh "$PRESET" "$BASELINE_SUMMARY_PATH" "$run_name")"
+  candidate_summary="$(printf '%s\n' "$candidate_output" | rg '^candidate_summary=' | sed 's/^candidate_summary=//')"
+  diff_path="$(printf '%s\n' "$candidate_output" | rg '^diff_path=' | sed 's/^diff_path=//')"
+
+  python3 "$SCRIPT_DIR/evaluate_benchmark_run.py" \
+    --baseline-summary "$BASELINE_SUMMARY_PATH" \
+    --candidate-summary "$candidate_summary" \
+    --diff "$diff_path" \
+    --decision-out "$decision_file" \
+    --protected-workloads "$PROTECTED_WORKLOADS"
+
+  local status
+  status="$(python3 - <<'PY' "$decision_file"
+import json, sys
+print(json.loads(open(sys.argv[1], encoding='utf-8').read())['status'])
+PY
+)"
+  if [[ "$status" == "keep" ]]; then
+    commit_candidate "$run_index"
+    append_loop_log "iteration $run_index kept"
+  else
+    discard_candidate
+    append_loop_log "iteration $run_index discarded"
+  fi
+}
+
+autoloop_main() {
+  cd "$ROOT_DIR"
+  ensure_report_dirs
+  append_loop_log "preset=$PRESET research_branch=$RESEARCH_BRANCH worktree=$WORKTREE_DIR model=${MODEL:-default}"
+  if [[ "$DRY_RUN" -ne 1 ]]; then
+    ensure_main_clean
+    if [[ "$SKIP_LOCAL_INFRA" -ne 1 ]]; then
+      ensure_local_infra
+    fi
+    init_worktree
+    ensure_worktree_clean
+  fi
+
+  BASELINE_SUMMARY_PATH=""
+  if [[ "$RUN_BASELINE" -eq 1 ]]; then
+    append_loop_log "capturing baseline"
+    capture_baseline
+  else
+    if ! BASELINE_SUMMARY_PATH="$(first_summary_under "$BASELINE_DIR" 2>/dev/null)"; then
+      append_loop_log "capturing baseline"
+      capture_baseline
+      BASELINE_SUMMARY_PATH=""
+    fi
+  fi
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    if [[ -z "$BASELINE_SUMMARY_PATH" ]]; then
+      BASELINE_SUMMARY_PATH="$BASELINE_DIR/<preset-dir>/benchmark-summary.json"
+    fi
+  else
+    BASELINE_SUMMARY_PATH="$(first_summary_under "$BASELINE_DIR")"
+  fi
+
+  local run_index
+  for ((run_index = 1; run_index <= ITERATIONS; run_index++)); do
+    if [[ "$DRY_RUN" -ne 1 ]]; then
+      ensure_worktree_clean
+    fi
+    append_loop_log "=== iteration $run_index of $ITERATIONS ==="
+    run_iteration "$run_index"
+    if [[ "$run_index" -lt "$ITERATIONS" && "$SLEEP_SECONDS" -gt 0 ]]; then
+      if [[ "$DRY_RUN" -eq 1 ]]; then
+        printf 'sleep %s\n' "$SLEEP_SECONDS"
+      else
+        sleep "$SLEEP_SECONDS"
+      fi
+    fi
+  done
+  append_loop_log "benchmark autoloop finished: preset=$PRESET iterations=$ITERATIONS"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  autoloop_main "$@"
+fi

--- a/tools/autoresearch/benchmark/scripts/baseline.sh
+++ b/tools/autoresearch/benchmark/scripts/baseline.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/autoresearch/benchmark/scripts/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+PRESET="${1:-small-live}"
+RUN_NAME="${2:-$(sanitize_name "$PRESET")}" 
+
+ensure_report_dirs
+
+OUTPUT_DIR="$REPORT_DIR/baseline/$RUN_NAME"
+ensure_clean_dir "$OUTPUT_DIR"
+
+GOCACHE="$ROOT_DIR/.gocache" GOFLAGS='-buildvcs=false' \
+  go run ./cmd/benchmark baseline -preset "$PRESET" -output-dir "$OUTPUT_DIR" >/dev/null
+
+SUMMARY_PATH="$(first_summary_under "$OUTPUT_DIR")"
+printf 'baseline_dir=%s\n' "$OUTPUT_DIR"
+printf 'baseline_summary=%s\n' "$SUMMARY_PATH"

--- a/tools/autoresearch/benchmark/scripts/common.sh
+++ b/tools/autoresearch/benchmark/scripts/common.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+COMMON_GIT_DIR="$(git rev-parse --path-format=absolute --git-common-dir)"
+AR_DIR="$ROOT_DIR/tools/autoresearch/benchmark"
+REPORT_DIR="$COMMON_GIT_DIR/autoresearch-benchmark"
+
+DEFAULT_PROTECTED_WORKLOADS=(
+  baseline-page-1
+  hot-selective-page
+  hot-low-selectivity-page
+  eav-selective-page
+  mixed-hot-eav-page
+  mixed-tier-window
+  hot-only-window
+  cold-only-window
+  deep-page-1000
+)
+
+ensure_report_dirs() {
+  mkdir -p "$REPORT_DIR/baseline" "$REPORT_DIR/candidates" "$REPORT_DIR/decisions" "$REPORT_DIR/logs"
+}
+
+log_path() {
+  local name="$1"
+  ensure_report_dirs
+  printf '%s/%s.log\n' "$REPORT_DIR/logs" "$name"
+}
+
+sanitize_name() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-'
+}
+
+join_by_comma() {
+  local IFS=,
+  printf '%s' "$*"
+}
+
+default_protected_workloads_csv() {
+  join_by_comma "${DEFAULT_PROTECTED_WORKLOADS[@]}"
+}
+
+ensure_clean_dir() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+}
+
+first_summary_under() {
+  local dir="$1"
+  local matches=("$dir"/*/benchmark-summary.json)
+  if [[ ${#matches[@]} -ne 1 || ! -f "${matches[0]}" ]]; then
+    printf 'expected exactly one benchmark-summary.json under %s\n' "$dir" >&2
+    return 1
+  fi
+  printf '%s\n' "${matches[0]}"
+}
+
+compose_cmd() {
+  if docker compose version >/dev/null 2>&1; then
+    printf '%s\n' 'docker compose'
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    printf '%s\n' 'docker-compose'
+    return 0
+  fi
+  return 1
+}
+
+wait_for_pg() {
+  local retries=30
+  local attempt=1
+  while [[ "$attempt" -le "$retries" ]]; do
+    if docker exec forma-postgres pg_isready -U postgres >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+wait_for_rustfs() {
+  local retries=30
+  local attempt=1
+  while [[ "$attempt" -le "$retries" ]]; do
+    if curl -fsS "http://localhost:9000/health" >/dev/null 2>&1 || curl -fsS "http://localhost:9001/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+ensure_local_infra() {
+  local compose_bin
+  local compose_file
+  compose_file="$ROOT_DIR/deploy/docker-compose.yml"
+
+  if [[ ! -f "$compose_file" ]]; then
+    printf 'compose file not found: %s\n' "$compose_file" >&2
+    return 1
+  fi
+
+  if ! compose_bin="$(compose_cmd)"; then
+    printf 'docker compose is required but not available\n' >&2
+    return 1
+  fi
+
+  if [[ "$compose_bin" == "docker compose" ]]; then
+    docker compose -f "$compose_file" up -d aurora-dsql rustfs
+  else
+    docker-compose -f "$compose_file" up -d aurora-dsql rustfs
+  fi
+
+  wait_for_pg
+  wait_for_rustfs
+}

--- a/tools/autoresearch/benchmark/scripts/evaluate_benchmark_run.py
+++ b/tools/autoresearch/benchmark/scripts/evaluate_benchmark_run.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def duration_to_ns(value) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def summarize_workload_changes(
+    diff_workloads: list[dict],
+) -> tuple[list[str], list[str]]:
+    improved: list[str] = []
+    regressed: list[str] = []
+    for workload in diff_workloads:
+        name = workload["name"]
+        if (
+            workload.get("missing_in_candidate")
+            or workload.get("correctness_failures_delta", 0) > 0
+            or workload.get("infra_failures_delta", 0) > 0
+        ):
+            regressed.append(name)
+            continue
+        if (
+            duration_to_ns(workload.get("avg_latency_delta", 0)) < 0
+            and workload.get("correctness_failures_delta", 0) <= 0
+            and workload.get("infra_failures_delta", 0) <= 0
+        ):
+            improved.append(name)
+        if (
+            duration_to_ns(workload.get("avg_latency_delta", 0)) > 0
+            or workload.get("qps_delta", 0) < 0
+        ):
+            regressed.append(name)
+    return sorted(set(improved)), sorted(set(regressed))
+
+
+def evaluate_protected_workloads(
+    protected: list[str], diff_workloads: list[dict]
+) -> list[dict]:
+    diff_by_name = {workload["name"]: workload for workload in diff_workloads}
+    regressions: list[dict] = []
+    for name in protected:
+        workload = diff_by_name.get(name)
+        if workload is None:
+            regressions.append({"name": name, "reasons": ["missing_in_diff"]})
+            continue
+        reasons: list[str] = []
+        if workload.get("missing_in_candidate"):
+            reasons.append("missing_in_candidate")
+        if workload.get("passed_changed"):
+            reasons.append("passed_changed")
+        if workload.get("correctness_failures_delta", 0) > 0:
+            reasons.append("correctness_failures_increased")
+        if workload.get("infra_failures_delta", 0) > 0:
+            reasons.append("infra_failures_increased")
+        if duration_to_ns(workload.get("avg_latency_delta", 0)) > 0:
+            reasons.append("avg_latency_regressed")
+        if workload.get("qps_delta", 0) < 0:
+            reasons.append("qps_regressed")
+        if reasons:
+            regressions.append(
+                {
+                    "name": name,
+                    "reasons": reasons,
+                    "avg_latency_delta": workload.get("avg_latency_delta", 0),
+                    "p95_latency_delta": workload.get("p95_latency_delta", 0),
+                    "qps_delta": workload.get("qps_delta", 0),
+                    "correctness_failures_delta": workload.get(
+                        "correctness_failures_delta", 0
+                    ),
+                    "infra_failures_delta": workload.get("infra_failures_delta", 0),
+                }
+            )
+    return regressions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate benchmark baseline/candidate artifacts and emit a keep/discard decision."
+    )
+    parser.add_argument("--baseline-summary", required=True)
+    parser.add_argument("--candidate-summary", required=True)
+    parser.add_argument("--diff", required=True)
+    parser.add_argument("--decision-out", required=True)
+    parser.add_argument("--protected-workloads", default="")
+    args = parser.parse_args()
+
+    baseline_summary = Path(args.baseline_summary)
+    candidate_summary = Path(args.candidate_summary)
+    diff_path = Path(args.diff)
+    decision_out = Path(args.decision_out)
+
+    baseline = load_json(baseline_summary)
+    candidate = load_json(candidate_summary)
+    diff = load_json(diff_path)
+
+    protected = [
+        item.strip() for item in args.protected_workloads.split(",") if item.strip()
+    ]
+    improved, regressed = summarize_workload_changes(diff.get("workloads", []))
+    protected_regressions = evaluate_protected_workloads(
+        protected, diff.get("workloads", [])
+    )
+
+    correctness_delta = diff.get("summary", {}).get("correctness_failures_delta", 0)
+    infra_delta = diff.get("summary", {}).get("infra_failures_delta", 0)
+    passed = bool(candidate.get("passed", False))
+
+    if not passed:
+        status = "discard"
+        reason = "candidate benchmark did not pass"
+    elif correctness_delta > 0:
+        status = "discard"
+        reason = "correctness failures increased"
+    elif infra_delta > 0:
+        status = "discard"
+        reason = "infrastructure failures increased"
+    elif protected_regressions:
+        status = "discard"
+        reason = "protected workloads regressed"
+    else:
+        status = "keep"
+        reason = "candidate preserved protected workloads and benchmark correctness"
+
+    decision = {
+        "status": status,
+        "reason": reason,
+        "baseline_summary": str(baseline_summary),
+        "candidate_summary": str(candidate_summary),
+        "diff_path": str(diff_path),
+        "baseline_benchmark_id": baseline.get("metadata", {}).get("benchmark_id", ""),
+        "candidate_benchmark_id": candidate.get("metadata", {}).get("benchmark_id", ""),
+        "candidate_passed": passed,
+        "correctness_failures_delta": correctness_delta,
+        "infra_failures_delta": infra_delta,
+        "protected_workloads": protected,
+        "protected_regressions": protected_regressions,
+        "improved_workloads": improved,
+        "regressed_workloads": regressed,
+    }
+
+    decision_out.parent.mkdir(parents=True, exist_ok=True)
+    decision_out.write_text(json.dumps(decision, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(decision, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/autoresearch/benchmark/scripts/opencode_autoresearch.sh
+++ b/tools/autoresearch/benchmark/scripts/opencode_autoresearch.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/autoresearch/benchmark/scripts/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./tools/autoresearch/benchmark/scripts/opencode_autoresearch.sh [options]
+
+Options:
+  -m, --model MODEL           OpenCode model in provider/model form
+      --mode MODE             Launch mode: tui | run (default: run)
+      --agent AGENT           Optional OpenCode agent name
+      --preset NAME           Benchmark preset (default: small-live)
+      --goal TEXT             Optimization goal text
+      --goal-file PATH        File containing optimization goal text
+      --protected-workloads CSV
+                              Comma-separated protected workloads
+      --print-prompt          Print rendered prompt and exit
+      --dry-run               Print the OpenCode command and exit
+  -c, --continue              Continue the last OpenCode session
+  -s, --session ID            Continue a specific OpenCode session
+      --fork                  Fork the session when continuing
+  -h, --help                  Show this help
+EOF
+}
+
+MODE="run"
+MODEL="github-copilot/gpt-5-mini"
+AGENT=""
+PRESET="small-live"
+GOAL_TEXT=""
+GOAL_FILE=""
+PROTECTED_WORKLOADS="$(default_protected_workloads_csv)"
+CONTINUE_LAST=0
+SESSION_ID=""
+FORK_SESSION=0
+PRINT_PROMPT=0
+DRY_RUN=0
+WORKTREE_DIR_OVERRIDE="${WORKTREE_DIR:-$ROOT_DIR}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m|--model)
+      MODEL="${2:-}"
+      shift 2
+      ;;
+    --mode)
+      MODE="${2:-}"
+      shift 2
+      ;;
+    --agent)
+      AGENT="${2:-}"
+      shift 2
+      ;;
+    --preset)
+      PRESET="${2:-}"
+      shift 2
+      ;;
+    --goal)
+      GOAL_TEXT="${2:-}"
+      shift 2
+      ;;
+    --goal-file)
+      GOAL_FILE="${2:-}"
+      shift 2
+      ;;
+    --protected-workloads)
+      PROTECTED_WORKLOADS="${2:-}"
+      shift 2
+      ;;
+    -c|--continue)
+      CONTINUE_LAST=1
+      shift
+      ;;
+    -s|--session)
+      SESSION_ID="${2:-}"
+      shift 2
+      ;;
+    --fork)
+      FORK_SESSION=1
+      shift
+      ;;
+    --print-prompt)
+      PRINT_PROMPT=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$GOAL_FILE" ]]; then
+  GOAL_TEXT="$(<"$GOAL_FILE")"
+fi
+
+if [[ -z "${GOAL_TEXT// }" ]]; then
+  printf 'an optimization goal is required via --goal or --goal-file\n' >&2
+  exit 1
+fi
+
+PROMPT="$(<"$AR_DIR/prompts/opencode-single-candidate.md")"
+PROMPT="${PROMPT//\{\{PRESET\}\}/$PRESET}"
+PROMPT="${PROMPT//\{\{PROTECTED_WORKLOADS\}\}/$PROTECTED_WORKLOADS}"
+PROMPT="${PROMPT//\{\{GOAL\}\}/$GOAL_TEXT}"
+PROMPT="${PROMPT//\{\{WORKTREE_DIR\}\}/$WORKTREE_DIR_OVERRIDE}"
+
+if [[ "$PRINT_PROMPT" -eq 1 ]]; then
+  printf '%s\n' "$PROMPT"
+  exit 0
+fi
+
+COMMAND=(opencode)
+if [[ "$MODE" == "run" ]]; then
+  COMMAND+=(run)
+fi
+if [[ -n "$MODEL" ]]; then
+  COMMAND+=(--model "$MODEL")
+fi
+if [[ -n "$AGENT" ]]; then
+  COMMAND+=(--agent "$AGENT")
+fi
+if [[ "$CONTINUE_LAST" -eq 1 ]]; then
+  COMMAND+=(--continue)
+fi
+if [[ -n "$SESSION_ID" ]]; then
+  COMMAND+=(--session "$SESSION_ID")
+fi
+if [[ "$FORK_SESSION" -eq 1 ]]; then
+  COMMAND+=(--fork)
+fi
+if [[ "$MODE" == "tui" ]]; then
+  COMMAND+=(--prompt "$PROMPT" "$ROOT_DIR")
+else
+  COMMAND+=(--title "autoresearch-benchmark:${PRESET}" -- "$PROMPT")
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf 'working directory: %s\n' "$ROOT_DIR"
+  printf 'command:'
+  printf ' %q' "${COMMAND[@]}"
+  printf '\n'
+  exit 0
+fi
+
+cd "$ROOT_DIR"
+exec "${COMMAND[@]}"

--- a/tools/autoresearch/benchmark/scripts/run_candidate.sh
+++ b/tools/autoresearch/benchmark/scripts/run_candidate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tools/autoresearch/benchmark/scripts/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+PRESET="${1:-small-live}"
+BASELINE_SUMMARY="${2:-}"
+RUN_NAME="${3:-candidate-$(date '+%Y%m%d-%H%M%S')}"
+
+if [[ -z "$BASELINE_SUMMARY" ]]; then
+  printf 'baseline summary path is required\n' >&2
+  exit 1
+fi
+
+ensure_report_dirs
+
+OUTPUT_DIR="$REPORT_DIR/candidates/$RUN_NAME"
+ensure_clean_dir "$OUTPUT_DIR"
+
+GOCACHE="$ROOT_DIR/.gocache" GOFLAGS='-buildvcs=false' \
+  go run ./cmd/benchmark baseline -preset "$PRESET" -output-dir "$OUTPUT_DIR" >/dev/null
+
+CANDIDATE_SUMMARY="$(first_summary_under "$OUTPUT_DIR")"
+DIFF_PATH="$OUTPUT_DIR/benchmark-diff.json"
+
+GOCACHE="$ROOT_DIR/.gocache" GOFLAGS='-buildvcs=false' \
+  go run ./cmd/benchmark compare -baseline "$BASELINE_SUMMARY" -candidate "$CANDIDATE_SUMMARY" -diff-out "$DIFF_PATH" >/dev/null
+
+printf 'candidate_dir=%s\n' "$OUTPUT_DIR"
+printf 'candidate_summary=%s\n' "$CANDIDATE_SUMMARY"
+printf 'diff_path=%s\n' "$DIFF_PATH"

--- a/tools/autoresearch/benchmark/scripts/test_evaluate_benchmark_run.sh
+++ b/tools/autoresearch/benchmark/scripts/test_evaluate_benchmark_run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+write_json() {
+  local path="$1"
+  local body="$2"
+  printf '%s\n' "$body" > "$path"
+}
+
+assert_contains() {
+  local path="$1"
+  local pattern="$2"
+  rg "$pattern" "$path" >/dev/null
+}
+
+baseline_summary="$TMP_DIR/baseline-summary.json"
+candidate_summary_keep="$TMP_DIR/candidate-keep-summary.json"
+candidate_summary_discard="$TMP_DIR/candidate-discard-summary.json"
+keep_diff="$TMP_DIR/keep-diff.json"
+discard_diff="$TMP_DIR/discard-diff.json"
+keep_decision="$TMP_DIR/keep-decision.json"
+discard_decision="$TMP_DIR/discard-decision.json"
+
+write_json "$baseline_summary" '{"metadata":{"benchmark_id":"bench-a"},"passed":true,"workloads":[{"name":"baseline-page-1","passed":true}]}'
+write_json "$candidate_summary_keep" '{"metadata":{"benchmark_id":"bench-b"},"passed":true,"workloads":[{"name":"baseline-page-1","passed":true}]}'
+write_json "$candidate_summary_discard" '{"metadata":{"benchmark_id":"bench-c"},"passed":false,"workloads":[{"name":"baseline-page-1","passed":false}]}'
+
+write_json "$keep_diff" '{"summary":{"correctness_failures_delta":0,"infra_failures_delta":0},"workloads":[{"name":"baseline-page-1","passed_changed":false,"correctness_failures_delta":0,"infra_failures_delta":0,"avg_latency_delta":-1000,"p95_latency_delta":-1000,"qps_delta":1.5}]}'
+write_json "$discard_diff" '{"summary":{"correctness_failures_delta":0,"infra_failures_delta":0},"workloads":[{"name":"baseline-page-1","passed_changed":false,"correctness_failures_delta":0,"infra_failures_delta":0,"avg_latency_delta":1000,"p95_latency_delta":1000,"qps_delta":-1.5}]}'
+
+python3 "$SCRIPT_DIR/evaluate_benchmark_run.py" \
+  --baseline-summary "$baseline_summary" \
+  --candidate-summary "$candidate_summary_keep" \
+  --diff "$keep_diff" \
+  --decision-out "$keep_decision" \
+  --protected-workloads baseline-page-1
+
+assert_contains "$keep_decision" '"status": "keep"'
+assert_contains "$keep_decision" '"improved_workloads": \['
+
+python3 "$SCRIPT_DIR/evaluate_benchmark_run.py" \
+  --baseline-summary "$baseline_summary" \
+  --candidate-summary "$candidate_summary_discard" \
+  --diff "$discard_diff" \
+  --decision-out "$discard_decision" \
+  --protected-workloads baseline-page-1
+
+assert_contains "$discard_decision" '"status": "discard"'
+assert_contains "$discard_decision" '"reason": "candidate benchmark did not pass"'
+
+printf 'benchmark decision evaluator test passed\n'


### PR DESCRIPTION
## Summary
- add a dedicated `tools/autoresearch/benchmark/` scaffold so performance iterations can use benchmark baseline, candidate, diff, and decision artifacts without changing the existing test-focused autoresearch loop
- add a benchmark decision evaluator that keeps candidates only when benchmark correctness holds and protected workloads do not regress
- add controller, prompt, and helper scripts plus a small evaluator regression test and README for local benchmark autoresearch usage

## Testing
- go test ./cmd/benchmark ./internal/e2e_harness/federated/benchmark
- bash tools/autoresearch/benchmark/scripts/test_evaluate_benchmark_run.sh
- bash tools/autoresearch/benchmark/scripts/opencode_autoresearch.sh --goal "Improve deep pagination without regressing protected workloads" --print-prompt
- bash tools/autoresearch/benchmark/scripts/autoloop.sh --goal "Improve deep pagination without regressing protected workloads" --iterations 1 --dry-run

## Notes
- this PR intentionally scopes `#49` to the benchmark autoresearch scaffold only; target briefs and deterministic gate tiers remain follow-up work in `#53`
- closes #49
