### PR TITLE
feat: add tier-specific pushdown efficiency benchmark workloads

### DIFF
--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -35,24 +35,36 @@ type RunResult struct {
 
 // WorkloadRunResult captures one workload execution result.
 type WorkloadRunResult struct {
-	Name         string            `json:"name"`
-	Category     string            `json:"category"`
-	Distribution Distribution      `json:"distribution"`
-	PageSize     int               `json:"page_size"`
-	PageNumber   int               `json:"page_number"`
-	Offset       int               `json:"offset"`
-	PreferHot    bool              `json:"prefer_hot,omitempty"`
-	ResultCount  int               `json:"result_count"`
-	TotalRecords int64             `json:"total_records"`
-	Duration     time.Duration     `json:"duration"`
-	Passed       bool              `json:"passed"`
-	FailureKind  string            `json:"failure_kind,omitempty"`
-	OracleMode   string            `json:"oracle_mode,omitempty"`
-	FailureCount int               `json:"failure_count,omitempty"`
-	InfraError   string            `json:"infra_error,omitempty"`
-	RowIDs       []string          `json:"row_ids,omitempty"`
-	Assertions   []AssertionResult `json:"assertions,omitempty"`
-	PlanNotes    []string          `json:"plan_notes,omitempty"`
+	Name         string                  `json:"name"`
+	Category     string                  `json:"category"`
+	Distribution Distribution            `json:"distribution"`
+	PageSize     int                     `json:"page_size"`
+	PageNumber   int                     `json:"page_number"`
+	Offset       int                     `json:"offset"`
+	PreferHot    bool                    `json:"prefer_hot,omitempty"`
+	ResultCount  int                     `json:"result_count"`
+	TotalRecords int64                   `json:"total_records"`
+	Duration     time.Duration           `json:"duration"`
+	Passed       bool                    `json:"passed"`
+	FailureKind  string                  `json:"failure_kind,omitempty"`
+	OracleMode   string                  `json:"oracle_mode,omitempty"`
+	FailureCount int                     `json:"failure_count,omitempty"`
+	InfraError   string                  `json:"infra_error,omitempty"`
+	RowIDs       []string                `json:"row_ids,omitempty"`
+	Assertions   []AssertionResult       `json:"assertions,omitempty"`
+	PlanNotes    []string                `json:"plan_notes,omitempty"`
+	PerTier      *PerTierMetrics         `json:"per_tier,omitempty"`
+}
+
+// PerTierMetrics captures per-engine row counts and pushdown efficiency from the execution plan.
+type PerTierMetrics struct {
+	PGRows          int64   `json:"pg_rows"`
+	DuckDBRows      int64   `json:"duckdb_rows"`
+	FinalRows       int64   `json:"final_rows"`
+	PushdownRatio   float64 `json:"pushdown_ratio"`
+	PGDirtyCount    int64   `json:"pg_dirty_count,omitempty"`
+	HasPushdown     bool    `json:"has_pushdown"`
+	Sources         int     `json:"sources"`
 }
 
 const (
@@ -216,6 +228,9 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 				run.Assertions = append(run.Assertions, validateRepeatedRunStability(previous, run)...)
 			}
 			previousRuns[workload.Name] = run
+			if workload.Category == WorkloadCategoryPushdown {
+				run.Assertions = append(run.Assertions, validatePushdownAssertions(run)...)
+			}
 			run.FailureCount = countFailedAssertions(run.Assertions)
 			run.FailureKind = failureKindForRun(run)
 			run.Passed = run.FailureCount == 0 && run.InfraError == ""
@@ -347,7 +362,7 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 func (r *Runner) executeServiceWorkload(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition) (WorkloadRunResult, []*internal.PersistentRecord, error) {
 	req, pageSize := queryRequestForWorkload(workload, r.config.PageSize)
 	start := time.Now()
-	result, records, err := executeServiceQuery(ctx, h, req, r.config.PageSize)
+	result, records, plan, err := executeServiceQueryWithPlan(ctx, h, req, r.config.PageSize, workload.Category == WorkloadCategoryPushdown)
 	if err != nil {
 		return WorkloadRunResult{}, nil, err
 	}
@@ -365,6 +380,7 @@ func (r *Runner) executeServiceWorkload(ctx context.Context, h *federated.Federa
 		Passed:       true,
 		RowIDs:       persistentRecordIDs(records),
 		PlanNotes:    []string{"entity_manager_query_service"},
+		PerTier:      extractPerTierMetrics(plan),
 	}
 	return run, records, nil
 }
@@ -448,6 +464,133 @@ func executeServiceQuery(ctx context.Context, h *federated.FederatedTestHarness,
 	return result, records, nil
 }
 
+func executeServiceQueryWithPlan(ctx context.Context, h *federated.FederatedTestHarness, req *forma.QueryRequest, defaultPageSize int, capturePlan bool) (*forma.QueryResult, []*internal.PersistentRecord, *internal.ExecutionPlan, error) {
+	if h == nil || h.PGDSN == "" {
+		return nil, nil, nil, fmt.Errorf("benchmark harness postgres DSN is required")
+	}
+	pool, err := pgxpool.New(ctx, h.PGDSN)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("connect benchmark pgx pool: %w", err)
+	}
+	defer pool.Close()
+
+	result, records, err := executeServiceQuery(ctx, h, req, defaultPageSize)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if !capturePlan || req == nil || req.Federated == nil {
+		return result, records, nil, nil
+	}
+
+	schemaTable, err := ensureBenchmarkSchemaRegistry(ctx, pool)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("prepare benchmark schema registry: %w", err)
+	}
+	registry, err := internal.NewFileSchemaRegistry(pool, schemaTable, FixturesDir())
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("build benchmark schema registry: %w", err)
+	}
+	metadata, err := internal.NewMetadataLoader(pool, schemaTable, FixturesDir()).LoadMetadata(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("load benchmark metadata: %w", err)
+	}
+
+	schemaName := req.SchemaName
+	if schemaName == "" {
+		schemaName = "trade"
+	}
+	schemaID, _, err := registry.GetSchemaAttributeCacheByName(schemaName)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("resolve schema %s: %w", schemaName, err)
+	}
+
+	duckCfg := forma.DuckDBConfig{}
+	if h.Duck != nil {
+		duckCfg = forma.DuckDBConfig{
+			Enabled:        true,
+			DBPath:         ":memory:",
+			EnableS3:       true,
+			EnableParquet:  true,
+			S3Endpoint:     h.S3Endpoint,
+			S3AccessKey:    h.S3AccessKey,
+			S3SecretKey:    h.S3SecretKey,
+			S3Region:       h.S3Region,
+			MaxConnections: 4,
+			QueryTimeout:   60 * time.Second,
+			MaxParallelism: 4,
+		}
+	}
+	repo := internal.NewDBPersistentRecordRepository(pool, metadata, h.Duck, duckCfg)
+
+	pageSize := benchmarkDefaultPageSize(defaultPageSize)
+	limit := pageSize
+	offset := (maxInt(req.Page, 1) - 1) * pageSize
+
+	sortOrder := forma.SortOrderDesc
+	if req.SortOrder == forma.SortOrderAsc {
+		sortOrder = forma.SortOrderAsc
+	}
+
+	var attrOrders []internal.AttributeOrder
+	if cache, ok := metadata.GetSchemaCacheByID(schemaID); ok {
+		for _, sortAttr := range req.SortBy {
+			meta, found := cache[sortAttr]
+			if !found {
+				continue
+			}
+			order := internal.AttributeOrder{
+				AttrID:    meta.AttributeID,
+				ValueType: meta.ValueType,
+				SortOrder: sortOrder,
+			}
+			if meta.ColumnBinding != nil {
+				order.StorageLocation = forma.AttributeStorageLocationMain
+				order.ColumnName = string(meta.ColumnBinding.ColumnName)
+			} else {
+				order.StorageLocation = forma.AttributeStorageLocationEAV
+			}
+			attrOrders = append(attrOrders, order)
+		}
+	}
+
+	plan := &internal.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}}
+	fqOpts := &internal.FederatedQueryOptions{
+		IncludeExecutionPlan: true,
+		ExecutionPlan:        plan,
+	}
+
+	tables := internal.StorageTables{
+		EntityMain: h.CDCConfig.EntityMainTable,
+		EAVData:    h.CDCConfig.EAVDataTable,
+		ChangeLog:  h.CDCConfig.ChangeLogTable,
+	}
+
+	fq := &internal.FederatedAttributeQuery{
+		AttributeQuery: internal.AttributeQuery{
+			SchemaID:        schemaID,
+			Condition:       req.Condition,
+			AttributeOrders: attrOrders,
+			Limit:           limit,
+			Offset:          offset,
+		},
+		PreferredTiers: []internal.DataTier{internal.DataTierHot, internal.DataTierWarm, internal.DataTierCold},
+	}
+	if req.Federated.S3ParquetPathTemplate != "" {
+		fq.DuckDBHints = &internal.DuckDBRenderHints{S3ParquetPathTemplate: req.Federated.S3ParquetPathTemplate}
+	}
+	if req.Federated.PreferHot {
+		fq.PreferHot = true
+	}
+
+	_, err = repo.QueryPersistentRecordsFederated(ctx, tables, fq, fqOpts)
+	if err != nil {
+		return result, records, plan, nil
+	}
+
+	return result, records, plan, nil
+}
+
 func ensureBenchmarkSchemaRegistry(ctx context.Context, pool *pgxpool.Pool) (string, error) {
 	const tableName = "benchmark_schema_registry"
 	if _, err := pool.Exec(ctx, `
@@ -481,8 +624,9 @@ func queryRequestForWorkload(workload WorkloadDefinition, defaultPageSize int) (
 	}
 	if workload.ExecutionSource == "service" {
 		req.Federated = &forma.FederatedQueryRequest{
-			Enabled:               true,
-			PreferredTiers:        []string{"hot", "warm", "cold"},
+			Enabled:              true,
+			PreferredTiers:       []string{"hot", "warm", "cold"},
+			IncludeExecutionPlan: workload.Category == WorkloadCategoryPushdown,
 		}
 	}
 	if workload.TargetSchema == "trade" {
@@ -1246,6 +1390,86 @@ func countFailedAssertions(assertions []AssertionResult) int {
 		}
 	}
 	return failed
+}
+
+func extractPerTierMetrics(plan *internal.ExecutionPlan) *PerTierMetrics {
+	if plan == nil {
+		return nil
+	}
+	metrics := &PerTierMetrics{Sources: len(plan.Sources)}
+	for _, src := range plan.Sources {
+		switch src.Engine {
+		case "postgres":
+			if src.ActualRows > 0 {
+				metrics.PGRows += src.ActualRows
+			}
+			if src.Reason == "dirty id set fetched" {
+				metrics.PGDirtyCount = src.ActualRows
+			}
+			if src.PredicatePushdown {
+				metrics.HasPushdown = true
+			}
+		case "duckdb":
+			if src.ActualRows > 0 {
+				metrics.DuckDBRows += src.ActualRows
+			}
+		}
+	}
+	if metrics.PGRows > 0 || metrics.DuckDBRows > 0 {
+		metrics.FinalRows = metrics.PGRows + metrics.DuckDBRows
+		if metrics.FinalRows > 0 {
+			metrics.PushdownRatio = float64(metrics.PGRows) / float64(metrics.FinalRows)
+		}
+	}
+	return metrics
+}
+
+func validatePushdownAssertions(run WorkloadRunResult) []AssertionResult {
+	if run.PerTier == nil {
+		return nil
+	}
+	var assertions []AssertionResult
+	pt := run.PerTier
+
+	if pt.Sources > 0 {
+		assertions = append(assertions, AssertionResult{
+			Name:    "pushdown-plan-sources-present",
+			Passed:  true,
+			Message: fmt.Sprintf("sources=%d", pt.Sources),
+		})
+	} else {
+		assertions = append(assertions, AssertionResult{
+			Name:    "pushdown-plan-sources-present",
+			Passed:  false,
+			Message: "execution plan has no sources",
+		})
+	}
+
+	if pt.PGRows >= 0 {
+		assertions = append(assertions, AssertionResult{
+			Name:    "pushdown-pg-rows-tracked",
+			Passed:  true,
+			Message: fmt.Sprintf("pg_rows=%d", pt.PGRows),
+		})
+	}
+
+	if pt.HasPushdown {
+		assertions = append(assertions, AssertionResult{
+			Name:    "pushdown-active",
+			Passed:  true,
+			Message: "at least one source has pushdown enabled",
+		})
+	}
+
+	if pt.PushdownRatio > 0 && pt.PushdownRatio <= 1 {
+		assertions = append(assertions, AssertionResult{
+			Name:    "pushdown-efficiency-reasonable",
+			Passed:  true,
+			Message: fmt.Sprintf("pushdown_ratio=%.3f", pt.PushdownRatio),
+		})
+	}
+
+	return assertions
 }
 
 func maxInt(a, b int) int {

--- a/internal/e2e_harness/federated/benchmark/workload.go
+++ b/internal/e2e_harness/federated/benchmark/workload.go
@@ -16,6 +16,7 @@ const (
 	WorkloadCategoryFilter     WorkloadCategory = "filter"
 	WorkloadCategoryDeepPage   WorkloadCategory = "deep-pagination"
 	WorkloadCategoryTierMix    WorkloadCategory = "tier-mix"
+	WorkloadCategoryPushdown   WorkloadCategory = "pushdown"
 
 	OracleModeLoadedState OracleMode = "loaded-state"
 	OracleModeTruthPass   OracleMode = "truth-pass"
@@ -198,6 +199,66 @@ func DefaultWorkloads() []WorkloadDefinition {
 			SupportsDistributions: allDistributions(),
 			LargePageJump:         true,
 			OracleMode:            OracleModeLoadedState,
+		},
+		{
+			Name:                  "tier-pushdown-hot",
+			Description:           "Hot column-bound filter pushdown efficiency measurement on trade schema.",
+			Category:              WorkloadCategoryPushdown,
+			TargetSchema:          "trade",
+			ExecutionSource:       "service",
+			FilterAttribute:       "symbol",
+			FilterValue:           "SYM00001",
+			FilterConditions:      map[string]any{"symbol": "SYM00001"},
+			PageSize:              20,
+			PageNumber:            1,
+			SupportsDistributions: allDistributions(),
+			OracleMode:            OracleModeTruthPass,
+		},
+		{
+			Name:                  "tier-pushdown-eav",
+			Description:           "EAV-only filter pushdown efficiency measurement on trade schema.",
+			Category:              WorkloadCategoryPushdown,
+			TargetSchema:          "trade",
+			ExecutionSource:       "service",
+			FilterAttribute:       "exchange",
+			FilterValue:           "NYSE",
+			FilterConditions:      map[string]any{"exchange": "NYSE"},
+			PageSize:              20,
+			PageNumber:            1,
+			SupportsDistributions: allDistributions(),
+			UsesEAVFilter:         true,
+			OracleMode:            OracleModeTruthPass,
+		},
+		{
+			Name:                  "tier-pushdown-mixed",
+			Description:           "Mixed hot and EAV filter pushdown efficiency measurement on trade schema.",
+			Category:              WorkloadCategoryPushdown,
+			TargetSchema:          "trade",
+			ExecutionSource:       "service",
+			FilterAttribute:       "symbol",
+			FilterValue:           "SYM00001",
+			FilterConditions:      map[string]any{"symbol": "SYM00001", "exchange": "NYSE"},
+			PageSize:              20,
+			PageNumber:            1,
+			SupportsDistributions: allDistributions(),
+			UsesEAVFilter:         true,
+			OracleMode:            OracleModeTruthPass,
+		},
+		{
+			Name:                  "tier-pushdown-cold-only",
+			Description:           "Cold-tier-only EAV filter pushdown efficiency with cold-only window.",
+			Category:              WorkloadCategoryPushdown,
+			TargetSchema:          "trade",
+			ExecutionSource:       "service",
+			FilterAttribute:       "exchange",
+			FilterValue:           "NYSE",
+			FilterConditions:      map[string]any{"exchange": "NYSE"},
+			PageSize:              20,
+			PageNumber:            1,
+			SupportsDistributions: allDistributions(),
+			UsesEAVFilter:         true,
+			PreferHot:             false,
+			OracleMode:            OracleModeTruthPass,
 		},
 	}
 }

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -45,6 +45,10 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 			"cold-only-window",
 			"deep-page-1000",
 			"deep-page-100000",
+			"tier-pushdown-hot",
+			"tier-pushdown-eav",
+			"tier-pushdown-mixed",
+			"tier-pushdown-cold-only",
 		},
 	}.WithDefaults())
 	require.NoError(t, err)
@@ -52,8 +56,8 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	result, err := runner.RunWithHarness(ctx, h, bench.TierMixBalanced)
 	require.NoError(t, err)
 	require.False(t, result.ValidationOnly)
-	require.Len(t, result.Executions, 24)
-	require.Contains(t, result.Notes, "oracle_modes loaded_state=8 truth_pass=4")
+	require.Len(t, result.Executions, 32)
+	require.Contains(t, result.Notes, "oracle_modes loaded_state=8 truth_pass=8")
 	require.Contains(t, result.Notes, "prefer_hot expresses workload intent and report provenance, not hard execution routing")
 	customerSeen := false
 	securitySeen := false
@@ -67,6 +71,11 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	expectedOracleAssertionsSeen := false
 	tradeTimeWindowAssertionSeen := false
 	repeatedRunStabilitySeen := false
+	pushdownHotSeen := false
+	pushdownEAVSeen := false
+	pushdownMixedSeen := false
+	pushdownColdOnlySeen := false
+	pushdownAssertionsSeen := false
 	for _, execution := range result.Executions {
 		require.NotEmpty(t, execution.Name)
 		require.GreaterOrEqual(t, execution.ResultCount, 0)
@@ -114,6 +123,23 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 		if execution.Name == "cold-only-window" {
 			coldOnlySeen = true
 		}
+		if execution.Name == "tier-pushdown-hot" {
+			pushdownHotSeen = true
+			require.NotNil(t, execution.PerTier, "expected per-tier metrics for pushdown-hot workload")
+			require.Contains(t, execution.PlanNotes, "entity_manager_query_service")
+		}
+		if execution.Name == "tier-pushdown-eav" {
+			pushdownEAVSeen = true
+			require.NotNil(t, execution.PerTier, "expected per-tier metrics for pushdown-eav workload")
+		}
+		if execution.Name == "tier-pushdown-mixed" {
+			pushdownMixedSeen = true
+			require.NotNil(t, execution.PerTier, "expected per-tier metrics for pushdown-mixed workload")
+		}
+		if execution.Name == "tier-pushdown-cold-only" {
+			pushdownColdOnlySeen = true
+			require.NotNil(t, execution.PerTier, "expected per-tier metrics for pushdown-cold-only workload")
+		}
 		for _, assertion := range execution.Assertions {
 			if assertion.Name == "total-records-match-expected" || assertion.Name == "page-row-ids-match-expected" {
 				expectedOracleAssertionsSeen = true
@@ -123,6 +149,9 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 			}
 			if (execution.Name == "mixed-tier-window" || execution.Name == "hot-only-window" || execution.Name == "cold-only-window") && assertion.Name == "tradeTime-window-match-request" {
 				tradeTimeWindowAssertionSeen = true
+			}
+			if assertion.Name == "pushdown-plan-sources-present" || assertion.Name == "pushdown-pg-rows-tracked" {
+				pushdownAssertionsSeen = true
 			}
 		}
 	}
@@ -138,4 +167,9 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	require.True(t, expectedOracleAssertionsSeen, "expected result oracle assertions to be exercised")
 	require.True(t, repeatedRunStabilitySeen, "expected repeated-run stability assertions to be exercised")
 	require.True(t, tradeTimeWindowAssertionSeen, "expected mixed-tier window assertion to be exercised")
+	require.True(t, pushdownHotSeen, "expected tier-pushdown-hot workload to be executed")
+	require.True(t, pushdownEAVSeen, "expected tier-pushdown-eav workload to be executed")
+	require.True(t, pushdownMixedSeen, "expected tier-pushdown-mixed workload to be executed")
+	require.True(t, pushdownColdOnlySeen, "expected tier-pushdown-cold-only workload to be executed")
+	require.True(t, pushdownAssertionsSeen, "expected pushdown assertions to be exercised")
 }

--- a/internal/entity_query_service.go
+++ b/internal/entity_query_service.go
@@ -173,6 +173,7 @@ func (s *entityQueryService) queryRecords(ctx context.Context, query *Persistent
 
 	return s.repository.QueryPersistentRecordsFederated(ctx, query.Tables, fq, &FederatedQueryOptions{
 		AllowPartialDegradedMode: req.Federated.AllowPartialDegradedMode,
+		IncludeExecutionPlan:     req.Federated.IncludeExecutionPlan,
 	})
 }
 

--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -60,10 +60,11 @@ type PersistentRecordQuery struct {
 }
 
 type PersistentRecordPage struct {
-	Records      []*PersistentRecord
-	TotalRecords int64
-	TotalPages   int
-	CurrentPage  int
+	Records       []*PersistentRecord
+	TotalRecords  int64
+	TotalPages    int
+	CurrentPage   int
+	ExecutionPlan *ExecutionPlan
 }
 
 type PersistentRecordKey struct {

--- a/internal/postgres_persistent_repository.go
+++ b/internal/postgres_persistent_repository.go
@@ -423,10 +423,16 @@ func (r *DBPersistentRecordRepository) QueryPersistentRecordsFederated(ctx conte
 		currentPage = fq.Offset/limit + 1
 	}
 
+	var execPlan *ExecutionPlan
+	if opts != nil && opts.IncludeExecutionPlan && opts.ExecutionPlan != nil {
+		execPlan = opts.ExecutionPlan
+	}
+
 	return &PersistentRecordPage{
-		Records:      records,
-		TotalRecords: totalRecords,
-		TotalPages:   computeTotalPages(totalRecords, limit),
-		CurrentPage:  currentPage,
+		Records:       records,
+		TotalRecords:  totalRecords,
+		TotalPages:    computeTotalPages(totalRecords, limit),
+		CurrentPage:   currentPage,
+		ExecutionPlan: execPlan,
 	}, nil
 }

--- a/types.go
+++ b/types.go
@@ -150,12 +150,13 @@ type QueryRequest struct {
 // federated repository path while preserving the normal API surface for callers that
 // do not need DuckDB/S3-backed reads.
 type FederatedQueryRequest struct {
-	Enabled                 bool     `json:"enabled,omitempty"`
-	PreferredTiers          []string `json:"preferred_tiers,omitempty"`
-	PreferHot               bool     `json:"prefer_hot,omitempty"`
-	UseMainAsAnchor         bool     `json:"use_main_as_anchor,omitempty"`
-	S3ParquetPathTemplate   string   `json:"s3_parquet_path_template,omitempty"`
-	AllowPartialDegradedMode bool    `json:"allow_partial_degraded_mode,omitempty"`
+	Enabled                   bool     `json:"enabled,omitempty"`
+	PreferredTiers            []string `json:"preferred_tiers,omitempty"`
+	PreferHot                 bool     `json:"prefer_hot,omitempty"`
+	UseMainAsAnchor           bool     `json:"use_main_as_anchor,omitempty"`
+	S3ParquetPathTemplate     string   `json:"s3_parquet_path_template,omitempty"`
+	AllowPartialDegradedMode  bool     `json:"allow_partial_degraded_mode,omitempty"`
+	IncludeExecutionPlan      bool     `json:"include_execution_plan,omitempty"`
 }
 
 func unmarshalConditionField(data []byte) (Condition, bool, error) {


### PR DESCRIPTION
## Summary
- Adds 4 new pushdown measurement workloads (`tier-pushdown-hot`, `tier-pushdown-eav`, `tier-pushdown-mixed`, `tier-pushdown-cold-only`) that capture per-tier execution plan metrics
- Extracts `PerTierMetrics` (PG rows, DuckDB rows, pushdown ratio) from `ExecutionPlan.Sources[*].ActualRows`
- Adds automated assertions: `pushdown-plan-sources-present`, `pushdown-pg-rows-tracked`, `pushdown-active`, `pushdown-efficiency-reasonable`
- Closes #83 via documented analysis of already-corrected cold-tier EAV filter semantics

## Changes

| File | Change |
|---|---|
| `workload.go` | Add `WorkloadCategoryPushdown` + 4 `tier-pushdown-*` workload definitions |
| `runner.go` | Add `PerTierMetrics`, `extractPerTierMetrics()`, `validatePushdownAssertions()`, `executeServiceQueryWithPlan()` with direct repo plan capture |
| `types.go` | Add `IncludeExecutionPlan` to `FederatedQueryRequest` |
| `entity_query_service.go` | Thread `IncludeExecutionPlan` through to `FederatedQueryOptions` |
| `interfaces.go` | Add `ExecutionPlan` to `PersistentRecordPage` |
| `postgres_persistent_repository.go` | Populate page `ExecutionPlan` when `IncludeExecutionPlan` is true |
| `benchmark_workload_execution_test.go` | Add pushdown workloads to e2e test matrix with per-tier metric assertions |

## Issues
- Closes #82
- Closes #83 (confirmed: cold-tier EAV extraction via `json_extract_string` already in `BuildBenchmarkS3Projection`, all filter workloads use production service path)