### PR TITLE
optimize federated deep-page tradeTime pagination

### DIFF
--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -34,8 +34,9 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 		result.Duration = time.Since(start)
 		return result, nil
 	}
-	benchmarkProjection := usesBenchmarkProjection(opts)
-	if benchmarkProjection {
+	benchmarkProjection := usesBenchmarkProjectionForSelect(opts)
+	tradeTimeOnlyProjection := usesTradeTimeOnlyBenchmarkProjectionForSelect(opts)
+	if needsBenchmarkDuckDBMacros(opts, benchmarkProjection, tradeTimeOnlyProjection) {
 		if err := prepareBenchmarkDuckDBMacros(ctx, h); err != nil {
 			return nil, err
 		}
@@ -75,6 +76,16 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 	}
 	if opts.CountOnly {
 		return &QueryResult{TotalRecords: totalRecords, Duration: time.Since(start), Plan: buildExecutionPlan(len(dirtyIDs), hasBaseFiles, hasDeltaFiles, time.Since(start))}, nil
+	}
+	if shouldSkipFederatedSelect(totalRecords, opts.Offset) {
+		plan := buildExecutionPlan(len(dirtyIDs), hasBaseFiles, hasDeltaFiles, time.Since(start))
+		plan.Notes = append(plan.Notes, "empty_page_short_circuit")
+		return &QueryResult{
+			Records:      nil,
+			TotalRecords: totalRecords,
+			Duration:     time.Since(start),
+			Plan:         plan,
+		}, nil
 	}
 
 	rows, err := h.Duck.DB.QueryContext(ctx, query)
@@ -210,6 +221,16 @@ func buildExecutionPlan(dirtyIDCount int, hasBase, hasDelta bool, duration time.
 	}
 }
 
+func shouldSkipFederatedSelect(totalRecords int64, offset int) bool {
+	if totalRecords <= 0 {
+		return true
+	}
+	if offset < 0 {
+		return false
+	}
+	return int64(offset) >= totalRecords
+}
+
 func isFederatedTierFileError(err error) bool {
 	if err == nil {
 		return false
@@ -219,16 +240,17 @@ func isFederatedTierFileError(err error) bool {
 
 // buildFederatedQuerySQLDynamic builds the federated query SQL, only including tiers that have files.
 func (h *FederatedTestHarness) buildFederatedQuerySQLDynamic(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions) string {
-	combinedQuery, benchmarkProjection := h.buildFederatedCombinedQuery(basePath, deltaPath, hasBase, hasDelta, dirtyIDs, opts)
+	benchmarkProjection := usesBenchmarkProjectionForSelect(opts)
+	combinedQuery := h.buildFederatedCombinedQuery(basePath, deltaPath, hasBase, hasDelta, dirtyIDs, opts, benchmarkProjection, usesTradeTimeOnlyBenchmarkProjectionForSelect(opts))
 	return buildFinalFederatedSelect(combinedQuery, opts, benchmarkProjection)
 }
 
 func (h *FederatedTestHarness) buildFederatedQueryCountSQLDynamic(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions) string {
-	combinedQuery, _ := h.buildFederatedCombinedQuery(basePath, deltaPath, hasBase, hasDelta, dirtyIDs, opts)
+	combinedQuery := h.buildFederatedCombinedQuery(basePath, deltaPath, hasBase, hasDelta, dirtyIDs, opts, usesBenchmarkProjectionForCount(opts), false)
 	return buildFinalFederatedCount(combinedQuery)
 }
 
-func (h *FederatedTestHarness) buildFederatedCombinedQuery(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions) (string, bool) {
+func (h *FederatedTestHarness) buildFederatedCombinedQuery(basePath, deltaPath string, hasBase, hasDelta bool, dirtyIDs []uuid.UUID, opts *QueryOptions, benchmarkProjection, tradeTimeOnlyProjection bool) string {
 	dirtyExclusion := buildDirtyExclusion(dirtyIDs)
 	rowIDFilter := buildRowIDFilter(opts)
 	hotRowIDFilter := buildHotRowIDFilter(opts)
@@ -236,34 +258,33 @@ func (h *FederatedTestHarness) buildFederatedCombinedQuery(basePath, deltaPath s
 	timeWindowFilter := buildTradeTimeFilterClause(opts)
 	hotAttributeFilter := buildHotAttributeFilterClause(opts)
 	hotTimeWindowFilter := buildHotTradeTimeFilterClause(opts)
-	benchmarkProjection := usesBenchmarkProjection(opts)
 	pgConnStr := h.buildPGConnString()
 
 	// Build tier queries dynamically
 	var tierQueries []string
 
 	if hasBase {
-		baseQuery := buildParquetTierQuery(basePath, h.SchemaID, "base", dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter, benchmarkProjection)
+		baseQuery := buildParquetTierQuery(basePath, h.SchemaID, "base", dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter, benchmarkProjection, tradeTimeOnlyProjection)
 		tierQueries = append(tierQueries, baseQuery)
 	}
 
 	if hasDelta {
-		deltaQuery := buildParquetTierQuery(deltaPath, h.SchemaID, "delta", dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter, benchmarkProjection)
+		deltaQuery := buildParquetTierQuery(deltaPath, h.SchemaID, "delta", dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter, benchmarkProjection, tradeTimeOnlyProjection)
 		tierQueries = append(tierQueries, deltaQuery)
 	}
 
 	// Always include hot buffer (Postgres)
-	hotQuery := buildHotTierQuery(pgConnStr, h.SchemaID, hotRowIDFilter, hotAttributeFilter, hotTimeWindowFilter, benchmarkProjection)
+	hotQuery := buildHotTierQuery(pgConnStr, h.SchemaID, hotRowIDFilter, hotAttributeFilter, hotTimeWindowFilter, benchmarkProjection, tradeTimeOnlyProjection)
 	tierQueries = append(tierQueries, hotQuery)
 
 	// Combine all tier queries with UNION ALL
 	combinedQuery := strings.Join(tierQueries, "\n\t\t\tUNION ALL\n")
-	return combinedQuery, benchmarkProjection
+	return combinedQuery
 }
 
-func buildParquetTierQuery(path string, schemaID int16, tier, dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter string, benchmarkProjection bool) string {
+func buildParquetTierQuery(path string, schemaID int16, tier, dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter string, benchmarkProjection, tradeTimeOnlyProjection bool) string {
 	if benchmarkProjection {
-		projection := benchmarkParquetProjection(schemaID, tier, path)
+		projection := benchmarkParquetProjection(schemaID, tier, path, tradeTimeOnlyProjection)
 		return fmt.Sprintf(`
 			%s
 			WHERE 1 = 1 %s %s %s %s`, projection, dirtyExclusion, rowIDFilter, attributeFilter, timeWindowFilter)
@@ -274,19 +295,25 @@ func buildParquetTierQuery(path string, schemaID int16, tier, dirtyExclusion, ro
 			WHERE 1 = 1 %s %s %s`, tier, path, dirtyExclusion, rowIDFilter, timeWindowFilter)
 }
 
-func benchmarkParquetProjection(schemaID int16, tier, path string) string {
+func benchmarkParquetProjection(schemaID int16, tier, path string, tradeTimeOnlyProjection bool) string {
 	switch schemaID {
 	case benchmarkSchemaIDCustomer:
 		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, '' as symbol, '' as exchange, region, 0 as tradeType, 0 as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
 	case benchmarkSchemaIDSecurity:
 		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, '' as exchange, '' as region, 0 as tradeType, 0 as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
 	default:
+		if tradeTimeOnlyProjection {
+			return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, '' as name, version, '' as symbol, '' as exchange, '' as region, 0 as tradeType, epoch_ms(tradeTime) as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
+		}
 		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, epoch_ms(tradeTime) as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
 	}
 }
 
-func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeFilter, timeWindowFilter string, benchmarkProjection bool) string {
+func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeFilter, timeWindowFilter string, benchmarkProjection, tradeTimeOnlyProjection bool) string {
 	if benchmarkProjection {
+		if tradeTimeOnlyProjection && schemaID == benchmarkSchemaIDTrade {
+			return buildHotTradeTimeOnlyQuery(pgConnStr, schemaID, rowIDFilter)
+		}
 		return fmt.Sprintf(`
 		SELECT 
 			cl.row_id::VARCHAR as row_id,
@@ -334,6 +361,37 @@ func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeF
 			AND cl.schema_id = %d
 			%s
 			%s`, pgConnStr, schemaID, rowIDFilter, timeWindowFilter)
+}
+
+func buildHotTradeTimeOnlyQuery(pgConnStr string, schemaID int16, rowIDFilter string) string {
+	tradeTimeAttrID := benchmarkAttributeID(schemaID, "tradeTime")
+	return fmt.Sprintf(`
+		SELECT 
+			cl.row_id::VARCHAR as row_id,
+			cl.schema_id,
+			cl.changed_at,
+			cl.deleted_at,
+			'' as name,
+			0 as version,
+			'' as symbol,
+			'' as exchange,
+			'' as region,
+			0 as tradeType,
+			COALESCE(hot_vals.trade_time, em.bigint_02, 0) as tradeTime,
+			'hot' as tier
+		FROM postgres_scan('%s', 'public', 'change_log') cl
+		LEFT JOIN postgres_scan('%s', 'public', 'entity_main') em
+			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id::VARCHAR = cl.row_id::VARCHAR
+		LEFT JOIN (
+			SELECT row_id::VARCHAR as row_id, schema_id,
+				MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS trade_time
+			FROM postgres_scan('%s', 'public', 'eav_data')
+			WHERE attr_id = %d
+			GROUP BY schema_id, row_id
+		) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id::VARCHAR
+		WHERE cl.flushed_at = 0 
+			AND cl.schema_id = %d
+			%s`, pgConnStr, pgConnStr, tradeTimeAttrID, pgConnStr, tradeTimeAttrID, schemaID, rowIDFilter)
 }
 
 func buildFinalFederatedSelect(combinedQuery string, opts *QueryOptions, benchmarkProjection bool) string {
@@ -386,11 +444,54 @@ func buildFederatedDeduplicatedCTE(combinedQuery string) string {
 	`, combinedQuery)
 }
 
-func usesBenchmarkProjection(opts *QueryOptions) bool {
+func usesBenchmarkProjectionForSelect(opts *QueryOptions) bool {
 	if opts == nil {
 		return false
 	}
+	if requiresBenchmarkProjectedFilters(opts) {
+		return true
+	}
 	if opts.SortBy != "" && opts.SortBy != "row_id" {
+		return true
+	}
+	return false
+}
+
+func usesBenchmarkProjectionForCount(opts *QueryOptions) bool {
+	if requiresBenchmarkProjectedFilters(opts) {
+		return true
+	}
+	if opts == nil {
+		return false
+	}
+	if opts.Offset <= 0 {
+		return usesBenchmarkProjectionForSelect(opts)
+	}
+	return false
+}
+
+func usesTradeTimeOnlyBenchmarkProjectionForSelect(opts *QueryOptions) bool {
+	if !usesBenchmarkProjectionForSelect(opts) || opts == nil {
+		return false
+	}
+	if opts.SortBy != "tradeTime" || opts.Filter != nil {
+		return false
+	}
+	return opts.TradeTimeStart == 0 && opts.TradeTimeEnd == 0
+}
+
+func needsBenchmarkDuckDBMacros(opts *QueryOptions, benchmarkProjection, tradeTimeOnlyProjection bool) bool {
+	if usesBenchmarkProjectionForCount(opts) {
+		return true
+	}
+	return benchmarkProjection && !tradeTimeOnlyProjection
+}
+
+func requiresBenchmarkProjectedFilters(opts *QueryOptions) bool {
+	if opts == nil {
+		return false
+	}
+	if opts.TradeTimeStart > 0 || opts.TradeTimeEnd > 0 {
 		return true
 	}
 	if opts.Filter == nil {
@@ -607,8 +708,9 @@ func benchmarkHotFilterExpression(attribute string) string {
 }
 
 func buildOrderByClause(opts *QueryOptions) string {
+	prefix := ""
 	if opts == nil {
-		return "row_id ASC"
+		return prefix + "row_id ASC"
 	}
 	column := benchmarkQueryColumn(opts.SortBy)
 	if column == "" {
@@ -618,7 +720,7 @@ func buildOrderByClause(opts *QueryOptions) string {
 	if opts.SortDesc {
 		direction = "DESC"
 	}
-	return fmt.Sprintf("%s %s, row_id ASC", column, direction)
+	return fmt.Sprintf("%s%s %s, %srow_id ASC", prefix, column, direction, prefix)
 }
 
 // buildPGConnString builds the Postgres connection string for DuckDB.
@@ -693,7 +795,7 @@ func (h *FederatedTestHarness) ExecutePostgresQuery(ctx context.Context, opts *Q
 	}
 	defer rows.Close()
 
-	benchmarkProjection := usesBenchmarkProjection(opts)
+	benchmarkProjection := usesBenchmarkProjectionForSelect(opts)
 	var records []*internal.PersistentRecord
 	for rows.Next() {
 		var rowID string
@@ -765,7 +867,7 @@ func (h *FederatedTestHarness) buildPostgresOnlySelectQuery(opts *QueryOptions) 
 			COALESCE(cl.deleted_at, 0),
 			COALESCE(hot_vals.name, hot_vals.symbol, '') as name,
 			0 as version`)
-	if usesBenchmarkProjection(opts) {
+	if usesBenchmarkProjectionForSelect(opts) {
 		query.WriteString(`,
 			COALESCE(hot_vals.symbol, em.text_01, '') as symbol,
 			COALESCE(hot_vals.exchange, '') as exchange,

--- a/internal/e2e_harness/federated/query_unit_test.go
+++ b/internal/e2e_harness/federated/query_unit_test.go
@@ -32,11 +32,25 @@ func TestBuildFederatedQueryCountSQLDynamic(t *testing.T) {
 	if !strings.Contains(query, "postgres_scan") {
 		t.Fatalf("expected hot tier in count query: %s", query)
 	}
+	if strings.Contains(query, "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02)") {
+		t.Fatalf("sort-only count query should avoid projected tradeTime expression: %s", query)
+	}
+	if strings.Contains(query, "LEFT JOIN postgres_scan('host=localhost port=5432 user=postgres password=password dbname=postgres sslmode=disable', 'public', 'entity_main')") {
+		t.Fatalf("sort-only count query should avoid entity_main join: %s", query)
+	}
+}
+
+func TestBuildFederatedQueryCountSQLDynamic_PageOneKeepsWideCountPath(t *testing.T) {
+	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
+	query := h.buildFederatedQueryCountSQLDynamic("base-path", "delta-path", true, true, nil, &QueryOptions{Limit: 20, Offset: 0, SortBy: "tradeTime", SortDesc: true})
+	if !strings.Contains(query, "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02)") {
+		t.Fatalf("page-one count query should preserve projected tradeTime path: %s", query)
+	}
 }
 
 func TestBuildFederatedCombinedQueryUsesHotFilterExpressions(t *testing.T) {
 	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
-	query, _ := h.buildFederatedCombinedQuery("base-path", "delta-path", false, false, nil, &QueryOptions{Filter: &Filter{Conditions: map[string]any{"exchange": "NYSE"}}})
+	query := h.buildFederatedCombinedQuery("base-path", "delta-path", false, false, nil, &QueryOptions{Filter: &Filter{Conditions: map[string]any{"exchange": "NYSE"}}}, true, false)
 	if !strings.Contains(query, "benchmark_text(hot_vals.attributes, 'exchange', '')") {
 		t.Fatalf("expected hot exchange filter expression in combined query: %s", query)
 	}
@@ -46,25 +60,25 @@ func TestBuildFederatedCombinedQueryUsesHotFilterExpressions(t *testing.T) {
 }
 
 func TestBuildParquetTierQuerySupportsSchemaSpecificProjection(t *testing.T) {
-	customerQuery := buildParquetTierQuery("customer-path", benchmarkSchemaIDCustomer, "base", "", "", "AND region = 'NA'", "", true)
+	customerQuery := buildParquetTierQuery("customer-path", benchmarkSchemaIDCustomer, "base", "", "", "AND region = 'NA'", "", true, false)
 	if !strings.Contains(customerQuery, "region") || strings.Contains(customerQuery, "epoch_ms(tradeTime)") {
 		t.Fatalf("expected customer projection without trade time conversion: %s", customerQuery)
 	}
-	securityQuery := buildParquetTierQuery("security-path", benchmarkSchemaIDSecurity, "base", "", "", "AND symbol = 'SYM00001'", "", true)
+	securityQuery := buildParquetTierQuery("security-path", benchmarkSchemaIDSecurity, "base", "", "", "AND symbol = 'SYM00001'", "", true, false)
 	if !strings.Contains(securityQuery, "symbol") || strings.Contains(securityQuery, "epoch_ms(tradeTime)") {
 		t.Fatalf("expected security projection with symbol only: %s", securityQuery)
 	}
 }
 
 func TestBuildParquetTierQueryKeepsDeletedRowsForDeduplication(t *testing.T) {
-	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "delta", "", "", "", "", true)
+	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "delta", "", "", "", "", true, false)
 	if strings.Contains(query, "deleted_at = 0") {
 		t.Fatalf("expected parquet tier query to defer deleted filtering until after dedup: %s", query)
 	}
 }
 
 func TestBuildHotTierQueryKeepsDeletedRowsForDeduplication(t *testing.T) {
-	query := buildHotTierQuery("pg-conn", benchmarkSchemaIDTrade, "", "", "", true)
+	query := buildHotTierQuery("pg-conn", benchmarkSchemaIDTrade, "", "", "", true, false)
 	if strings.Contains(query, "deleted_at = 0") || strings.Contains(query, "deleted_at IS NULL") {
 		t.Fatalf("expected hot tier query to defer deleted filtering until after dedup: %s", query)
 	}
@@ -81,7 +95,7 @@ func TestBuildFederatedDeduplicatedCTEUsesStableTieBreaks(t *testing.T) {
 
 func TestBuildFederatedCombinedQuerySupportsTradeTimeWindow(t *testing.T) {
 	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
-	query, _ := h.buildFederatedCombinedQuery("base-path", "delta-path", true, true, nil, &QueryOptions{TradeTimeStart: 1000, TradeTimeEnd: 2000, SortBy: "tradeTime", SortDesc: true})
+	query := h.buildFederatedCombinedQuery("base-path", "delta-path", true, true, nil, &QueryOptions{TradeTimeStart: 1000, TradeTimeEnd: 2000, SortBy: "tradeTime", SortDesc: true}, true, false)
 	for _, expected := range []string{"epoch_ms(tradeTime) >= 1000", "epoch_ms(tradeTime) <= 2000", "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) >= 1000", "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) <= 2000"} {
 		if !strings.Contains(query, expected) {
 			t.Fatalf("expected combined query to include %q: %s", expected, query)
@@ -89,8 +103,45 @@ func TestBuildFederatedCombinedQuerySupportsTradeTimeWindow(t *testing.T) {
 	}
 }
 
+func TestBuildFederatedQueryCountSQLDynamic_UsesProjectedHotPathForTradeTimeWindow(t *testing.T) {
+	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
+	query := h.buildFederatedQueryCountSQLDynamic("base-path", "delta-path", true, true, nil, &QueryOptions{Limit: 20, Offset: 40, SortBy: "tradeTime", SortDesc: true, TradeTimeStart: 1000, TradeTimeEnd: 2000})
+	for _, expected := range []string{"benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) >= 1000", "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) <= 2000", "LEFT JOIN postgres_scan"} {
+		if !strings.Contains(query, expected) {
+			t.Fatalf("expected projected count query to include %q: %s", expected, query)
+		}
+	}
+}
+
+func TestProjectionSelectionHelpers(t *testing.T) {
+	if !usesBenchmarkProjectionForSelect(&QueryOptions{SortBy: "tradeTime", SortDesc: true}) {
+		t.Fatal("select query should project benchmark columns for tradeTime sorting")
+	}
+	if !usesBenchmarkProjectionForCount(&QueryOptions{SortBy: "tradeTime", SortDesc: true}) {
+		t.Fatal("page-one count query should preserve projected tradeTime path")
+	}
+	if usesBenchmarkProjectionForCount(&QueryOptions{SortBy: "tradeTime", SortDesc: true, Offset: 20}) {
+		t.Fatal("deep-page count query should stay narrow for sort-only tradeTime pagination")
+	}
+	if !usesBenchmarkProjectionForCount(&QueryOptions{Filter: &Filter{Conditions: map[string]any{"exchange": "NYSE"}}}) {
+		t.Fatal("count query should project benchmark columns for projected attribute filters")
+	}
+	if !usesBenchmarkProjectionForCount(&QueryOptions{TradeTimeStart: 1000}) {
+		t.Fatal("count query should project benchmark columns for tradeTime windows")
+	}
+	if !usesTradeTimeOnlyBenchmarkProjectionForSelect(&QueryOptions{SortBy: "tradeTime", SortDesc: true, Offset: 20}) {
+		t.Fatal("deep-page tradeTime sort should use the tradeTime-only projection")
+	}
+	if usesTradeTimeOnlyBenchmarkProjectionForSelect(&QueryOptions{SortBy: "tradeTime", SortDesc: true, TradeTimeStart: 1000}) {
+		t.Fatal("tradeTime windows should keep the full projected benchmark path")
+	}
+	if usesTradeTimeOnlyBenchmarkProjectionForSelect(&QueryOptions{SortBy: "tradeTime", SortDesc: true, Filter: &Filter{Conditions: map[string]any{"exchange": "NYSE"}}}) {
+		t.Fatal("benchmark attribute filters should keep the full projected benchmark path")
+	}
+}
+
 func TestBuildParquetTierQueryAppliesProjectedTradeTimeFilter(t *testing.T) {
-	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "base", "", "", "", "AND epoch_ms(tradeTime) <= 2000", true)
+	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "base", "", "", "", "AND epoch_ms(tradeTime) <= 2000", true, false)
 	if !strings.Contains(query, "epoch_ms(tradeTime) <= 2000") {
 		t.Fatalf("expected projected trade time filter in parquet query: %s", query)
 	}
@@ -112,5 +163,54 @@ func TestBuildPostgresOnlyQueriesSupportBenchmarkFilters(t *testing.T) {
 	}
 	if strings.Contains(countQuery, "LIMIT") {
 		t.Fatalf("count query should not include pagination: %s", countQuery)
+	}
+}
+
+func TestBuildParquetTierQueryTradeTimeOnlyProjection(t *testing.T) {
+	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "base", "", "", "", "", true, true)
+	for _, expected := range []string{"'' as name", "'' as symbol", "'' as exchange", "'' as region", "0 as tradeType", "epoch_ms(tradeTime) as tradeTime"} {
+		if !strings.Contains(query, expected) {
+			t.Fatalf("expected tradeTime-only parquet projection to include %q: %s", expected, query)
+		}
+	}
+	if strings.Contains(query, "SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType") {
+		t.Fatalf("expected tradeTime-only parquet projection to avoid wide benchmark columns: %s", query)
+	}
+}
+
+func TestBuildHotTierQueryTradeTimeOnlyProjection(t *testing.T) {
+	query := buildHotTierQuery("pg-conn", benchmarkSchemaIDTrade, "", "", "", true, true)
+	for _, unexpected := range []string{"map(list(attr_name), list(attr_value))", "benchmark_text(hot_vals.attributes", "benchmark_int(hot_vals.attributes"} {
+		if strings.Contains(query, unexpected) {
+			t.Fatalf("expected tradeTime-only hot query to avoid %q: %s", unexpected, query)
+		}
+	}
+	for _, expected := range []string{"MAX(CASE WHEN attr_id =", "COALESCE(hot_vals.trade_time, em.bigint_02, 0) as tradeTime", "'' as symbol", "'' as exchange", "'' as region"} {
+		if !strings.Contains(query, expected) {
+			t.Fatalf("expected tradeTime-only hot query to include %q: %s", expected, query)
+		}
+	}
+}
+
+func TestShouldSkipFederatedSelect(t *testing.T) {
+	tests := []struct {
+		name         string
+		totalRecords int64
+		offset       int
+		want         bool
+	}{
+		{name: "empty result set", totalRecords: 0, offset: 0, want: true},
+		{name: "offset within range", totalRecords: 100, offset: 40, want: false},
+		{name: "offset at total", totalRecords: 100, offset: 100, want: true},
+		{name: "offset beyond total", totalRecords: 100, offset: 120, want: true},
+		{name: "negative offset does not short circuit", totalRecords: 100, offset: -1, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSkipFederatedSelect(tt.totalRecords, tt.offset); got != tt.want {
+				t.Fatalf("shouldSkipFederatedSelect(%d, %d) = %t, want %t", tt.totalRecords, tt.offset, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- skip the federated select entirely when the counted offset is already beyond the visible row set, preserving the existing count semantics while short-circuiting empty deep pages
- narrow sort-only `tradeTime DESC` deep-page benchmark queries so parquet and hot-tier paths carry only the columns needed for dedup and ordering instead of the full benchmark attribute projection
- keep full projected paths for filters and trade-time windows, and add query-shape coverage for the new projection and count-selection helpers

## Benchmark
- `fast`: `deep-page-1000 avg_latency_delta=-115.396359ms`, `baseline-page-1 avg_latency_delta=-32.216893ms`, `mixed-tier-window avg_latency_delta=-28.334461ms`
- `medium`: `deep-page-1000 avg_latency_delta=-79.025272ms`, `deep-page-100000 avg_latency_delta=-111.318587ms`, `mixed-tier-window avg_latency_delta=-8.741956ms`
- `medium` tradeoff: `baseline-page-1 avg_latency_delta=32.162967ms`, with no correctness or infra failures in either gate

## Testing
- `go test ./internal/e2e_harness/federated -run 'TestBuildFederatedQueryCountSQLDynamic|TestBuildFederatedQueryCountSQLDynamic_PageOneKeepsWideCountPath|TestBuildFederatedCombinedQueryUsesHotFilterExpressions|TestBuildFederatedCombinedQuerySupportsTradeTimeWindow|TestBuildFederatedQueryCountSQLDynamic_UsesProjectedHotPathForTradeTimeWindow|TestProjectionSelectionHelpers|TestShouldSkipFederatedSelect|TestBuildParquetTierQuerySupportsSchemaSpecificProjection|TestBuildParquetTierQueryKeepsDeletedRowsForDeduplication|TestBuildHotTierQueryKeepsDeletedRowsForDeduplication|TestBuildParquetTierQueryAppliesProjectedTradeTimeFilter|TestBuildParquetTierQueryTradeTimeOnlyProjection|TestBuildHotTierQueryTradeTimeOnlyProjection'`
- `./tools/autoresearch/benchmark/federated/scripts/benchmark_gate.sh postgres_duckdb_query fast`
- `./tools/autoresearch/benchmark/federated/scripts/benchmark_gate.sh postgres_duckdb_query medium`