### PR TITLE
docs: align documentation with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,157 @@
 # Forma
 
-## Why Develop Forma?
+Forma is a general-purpose data management system built on PostgreSQL. It uses JSON Schema for data definition and a dual storage model (Hot Fields Table + EAV Table) to handle highly dynamic data structures without schema migrations.
 
-Forma is a general-purpose data management system designed to address the limitations of traditional relational databases (RDBMS) when handling highly dynamic and diverse data structures. As modern applications increasingly demand flexibility and scalability, Forma provides an efficient and easily extensible solution that allows developers to store, query, and manage various types of data without the need for frequent database schema modifications.
+## Prerequisites
 
-Forma chooses **JSON Schema** as the core method for data definition, enabling users to flexibly define and adjust data structures without worrying about the complexity of table structure changes in traditional databases. By storing data in a dual storage structure of **"Hot Fields Table + EAV Table"**, Forma supports complex query and sorting operations while maintaining high performance.
+- **Go** 1.26+
+- **Docker & Docker Compose** (for local PostgreSQL and S3-compatible storage)
+- **Bun** (for E2E test scripts)
+- **k6** (for load testing; Docker fallback available)
 
-## Why Choose Forma?
+## Quick Start
 
-### Forma vs RDBMS
+```bash
+# Clone and enter the project
+git clone https://github.com/lychee-technology/forma.git
+cd forma
 
-*   **Schema Evolution**: Modifying table structures (Schema Migration) in traditional RDBMS often involves table locking and downtime risks. Forma uses **JSON Schema** to define logical structures, utilizing a **"Hot Fields Table (Entity Main) + EAV Table"** dual storage pattern underneath. Adding or modifying attributes only requires updating metadata without touching the physical table structure, achieving zero-downtime evolution.
-*   **Complex Structure Support**: Traditional RDBMS usually requires multi-table joins to handle nested objects or arrays. Forma's **Transformer** layer automatically flattens nested JSON for storage while maintaining the ability to query arrays and deep attributes.
+# Start PostgreSQL via Docker Compose
+docker compose -f deploy/docker-compose.yml up -d
 
-### Forma vs MongoDB
+# Build all binaries
+make build-all
 
-*   **ACID Transaction Guarantee**: Built on top of **PostgreSQL**, Forma naturally inherits strict ACID transaction properties, ensuring strong consistency for core business data and avoiding the shortcomings of some NoSQL databases in strong consistency scenarios.
-*   **Power of SQL Optimizer**: Forma doesn't just store JSON; its built-in `SQLGenerator` compiles complex JSON filter conditions into efficient SQL queries (utilizing CTEs and Exists subqueries). This fully leverages Postgres's powerful query optimizer and avoids the common N+1 query problem found in EAV models.
+# Initialize database tables (required once)
+./build/tools init-db \
+  --db-host localhost \
+  --db-port 5432 \
+  --db-name forma \
+  --db-user postgres \
+  --db-password postgres \
+  --db-ssl-mode disable \
+  --schema-dir cmd/server/schemas
 
-### Forma vs KV Store
+# Start the server
+SCHEMA_DIR=cmd/server/schemas ./build/server
+```
 
-*   **Multi-dimensional Retrieval Capabilities**: KV Stores excel at retrieving Values by Key but struggle with complex conditional filtering (e.g., `age > 20 AND status = 'active'`). Forma supports combination filtering, sorting, and pagination on arbitrary attributes, and even cross-schema search.
-*   **Data Validation & Type Safety**: KV Stores typically treat Values as black boxes. Forma strictly follows JSON Schema for data validation (types, formats, required fields), ensuring the quality of incoming data.
+Or use the convenience script that does all of the above:
 
-## Use Cases
+```bash
+./scripts/local_server.sh
+```
 
-### OLTP Applications
+The server listens on port `8080` by default. Configure via environment variables:
 
-*   **Dynamic Business Systems**: Ideal for systems like CRM, ERP, or CMS that require frequent data model adjustments or support for user-defined fields (Custom Fields).
-*   **Automated RESTful API**: Developers only need to define the JSON Schema, and Forma automatically provides standard CRUD interfaces (Create, Read, Update, Delete), significantly shortening the backend development cycle.
-*   **High-Performance Read/Write**: Core high-frequency fields are stored in the "Hot Fields Table", ensuring read/write performance on critical paths is comparable to native SQL tables, while supporting high-concurrency transaction processing.
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_NAME` | `forma` | Database name |
+| `DB_USER` | `postgres` | Database user |
+| `DB_PASSWORD` | `` | Database password |
+| `DB_SSL_MODE` | `disable` | SSL mode |
+| `SCHEMA_DIR` | `` | Directory containing schema JSON files |
+| `PORT` | `8080` | HTTP listen port |
 
-### OLAP Applications
+## API Reference
 
-*   **Real-time Operational Analysis**: Leverages Postgres's query capabilities to support real-time statistics and aggregation analysis of business data.
-*   **Data Lake Integration**: Supports exporting structured data to columnar formats like Parquet and storing it in S3, enabling integration with big data platforms for offline analysis and report generation. Parquet files can be partitioned by `schema_id` and `row_id` for efficient updates and queries.
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/{schema}` | Create records (single object or array) |
+| `GET` | `/api/v1/{schema}/{row_id}` | Get a single record |
+| `GET` | `/api/v1/{schema}` | Query records with pagination (`?page=&items_per_page=&sort_by=&sort_order=&attrs=`) |
+| `PUT` | `/api/v1/{schema}/{row_id}` | Update a record |
+| `DELETE` | `/api/v1/{schema}` | Batch delete (JSON body: array of row_id strings) |
+| `GET` | `/api/v1/search` | Cross-schema search (`?schemas=&q=&page=&items_per_page=`) |
+| `POST` | `/api/v1/advanced_query` | Advanced query with condition DSL (JSON body) |
+
+## Testing
+
+### Unit & Integration Tests
+
+```bash
+# Run all unit and integration tests
+make test
+
+# Run with coverage report
+make coverage
+
+# Run linter
+make lint
+```
+
+### Go E2E Harness (container-based)
+
+Requires Docker. Validates the three-tier federated query architecture (Postgres Hot + S3 Delta/Base → DuckDB merge-on-read).
+
+```bash
+# Smoke test: verify infrastructure starts
+go test -v ./internal/e2e_harness/... -timeout=5m
+
+# Full federated suite (functional + consistency + failure modes)
+go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=30m
+
+# Performance tests only (longer timeout)
+go test -v ./internal/e2e_harness/federated/... -run TestPerformance -tags=e2e -timeout=60m
+```
+
+### Bun E2E (black-box API validation)
+
+Requires a running Forma server and PostgreSQL.
+
+```bash
+cd tests/e2e
+cp .env.example .env
+bun install
+
+# Default pipeline: register schemas → generate data → CDC flush → federated check
+bun run test
+
+# Individual steps
+bun run register-schemas
+bun run gen-data -- --schema all --count 10000
+bun run cdc-flush
+bun run federated-check
+
+# Extended steps
+bun run cdc-init          # Backfill base parquet
+bun run compactor -- --all # Merge delta into base
+```
+
+### k6 Load Testing
+
+```bash
+cd tests/e2e
+bun run build-k6
+
+bun run k6-smoke   # 5 VUs, 30s
+bun run k6-full    # 30 VUs, 2m
+bun run k6-perf    # 100 VUs, 5m
+```
+
+### Benchmarks
+
+```bash
+make benchmark-smoke       # CI smoke validation
+make benchmark-regression  # Small live subset
+make benchmark-heavy       # Heavy planning set
+```
+
+## Documentation
+
+- [Documentation Index](docs/index.md)
+- [E2E Test Matrix](docs/e2e-tests-en.md)
+- [Integration Test Cases](docs/integ-tests-en.md)
+- [Go E2E Harness README](internal/e2e_harness/README.md)
+- [Bun E2E README](tests/e2e/README.md)
+
+## Why Forma?
+
+Forma targets the gap between rigid RDBMS schemas and schema-less NoSQL stores:
+
+- **Zero-Downtime Schema Evolution** — Add or modify fields by updating JSON Schema metadata; no `ALTER TABLE` required.
+- **ACID on PostgreSQL** — Inherits full transactional guarantees from Postgres.
+- **Smart SQL Generation** — CTE + JSON_AGG eliminates N+1 queries in EAV models.
+- **Federated Query (Lakehouse)** — PostgreSQL for OLTP, DuckDB + Parquet on S3 for OLAP. Anti-Join + Dirty Set ensures consistency across tiers.

--- a/docs/cn/README.cn.md
+++ b/docs/cn/README.cn.md
@@ -1,40 +1,157 @@
 # Forma
 
-## 为什么要开发 Forma？
+Forma 是一个基于 PostgreSQL 构建的通用数据管理系统。它使用 JSON Schema 进行数据定义，采用双存储模型（热字段表 + EAV 表）来处理高度动态的数据结构，无需频繁修改数据库架构。
 
+## 环境依赖
 
-Forma 是一个通用数据管理系统，旨在解决传统关系型数据库在处理高度动态和多样化数据结构时的局限性。随着现代应用程序对灵活性和可扩展性的需求不断增加，Forma 提供了一种高效且易于扩展的解决方案，使开发者能够轻松地存储、查询和管理各种类型的数据，而无需频繁修改数据库架构。
+- **Go** 1.26+
+- **Docker & Docker Compose**（用于本地 PostgreSQL 和 S3 兼容存储）
+- **Bun**（用于 E2E 测试脚本）
+- **k6**（用于压力测试；可通过 Docker 替代）
 
-Forma 选择了基于JSON Schema作为数据定义的核心方式，这使得用户可以灵活地定义和调整数据结构，而无需担心传统数据库中的表结构变更带来的复杂性。通过将数据存储在“热字段表 + EAV 表”的双存储结构中，Forma 能够在保持高性能的同时，支持复杂的查询和排序操作。
+## 快速开始
 
+```bash
+# 克隆项目
+git clone https://github.com/lychee-technology/forma.git
+cd forma
 
+# 启动 PostgreSQL（Docker Compose）
+docker compose -f deploy/docker-compose.yml up -d
+
+# 编译所有二进制文件
+make build-all
+
+# 初始化数据库表（首次运行必需）
+./build/tools init-db \
+  --db-host localhost \
+  --db-port 5432 \
+  --db-name forma \
+  --db-user postgres \
+  --db-password postgres \
+  --db-ssl-mode disable \
+  --schema-dir cmd/server/schemas
+
+# 启动服务器
+SCHEMA_DIR=cmd/server/schemas ./build/server
+```
+
+或使用一键脚本：
+
+```bash
+./scripts/local_server.sh
+```
+
+服务默认监听 `8080` 端口。通过环境变量配置：
+
+| 变量 | 默认值 | 说明 |
+|----------|---------|-------------|
+| `DB_HOST` | `localhost` | PostgreSQL 主机 |
+| `DB_PORT` | `5432` | PostgreSQL 端口 |
+| `DB_NAME` | `forma` | 数据库名 |
+| `DB_USER` | `postgres` | 数据库用户 |
+| `DB_PASSWORD` | `` | 数据库密码 |
+| `DB_SSL_MODE` | `disable` | SSL 模式 |
+| `SCHEMA_DIR` | `` | Schema JSON 文件目录 |
+| `PORT` | `8080` | HTTP 监听端口 |
+
+## API 参考
+
+| 方法 | 路径 | 说明 |
+|--------|------|-------------|
+| `POST` | `/api/v1/{schema}` | 创建记录（支持单对象或数组） |
+| `GET` | `/api/v1/{schema}/{row_id}` | 获取单条记录 |
+| `GET` | `/api/v1/{schema}` | 分页查询（`?page=&items_per_page=&sort_by=&sort_order=&attrs=`） |
+| `PUT` | `/api/v1/{schema}/{row_id}` | 更新记录 |
+| `DELETE` | `/api/v1/{schema}` | 批量删除（JSON body：row_id 字符串数组） |
+| `GET` | `/api/v1/search` | 跨 Schema 搜索（`?schemas=&q=&page=&items_per_page=`） |
+| `POST` | `/api/v1/advanced_query` | 高级查询，使用条件 DSL（JSON body） |
+
+## 测试
+
+### 单元测试与集成测试
+
+```bash
+# 运行所有单元和集成测试
+make test
+
+# 运行测试并生成覆盖率报告
+make coverage
+
+# 运行 Lint 检查
+make lint
+```
+
+### Go E2E Harness（基于容器）
+
+需要 Docker。验证三层联邦查询架构（Postgres Hot + S3 Delta/Base → DuckDB merge-on-read）。
+
+```bash
+# 冒烟测试：验证基础设施是否正常启动
+go test -v ./internal/e2e_harness/... -timeout=5m
+
+# 完整联邦测试套件（功能 + 一致性 + 故障模式）
+go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=30m
+
+# 仅性能测试（需要更长超时时间）
+go test -v ./internal/e2e_harness/federated/... -run TestPerformance -tags=e2e -timeout=60m
+```
+
+### Bun E2E（黑盒 API 验证）
+
+需要运行中的 Forma 服务器和 PostgreSQL。
+
+```bash
+cd tests/e2e
+cp .env.example .env
+bun install
+
+# 默认流程：注册 Schema → 生成数据 → CDC 刷新 → 联邦查询校验
+bun run test
+
+# 单独步骤
+bun run register-schemas
+bun run gen-data -- --schema all --count 10000
+bun run cdc-flush
+bun run federated-check
+
+# 扩展步骤
+bun run cdc-init          # 回填 Base Parquet
+bun run compactor -- --all # 合并 Delta 到 Base
+```
+
+### k6 压力测试
+
+```bash
+cd tests/e2e
+bun run build-k6
+
+bun run k6-smoke   # 5 VUs, 30s
+bun run k6-full    # 30 VUs, 2m
+bun run k6-perf    # 100 VUs, 5m
+```
+
+### 性能基准测试
+
+```bash
+make benchmark-smoke       # CI 冒烟验证
+make benchmark-regression  # 小规模实时数据子集
+make benchmark-heavy       # 大规模规划数据
+```
+
+## 文档
+
+- [文档索引](docs/index.md)
+- [E2E 测试矩阵](docs/e2e-tests-cn.md)
+- [集成测试用例](docs/integ-tests-cn.md)
+- [Go E2E Harness 说明](internal/e2e_harness/README.md)
+- [Bun E2E 说明](tests/e2e/README.md)
 
 ## 为什么选择 Forma？
 
-### Forma vs RDBMS
+Forma 弥补了传统 RDBMS 刚性 Schema 与无 Schema NoSQL 之间的空白：
 
-* **动态架构 (Schema Evolution)**：传统 RDBMS 修改表结构（Schema Migration）往往伴随着锁表和停机风险。Forma 利用 **JSON Schema** 定义逻辑结构，底层采用 **“热字段表 (Entity Main) + EAV 表”** 的双存储模式。新增或修改属性只需更新元数据，无需触碰物理表结构，实现零停机演进。
-* **复杂结构支持**：传统 RDBMS 处理嵌套对象或数组通常需要多表关联（Join）。Forma 的转换层（Transformer）能自动将嵌套 JSON 展平存储，同时保持对数组和深层属性的查询能力。
-
-### Forma vs MongoDB
-
-* **ACID 事务保障**：Forma 建立在 **PostgreSQL** 之上，天然继承了严格的 ACID 事务特性，确保核心业务数据的强一致性，避免了部分 NoSQL 数据库在强一致性场景下的短板。
-* **SQL 优化器的力量**：Forma 不仅仅是存储 JSON，它通过内置的 `SQLGenerator` 将复杂的 JSON 过滤条件编译为高效的 SQL 查询（利用 CTE 和 Exists 子查询），充分利用 Postgres 强大的查询优化器，避免了 EAV 模型常见的 N+1 查询问题。
-
-### Forma vs KV Store
-
-* **多维检索能力**：KV Store 擅长通过 Key 获取 Value，但难以处理复杂的条件筛选（如：`age > 20 AND status = 'active'`）。Forma 支持任意属性的组合过滤、排序和分页，甚至跨 Schema 搜索。
-* **数据校验与类型安全**：KV Store 通常视 Value 为黑盒。Forma 严格遵循 JSON Schema 进行数据校验（类型、格式、必填项），确保入库数据的质量。
-
-## 使用场景
-
-### OLTP 应用
-
-* **动态业务系统**：适合 CRM、ERP 或 CMS 等需要频繁调整数据模型或支持用户自定义字段（Custom Fields）的系统。
-* **RESTful API 自动化**：开发者只需定义 JSON Schema，Forma 即可自动提供标准的 CRUD 接口（创建、查询、更新、删除），极大缩短后端开发周期。
-* **高性能读写**：核心高频字段存储在“热字段表”中，保证了关键路径的读写性能媲美原生 SQL 表，同时支持高并发的事务处理。
-
-### OLAP 应用
-
-* **实时运营分析**：基于 Postgres 的查询能力，支持对业务数据进行实时的统计和聚合分析。
-* **数据湖集成**：支持将结构化数据导出为 Parquet 等列式格式并存储到 S3，对接大数据平台进行离线分析和报表生成。Parquet 文件可按照 `schema_id` 和 `row_id` 进行分区，方便高效更新和查询。
+- **零停机 Schema 演进** — 通过更新 JSON Schema 元数据即可增删字段，无需 `ALTER TABLE`。
+- **ACID 事务保障** — 基于 PostgreSQL，继承完整的 ACID 事务特性。
+- **智能 SQL 生成** — CTE + JSON_AGG 消除 EAV 模型常见的 N+1 查询问题。
+- **联邦查询 (Lakehouse)** — PostgreSQL 负责 OLTP，DuckDB + S3 Parquet 负责 OLAP。Anti-Join + Dirty Set 保证跨层数据一致性。

--- a/docs/cn/Roadmap.md
+++ b/docs/cn/Roadmap.md
@@ -2,4 +2,4 @@
 
 ## Upcoming Features
 
-- CLI Tooling for generating client code (ETA Q4 2025)
+- CLI Tooling for generating client code

--- a/docs/cn/api.md
+++ b/docs/cn/api.md
@@ -1,1 +1,46 @@
-# Please reference to the [RFC](https://github.com/Lychee-Technology/rfc/blob/main/CN/API-specs.cn.md) for more details.
+# Forma API
+
+## HTTP Endpoints
+
+Base URL: `http://localhost:8080` (configurable via `PORT` env var).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/{schema}` | Create records (single JSON object or JSON array). Returns `201`. |
+| `GET` | `/api/v1/{schema}/{row_id}` | Get a single record by row_id. Returns `200` or `404`. |
+| `GET` | `/api/v1/{schema}` | Query records with pagination, sorting, and attribute projection. |
+| `PUT` | `/api/v1/{schema}/{row_id}` | Update a record (full object replacement). |
+| `DELETE` | `/api/v1/{schema}` | Batch delete. JSON body: array of row_id strings. Transactional. |
+| `DELETE` | `/api/v1/{schema}/{row_id}` | Single record delete. |
+| `GET` | `/api/v1/search` | Cross-schema full-text search. `?schemas=a,b&q=term&page=1&items_per_page=20` |
+| `POST` | `/api/v1/advanced_query` | Advanced query with condition DSL (JSON body). |
+
+## Query Parameters (List/Query)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | int | 1 | Page number |
+| `items_per_page` | int | 20 | Items per page (max 100) |
+| `sort_by` | string | — | Comma-separated attribute names for sorting |
+| `sort_order` | string | `asc` | Sort direction (`asc` or `desc`) |
+| `attrs` | string | — | Comma-separated attribute names for projection |
+
+## Advanced Query DSL
+
+Reference: [Advanced Query documentation](./advanced_query.md)
+
+## Error Codes
+
+| Status | Meaning |
+|--------|---------|
+| `201` | Record(s) created |
+| `200` | Success |
+| `400` | Invalid request (bad path, missing params, invalid JSON) |
+| `404` | Record not found |
+| `405` | Method not allowed |
+| `409` | Conflict (e.g., duplicate) |
+| `500` | Internal server error |
+
+## References
+
+- Full RFC: [API Specs RFC](https://github.com/Lychee-Technology/rfc/blob/main/CN/API-specs.cn.md)

--- a/docs/cn/query.md
+++ b/docs/cn/query.md
@@ -1,6 +1,6 @@
 # 查询数据功能
 
-LTBase 支持基于JSON Schema自动生成数据CRUD API功能。基于 (Model)[./model.md] 中定义的数据模型，系统支持CRUD查询操作。
+Forma 支持基于JSON Schema自动生成数据CRUD API功能。基于 [Model](./model.md) 中定义的数据模型，系统支持CRUD查询操作。
 
 
 
@@ -8,7 +8,7 @@ LTBase 支持基于JSON Schema自动生成数据CRUD API功能。基于 (Model)[
 
 ### 定义Schema
 
-JSON Schema定义了实体的属性和数据类型。用户可以通过Control Plane API创建和管理Schema。LTBase扩展了JSON Schema，允许用户指定：
+JSON Schema定义了实体的属性和数据类型。用户可以通过Control Plane API创建和管理Schema。Forma扩展了JSON Schema，允许用户指定：
 
 1. 哪些属性需要存储在`entity main`表中以优化查询性能。
 2. 哪些属性需要索引以支持高效的过滤查询。
@@ -49,7 +49,7 @@ UUID类型的属性优先存储在uuid列中。如果uuid列已经用尽，则�
 
 ### 元数据映射
 
-LTBase自己也维护了一些元数据：
+Forma自己也维护了一些元数据：
 * `RowID`，每条记录的唯一标识符，UUIDv7格式。
 * `CreatedAt`，记录创建时间，Unix时间戳，毫秒级别的整数（bigint）
 * `UpdatedAt`，记录最后更新时间，Unix时间戳，毫秒级别的整数（bigint）
@@ -63,7 +63,7 @@ LTBase自己也维护了一些元数据：
 
 ### 为Schema 的 Metadata 
 
-为了记录Schema中的字段与数据库中字段的映射关系，LTBase自动根据用户对Schema的配置生成Schema Metadata信息。Schema Metadata结构如下：
+为了记录Schema中的字段与数据库中字段的映射关系，Forma自动根据用户对Schema的配置生成Schema Metadata信息。Schema Metadata结构如下：
 
 ```json
 {
@@ -90,7 +90,7 @@ Data Plane提供基于Schema的CRUD查询API。
 
 ## 字段映射
 
-一个entity中的属性根据Schema的定义会被映射到数据库中的`entity main`表或者`eav data`表中。LTBase会根据Schema的Metadata信息来决定每个属性的存储位置。LTBase会根据Schema Metadata来生成相应的SQL语句以实现CRUD操作。
+一个entity中的属性根据Schema的定义会被映射到数据库中的`entity main`表或者`eav data`表中。Forma会根据Schema的Metadata信息来决定每个属性的存储位置。Forma会根据Schema Metadata来生成相应的SQL语句以实现CRUD操作。
 
 
 ### 从JSON对象到PersistentRecord的转换

--- a/docs/cn/schema_versioning.md
+++ b/docs/cn/schema_versioning.md
@@ -2,7 +2,7 @@
 
 ## 允许的Schema变更操作类型 （backwards compatible）
 
-当用户进行允许的Schema变更时，LTBase会支持对已有数据的平滑迁移，确保数据的一致性和可用性。允许的Schema变更类型包括但不限于：
+当用户进行允许的Schema变更时，Forma会支持对已有数据的平滑迁移，确保数据的一致性和可用性。允许的Schema变更类型包括但不限于：
 
 1.  **添加新的可选字段 (Add Optional Field)**
     *   在 `properties` 中增加新的字段定义。
@@ -26,7 +26,7 @@
 
 ## 不允许的Schema变更操作类型 （NOT backwards compatible）
 
-如果用户尝试进行不允许的Schema变更，LTBase会拒绝该变更请求，并返回相应的错误信息。不允许的Schema变更类型包括但不限于：
+如果用户尝试进行不允许的Schema变更，Forma会拒绝该变更请求，并返回相应的错误信息。不允许的Schema变更类型包括但不限于：
 
 1.  **添加新的必填字段 (Add Required Field)**
     *   在 `properties` 中增加新字段，并将其加入 `required` 列表。

--- a/docs/cn/代码阅读指南.md
+++ b/docs/cn/代码阅读指南.md
@@ -1,50 +1,52 @@
 # 代码阅读指南
 
-面向首次阅读代码的同学，下面梳理了核心目标、数据流、关键模块和推荐的阅读顺序，方便在 IDE 里快速定位。
+面向首次阅读的同学，下面梳理了核心目标、数据流、关键模块和推荐的阅读顺序，方便在 IDE 里快速定位。
 
 ## 项目概览与运行方式
-- 目标：提供基于 JSON Schema 的实体存储/查询服务，底层落地到 PostgreSQL 的 “热字段表 + EAV 表” 双存储结构，支持排序、条件组合和跨 Schema 查询。
-- 入口：`cmd/server/main.go` 读取环境变量拼装 `internal.Config`，通过 `cmd/server/factory.go` 构建 `EntityManager`、元数据缓存和 HTTP 路由（`cmd/server/handlers.go`）。
-- 配置：默认配置在 `internal/config.go`，数据库表名可通过 `Config.Database.TableNames` 覆盖，运行时通过 `DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD/DB_SSL_MODE` 等环境变量注入。
-- 运行与构建：开发期可直接 `go run ./cmd/server`；统一测试命令为 `go test ./...`（参见根目录 `Makefile`）；`make build` 会为常见平台产出二进制到 `build/`。
-- 依赖数据：Schema 定义与属性映射位于 `cmd/server/schemas/*.json` 与 `*_attributes.json`，示例有 `lead` 与 `listing`。
+- 目标：提供基于 JSON Schema 的实体存储/查询服务，底层落地到 PostgreSQL 的 "热字段表 + EAV 表" 双存储结构，支持排序、条件组合和跨 Schema 查询。
+- 入口：`cmd/server/main.go` 读取环境变量拼装配置，通过 `internal/bootstrap/` 构建数据库连接池，再由 `factory` 构建 `EntityManager` 和 HTTP 路由（`internal/httpapi/server.go`）。
+- 配置：默认配置通过 `internal/bootstrap` 的环境变量解析（`DatabaseConfigFromEnv` / `TableNamesFromEnv`），支持 `DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD/DB_SSL_MODE` 等环境变量注入。
+- 运行与构建：开发期可直接 `go run ./cmd/server`；统一测试命令为 `make test`（参见根目录 `Makefile`）；`make build-all` 会为当前平台产出二进制到 `build/`。
+- 依赖数据：Schema 定义与属性映射位于 `cmd/server/schemas/*.json` 与 `*_attributes.json`，示例有 `lead`、`visit`、`log`。
 
 ## 数据流速览
-1) **HTTP → Handler**：`cmd/server/handlers.go` 解析路径/查询参数/请求体，转成 `forma.EntityOperation` 或 `forma.QueryRequest` 调用 manager。  
+1) **HTTP → Handler**：`internal/httpapi/server.go` 解析路径/查询参数/请求体，转成 `forma.EntityOperation` 或 `forma.QueryRequest` 调用 manager。  
 2) **业务层 (EntityManager)**：`internal/entity_manager.go` 负责校验、Schema 解析、组装排序/分页、调用存储层，并将持久化记录还原为 `forma.DataRecord`。  
 3) **转换层**：`internal/transformer.go` 把 JSON 展平为属性列表（含数组索引）、或反向重建嵌套结构；`internal/persistent_transformer.go` 决定哪些属性落在主表热列、哪些保留在 EAV。  
-4) **存储层**：`internal/postgres_persistent_repository.go` 使用 pgx 访问两张表；插入/更新走事务，查询时先在 EAV 表里筛选/排序（`advanced_query_template.go` 与 `sql_generator.go` 生成 SQL），再回表补全主表字段。  
-5) **元数据**：`internal/metadata_loader.go` 从数据库表（默认 `schema_registry`）加载 SchemaID 与属性映射，再结合磁盘上的 `*_attributes.json` 形成 `MetadataCache`，供查询/转换层快速查表。额外的文件式 `SchemaRegistry` 在 `internal/schema_registry.go`，兼容老路径。  
-6) **扩展/实验**：`internal/queryoptimizer` 目录放着尚未实现的优化器骨架（当前返回 `ErrNotImplemented`），阅读时可忽略其调用路径。
+4) **存储层**：`internal/postgres_persistent_repository.go` 使用 pgx 访问两张表；插入/更新走事务，查询时先在 EAV 表里筛选/排序，再回表补全主表字段。  
+5) **元数据**：`internal/metadata_loader.go` 从数据库表加载 SchemaID 与属性映射，再结合磁盘上的 `*_attributes.json` 形成 `MetadataCache`，供查询/转换层快速查表。额外的文件式 `SchemaRegistry` 通过 `internal.NewFileSchemaRegistry` 创建。  
+6) **查询优化器**：`internal/queryoptimizer/` 目录包含基于 CTE 的优化查询路径（当前已实现，替代部分旧查询逻辑）。
 
 ## 关键模块卡片
-- **接口与模型**：`types.go` 描述 API 层结构体，`internal/interfaces.go` 定义核心接口（Transformer、PersistentRecordRepository 等）和内部持久化模型 `PersistentRecord`。
+- **接口与模型**：`types.go` 描述 API 层结构体，`internal/interfaces.go` 定义核心接口和内部持久化模型 `PersistentRecord`。
 - **Transformer**：`internal/transformer.go` 负责 JSON ↔ 属性的双向转换，支持数组索引压缩为 `ArrayIndices` 字符串，并按属性定义类型做解析/校验。
-- **持久化 Transformer**：`internal/persistent_transformer.go` 依据属性的 `MainColumnBinding` 将值写入 `PersistentRecord` 的各列 map（文本、小整型、整型、大整型、双精度）或 EAV 列表，并提供反向读取。
+- **持久化 Transformer**：`internal/persistent_transformer.go` 依据属性的 `MainColumnBinding` 将值写入 `PersistentRecord` 的各列 map 或 EAV 列表，并提供反向读取。
 - **元数据解析**：`internal/metadata_types.go`/`internal/metadata_parser.go` 描述属性元数据字段（ValueType、主表绑定、回退存储等），解析 `*_attributes.json` 时会自动推导存储/回退信息。
-- **存储与 SQL**：`internal/postgres_persistent_repository.go` 实现 CRUD 与高级查询。过滤条件由 `internal/sql_generator.go` 把 `CompositeCondition/KvCondition` 递归翻译成子查询 EXISTS 片段；排序依赖 `advanced_query_template.go` 生成的 CTE，对排序键做一次性查询并带回总数。
-- **业务编排**：`internal/entity_manager.go` 组合以上组件，实现 Create/Update/Delete/Query/Batch/CrossSchemaSearch，并在 `storageTables()` 里读取配置定义的表名。
-- **HTTP 层**：`cmd/server/handlers.go` 支持的路由包括：
+- **存储与 SQL**：`internal/postgres_persistent_repository.go` 实现 CRUD 与高级查询。过滤条件由 `internal/sql_generator.go` 递归翻译成子查询 EXISTS 片段；排序依赖 CTE 模板生成。
+- **业务编排**：`internal/entity_manager.go` 组合以上组件，实现 Create/Update/Delete/Query/Batch/CrossSchemaSearch。各子服务已拆分为独立文件（`entity_manager_crud.go`、`entity_manager_batch.go`、`entity_manager_query.go`、`entity_manager_relations.go`）。
+- **HTTP 层**：`internal/httpapi/server.go` 支持的路由包括：
   - `POST /api/v1/{schema}` 创建（支持单条或数组）
-  - `GET /api/v1/{schema}` 分页查询；`GET /api/v1/{schema}/{row_id}` 读取单条
-  - `PUT /api/v1/{schema}/{row_id}` 更新（整对象覆盖式）
-  - `DELETE /api/v1/{schema}` 批量删除；`DELETE /api/v1/{schema}/{row_id}` 单条删除
-  - `POST /api/v1/advanced_query` 组合条件查询；`GET /api/v1/search` 跨 schema 搜索占位实现
-  辅助解析/响应函数在 `cmd/server/utils.go`。
-- **测试**：单元测试覆盖转换/SQL 生成等（如 `internal/transformer_test.go`、`internal/sql_generator_test.go`）；`internal/integration_suite_test.go` 和 `internal/postgres_persistent_repository_integration_test.go` 需要可访问的 Postgres（默认 `TEST_POSTGRES_DSN` / `DATABASE_URL`，否则自动 skip）。
+  - `GET /api/v1/{schema}/{row_id}` 读取单条
+  - `GET /api/v1/{schema}` 分页查询（`?page=&items_per_page=&sort_by=&sort_order=&attrs=`）
+  - `PUT /api/v1/{schema}/{row_id}` 更新
+  - `DELETE /api/v1/{schema}` 批量删除；带 `/{row_id}` 则单条删除
+  - `POST /api/v1/advanced_query` 组合条件查询
+  - `GET /api/v1/search` 跨 Schema 搜索（`?schemas=&q=&page=&items_per_page=`）
+- **CDC 与联邦查询**：CDC flush/init 逻辑在 `internal/cdc/`，联邦查询通过 `internal/postgres_duckdb_federated_repository.go` 实现三层（Hot/Delta/Base）联合查询。
+- **测试**：单元测试覆盖转换/SQL 生成等（`internal/transformer_test.go`、`internal/sql_generator_test.go`）；集成测试在 `internal/` 下以 `Integration` 后缀命名，需要可访问的 Postgres。
 
 ## 推荐阅读路径
 1. `types.go` 了解外部 API/模型；`internal/interfaces.go` 看内部接口与持久化模型。
-2. `cmd/server/main.go` + `cmd/server/factory.go` 理解启动流程、配置来源与依赖注入。
+2. `cmd/server/main.go` + `internal/bootstrap/` 理解启动流程、配置来源与依赖注入。
 3. `internal/config.go` 熟悉可调参数和表名配置；同时浏览 `cmd/server/schemas` 感受 Schema/属性声明格式。
 4. `internal/metadata_loader.go` 与 `internal/schema_registry.go` 理解元数据的来源（DB vs. 文件）及缓存结构。
 5. `internal/transformer.go` → `internal/persistent_transformer.go` → `internal/metadata_types.go` 形成对数据展平与热列绑定的整体认识。
-6. `internal/postgres_persistent_repository.go`（配合 `advanced_query_template.go`、`sql_generator.go`）阅读持久化与查询执行逻辑。
-7. 回到 `internal/entity_manager.go` 理解业务编排与错误处理，再看 `cmd/server/handlers.go` 了解 HTTP 映射。
-8. 最后根据需要浏览 `internal/queryoptimizer`（实验性）、`docs/*.md`（功能说明），和对应测试用例验证行为。
+6. `internal/postgres_persistent_repository.go` 阅读持久化与查询执行逻辑。
+7. 回到 `internal/entity_manager.go` 理解业务编排与错误处理，再看 `internal/httpapi/server.go` 了解 HTTP 映射。
+8. 最后根据需要浏览 `internal/queryoptimizer/`、`internal/cdc/`，和对应测试用例验证行为。
 
 ## 现有文档速查
-- `docs/api.md`：API 形态与示例。
-- `docs/query.md` / `docs/advanced_query.md`：查询能力介绍。
-- `docs/OPTIMIZER_IMPLEMENTATION.md`、`docs/query_optimizer.md`：优化器设计思路草稿。
-- `docs/schema_versioning.md`、`docs/model.md`、`docs/Roadmap.md`：版本、数据模型及规划。
+- `docs/cn/api.md`：API 形态与示例。
+- `docs/cn/query.md` / `docs/cn/advanced_query.md`：查询能力介绍。
+- `docs/cn/OPTIMIZER_IMPLEMENTATION.md`、`docs/cn/query_optimizer.md`：优化器设计思路。
+- `docs/cn/schema_versioning.md`、`docs/cn/model.md`、`docs/cn/Roadmap.md`：版本、数据模型及规划。

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,20 @@ Forma solves this with a modern take on the EAV pattern:
 git clone https://github.com/ruoshui/forma.git
 cd forma
 
-# Start the development environment
-make dev
+# Start PostgreSQL
+docker compose -f deploy/docker-compose.yml up -d
+
+# Build all binaries
+make build-all
+
+# Initialize database
+./build/tools init-db \
+  --db-host localhost --db-port 5432 --db-name forma \
+  --db-user postgres --db-password postgres --db-ssl-mode disable \
+  --schema-dir cmd/server/schemas
+
+# Start the server
+SCHEMA_DIR=cmd/server/schemas ./build/server
 
 # Run tests
 make test

--- a/docs/integ-tests-cn.md
+++ b/docs/integ-tests-cn.md
@@ -20,7 +20,7 @@
 
 ### 2.1 最低依赖
 
-- Go 1.21+
+- Go 1.26+
 - Docker / Docker Compose
 - PostgreSQL（本地默认：`localhost:5432/forma`）
 - S3 兼容存储（本地常用 RustFS）
@@ -373,4 +373,4 @@
 - Federated E2E：`internal/e2e_harness/federated/*_test.go`  
 - Bun E2E：`tests/e2e/scripts/*.ts`  
 - 负载测试：`tests/e2e/k6/scenarios.ts`  
-- 服务 API：`cmd/server/handlers.go`、`cmd/lambda/handlers.go`
+- 服务 API：`internal/httpapi/server.go`、`cmd/lambda/main.go`

--- a/docs/integ-tests-en.md
+++ b/docs/integ-tests-en.md
@@ -20,7 +20,7 @@ Pure unit-test-level assertions are out of scope.
 
 ### 2.1 Minimum Dependencies
 
-- Go 1.21+
+- Go 1.26+
 - Docker / Docker Compose
 - PostgreSQL (local default: `localhost:5432/forma`)
 - S3-compatible storage (commonly RustFS locally)
@@ -373,4 +373,4 @@ Note: These manual cases close automation gaps and cover pre-production must-che
 - Federated E2E: `internal/e2e_harness/federated/*_test.go`  
 - Bun E2E scripts: `tests/e2e/scripts/*.ts`  
 - Load testing: `tests/e2e/k6/scenarios.ts`  
-- Service APIs: `cmd/server/handlers.go`, `cmd/lambda/handlers.go`
+- Service APIs: `internal/httpapi/server.go`, `cmd/lambda/main.go`

--- a/docs/refactor-plan.md
+++ b/docs/refactor-plan.md
@@ -1,5 +1,12 @@
 # Forma Refactor Plan (Findings Only)
 
+> **注意**：本文档中的文件路径（如 `cmd/server/handlers.go`、`cmd/server/factory.go`、`cmd/lambda/handlers.go`）对应重构前（≈2026-02 之前）的代码结构。当前代码中这些模块已迁移至：
+> - HTTP 处理 → `internal/httpapi/server.go`
+> - 启动/配置构建 → `internal/bootstrap/`
+> - Lambda 处理 → `cmd/lambda/main.go`（不再有独立 handlers.go）
+>
+> Finding 部分保留原始路径以忠实记录重构前的发现。
+
 ## 评审基准
 - 参考 [Refactoring.Guru - Code Smells](https://refactoring.guru/refactoring/smells) 及其子类（尤其是 `Duplicate Code`, `Long Method`, `Long Parameter List`, `Data Clumps`, `Large Class`, `Switch Statements`, `Shotgun Surgery`, `Divergent Change`）。
 - 本文仅记录重构发现，不包含代码修改方案的落地实现。


### PR DESCRIPTION
## Summary

Sweeping documentation update to fix inconsistencies between the docs and the actual project implementation.

## Changes

### P0 — Critical fixes (stale/obsolete file references)
- **`docs/cn/代码阅读指南.md`**: Rewrote to reflect current source structure — `cmd/server/handlers.go`/`factory.go`/`utils.go` → `internal/httpapi/server.go` + `internal/bootstrap/`, updated module list, test commands, and routes.
- **`docs/integ-tests-en.md` / `docs/integ-tests-cn.md`**: Fixed reference paths (line 376) from deleted files to current locations.
- **`docs/refactor-plan.md`**: Added a prominent historical-context notice explaining that all file paths in the Findings section reflect pre-refactoring code (≈2026-02), with current module locations listed.

### P1 — Naming and version fixes
- **`docs/cn/query.md`**: Renamed 6× `LTBase` → `Forma`, fixed broken Markdown link syntax.
- **`docs/cn/schema_versioning.md`**: Renamed 2× `LTBase` → `Forma`.
- **`docs/integ-tests-en.md` / `docs/integ-tests-cn.md`**: Bumped Go requirement from `1.21+` to `1.26+` (matches go.mod).
- **`docs/cn/api.md`**: Replaced one-line external redirect with a full API reference (endpoints, parameters, error codes).

### P2 — Minor
- **`docs/cn/Roadmap.md`**: Removed expired "ETA Q4 2025".

### Usage & testing (new content)
- **`README.md`** and **`docs/cn/README.cn.md`**: Added prerequisites, quick-start, API reference, and comprehensive testing sections (unit, Go E2E harness, Bun E2E, k6 load, benchmarks).
- **`docs/index.md`**: Fixed Quick Start section — replaced non-existent `make dev` with actual `docker compose` → `make build-all` → `init-db` → `./build/server` workflow.

## Verified

- Zero remaining `LTBase` references in `docs/`
- Zero remaining references to deleted `cmd/server/handlers.go`, `cmd/server/factory.go`, or `cmd/lambda/handlers.go` outside of the `refactor-plan.md` historical context
- All `make build` references are correctly `make build-all`