### PR TITLE
Replace federated hot-tier EAV map aggregation with targeted pivot using attr_id pushdown

### DIFF
--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -256,8 +256,8 @@ func (h *FederatedTestHarness) buildFederatedCombinedQuery(basePath, deltaPath s
 	hotRowIDFilter := buildHotRowIDFilter(opts)
 	attributeFilter := buildAttributeFilterClause(opts)
 	timeWindowFilter := buildTradeTimeFilterClause(opts)
-	hotAttributeFilter := buildHotAttributeFilterClause(opts)
-	hotTimeWindowFilter := buildHotTradeTimeFilterClause(opts)
+	hotAttributeFilter := buildHotAttributeFilterClauseTargeted(opts)
+	hotTimeWindowFilter := buildHotTradeTimeFilterClauseTargeted(opts)
 	pgConnStr := h.buildPGConnString()
 
 	// Build tier queries dynamically
@@ -314,38 +314,7 @@ func buildHotTierQuery(pgConnStr string, schemaID int16, rowIDFilter, attributeF
 		if tradeTimeOnlyProjection && schemaID == benchmarkSchemaIDTrade {
 			return buildHotTradeTimeOnlyQuery(pgConnStr, schemaID, rowIDFilter)
 		}
-		return fmt.Sprintf(`
-		SELECT 
-			cl.row_id::VARCHAR as row_id,
-			cl.schema_id,
-			cl.changed_at,
-			cl.deleted_at,
-			benchmark_name(hot_vals.attributes) as name,
-			0 as version,
-			benchmark_text(hot_vals.attributes, 'symbol', em.text_01) as symbol,
-			benchmark_text(hot_vals.attributes, 'exchange', '') as exchange,
-			benchmark_text(hot_vals.attributes, 'region', em.text_02) as region,
-			benchmark_int(hot_vals.attributes, 'tradeType', em.smallint_01) as tradeType,
-			benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) as tradeTime,
-			'hot' as tier
-		FROM postgres_scan('%s', 'public', 'change_log') cl
-		LEFT JOIN postgres_scan('%s', 'public', 'entity_main') em
-			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id::VARCHAR = cl.row_id::VARCHAR
-		LEFT JOIN (
-			SELECT row_id::VARCHAR as row_id, schema_id, map(list(attr_name), list(attr_value)) as attributes
-			FROM (
-				SELECT e.row_id, e.schema_id, benchmark_attr_name(e.schema_id, e.attr_id) as attr_name,
-					COALESCE(e.value_text, CAST(CAST(e.value_numeric AS BIGINT) AS VARCHAR), '') as attr_value
-				FROM postgres_scan('%s', 'public', 'eav_data') e
-				WHERE benchmark_attr_name(e.schema_id, e.attr_id) <> ''
-			)
-			GROUP BY schema_id, row_id
-		) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id::VARCHAR
-		WHERE cl.flushed_at = 0 
-			AND cl.schema_id = %d
-			%s
-			%s
-			%s`, pgConnStr, pgConnStr, pgConnStr, schemaID, rowIDFilter, attributeFilter, timeWindowFilter)
+		return buildHotTierQueryTargeted(pgConnStr, schemaID, rowIDFilter, attributeFilter, timeWindowFilter)
 	}
 	return fmt.Sprintf(`
 		SELECT 
@@ -480,11 +449,111 @@ func usesTradeTimeOnlyBenchmarkProjectionForSelect(opts *QueryOptions) bool {
 	return opts.TradeTimeStart == 0 && opts.TradeTimeEnd == 0
 }
 
-func needsBenchmarkDuckDBMacros(opts *QueryOptions, benchmarkProjection, tradeTimeOnlyProjection bool) bool {
-	if usesBenchmarkProjectionForCount(opts) {
-		return true
+type hotTierEAVMapping struct {
+	attrIDList   string
+	pivotColumns string
+	selectExprs  string
+	nameExpr     string
+}
+
+func hotTierEAVMappingForSchema(schemaID int16) hotTierEAVMapping {
+	switch schemaID {
+	case benchmarkSchemaIDTrade:
+		symbolID := benchmarkAttributeID(schemaID, "symbol")
+		exchangeID := benchmarkAttributeID(schemaID, "exchange")
+		regionID := benchmarkAttributeID(schemaID, "region")
+		tradeTypeID := benchmarkAttributeID(schemaID, "tradeType")
+		tradeTimeID := benchmarkAttributeID(schemaID, "tradeTime")
+		nameID := benchmarkAttributeID(schemaID, "name")
+		return hotTierEAVMapping{
+			attrIDList: fmt.Sprintf("%d, %d, %d, %d, %d, %d", symbolID, exchangeID, regionID, tradeTypeID, tradeTimeID, nameID),
+			pivotColumns: fmt.Sprintf(
+				"MAX(CASE WHEN attr_id = %d THEN value_text END) AS symbol,\n\t\t\t"+
+					"MAX(CASE WHEN attr_id = %d THEN value_text END) AS exchange,\n\t\t\t"+
+					"MAX(CASE WHEN attr_id = %d THEN value_text END) AS region,\n\t\t\t"+
+					"MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS tradeType,\n\t\t\t"+
+					"MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS tradeTime,\n\t\t\t"+
+					"MAX(CASE WHEN attr_id = %d THEN value_text END) AS name",
+				symbolID, exchangeID, regionID, tradeTypeID, tradeTimeID, nameID),
+			selectExprs: "COALESCE(hot_vals.symbol, em.text_01) as symbol,\n\t\t\t" +
+				"COALESCE(hot_vals.exchange, '') as exchange,\n\t\t\t" +
+				"COALESCE(hot_vals.region, em.text_02) as region,\n\t\t\t" +
+				"COALESCE(hot_vals.tradeType, em.smallint_01) as tradeType,\n\t\t\t" +
+				"COALESCE(hot_vals.tradeTime, em.bigint_02) as tradeTime",
+			nameExpr: "COALESCE(hot_vals.name, hot_vals.symbol, '')",
+		}
+	case benchmarkSchemaIDCustomer:
+		regionID := benchmarkAttributeID(schemaID, "region")
+		nameID := benchmarkAttributeID(schemaID, "name")
+		return hotTierEAVMapping{
+			attrIDList: fmt.Sprintf("%d, %d", regionID, nameID),
+			pivotColumns: fmt.Sprintf(
+				"MAX(CASE WHEN attr_id = %d THEN value_text END) AS region,\n\t\t\t"+
+					"MAX(CASE WHEN attr_id = %d THEN value_text END) AS name",
+				regionID, nameID),
+			selectExprs: "'' as symbol,\n\t\t\t" +
+				"'' as exchange,\n\t\t\t" +
+				"COALESCE(hot_vals.region, em.text_02) as region,\n\t\t\t" +
+				"0 as tradeType,\n\t\t\t" +
+				"0 as tradeTime",
+			nameExpr: "COALESCE(hot_vals.name, '')",
+		}
+	case benchmarkSchemaIDSecurity:
+		symbolID := benchmarkAttributeID(schemaID, "symbol")
+		nameID := benchmarkAttributeID(schemaID, "companyName")
+		return hotTierEAVMapping{
+			attrIDList: fmt.Sprintf("%d, %d", symbolID, nameID),
+			pivotColumns: fmt.Sprintf(
+				"MAX(CASE WHEN attr_id = %d THEN value_text END) AS symbol,\n\t\t\t"+
+					"MAX(CASE WHEN attr_id = %d THEN value_text END) AS name",
+				symbolID, nameID),
+			selectExprs: "COALESCE(hot_vals.symbol, em.text_01) as symbol,\n\t\t\t" +
+				"'' as exchange,\n\t\t\t" +
+				"'' as region,\n\t\t\t" +
+				"0 as tradeType,\n\t\t\t" +
+				"0 as tradeTime",
+			nameExpr: "COALESCE(hot_vals.name, hot_vals.symbol, '')",
+		}
+	default:
+		return hotTierEAVMapping{}
 	}
-	return benchmarkProjection && !tradeTimeOnlyProjection
+}
+
+func buildHotTierQueryTargeted(pgConnStr string, schemaID int16, rowIDFilter, attributeFilter, timeWindowFilter string) string {
+	m := hotTierEAVMappingForSchema(schemaID)
+	return fmt.Sprintf(`
+		SELECT 
+			cl.row_id::VARCHAR as row_id,
+			cl.schema_id,
+			cl.changed_at,
+			cl.deleted_at,
+			%s as name,
+			0 as version,
+			%s,
+			'hot' as tier
+		FROM postgres_scan('%s', 'public', 'change_log') cl
+		LEFT JOIN postgres_scan('%s', 'public', 'entity_main') em
+			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id::VARCHAR = cl.row_id::VARCHAR
+		LEFT JOIN (
+			SELECT row_id::VARCHAR as row_id, schema_id,
+				%s
+			FROM postgres_scan('%s', 'public', 'eav_data')
+			WHERE attr_id IN (%s)
+			GROUP BY schema_id, row_id
+		) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id::VARCHAR
+		WHERE cl.flushed_at = 0 
+			AND cl.schema_id = %d
+			%s
+			%s
+			%s`,
+		m.nameExpr, m.selectExprs,
+		pgConnStr, pgConnStr,
+		m.pivotColumns, pgConnStr, m.attrIDList,
+		schemaID, rowIDFilter, attributeFilter, timeWindowFilter)
+}
+
+func needsBenchmarkDuckDBMacros(opts *QueryOptions, benchmarkProjection, tradeTimeOnlyProjection bool) bool {
+	return false
 }
 
 func requiresBenchmarkProjectedFilters(opts *QueryOptions) bool {
@@ -566,12 +635,12 @@ func parquetTradeTimeFilterExpression() string {
 	return "epoch_ms(tradeTime)"
 }
 
-func buildHotTradeTimeFilterClause(opts *QueryOptions) string {
+func buildHotTradeTimeFilterClauseTargeted(opts *QueryOptions) string {
 	if opts == nil {
 		return ""
 	}
 	parts := make([]string, 0, 2)
-	expression := benchmarkHotFilterExpression("tradeTime")
+	expression := targetedHotFilterExpression("tradeTime")
 	if opts.TradeTimeStart > 0 {
 		parts = append(parts, fmt.Sprintf("AND %s >= %d", expression, opts.TradeTimeStart))
 	}
@@ -675,13 +744,13 @@ func prepareBenchmarkDuckDBMacros(ctx context.Context, h *FederatedTestHarness) 
 	return nil
 }
 
-func buildHotAttributeFilterClause(opts *QueryOptions) string {
+func buildHotAttributeFilterClauseTargeted(opts *QueryOptions) string {
 	if opts == nil || opts.Filter == nil || len(opts.Filter.Conditions) == 0 {
 		return ""
 	}
 	parts := make([]string, 0, len(opts.Filter.Conditions))
 	for key, value := range opts.Filter.Conditions {
-		expression := benchmarkHotFilterExpression(key)
+		expression := targetedHotFilterExpression(key)
 		if expression == "" {
 			continue
 		}
@@ -690,18 +759,18 @@ func buildHotAttributeFilterClause(opts *QueryOptions) string {
 	return strings.Join(parts, " ")
 }
 
-func benchmarkHotFilterExpression(attribute string) string {
+func targetedHotFilterExpression(attribute string) string {
 	switch attribute {
 	case "symbol":
-		return "benchmark_text(hot_vals.attributes, 'symbol', em.text_01)"
+		return "COALESCE(hot_vals.symbol, em.text_01)"
 	case "exchange":
-		return "benchmark_text(hot_vals.attributes, 'exchange', '')"
+		return "COALESCE(hot_vals.exchange, '')"
 	case "region":
-		return "benchmark_text(hot_vals.attributes, 'region', em.text_02)"
+		return "COALESCE(hot_vals.region, em.text_02)"
 	case "tradeType":
-		return "benchmark_int(hot_vals.attributes, 'tradeType', em.smallint_01)"
+		return "COALESCE(hot_vals.tradeType, em.smallint_01)"
 	case "tradeTime":
-		return "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02)"
+		return "COALESCE(hot_vals.tradeTime, em.bigint_02)"
 	default:
 		return ""
 	}

--- a/internal/e2e_harness/federated/query_unit_test.go
+++ b/internal/e2e_harness/federated/query_unit_test.go
@@ -32,7 +32,7 @@ func TestBuildFederatedQueryCountSQLDynamic(t *testing.T) {
 	if !strings.Contains(query, "postgres_scan") {
 		t.Fatalf("expected hot tier in count query: %s", query)
 	}
-	if strings.Contains(query, "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02)") {
+	if strings.Contains(query, "COALESCE(hot_vals.tradeTime, em.bigint_02)") {
 		t.Fatalf("sort-only count query should avoid projected tradeTime expression: %s", query)
 	}
 	if strings.Contains(query, "LEFT JOIN postgres_scan('host=localhost port=5432 user=postgres password=password dbname=postgres sslmode=disable', 'public', 'entity_main')") {
@@ -43,7 +43,7 @@ func TestBuildFederatedQueryCountSQLDynamic(t *testing.T) {
 func TestBuildFederatedQueryCountSQLDynamic_PageOneKeepsWideCountPath(t *testing.T) {
 	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
 	query := h.buildFederatedQueryCountSQLDynamic("base-path", "delta-path", true, true, nil, &QueryOptions{Limit: 20, Offset: 0, SortBy: "tradeTime", SortDesc: true})
-	if !strings.Contains(query, "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02)") {
+	if !strings.Contains(query, "COALESCE(hot_vals.tradeTime, em.bigint_02)") {
 		t.Fatalf("page-one count query should preserve projected tradeTime path: %s", query)
 	}
 }
@@ -51,7 +51,7 @@ func TestBuildFederatedQueryCountSQLDynamic_PageOneKeepsWideCountPath(t *testing
 func TestBuildFederatedCombinedQueryUsesHotFilterExpressions(t *testing.T) {
 	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
 	query := h.buildFederatedCombinedQuery("base-path", "delta-path", false, false, nil, &QueryOptions{Filter: &Filter{Conditions: map[string]any{"exchange": "NYSE"}}}, true, false)
-	if !strings.Contains(query, "benchmark_text(hot_vals.attributes, 'exchange', '')") {
+	if !strings.Contains(query, "COALESCE(hot_vals.exchange, '')") {
 		t.Fatalf("expected hot exchange filter expression in combined query: %s", query)
 	}
 	if !strings.Contains(query, "postgres_scan") {
@@ -96,7 +96,7 @@ func TestBuildFederatedDeduplicatedCTEUsesStableTieBreaks(t *testing.T) {
 func TestBuildFederatedCombinedQuerySupportsTradeTimeWindow(t *testing.T) {
 	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
 	query := h.buildFederatedCombinedQuery("base-path", "delta-path", true, true, nil, &QueryOptions{TradeTimeStart: 1000, TradeTimeEnd: 2000, SortBy: "tradeTime", SortDesc: true}, true, false)
-	for _, expected := range []string{"epoch_ms(tradeTime) >= 1000", "epoch_ms(tradeTime) <= 2000", "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) >= 1000", "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) <= 2000"} {
+	for _, expected := range []string{"epoch_ms(tradeTime) >= 1000", "epoch_ms(tradeTime) <= 2000", "COALESCE(hot_vals.tradeTime, em.bigint_02) >= 1000", "COALESCE(hot_vals.tradeTime, em.bigint_02) <= 2000"} {
 		if !strings.Contains(query, expected) {
 			t.Fatalf("expected combined query to include %q: %s", expected, query)
 		}
@@ -106,7 +106,7 @@ func TestBuildFederatedCombinedQuerySupportsTradeTimeWindow(t *testing.T) {
 func TestBuildFederatedQueryCountSQLDynamic_UsesProjectedHotPathForTradeTimeWindow(t *testing.T) {
 	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
 	query := h.buildFederatedQueryCountSQLDynamic("base-path", "delta-path", true, true, nil, &QueryOptions{Limit: 20, Offset: 40, SortBy: "tradeTime", SortDesc: true, TradeTimeStart: 1000, TradeTimeEnd: 2000})
-	for _, expected := range []string{"benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) >= 1000", "benchmark_bigint(hot_vals.attributes, 'tradeTime', em.bigint_02) <= 2000", "LEFT JOIN postgres_scan"} {
+	for _, expected := range []string{"COALESCE(hot_vals.tradeTime, em.bigint_02) >= 1000", "COALESCE(hot_vals.tradeTime, em.bigint_02) <= 2000", "LEFT JOIN postgres_scan"} {
 		if !strings.Contains(query, expected) {
 			t.Fatalf("expected projected count query to include %q: %s", expected, query)
 		}
@@ -188,6 +188,198 @@ func TestBuildHotTierQueryTradeTimeOnlyProjection(t *testing.T) {
 	for _, expected := range []string{"MAX(CASE WHEN attr_id =", "COALESCE(hot_vals.trade_time, em.bigint_02, 0) as tradeTime", "'' as symbol", "'' as exchange", "'' as region"} {
 		if !strings.Contains(query, expected) {
 			t.Fatalf("expected tradeTime-only hot query to include %q: %s", expected, query)
+		}
+	}
+}
+
+func TestNeedsBenchmarkDuckDBMacrosAlwaysFalse(t *testing.T) {
+	if needsBenchmarkDuckDBMacros(&QueryOptions{SortBy: "tradeTime", SortDesc: true}, true, false) {
+		t.Fatal("benchmark duckdb macros should never be required with targeted EAV pivot")
+	}
+	if needsBenchmarkDuckDBMacros(&QueryOptions{Filter: &Filter{Conditions: map[string]any{"exchange": "NYSE"}}}, true, false) {
+		t.Fatal("benchmark duckdb macros should never be required with targeted EAV pivot")
+	}
+	if needsBenchmarkDuckDBMacros(&QueryOptions{TradeTimeStart: 1000}, true, false) {
+		t.Fatal("benchmark duckdb macros should never be required with targeted EAV pivot")
+	}
+}
+
+func TestHotTierEAVMappingForSchemaTrade(t *testing.T) {
+	m := hotTierEAVMappingForSchema(benchmarkSchemaIDTrade)
+	for _, expected := range []string{
+		"MAX(CASE WHEN attr_id =",
+		"AS exchange",
+		"AS tradeType",
+		"AS tradeTime",
+		"AS name",
+	} {
+		if !strings.Contains(m.pivotColumns, expected) {
+			t.Fatalf("expected trade pivot to include %q: %s", expected, m.pivotColumns)
+		}
+	}
+	if !strings.Contains(m.selectExprs, "COALESCE(hot_vals.exchange, '')") {
+		t.Fatalf("expected trade select to include exchange fallback: %s", m.selectExprs)
+	}
+	if m.nameExpr != "COALESCE(hot_vals.name, hot_vals.symbol, '')" {
+		t.Fatalf("expected trade name expression: %s", m.nameExpr)
+	}
+	if !strings.Contains(m.attrIDList, ",") {
+		t.Fatalf("expected trade attr IDs: %s", m.attrIDList)
+	}
+}
+
+func TestHotTierEAVMappingForSchemaCustomer(t *testing.T) {
+	m := hotTierEAVMappingForSchema(benchmarkSchemaIDCustomer)
+	if strings.Contains(m.pivotColumns, "AS symbol") {
+		t.Fatalf("customer pivot should not include symbol: %s", m.pivotColumns)
+	}
+	if !strings.Contains(m.selectExprs, "'' as symbol") {
+		t.Fatalf("expected customer select to use literal symbol: %s", m.selectExprs)
+	}
+	if !strings.Contains(m.selectExprs, "0 as tradeType") {
+		t.Fatalf("expected customer select to use literal tradeType: %s", m.selectExprs)
+	}
+}
+
+func TestHotTierEAVMappingForSchemaSecurity(t *testing.T) {
+	m := hotTierEAVMappingForSchema(benchmarkSchemaIDSecurity)
+	if !strings.Contains(m.pivotColumns, "AS symbol") {
+		t.Fatalf("security pivot should include symbol: %s", m.pivotColumns)
+	}
+	if !strings.Contains(m.selectExprs, "COALESCE(hot_vals.symbol, em.text_01)") {
+		t.Fatalf("expected security select to include symbol COALESCE: %s", m.selectExprs)
+	}
+}
+
+func TestBuildHotTierQueryTargetedTrade(t *testing.T) {
+	query := buildHotTierQueryTargeted("pg-conn", benchmarkSchemaIDTrade, "",
+		"AND COALESCE(hot_vals.exchange, '') = 'NYSE'",
+		"AND COALESCE(hot_vals.tradeTime, em.bigint_02) >= 1000")
+	for _, expected := range []string{
+		"COALESCE(hot_vals.name, hot_vals.symbol, '') as name",
+		"COALESCE(hot_vals.symbol, em.text_01) as symbol",
+		"COALESCE(hot_vals.exchange, '') as exchange",
+		"COALESCE(hot_vals.region, em.text_02) as region",
+		"COALESCE(hot_vals.tradeType, em.smallint_01) as tradeType",
+		"COALESCE(hot_vals.tradeTime, em.bigint_02) as tradeTime",
+		"MAX(CASE WHEN attr_id =",
+		"attr_id IN (",
+		"COALESCE(hot_vals.exchange, '') = 'NYSE'",
+		"COALESCE(hot_vals.tradeTime, em.bigint_02) >= 1000",
+	} {
+		if !strings.Contains(query, expected) {
+			t.Fatalf("expected targeted trade hot query to include %q: %s", expected, query)
+		}
+	}
+	for _, unexpected := range []string{"map(list(attr_name)", "benchmark_text(hot_vals.attributes", "benchmark_int(hot_vals.attributes", "benchmark_bigint(hot_vals.attributes"} {
+		if strings.Contains(query, unexpected) {
+			t.Fatalf("expected targeted hot query to avoid %q: %s", unexpected, query)
+		}
+	}
+}
+
+func TestBuildHotTierQueryTargetedCustomer(t *testing.T) {
+	query := buildHotTierQueryTargeted("pg-conn", benchmarkSchemaIDCustomer, "",
+		"AND COALESCE(hot_vals.region, em.text_02) = 'NA'", "")
+	for _, expected := range []string{
+		"COALESCE(hot_vals.name, '') as name",
+		"'' as symbol",
+		"'' as exchange",
+		"COALESCE(hot_vals.region, em.text_02) as region",
+		"0 as tradeType",
+		"0 as tradeTime",
+	} {
+		if !strings.Contains(query, expected) {
+			t.Fatalf("expected targeted customer hot query to include %q: %s", expected, query)
+		}
+	}
+}
+
+func TestBuildHotTierQueryTargetedSecurity(t *testing.T) {
+	query := buildHotTierQueryTargeted("pg-conn", benchmarkSchemaIDSecurity, "",
+		"AND COALESCE(hot_vals.symbol, em.text_01) = 'SYM00001'", "")
+	for _, expected := range []string{
+		"COALESCE(hot_vals.name, hot_vals.symbol, '') as name",
+		"COALESCE(hot_vals.symbol, em.text_01) as symbol",
+		"'' as exchange",
+		"'' as region",
+		"0 as tradeType",
+		"0 as tradeTime",
+	} {
+		if !strings.Contains(query, expected) {
+			t.Fatalf("expected targeted security hot query to include %q: %s", expected, query)
+		}
+	}
+}
+
+func TestBuildHotAttributeFilterClauseTargeted(t *testing.T) {
+	clause := buildHotAttributeFilterClauseTargeted(&QueryOptions{
+		Filter: &Filter{Conditions: map[string]any{
+			"symbol":    "SYM00001",
+			"exchange":  "NYSE",
+			"tradeType": 0,
+		}},
+	})
+	for _, expected := range []string{
+		"COALESCE(hot_vals.symbol, em.text_01) = 'SYM00001'",
+		"COALESCE(hot_vals.exchange, '') = 'NYSE'",
+		"COALESCE(hot_vals.tradeType, em.smallint_01) = 0",
+	} {
+		if !strings.Contains(clause, expected) {
+			t.Fatalf("expected filter clause to include %q: %s", expected, clause)
+		}
+	}
+}
+
+func TestBuildHotTradeTimeFilterClauseTargeted(t *testing.T) {
+	clause := buildHotTradeTimeFilterClauseTargeted(&QueryOptions{TradeTimeStart: 1000, TradeTimeEnd: 2000})
+	for _, expected := range []string{
+		"COALESCE(hot_vals.tradeTime, em.bigint_02) >= 1000",
+		"COALESCE(hot_vals.tradeTime, em.bigint_02) <= 2000",
+	} {
+		if !strings.Contains(clause, expected) {
+			t.Fatalf("expected time filter clause to include %q: %s", expected, clause)
+		}
+	}
+}
+
+func TestBuildHotTierQueryDelegatesToTargetedForBenchmarkProjection(t *testing.T) {
+	query := buildHotTierQuery("pg-conn", benchmarkSchemaIDTrade, "", "AND COALESCE(hot_vals.exchange, '') = 'NYSE'", "", true, false)
+	for _, unexpected := range []string{"map(list(attr_name)", "benchmark_text(hot_vals.attributes"} {
+		if strings.Contains(query, unexpected) {
+			t.Fatalf("expected hot tier query to avoid %q with benchmark projection: %s", unexpected, query)
+		}
+	}
+	if !strings.Contains(query, "COALESCE(hot_vals.exchange, '') = 'NYSE'") {
+		t.Fatalf("expected hot tier query to pass through targeted filter: %s", query)
+	}
+}
+
+func TestBuildHotTierQueryNonBenchmarkPathUnchanged(t *testing.T) {
+	query := buildHotTierQuery("pg-conn", benchmarkSchemaIDTrade, "", "", "", false, false)
+	if !strings.Contains(query, "'' as name") {
+		t.Fatalf("expected non-benchmark hot query to have literal name: %s", query)
+	}
+	if strings.Contains(query, "hot_vals") || strings.Contains(query, "entity_main") || strings.Contains(query, "eav_data") {
+		t.Fatalf("expected non-benchmark hot query to avoid eav and entity_main: %s", query)
+	}
+}
+
+func TestTargetedHotFilterExpression(t *testing.T) {
+	tests := []struct {
+		attr     string
+		expected string
+	}{
+		{"symbol", "COALESCE(hot_vals.symbol, em.text_01)"},
+		{"exchange", "COALESCE(hot_vals.exchange, '')"},
+		{"region", "COALESCE(hot_vals.region, em.text_02)"},
+		{"tradeType", "COALESCE(hot_vals.tradeType, em.smallint_01)"},
+		{"tradeTime", "COALESCE(hot_vals.tradeTime, em.bigint_02)"},
+		{"unknown", ""},
+	}
+	for _, tt := range tests {
+		if got := targetedHotFilterExpression(tt.attr); got != tt.expected {
+			t.Fatalf("targetedHotFilterExpression(%q) = %q, want %q", tt.attr, got, tt.expected)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Replaces the expensive `map(list(attr_name), list(attr_value))` + DuckDB macro pattern in `buildHotTierQuery` with a targeted `MAX(CASE WHEN attr_id = X THEN value END)` pivot that pushes `attr_id` filters into the `postgres_scan` subquery and uses direct `COALESCE` expressions instead of DuckDB macros.

- Eliminates dependency on DuckDB macros (`benchmark_text/int/bigint/name`) for the hot-tier query path
- Pushes `attr_id IN (...)` into the EAV `postgres_scan` to reduce the number of rows fetched from Postgres
- Replaces `map(list(...), list(...))` aggregation with individual `MAX(CASE WHEN...)` pivot columns
- Uses `COALESCE(hot_vals.col, em.col)` expressions instead of macro calls for both SELECT and WHERE clauses
- Schema-specific EAV attribute mappings for trade, customer, and security schemas

## Benchmark Results

**Fast gate** (`deep-page-1000`, protected: `baseline-page-1`, `mixed-tier-window`):
| Workload | Avg latency delta | P95 latency delta |
|----------|------------------|-------------------|
| baseline-page-1 | **-44.0ms** | -44.0ms |
| deep-page-1000 | **-17.9ms** | -17.9ms |
| mixed-tier-window | **-11.4ms** | -11.4ms |

**Medium gate** (adds `deep-page-100000`, 2 iterations):
| Workload | Avg latency delta | P95 latency delta |
|----------|------------------|-------------------|
| baseline-page-1 | +92.1ms | +87.4ms |
| deep-page-1000 | **-38.7ms** | -39.4ms |
| deep-page-100000 | +4.9ms | +3.6ms |
| mixed-tier-window | **-69.6ms** | -109.3ms |

- `correctness_failures_delta = 0` on both gates
- All row IDs match baseline exactly
- `infra_failures_delta = 0`

## Testing
- `go test ./internal/e2e_harness/federated/...` — 27/27 tests pass (including new targeted-EAV tests)
- Benchmark fast + medium gates validated