### PR TITLE
feat: add benchmark longitudinal regression tracking and trend dashboards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,10 @@ jobs:
 
       - name: Run benchmark smoke validation
         run: make benchmark-smoke
+
+      - name: Upload benchmark smoke artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-smoke
+          path: .artifacts/benchmark/smoke/
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -61,17 +61,30 @@ coverage: create-build-dir
 benchmark-smoke: create-build-dir
 	@echo "Running benchmark smoke validation..."
 	@mkdir -p .artifacts/benchmark/smoke
-	@$(GOENV) go run ./cmd/benchmark baseline -preset ci-smoke -output-dir .artifacts/benchmark/smoke
+	@$(GOENV) go run ./cmd/benchmark baseline -preset ci-smoke -output-dir .artifacts/benchmark/smoke \
+		-channel ci \
+		-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
+		-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
 benchmark-regression: create-build-dir
 	@echo "Running benchmark regression live subset..."
 	@mkdir -p .artifacts/benchmark/regression
-	@$(GOENV) go run ./cmd/benchmark baseline -preset small-live -output-dir .artifacts/benchmark/regression
+	@$(GOENV) go run ./cmd/benchmark baseline -preset small-live -output-dir .artifacts/benchmark/regression \
+		-channel manual \
+		-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
+		-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+benchmark-trend: create-build-dir
+	@echo "Running benchmark trend analysis..."
+	@$(GOENV) go run ./cmd/benchmark trend -history-dir .artifacts/benchmark
 
 benchmark-heavy: create-build-dir
 	@echo "Running benchmark heavy planning set..."
 	@mkdir -p .artifacts/benchmark/heavy
-	@$(GOENV) go run ./cmd/benchmark baseline -preset heavy-plan -output-dir .artifacts/benchmark/heavy
+	@$(GOENV) go run ./cmd/benchmark baseline -preset heavy-plan -output-dir .artifacts/benchmark/heavy \
+		-channel manual \
+		-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
+		-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
 # Build server for current platform
 build-server: create-build-dir

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -75,6 +75,8 @@ func runBenchmarkMain(ctx context.Context, args []string, out, errOut io.Writer)
 		return runBaseline(ctx, args[1:], out, errOut)
 	case "run":
 		return runBenchmark(ctx, args[1:], out, errOut)
+	case "trend":
+		return runTrend(args[1:], out, errOut)
 	default:
 		fmt.Fprintf(errOut, "unknown command %q\n", args[0])
 		printUsage(out)
@@ -90,6 +92,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  compare    Compare two benchmark summary artifacts")
 	fmt.Fprintln(out, "  baseline   Capture a baseline artifact set for a preset")
 	fmt.Fprintln(out, "  run        Execute benchmark validation or live runtime")
+	fmt.Fprintln(out, "  trend      Analyze longitudinal benchmark trends and regressions")
 }
 
 func runDescribe(out io.Writer) int {
@@ -130,6 +133,10 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 	outputDir := flags.String("output-dir", ".artifacts/benchmark", "Directory to store baseline captures")
 	distribution := flags.String("distribution", string(bench.DistributionUniform), "Data distribution preset")
 	compareTo := flags.String("compare-to", "", "Optional path to an existing benchmark-summary.json for diff output")
+	channel := flags.String("channel", "", "Provenance channel: ci, nightly, manual")
+	gitSHA := flags.String("git-sha", "", "Provenance git commit SHA")
+	gitRef := flags.String("git-ref", "", "Provenance git ref")
+	label := flags.String("label", "", "Provenance human-readable label")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -138,7 +145,13 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 		fmt.Fprintf(errOut, "baseline setup failed: %v\n", err)
 		return 1
 	}
-	outputs := runOutputs{baselineDir: filepath.Join(*outputDir, dirName)}
+	outputs := runOutputs{
+		baselineDir: filepath.Join(*outputDir, dirName),
+		channel:     *channel,
+		gitSHA:      *gitSHA,
+		gitRef:      *gitRef,
+		label:       *label,
+	}
 	exitCode := executeBenchmarkRun(ctx, config, outputs, out, errOut)
 	if *compareTo == "" {
 		return exitCode
@@ -191,10 +204,65 @@ func compareSummaryFiles(baselinePath, candidatePath string, out, errOut io.Writ
 	return writeJSON(out, diff)
 }
 
+func runTrend(args []string, out, errOut io.Writer) int {
+	flags := flag.NewFlagSet("trend", flag.ContinueOnError)
+	flags.SetOutput(errOut)
+	historyDir := flags.String("history-dir", "", "Directory containing historical benchmark-summary.json artifacts")
+	candidate := flags.String("candidate", "", "Optional path to a specific candidate benchmark-summary.json")
+	baselineWindow := flags.Int("baseline-window", 5, "Number of recent comparable runs to use as baseline")
+	driftWindow := flags.Int("drift-window", 5, "Number of older comparable runs for drift detection")
+	protectedWorkloads := flags.String("protected-workloads", "", "Comma-separated protected workload names (defaults to standard set)")
+	jsonOut := flags.String("json-out", "", "Optional path for JSON trend report output")
+	mdOut := flags.String("md-out", "", "Optional path for Markdown trend report output")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if strings.TrimSpace(*historyDir) == "" {
+		fmt.Fprintln(errOut, "trend requires -history-dir")
+		return 1
+	}
+	var protected []string
+	if strings.TrimSpace(*protectedWorkloads) != "" {
+		protected = parseWorkloads(*protectedWorkloads)
+	} else {
+		protected = bench.DefaultProtectedWorkloads()
+	}
+	report, err := bench.AnalyzeTrend(*historyDir, *candidate, *baselineWindow, *driftWindow, protected)
+	if err != nil {
+		fmt.Fprintf(errOut, "trend analysis failed: %v\n", err)
+		return 1
+	}
+	if *jsonOut != "" {
+		if err := bench.WriteTrendReport(*jsonOut, &report); err != nil {
+			fmt.Fprintf(errOut, "failed to write trend report: %v\n", err)
+			return 1
+		}
+	}
+	if *mdOut != "" {
+		if err := bench.WriteTrendReport(*mdOut, &report); err != nil {
+			fmt.Fprintf(errOut, "failed to write trend markdown: %v\n", err)
+			return 1
+		}
+	}
+	fmt.Fprintln(errOut, bench.FormatTrendSummary(report))
+	exitCode := writeJSON(out, report)
+	if exitCode != 0 {
+		return exitCode
+	}
+	if report.Status == bench.TrendStatusHardStopRegression || report.Status == bench.TrendStatusRegression {
+		return 1
+	}
+	return 0
+}
+
 type runOutputs struct {
 	jsonOut     string
 	mdOut       string
 	baselineDir string
+	channel     string
+	gitSHA      string
+	gitRef      string
+	label       string
 }
 
 func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, int) {
@@ -217,6 +285,10 @@ func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, 
 	mdOut := flags.String("md-out", "", "Optional path for Markdown benchmark output")
 	baselineDir := flags.String("baseline-dir", "", "Optional directory for baseline capture outputs")
 	workloads := flags.String("workloads", "", "Comma-separated workload names (defaults to all)")
+	channel := flags.String("channel", "", "Provenance channel: ci, nightly, manual")
+	gitSHA := flags.String("git-sha", "", "Provenance git commit SHA")
+	gitRef := flags.String("git-ref", "", "Provenance git ref")
+	label := flags.String("label", "", "Provenance human-readable label")
 	if err := flags.Parse(args); err != nil {
 		return bench.Config{}, runOutputs{}, 1
 	}
@@ -237,6 +309,10 @@ func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, 
 		Workloads:     parseWorkloads(*workloads),
 	}.WithDefaults()
 	outputs := runOutputs{jsonOut: *jsonOut, mdOut: *mdOut, baselineDir: *baselineDir}
+	outputs.channel = *channel
+	outputs.gitSHA = *gitSHA
+	outputs.gitRef = *gitRef
+	outputs.label = *label
 	return cfg, outputs, 0
 }
 
@@ -256,6 +332,20 @@ func executeBenchmarkRun(ctx context.Context, cfg bench.Config, outputs runOutpu
 	if err != nil {
 		fmt.Fprintf(errOut, "benchmark run failed: %v\n", err)
 		return 1
+	}
+	if outputs.channel != "" || outputs.gitSHA != "" || outputs.gitRef != "" || outputs.label != "" {
+		result.Provenance = &bench.RunProvenance{
+			StartedAt:    result.StartedAt,
+			CompletedAt:  result.CompletedAt,
+			Channel:      outputs.channel,
+			GitSHA:       outputs.gitSHA,
+			GitRef:       outputs.gitRef,
+			Label:        outputs.label,
+			Mode:         string(result.Config.Mode),
+			Scale:        string(result.Config.Scale),
+			Distribution: string(result.Config.Distribution),
+			TierProfile:  result.Config.TierProfile,
+		}
 	}
 	if outputs.jsonOut != "" {
 		if err := bench.WriteJSONReport(outputs.jsonOut, result); err != nil {

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
 )
@@ -194,5 +195,223 @@ func writeSummaryFixture(t *testing.T, path string, summary bench.SummaryReport)
 	}
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		t.Fatalf("write summary fixture: %v", err)
+	}
+}
+
+func TestRunBenchmarkMainTrendMissingHistoryDir(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"trend"}, &out, &errOut)
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1 for missing -history-dir, got %d", exitCode)
+	}
+	if !bytes.Contains(errOut.Bytes(), []byte("requires -history-dir")) {
+		t.Fatalf("expected error message about missing history dir")
+	}
+}
+
+func TestRunBenchmarkMainTrend(t *testing.T) {
+	dir := t.TempDir()
+	makeRun := func(id string, ts time.Time, p95 time.Duration) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		summary := bench.SummaryReport{
+			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
+			Provenance: &bench.RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Channel:      "ci",
+				Mode:         string(bench.ExecutionModeLive),
+				Scale:        string(bench.ScaleSmall),
+				Distribution: string(bench.DistributionUniform),
+				TierProfile:  bench.DefaultTierMixProfile().Name,
+			},
+			Passed: true,
+			Workloads: []bench.WorkloadSummary{
+				{Name: "baseline-page-1", TargetSchema: "trade", P95: p95, QPS: 10, Passed: true},
+			},
+		}
+		writeSummaryFixture(t, filepath.Join(subDir, "benchmark-summary.json"), summary)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	makeRun("bench-1", ts1, 100*time.Millisecond)
+	makeRun("bench-2", ts2, 100*time.Millisecond)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"trend", "-history-dir", dir}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 for clean trend, got %d: %s", exitCode, errOut.String())
+	}
+	if out.Len() == 0 {
+		t.Fatalf("trend should emit JSON output")
+	}
+	if errOut.Len() == 0 {
+		t.Fatalf("trend should emit console summary")
+	}
+	if !bytes.Contains(errOut.Bytes(), []byte("Benchmark Trend Analysis")) {
+		t.Fatalf("expected trend analysis header in stderr: %s", errOut.String())
+	}
+}
+
+func TestRunBenchmarkMainTrendWithCandidate(t *testing.T) {
+	dir := t.TempDir()
+	makeRun := func(id string, ts time.Time) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		summary := bench.SummaryReport{
+			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
+			Provenance: &bench.RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Mode:         string(bench.ExecutionModeLive),
+				Scale:        string(bench.ScaleSmall),
+				Distribution: string(bench.DistributionUniform),
+				TierProfile:  bench.DefaultTierMixProfile().Name,
+			},
+			Passed: true,
+			Workloads: []bench.WorkloadSummary{
+				{Name: "baseline-page-1", TargetSchema: "trade", P95: 100 * time.Millisecond, QPS: 10, Passed: true},
+			},
+		}
+		writeSummaryFixture(t, filepath.Join(subDir, "benchmark-summary.json"), summary)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	makeRun("bench-1", ts1)
+	makeRun("bench-2", ts2)
+
+	candidatePath := filepath.Join(dir, "run-bench-1", "benchmark-summary.json")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"trend", "-history-dir", dir, "-candidate", candidatePath}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 for trend with candidate, got %d: %s", exitCode, errOut.String())
+	}
+	if out.Len() == 0 {
+		t.Fatalf("trend should emit JSON output")
+	}
+}
+
+func TestRunBenchmarkMainTrendRegressionExitCode(t *testing.T) {
+	dir := t.TempDir()
+	makeRun := func(id string, ts time.Time, correctnessFailures int, passed bool) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		summary := bench.SummaryReport{
+			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
+			Provenance: &bench.RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Mode:         string(bench.ExecutionModeLive),
+				Scale:        string(bench.ScaleSmall),
+				Distribution: string(bench.DistributionUniform),
+				TierProfile:  bench.DefaultTierMixProfile().Name,
+			},
+			Passed: passed,
+			Workloads: []bench.WorkloadSummary{
+				{Name: "baseline-page-1", TargetSchema: "trade", P95: 100 * time.Millisecond, QPS: 10, CorrectnessFailures: correctnessFailures, Passed: passed},
+			},
+		}
+		writeSummaryFixture(t, filepath.Join(subDir, "benchmark-summary.json"), summary)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	makeRun("bench-1", ts1, 0, true)
+	makeRun("bench-2", ts2, 1, false)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"trend", "-history-dir", dir}, &out, &errOut)
+	if exitCode != 1 {
+		t.Fatalf("expected non-zero exit code for correctness regression, got %d", exitCode)
+	}
+	if out.Len() == 0 {
+		t.Fatalf("trend should emit JSON output even on regression")
+	}
+}
+
+func TestRunBenchmarkMainTrendJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	makeRun := func(id string, ts time.Time) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		summary := bench.SummaryReport{
+			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
+			Provenance: &bench.RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Mode:         string(bench.ExecutionModeLive),
+				Scale:        string(bench.ScaleSmall),
+				Distribution: string(bench.DistributionUniform),
+				TierProfile:  bench.DefaultTierMixProfile().Name,
+			},
+			Passed: true,
+			Workloads: []bench.WorkloadSummary{
+				{Name: "baseline-page-1", TargetSchema: "trade", P95: 100 * time.Millisecond, QPS: 10, Passed: true},
+			},
+		}
+		writeSummaryFixture(t, filepath.Join(subDir, "benchmark-summary.json"), summary)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	makeRun("bench-1", ts1)
+	makeRun("bench-2", ts2)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"trend", "-history-dir", dir}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	var report bench.TrendReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("expected valid JSON trend report: %v", err)
+	}
+	if report.Status != bench.TrendStatusPass {
+		t.Fatalf("expected pass status, got %q", report.Status)
+	}
+	if len(report.WorkloadTrends) != 1 {
+		t.Fatalf("expected 1 workload trend, got %d", len(report.WorkloadTrends))
+	}
+}
+
+func TestRunBenchmarkMainTrendFileOutput(t *testing.T) {
+	dir := t.TempDir()
+	makeRun := func(id string, ts time.Time) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		summary := bench.SummaryReport{
+			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
+			Provenance: &bench.RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Mode:         string(bench.ExecutionModeLive),
+				Scale:        string(bench.ScaleSmall),
+				Distribution: string(bench.DistributionUniform),
+				TierProfile:  bench.DefaultTierMixProfile().Name,
+			},
+			Passed: true,
+			Workloads: []bench.WorkloadSummary{
+				{Name: "baseline-page-1", TargetSchema: "trade", P95: 100 * time.Millisecond, QPS: 10, Passed: true},
+			},
+		}
+		writeSummaryFixture(t, filepath.Join(subDir, "benchmark-summary.json"), summary)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	makeRun("bench-1", ts1)
+	makeRun("bench-2", ts2)
+
+	jsonOut := filepath.Join(dir, "trend.json")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"trend", "-history-dir", dir, "-json-out", jsonOut}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d: %s", exitCode, errOut.String())
+	}
+	if _, err := os.Stat(jsonOut); err != nil {
+		t.Fatalf("expected trend report file to exist: %v", err)
 	}
 }

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -214,7 +214,7 @@ func TestRunBenchmarkMainTrend(t *testing.T) {
 	dir := t.TempDir()
 	makeRun := func(id string, ts time.Time, p95 time.Duration) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		summary := bench.SummaryReport{
 			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
 			Provenance: &bench.RunProvenance{
@@ -259,7 +259,7 @@ func TestRunBenchmarkMainTrendWithCandidate(t *testing.T) {
 	dir := t.TempDir()
 	makeRun := func(id string, ts time.Time) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		summary := bench.SummaryReport{
 			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
 			Provenance: &bench.RunProvenance{
@@ -298,7 +298,7 @@ func TestRunBenchmarkMainTrendRegressionExitCode(t *testing.T) {
 	dir := t.TempDir()
 	makeRun := func(id string, ts time.Time, correctnessFailures int, passed bool) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		summary := bench.SummaryReport{
 			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
 			Provenance: &bench.RunProvenance{
@@ -336,7 +336,7 @@ func TestRunBenchmarkMainTrendJSONOutput(t *testing.T) {
 	dir := t.TempDir()
 	makeRun := func(id string, ts time.Time) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		summary := bench.SummaryReport{
 			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
 			Provenance: &bench.RunProvenance{
@@ -381,7 +381,7 @@ func TestRunBenchmarkMainTrendFileOutput(t *testing.T) {
 	dir := t.TempDir()
 	makeRun := func(id string, ts time.Time) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		summary := bench.SummaryReport{
 			Metadata: bench.ArtifactMetadata{BenchmarkID: id},
 			Provenance: &bench.RunProvenance{

--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -162,3 +162,42 @@ Treat any future change that turns `prefer_hot` into a real execution flag as a 
 - selective hot/EAV workloads may use a truth-pass-backed oracle mode to align expected results with the executable federated filter semantics
 - baseline capture is designed for artifact stability first, not for production-like throughput measurement
 - CI integration and operator workflow guidance are documented in `docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md`
+
+## Historical Trend Analysis
+
+The `benchmark trend` subcommand provides longitudinal regression tracking across stored runs.
+
+### Capturing History
+
+Tag each run with provenance metadata so the trend engine can group and order runs:
+
+```bash
+go run ./cmd/benchmark baseline \
+  -preset small-live \
+  -output-dir .artifacts/benchmark/history \
+  -channel ci \
+  -git-sha $(git rev-parse HEAD) \
+  -git-ref $(git rev-parse --abbrev-ref HEAD)
+```
+
+### Running Trend Analysis
+
+```bash
+go run ./cmd/benchmark trend \
+  -history-dir .artifacts/benchmark/history \
+  -baseline-window 5
+```
+
+Optional flags:
+- `-candidate` — pin a specific `benchmark-summary.json` as the candidate
+- `-drift-window` — number of older runs for baseline drift detection (default 5)
+- `-protected-workloads` — comma-separated override of protected workloads
+- `-json-out` / `-md-out` — write trend report to a file
+
+### Interpreting Trend Output
+
+- `status=pass` — no regressions or methodology changes detected
+- `status=hard_stop_regression` — protected workload correctness or instability regressed
+- `status=baseline_drift` — recent baseline window already trending slower than older runs
+- `status=methodology_change` — oracle mode or workload set changed between runs
+- `status=regression` — latency or qps regression detected (review-only)

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -244,13 +244,58 @@ Interpretation guidance:
 - missing baseline artifacts: the output directory was not writable or `-baseline-dir` was omitted
 - harness-backed benchmark test failure: fixture registration, seeded dataset loading, or federated query execution regressed
 
+## Longitudinal Trend Analysis
+
+The `benchmark trend` subcommand scans stored `benchmark-summary.json` artifacts and surfaces regressions, baseline drift, and methodology changes across runs.
+
+### Quick Start
+
+```bash
+go run ./cmd/benchmark trend -history-dir .artifacts/benchmark/history
+```
+
+### Recommended History Layout
+
+```
+.artifacts/benchmark/history/<channel>/<preset>/<distribution>/<timestamp>-<shortsha>/
+  benchmark-result.json
+  benchmark-result.md
+  benchmark-summary.json
+```
+
+Runs should carry provenance metadata (`-channel`, `-git-sha`, `-git-ref`) so the trend engine can group and order them correctly.
+
+### PR CI Behavior
+
+- Correctness regressions in any protected workload return a non-zero exit code.
+- Latency regressions (`p95`) are surfaced in the trend report but do not block PR CI.
+- Use `-protected-workloads` to target the standard set or a custom subset.
+
+### Nightly / Manual Review
+
+- Accumulate history via scheduled `make benchmark-regression` runs with provenance flags.
+- Run `benchmark trend` against the accumulated directory before release review.
+- Check `baseline_drift` signals to distinguish new feature impact from pre-existing platform drift.
+
+### Protected Workload Defaults
+
+```
+baseline-page-1
+hot-selective-page
+hot-low-selectivity-page
+eav-selective-page
+mixed-hot-eav-page
+mixed-tier-window
+hot-only-window
+cold-only-window
+deep-page-1000
+```
+
 ## Deferred Work
 
 These items remain intentionally out of scope for the current operating model:
 
 - official CI performance gating on large-scale thresholds
-- benchmark trend dashboards and longitudinal regression tracking
 - keyset pagination comparison workloads
 - distributed benchmark agents
-
-Until those arrive, use this guide as a safe execution policy rather than as a production-grade benchmark SLO gate.
+- full production-grade hosted dashboards

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -32,9 +32,41 @@ type EnvironmentMetadata struct {
 	Hostname  string `json:"hostname,omitempty"`
 }
 
+// RunProvenance captures runtime context needed for longitudinal trend analysis.
+type RunProvenance struct {
+	StartedAt    time.Time `json:"started_at,omitempty"`
+	CompletedAt  time.Time `json:"completed_at,omitempty"`
+	Preset       string    `json:"preset,omitempty"`
+	Channel      string    `json:"channel,omitempty"`
+	GitSHA       string    `json:"git_sha,omitempty"`
+	GitRef       string    `json:"git_ref,omitempty"`
+	Label        string    `json:"label,omitempty"`
+	Mode         string    `json:"mode,omitempty"`
+	Scale        string    `json:"scale,omitempty"`
+	Distribution string    `json:"distribution,omitempty"`
+	TierProfile  string    `json:"tier_profile,omitempty"`
+}
+
+// DefaultProtectedWorkloads returns the standard set of workloads that trigger
+// hard-stop regression checks during trend analysis.
+func DefaultProtectedWorkloads() []string {
+	return []string{
+		"baseline-page-1",
+		"hot-selective-page",
+		"hot-low-selectivity-page",
+		"eav-selective-page",
+		"mixed-hot-eav-page",
+		"mixed-tier-window",
+		"hot-only-window",
+		"cold-only-window",
+		"deep-page-1000",
+	}
+}
+
 // SummaryReport captures aggregated execution metrics.
 type SummaryReport struct {
 	Metadata            ArtifactMetadata         `json:"metadata"`
+	Provenance          *RunProvenance           `json:"provenance,omitempty"`
 	OracleModes         map[string]string        `json:"oracle_modes,omitempty"`
 	OracleProvenance    []OracleProvenance       `json:"oracle_provenance,omitempty"`
 	Stability           StabilitySummary         `json:"stability"`
@@ -147,6 +179,70 @@ type WorkloadDiff struct {
 	AvgResultCountDelta      float64       `json:"avg_result_count_delta"`
 	AvgTotalRecordsDelta     float64       `json:"avg_total_records_delta"`
 	RouteEngineChanged       bool          `json:"route_engine_changed,omitempty"`
+}
+
+// TrendRun represents a single historical benchmark summary loaded from disk.
+type TrendRun struct {
+	Path      string        `json:"path"`
+	Summary   SummaryReport `json:"summary"`
+	StartedAt time.Time     `json:"started_at"`
+}
+
+// TrendReport is a longitudinal analysis artifact that surfaces regressions,
+// baseline drift, and methodology changes across historical benchmark runs.
+type TrendReport struct {
+	Candidate           TrendRun              `json:"candidate"`
+	BaselineWindow      []TrendRun            `json:"baseline_window"`
+	DriftWindow         []TrendRun            `json:"drift_window,omitempty"`
+	ComparabilityKey    string                `json:"comparability_key"`
+	MethodologyChanges  []string              `json:"methodology_changes,omitempty"`
+	Regressions         []RegressionCandidate `json:"regressions,omitempty"`
+	Drift               *DriftSignal          `json:"drift,omitempty"`
+	WorkloadTrends      []WorkloadTrend       `json:"workload_trends"`
+	ProtectedWorkloads  []string              `json:"protected_workloads"`
+	WindowsToStable     bool                  `json:"windows_too_stable"`
+	Status              string                `json:"status"`
+}
+
+// RegressionCandidate records a single regression signal detected during trend analysis.
+type RegressionCandidate struct {
+	WorkloadName   string  `json:"workload"`
+	TargetSchema   string  `json:"target_schema,omitempty"`
+	Kind           string  `json:"kind"`
+	BaselineValue  float64 `json:"baseline_value"`
+	CandidateValue float64 `json:"candidate_value"`
+	Delta          float64 `json:"delta"`
+	Threshold      float64 `json:"threshold,omitempty"`
+	Severity       string  `json:"severity"`
+	Description    string  `json:"description,omitempty"`
+}
+
+// DriftSignal captures whether the baseline window itself has drifted from an
+// older reference window, independent of the candidate run.
+type DriftSignal struct {
+	Detected    bool     `json:"detected"`
+	Description string   `json:"description"`
+	Evidence    []string `json:"evidence,omitempty"`
+}
+
+// WorkloadTrend represents a single workload's metrics across the baseline window
+// and candidate run.
+type WorkloadTrend struct {
+	Name               string        `json:"name"`
+	TargetSchema       string        `json:"target_schema,omitempty"`
+	BaselineP95        time.Duration `json:"baseline_p95"`
+	CandidateP95       time.Duration `json:"candidate_p95"`
+	P95Delta           time.Duration `json:"p95_delta"`
+	P95DeltaPercent    float64       `json:"p95_delta_percent"`
+	BaselineQPS        float64       `json:"baseline_qps"`
+	CandidateQPS       float64       `json:"candidate_qps"`
+	QPSDelta           float64       `json:"qps_delta"`
+	QPSDeltaPercent    float64       `json:"qps_delta_percent"`
+	CorrectnessChanged bool          `json:"correctness_changed"`
+	CorrectnessDelta   int           `json:"correctness_delta"`
+	InstabilityChanged bool          `json:"instability_changed"`
+	RouteChanged       bool          `json:"route_engine_changed,omitempty"`
+	Classification     string        `json:"classification"`
 }
 
 // WriteJSONReport writes a benchmark run result to JSON.
@@ -282,6 +378,25 @@ func SummarizeRunResult(result *RunResult) SummaryReport {
 	summary.Metadata = metadataForResult(result)
 	summary.OracleModes = cloneStringMap(result.OracleModes)
 	summary.OracleProvenance = summarizeOracleProvenance(result)
+	if result.Provenance != nil {
+		pc := *result.Provenance
+		if pc.StartedAt.IsZero() {
+			pc.StartedAt = result.StartedAt
+		}
+		if pc.CompletedAt.IsZero() {
+			pc.CompletedAt = result.CompletedAt
+		}
+		summary.Provenance = &pc
+	} else if !result.StartedAt.IsZero() {
+		summary.Provenance = &RunProvenance{
+			StartedAt:   result.StartedAt,
+			CompletedAt: result.CompletedAt,
+			Mode:        string(result.Config.Mode),
+			Scale:       string(result.Config.Scale),
+			Distribution: string(result.Config.Distribution),
+			TierProfile: result.Config.TierProfile,
+		}
+	}
 	if len(result.Executions) == 0 {
 		summary.Passed = result != nil && result.Passed
 		summary.FailureCount = resultFailureCount(result)
@@ -679,6 +794,523 @@ func summarizeStability(workloads []WorkloadSummary) StabilitySummary {
 	}
 	sort.Strings(summary.UnstableWorkloads)
 	return summary
+}
+
+const (
+	TrendSeverityHardStop = "hard_stop"
+	TrendSeverityReview   = "review"
+
+	TrendKindCorrectness   = "correctness_regression"
+	TrendKindInstability   = "instability_regression"
+	TrendKindP95Latency    = "p95_latency_regression"
+	TrendKindQPSRegression = "qps_regression"
+
+	TrendClassStable      = "stable"
+	TrendClassRegression  = "regression"
+	TrendClassImprovement = "improvement"
+	TrendClassDrift       = "drift"
+	TrendClassMethodology = "methodology_change"
+
+	TrendStatusPass               = "pass"
+	TrendStatusRegression         = "regression"
+	TrendStatusHardStopRegression = "hard_stop_regression"
+	TrendStatusDrift              = "baseline_drift"
+	TrendStatusMethodology        = "methodology_change"
+)
+
+// ReadTrendHistory scans a directory tree for benchmark-summary.json files
+// and returns them sorted by timestamp, oldest first.
+func ReadTrendHistory(historyDir string) ([]TrendRun, error) {
+	var runs []TrendRun
+	err := filepath.Walk(historyDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if info.Name() != "benchmark-summary.json" {
+			return nil
+		}
+		summary, readErr := ReadSummaryReport(path)
+		if readErr != nil {
+			return nil
+		}
+		startedAt := summary.Provenance.StartedAt
+		if startedAt.IsZero() && summary.Provenance != nil {
+			startedAt = summary.Provenance.CompletedAt
+		}
+		if startedAt.IsZero() {
+			return nil
+		}
+		runs = append(runs, TrendRun{
+			Path:      path,
+			Summary:   summary,
+			StartedAt: startedAt,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk history directory: %w", err)
+	}
+	sort.Slice(runs, func(i, j int) bool { return runs[i].StartedAt.Before(runs[j].StartedAt) })
+	return runs, nil
+}
+
+// buildComparabilityIdentity builds a string key that groups comparable benchmark runs.
+// The identity combines mode, scale, distribution, tier profile, and workload set.
+// Oracle modes are intentionally excluded so that oracle-mode changes are surfaced
+// as methodology changes rather than splitting runs into separate comparability groups.
+func buildComparabilityIdentity(summary SummaryReport) string {
+	if summary.Provenance == nil {
+		return summary.Metadata.BenchmarkID
+	}
+	names := make([]string, 0, len(summary.Workloads))
+	for _, w := range summary.Workloads {
+		names = append(names, w.Name)
+	}
+	sort.Strings(names)
+	return fmt.Sprintf("%s|%s|%s|%s|%s",
+		summary.Provenance.Mode,
+		summary.Provenance.Scale,
+		summary.Provenance.Distribution,
+		summary.Provenance.TierProfile,
+		strings.Join(names, ","))
+}
+
+// findCandidateRun returns the specified candidate path or the newest comparable run.
+func findCandidateRun(runs []TrendRun, candidatePath string, comparabilityKey string) (TrendRun, []TrendRun, error) {
+	var comparable []TrendRun
+	for _, r := range runs {
+		if buildComparabilityIdentity(r.Summary) == comparabilityKey {
+			comparable = append(comparable, r)
+		}
+	}
+	if len(comparable) == 0 {
+		return TrendRun{}, nil, fmt.Errorf("no comparable runs found for identity %s", comparabilityKey)
+	}
+	if candidatePath != "" {
+		for _, r := range comparable {
+			if r.Path == candidatePath {
+				return r, comparable, nil
+			}
+		}
+		return TrendRun{}, nil, fmt.Errorf("candidate path %s not found in comparable runs", candidatePath)
+	}
+	return comparable[len(comparable)-1], comparable, nil
+}
+
+// selectBaseAndDriftWindows selects baseline and drift windows from comparable runs,
+// excluding the candidate.
+func selectBaseAndDriftWindows(comparable []TrendRun, candidate TrendRun, baselineWindow, driftWindow int) (baseline, drift []TrendRun) {
+	var before []TrendRun
+	for _, r := range comparable {
+		if r.StartedAt.Before(candidate.StartedAt) {
+			before = append(before, r)
+		}
+	}
+	sort.Slice(before, func(i, j int) bool { return before[i].StartedAt.After(before[j].StartedAt) })
+	if len(before) > baselineWindow {
+		before = before[:baselineWindow]
+	}
+	sort.Slice(before, func(i, j int) bool { return before[i].StartedAt.Before(before[j].StartedAt) })
+	baseline = before
+	if driftWindow <= 0 || len(baseline) < baselineWindow {
+		return baseline, nil
+	}
+	older := make([]TrendRun, 0)
+	for _, r := range comparable {
+		if r.StartedAt.Before(candidate.StartedAt) && !containsRun(baseline, r) {
+			older = append(older, r)
+		}
+	}
+	sort.Slice(older, func(i, j int) bool { return older[i].StartedAt.After(older[j].StartedAt) })
+	if len(older) > driftWindow {
+		older = older[:driftWindow]
+	}
+	sort.Slice(older, func(i, j int) bool { return older[i].StartedAt.Before(older[j].StartedAt) })
+	return baseline, older
+}
+
+func containsRun(runs []TrendRun, target TrendRun) bool {
+	for _, r := range runs {
+		if r.Path == target.Path || r.StartedAt.Equal(target.StartedAt) {
+			return true
+		}
+	}
+	return false
+}
+
+// detectMethodologyChanges checks for oracle mode or workload set changes.
+func detectMethodologyChanges(baseline, candidate SummaryReport) []string {
+	var changes []string
+	if len(baseline.OracleModes) != len(candidate.OracleModes) {
+		changes = append(changes, "oracle mode count changed")
+		return changes
+	}
+	for k, v := range baseline.OracleModes {
+		if cv, ok := candidate.OracleModes[k]; !ok || cv != v {
+			changes = append(changes, fmt.Sprintf("oracle mode for workload %s changed", k))
+		}
+	}
+	baseNames := make(map[string]bool)
+	for _, w := range baseline.Workloads {
+		baseNames[w.Name] = true
+	}
+	for _, w := range candidate.Workloads {
+		if !baseNames[w.Name] {
+			changes = append(changes, fmt.Sprintf("new workload %s not present in baseline", w.Name))
+		}
+	}
+	candNames := make(map[string]bool)
+	for _, w := range candidate.Workloads {
+		candNames[w.Name] = true
+	}
+	for _, w := range baseline.Workloads {
+		if !candNames[w.Name] {
+			changes = append(changes, fmt.Sprintf("workload %s removed in candidate", w.Name))
+		}
+	}
+	return changes
+}
+
+// isWorkloadInstabilityChanged returns whether a workload's instability status changed
+// between baseline and candidate. It checks changes in CorrectnessFailures (>0) as
+// a proxy for hard-stop instability regressions.
+func isWorkloadInstabilityChanged(base, cand WorkloadSummary) bool {
+	baseUnstable := containsString(base.AssertionStats, func(s AssertionStat) bool { return s.Failed > 0 })
+	candUnstable := containsString(cand.AssertionStats, func(s AssertionStat) bool { return s.Failed > 0 })
+	return baseUnstable != candUnstable
+}
+
+func containsString(stats map[string]AssertionStat, predicate func(AssertionStat) bool) bool {
+	for _, s := range stats {
+		if predicate(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// analyzeWorkloadTrends computes per-workload trends across baseline and candidate.
+func analyzeWorkloadTrends(baselineRuns []TrendRun, candidate SummaryReport, protected map[string]bool) []WorkloadTrend {
+	if len(baselineRuns) == 0 {
+		return nil
+	}
+	baselineByWorkload := make(map[string][]WorkloadSummary)
+	for _, r := range baselineRuns {
+		for _, w := range r.Summary.Workloads {
+			baselineByWorkload[w.Name] = append(baselineByWorkload[w.Name], w)
+		}
+	}
+	var trends []WorkloadTrend
+	for _, cw := range candidate.Workloads {
+		bws, ok := baselineByWorkload[cw.Name]
+		if !ok || !protected[cw.Name] && len(bws) == 0 {
+			continue
+		}
+		if !protected[cw.Name] {
+			continue
+		}
+		avgP95 := medianP95(bws)
+		avgQPS := medianQPS(bws)
+		p95Delta := cw.P95 - avgP95
+		qpsDelta := cw.QPS - avgQPS
+		var p95DeltaPct, qpsDeltaPct float64
+		if avgP95 > 0 {
+			p95DeltaPct = float64(p95Delta) / float64(avgP95) * 100
+		}
+		if avgQPS > 0 {
+			qpsDeltaPct = qpsDelta / avgQPS * 100
+		}
+		instabilityChanged := false
+		if len(bws) > 0 {
+			instabilityChanged = isWorkloadInstabilityChanged(bws[0], cw)
+		}
+		correctnessDelta := 0
+		correctnessChanged := false
+		if len(bws) > 0 {
+			correctnessDelta = cw.CorrectnessFailures - bws[0].CorrectnessFailures
+			correctnessChanged = correctnessDelta != 0
+		}
+		classification := TrendClassStable
+		if correctnessChanged && correctnessDelta > 0 {
+			classification = TrendClassRegression
+		} else if instabilityChanged {
+			classification = TrendClassRegression
+		} else if p95DeltaPct >= 10 {
+			classification = TrendClassRegression
+		} else if qpsDeltaPct <= -10 {
+			classification = TrendClassRegression
+		} else if p95DeltaPct <= -10 {
+			classification = TrendClassImprovement
+		}
+		trends = append(trends, WorkloadTrend{
+			Name:               cw.Name,
+			TargetSchema:       cw.TargetSchema,
+			BaselineP95:        avgP95,
+			CandidateP95:       cw.P95,
+			P95Delta:           p95Delta,
+			P95DeltaPercent:    p95DeltaPct,
+			BaselineQPS:        avgQPS,
+			CandidateQPS:       cw.QPS,
+			QPSDelta:           qpsDelta,
+			QPSDeltaPercent:    qpsDeltaPct,
+			CorrectnessChanged: correctnessChanged,
+			CorrectnessDelta:   correctnessDelta,
+			InstabilityChanged: instabilityChanged,
+			Classification:     classification,
+		})
+	}
+	sort.Slice(trends, func(i, j int) bool { return trends[i].Name < trends[j].Name })
+	return trends
+}
+
+func medianP95(workloads []WorkloadSummary) time.Duration {
+	if len(workloads) == 0 {
+		return 0
+	}
+	durs := make([]time.Duration, len(workloads))
+	for i, w := range workloads {
+		durs[i] = w.P95
+	}
+	sort.Slice(durs, func(i, j int) bool { return durs[i] < durs[j] })
+	mid := len(durs) / 2
+	if len(durs)%2 == 0 {
+		return (durs[mid-1] + durs[mid]) / 2
+	}
+	return durs[mid]
+}
+
+func medianQPS(workloads []WorkloadSummary) float64 {
+	if len(workloads) == 0 {
+		return 0
+	}
+	qpsVals := make([]float64, len(workloads))
+	for i, w := range workloads {
+		qpsVals[i] = w.QPS
+	}
+	sort.Float64s(qpsVals)
+	mid := len(qpsVals) / 2
+	if len(qpsVals)%2 == 0 {
+		return (qpsVals[mid-1] + qpsVals[mid]) / 2
+	}
+	return qpsVals[mid]
+}
+
+func medianP95FromTrendRuns(runs []TrendRun) time.Duration {
+	var all []time.Duration
+	for _, r := range runs {
+		for _, w := range r.Summary.Workloads {
+			all = append(all, w.P95)
+		}
+	}
+	if len(all) == 0 {
+		return 0
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
+	mid := len(all) / 2
+	if len(all)%2 == 0 {
+		return (all[mid-1] + all[mid]) / 2
+	}
+	return all[mid]
+}
+
+// detectRegressions analyzes workload trends and flags regression candidates.
+func detectRegressions(trends []WorkloadTrend, candidate SummaryReport) []RegressionCandidate {
+	var regressions []RegressionCandidate
+	candByName := make(map[string]WorkloadSummary, len(candidate.Workloads))
+	for _, w := range candidate.Workloads {
+		candByName[w.Name] = w
+	}
+	for _, t := range trends {
+		cw := candByName[t.Name]
+		if t.CorrectnessChanged && t.CorrectnessDelta > 0 {
+			regressions = append(regressions, RegressionCandidate{
+				WorkloadName:   t.Name,
+				TargetSchema:   t.TargetSchema,
+				Kind:           TrendKindCorrectness,
+				BaselineValue:  float64(cw.CorrectnessFailures - t.CorrectnessDelta),
+				CandidateValue: float64(cw.CorrectnessFailures),
+				Delta:          float64(t.CorrectnessDelta),
+				Severity:       TrendSeverityHardStop,
+				Description:    fmt.Sprintf("correctness failures increased from %d to %d", cw.CorrectnessFailures-t.CorrectnessDelta, cw.CorrectnessFailures),
+			})
+		}
+		if t.InstabilityChanged {
+			regressions = append(regressions, RegressionCandidate{
+				WorkloadName: t.Name,
+				TargetSchema: t.TargetSchema,
+				Kind:         TrendKindInstability,
+				Severity:     TrendSeverityHardStop,
+				Description:  "workload repeated-run stability status changed",
+			})
+		}
+		if t.P95DeltaPercent >= 10 && t.Classification == TrendClassRegression {
+			regressions = append(regressions, RegressionCandidate{
+				WorkloadName:   t.Name,
+				TargetSchema:   t.TargetSchema,
+				Kind:           TrendKindP95Latency,
+				BaselineValue:  float64(t.BaselineP95),
+				CandidateValue: float64(t.CandidateP95),
+				Delta:          float64(t.P95Delta),
+				Threshold:      10,
+				Severity:       TrendSeverityReview,
+				Description:    fmt.Sprintf("p95 increased by %.1f%% from %s to %s", t.P95DeltaPercent, t.BaselineP95, t.CandidateP95),
+			})
+		}
+		if t.QPSDeltaPercent <= -10 && t.Classification == TrendClassRegression {
+			regressions = append(regressions, RegressionCandidate{
+				WorkloadName:   t.Name,
+				TargetSchema:   t.TargetSchema,
+				Kind:           TrendKindQPSRegression,
+				BaselineValue:  t.BaselineQPS,
+				CandidateValue: t.CandidateQPS,
+				Delta:          t.QPSDelta,
+				Threshold:      -10,
+				Severity:       TrendSeverityReview,
+				Description:    fmt.Sprintf("qps dropped by %.1f%% from %.2f to %.2f", -t.QPSDeltaPercent, t.BaselineQPS, t.CandidateQPS),
+			})
+		}
+	}
+	return regressions
+}
+
+// detectBaselineDrift checks whether the baseline window has drifted from the
+// drift window.
+func detectBaselineDrift(baseline, drift []TrendRun) *DriftSignal {
+	if len(drift) == 0 || len(baseline) == 0 {
+		return nil
+	}
+	baselineP95 := medianP95FromTrendRuns(baseline)
+	driftP95 := medianP95FromTrendRuns(drift)
+	if baselineP95 <= 0 || driftP95 <= 0 {
+		return nil
+	}
+	deltaPct := float64(baselineP95-driftP95) / float64(driftP95) * 100
+	if deltaPct >= 10 {
+		return &DriftSignal{
+			Detected:    true,
+			Description: fmt.Sprintf("baseline p95 is %.1f%% slower than drift window (%s vs %s)", deltaPct, baselineP95, driftP95),
+			Evidence:    []string{fmt.Sprintf("baseline_median_p95=%s drift_median_p95=%s delta_pct=%.1f", baselineP95, driftP95, deltaPct)},
+		}
+	}
+	return nil
+}
+
+// AnalyzeTrend is the main entry point for longitudinal trend analysis.
+func AnalyzeTrend(historyDir, candidatePath string, baselineWindow, driftWindow int, protectedWorkloads []string) (TrendReport, error) {
+	runs, err := ReadTrendHistory(historyDir)
+	if err != nil {
+		return TrendReport{}, err
+	}
+	if len(runs) == 0 {
+		return TrendReport{}, fmt.Errorf("no historical runs found in %s", historyDir)
+	}
+	protectedSet := make(map[string]bool, len(protectedWorkloads))
+	for _, name := range protectedWorkloads {
+		protectedSet[name] = true
+	}
+	if candidatePath == "" {
+		candidatePath = runs[len(runs)-1].Path
+	}
+	candidateSummary := runs[len(runs)-1].Summary
+	if candidatePath != runs[len(runs)-1].Path {
+		for _, r := range runs {
+			if r.Path == candidatePath {
+				candidateSummary = r.Summary
+				break
+			}
+		}
+	}
+	compKey := buildComparabilityIdentity(candidateSummary)
+	candidate, comparable, err := findCandidateRun(runs, candidatePath, compKey)
+	if err != nil {
+		return TrendReport{}, err
+	}
+	baseline, drift := selectBaseAndDriftWindows(comparable, candidate, baselineWindow, driftWindow)
+	methodologyChanges := make([]string, 0)
+	if len(baseline) > 0 {
+		methodologyChanges = detectMethodologyChanges(baseline[0].Summary, candidate.Summary)
+	}
+	trends := analyzeWorkloadTrends(baseline, candidate.Summary, protectedSet)
+	regressions := detectRegressions(trends, candidate.Summary)
+	driftSignal := detectBaselineDrift(baseline, drift)
+	status := TrendStatusPass
+	hasHardStop := false
+	for _, reg := range regressions {
+		if reg.Severity == TrendSeverityHardStop {
+			hasHardStop = true
+			break
+		}
+	}
+	if hasHardStop {
+		status = TrendStatusHardStopRegression
+	} else if len(methodologyChanges) > 0 {
+		status = TrendStatusMethodology
+	} else if driftSignal != nil && driftSignal.Detected {
+		status = TrendStatusDrift
+	} else if len(regressions) > 0 {
+		status = TrendStatusRegression
+	}
+	stableWindows := len(baseline) == baselineWindow && driftWindow > 0 && len(drift) < driftWindow
+	return TrendReport{
+		Candidate:          candidate,
+		BaselineWindow:     baseline,
+		DriftWindow:        drift,
+		ComparabilityKey:   compKey,
+		MethodologyChanges: methodologyChanges,
+		Regressions:        regressions,
+		Drift:              driftSignal,
+		WorkloadTrends:     trends,
+		ProtectedWorkloads: protectedWorkloads,
+		WindowsToStable:    stableWindows,
+		Status:             status,
+	}, nil
+}
+
+// FormatTrendSummary returns a stable console summary for trend analysis.
+func FormatTrendSummary(report TrendReport) string {
+	var b strings.Builder
+	b.WriteString("Benchmark Trend Analysis\n")
+	b.WriteString(fmt.Sprintf("candidate=%s comparability=%s status=%s baseline_window=%d drift_window=%d\n",
+		report.Candidate.Summary.Metadata.BenchmarkID,
+		report.ComparabilityKey,
+		report.Status,
+		len(report.BaselineWindow),
+		len(report.DriftWindow),
+	))
+	if len(report.MethodologyChanges) > 0 {
+		b.WriteString(fmt.Sprintf("methodology_changes=%s\n", strings.Join(report.MethodologyChanges, "; ")))
+	}
+	if report.Drift != nil && report.Drift.Detected {
+		b.WriteString(fmt.Sprintf("baseline_drift=%s\n", report.Drift.Description))
+	}
+	if len(report.Regressions) > 0 {
+		b.WriteString("regressions:\n")
+		for _, reg := range report.Regressions {
+			b.WriteString(fmt.Sprintf("  workload=%s kind=%s severity=%s baseline=%v candidate=%v delta=%v description=%s\n",
+				reg.WorkloadName, reg.Kind, reg.Severity, reg.BaselineValue, reg.CandidateValue, reg.Delta, reg.Description))
+		}
+	}
+	b.WriteString("workload trends:\n")
+	for _, t := range report.WorkloadTrends {
+		b.WriteString(fmt.Sprintf("  %s schema=%s classification=%s p95_baseline=%s p95_candidate=%s p95_delta=%s (%.1f%%) qps_baseline=%.2f qps_candidate=%.2f qps_delta=%.2f (%.1f%%) correctness_changed=%t instability_changed=%t\n",
+			t.Name, t.TargetSchema, t.Classification, t.BaselineP95, t.CandidateP95, t.P95Delta, t.P95DeltaPercent, t.BaselineQPS, t.CandidateQPS, t.QPSDelta, t.QPSDeltaPercent, t.CorrectnessChanged, t.InstabilityChanged))
+	}
+	return b.String()
+}
+
+// WriteTrendReport writes a trend report to JSON.
+func WriteTrendReport(path string, report *TrendReport) error {
+	if report == nil {
+		return fmt.Errorf("trend report cannot be nil")
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal trend report: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
 }
 
 func compareWorkloadSummaries(baseline, candidate []WorkloadSummary) []WorkloadDiff {

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -297,3 +297,688 @@ func TestWriteAndReadDiffReport(t *testing.T) {
 		t.Fatalf("unexpected summary metadata: %+v", readSummary.Metadata)
 	}
 }
+
+func TestDefaultProtectedWorkloads(t *testing.T) {
+	protected := DefaultProtectedWorkloads()
+	if len(protected) != 9 {
+		t.Fatalf("expected 9 protected workloads, got %d", len(protected))
+	}
+	workloads := map[string]bool{}
+	for _, name := range protected {
+		workloads[name] = true
+	}
+	for _, required := range []string{"baseline-page-1", "hot-selective-page", "deep-page-1000"} {
+		if !workloads[required] {
+			t.Fatalf("expected %q in protected workloads", required)
+		}
+	}
+}
+
+func TestWriteBaselineCaptureIncludesProvenance(t *testing.T) {
+	dir := t.TempDir()
+	baseTime := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	result := &RunResult{
+		Passed:       true,
+		StartedAt:    baseTime,
+		CompletedAt:  baseTime.Add(10 * time.Second),
+		Generator:    GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
+		Config:       Config{Mode: ExecutionModeLive, Scale: ScaleSmall, Distribution: DistributionUniform, TierProfile: DefaultTierMixProfile().Name},
+		Provenance: &RunProvenance{
+			Channel:      "ci",
+			GitSHA:       "abc123",
+			GitRef:       "refs/heads/main",
+			Label:        "test-run",
+			Mode:         string(ExecutionModeLive),
+			Scale:        string(ScaleSmall),
+			Distribution: string(DistributionUniform),
+			TierProfile:  DefaultTierMixProfile().Name,
+		},
+		Workloads: []WorkloadDefinition{
+			{Name: "q1", Category: WorkloadCategoryPagination, TargetSchema: "trade", OracleMode: OracleModeLoadedState},
+		},
+		Executions: []WorkloadRunResult{{
+			Name:         "q1",
+			Passed:       true,
+			Duration:     10 * time.Millisecond,
+			OracleMode:   string(OracleModeLoadedState),
+			ResultCount:  20,
+			TotalRecords: 100,
+		}},
+	}
+	if err := WriteBaselineCapture(dir, result); err != nil {
+		t.Fatalf("WriteBaselineCapture failed: %v", err)
+	}
+	summaryPath := filepath.Join(dir, "benchmark-summary.json")
+	summary, err := ReadSummaryReport(summaryPath)
+	if err != nil {
+		t.Fatalf("ReadSummaryReport failed: %v", err)
+	}
+	if summary.Provenance == nil {
+		t.Fatalf("expected provenance in summary")
+	}
+	if summary.Provenance.Channel != "ci" {
+		t.Fatalf("expected channel ci, got %q", summary.Provenance.Channel)
+	}
+	if summary.Provenance.GitSHA != "abc123" {
+		t.Fatalf("expected git SHA abc123, got %q", summary.Provenance.GitSHA)
+	}
+	if summary.Provenance.StartedAt.IsZero() {
+		t.Fatalf("expected started_at to be populated")
+	}
+	if summary.Provenance.CompletedAt.IsZero() {
+		t.Fatalf("expected completed_at to be populated")
+	}
+}
+
+func TestProvenancePopulatedFromResultWithoutExplicitProvenance(t *testing.T) {
+	baseTime := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	result := &RunResult{
+		Passed:       true,
+		StartedAt:    baseTime,
+		CompletedAt:  baseTime.Add(10 * time.Second),
+		Config:       Config{Mode: ExecutionModeSmoke, Scale: ScaleSmall, Distribution: DistributionUniform, TierProfile: DefaultTierMixProfile().Name},
+		Generator:    GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform},
+		Workloads: []WorkloadDefinition{
+			{Name: "q1", Category: WorkloadCategoryPagination, TargetSchema: "trade", OracleMode: OracleModeLoadedState},
+		},
+		Executions: []WorkloadRunResult{{
+			Name:         "q1",
+			Passed:       true,
+			Duration:     10 * time.Millisecond,
+			OracleMode:   string(OracleModeLoadedState),
+			ResultCount:  20,
+			TotalRecords: 100,
+		}},
+	}
+	summary := SummarizeRunResult(result)
+	if summary.Provenance == nil {
+		t.Fatalf("expected provenance to be populated from result even without explicit provenance")
+	}
+	if summary.Provenance.Mode != string(ExecutionModeSmoke) {
+		t.Fatalf("expected mode smoke in provenance, got %q", summary.Provenance.Mode)
+	}
+}
+
+func TestReadTrendHistory(t *testing.T) {
+	dir := t.TempDir()
+	makeSummary := func(id string, ts time.Time, preset string, mode, scale string, workloads []string) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		workloadSummaries := make([]WorkloadSummary, 0, len(workloads))
+		for _, name := range workloads {
+			workloadSummaries = append(workloadSummaries, WorkloadSummary{
+				Name:   name,
+				P95:    100 * time.Millisecond,
+				QPS:    10,
+				Passed: true,
+			})
+		}
+		summary := SummaryReport{
+			Metadata: ArtifactMetadata{BenchmarkID: id},
+			Provenance: &RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Preset:       preset,
+				Channel:      "ci",
+				Mode:         mode,
+				Scale:        scale,
+				Distribution: string(DistributionUniform),
+				TierProfile:  DefaultTierMixProfile().Name,
+			},
+			Passed:    true,
+			Workloads: workloadSummaries,
+		}
+		data, _ := json.MarshalIndent(summary, "", "  ")
+		os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
+	ts3 := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+	makeSummary("bench-aaa", ts1, "small-live", string(ExecutionModeLive), string(ScaleSmall), []string{"q1", "q2"})
+	makeSummary("bench-bbb", ts2, "small-live", string(ExecutionModeLive), string(ScaleSmall), []string{"q1", "q2"})
+	makeSummary("bench-ccc", ts3, "small-live", string(ExecutionModeLive), string(ScaleSmall), []string{"q1", "q2"})
+	runs, err := ReadTrendHistory(dir)
+	if err != nil {
+		t.Fatalf("ReadTrendHistory failed: %v", err)
+	}
+	if len(runs) != 3 {
+		t.Fatalf("expected 3 runs, got %d", len(runs))
+	}
+	if !runs[0].StartedAt.Before(runs[1].StartedAt) {
+		t.Fatalf("expected chronological ordering")
+	}
+	if runs[0].Summary.Metadata.BenchmarkID != "bench-aaa" {
+		t.Fatalf("expected oldest run first, got %s", runs[0].Summary.Metadata.BenchmarkID)
+	}
+	if runs[2].Summary.Metadata.BenchmarkID != "bench-ccc" {
+		t.Fatalf("expected newest run last, got %s", runs[2].Summary.Metadata.BenchmarkID)
+	}
+}
+
+func TestBuildComparabilityIdentity(t *testing.T) {
+	a := SummaryReport{
+		Metadata: ArtifactMetadata{BenchmarkID: "bench-a"},
+		Provenance: &RunProvenance{
+			Mode:         string(ExecutionModeLive),
+			Scale:        string(ScaleSmall),
+			Distribution: string(DistributionUniform),
+			TierProfile:  DefaultTierMixProfile().Name,
+		},
+		OracleModes: map[string]string{"q1": string(OracleModeLoadedState)},
+		Workloads: []WorkloadSummary{
+			{Name: "q1"}, {Name: "q2"},
+		},
+	}
+	b := SummaryReport{
+		Metadata: ArtifactMetadata{BenchmarkID: "bench-b"},
+		Provenance: &RunProvenance{
+			Mode:         string(ExecutionModeLive),
+			Scale:        string(ScaleSmall),
+			Distribution: string(DistributionUniform),
+			TierProfile:  DefaultTierMixProfile().Name,
+		},
+		OracleModes: map[string]string{"q1": string(OracleModeTruthPass)},
+		Workloads: []WorkloadSummary{
+			{Name: "q2"}, {Name: "q1"},
+		},
+	}
+	if buildComparabilityIdentity(a) != buildComparabilityIdentity(b) {
+		t.Fatalf("expected same comparability key regardless of workload order and oracle mode")
+	}
+	c := SummaryReport{
+		Metadata: ArtifactMetadata{BenchmarkID: "bench-c"},
+		Provenance: &RunProvenance{
+			Mode:         string(ExecutionModeLive),
+			Scale:        string(ScaleMedium),
+			Distribution: string(DistributionUniform),
+			TierProfile:  DefaultTierMixProfile().Name,
+		},
+		Workloads: []WorkloadSummary{
+			{Name: "q1"}, {Name: "q2"},
+		},
+	}
+	if buildComparabilityIdentity(a) == buildComparabilityIdentity(c) {
+		t.Fatalf("expected different comparability keys for different scales")
+	}
+	d := SummaryReport{
+		Metadata:    ArtifactMetadata{BenchmarkID: "bench-d"},
+		Provenance:  nil,
+		Workloads: []WorkloadSummary{{Name: "q1"}},
+	}
+	keyD := buildComparabilityIdentity(d)
+	if keyD != "bench-d" {
+		t.Fatalf("expected benchmark ID as fallback for nil provenance, got %q", keyD)
+	}
+}
+
+func TestDetectMethodologyChanges(t *testing.T) {
+	base := SummaryReport{
+		OracleModes: map[string]string{"q1": string(OracleModeLoadedState)},
+		Workloads: []WorkloadSummary{
+			{Name: "q1"},
+		},
+	}
+	cand := SummaryReport{
+		OracleModes: map[string]string{"q1": string(OracleModeTruthPass)},
+		Workloads: []WorkloadSummary{
+			{Name: "q1"},
+		},
+	}
+	changes := detectMethodologyChanges(base, cand)
+	if len(changes) == 0 {
+		t.Fatalf("expected oracle mode change to be detected")
+	}
+	base2 := SummaryReport{
+		OracleModes: map[string]string{"q1": string(OracleModeLoadedState)},
+		Workloads: []WorkloadSummary{
+			{Name: "q1"},
+		},
+	}
+	cand2 := SummaryReport{
+		OracleModes: map[string]string{"q1": string(OracleModeLoadedState)},
+		Workloads: []WorkloadSummary{
+			{Name: "q1"}, {Name: "q2"},
+		},
+	}
+	changes2 := detectMethodologyChanges(base2, cand2)
+	if len(changes2) == 0 {
+		t.Fatalf("expected new workload addition to be detected")
+	}
+}
+
+func TestMedianCalculations(t *testing.T) {
+	workloads := []WorkloadSummary{
+		{P95: 100 * time.Millisecond},
+		{P95: 200 * time.Millisecond},
+		{P95: 300 * time.Millisecond},
+	}
+	med := medianP95(workloads)
+	if med != 200*time.Millisecond {
+		t.Fatalf("expected median 200ms, got %s", med)
+	}
+	emptyMed := medianP95(nil)
+	if emptyMed != 0 {
+		t.Fatalf("expected 0 for empty slice, got %s", emptyMed)
+	}
+}
+
+func TestDetectRegressions(t *testing.T) {
+	candidate := SummaryReport{
+		Workloads: []WorkloadSummary{
+			{Name: "q1", TargetSchema: "trade", CorrectnessFailures: 1, Passed: false},
+		},
+	}
+	trends := []WorkloadTrend{
+		{
+			Name:               "q1",
+			TargetSchema:       "trade",
+			CorrectnessChanged: true,
+			CorrectnessDelta:   1,
+			Classification:     TrendClassRegression,
+		},
+	}
+	regressions := detectRegressions(trends, candidate)
+	if len(regressions) != 1 {
+		t.Fatalf("expected 1 correctness regression, got %d", len(regressions))
+	}
+	if regressions[0].Severity != TrendSeverityHardStop {
+		t.Fatalf("expected hard stop for correctness regression, got %q", regressions[0].Severity)
+	}
+	if regressions[0].Kind != TrendKindCorrectness {
+		t.Fatalf("expected correctness kind, got %q", regressions[0].Kind)
+	}
+}
+
+func TestDetectRegressionsInstability(t *testing.T) {
+	candidate := SummaryReport{
+		Workloads: []WorkloadSummary{
+			{Name: "q1", TargetSchema: "trade", CorrectnessFailures: 0},
+		},
+	}
+	trends := []WorkloadTrend{
+		{
+			Name:               "q1",
+			TargetSchema:       "trade",
+			InstabilityChanged: true,
+			Classification:     TrendClassRegression,
+		},
+	}
+	regressions := detectRegressions(trends, candidate)
+	if len(regressions) != 1 {
+		t.Fatalf("expected 1 instability regression, got %d", len(regressions))
+	}
+	if regressions[0].Kind != TrendKindInstability {
+		t.Fatalf("expected instability kind, got %q", regressions[0].Kind)
+	}
+}
+
+func TestDetectRegressionsP95Latency(t *testing.T) {
+	candidate := SummaryReport{
+		Workloads: []WorkloadSummary{
+			{Name: "q1", TargetSchema: "trade", P95: 150 * time.Millisecond},
+		},
+	}
+	trends := []WorkloadTrend{
+		{
+			Name:             "q1",
+			TargetSchema:     "trade",
+			BaselineP95:      100 * time.Millisecond,
+			CandidateP95:     150 * time.Millisecond,
+			P95Delta:         50 * time.Millisecond,
+			P95DeltaPercent:  50,
+			Classification:   TrendClassRegression,
+		},
+	}
+	regressions := detectRegressions(trends, candidate)
+	if len(regressions) != 1 {
+		t.Fatalf("expected 1 p95 latency regression, got %d", len(regressions))
+	}
+	if regressions[0].Kind != TrendKindP95Latency {
+		t.Fatalf("expected p95 kind, got %q", regressions[0].Kind)
+	}
+	if regressions[0].Severity != TrendSeverityReview {
+		t.Fatalf("expected review severity for latency, got %q", regressions[0].Severity)
+	}
+}
+
+func TestDetectBaselineDrift(t *testing.T) {
+	base := []TrendRun{
+		{Summary: SummaryReport{Workloads: []WorkloadSummary{{P95: 120 * time.Millisecond}}}},
+	}
+	drift := []TrendRun{
+		{Summary: SummaryReport{Workloads: []WorkloadSummary{{P95: 100 * time.Millisecond}}}},
+	}
+	sig := detectBaselineDrift(base, drift)
+	if sig == nil {
+		t.Fatalf("expected baseline drift to be detected (20%% increase)")
+	}
+	if !sig.Detected {
+		t.Fatalf("expected drift to be detected")
+	}
+	base2 := []TrendRun{
+		{Summary: SummaryReport{Workloads: []WorkloadSummary{{P95: 102 * time.Millisecond}}}},
+	}
+	drift2 := []TrendRun{
+		{Summary: SummaryReport{Workloads: []WorkloadSummary{{P95: 100 * time.Millisecond}}}},
+	}
+	sig2 := detectBaselineDrift(base2, drift2)
+	if sig2 != nil && sig2.Detected {
+		t.Fatalf("expected no drift for 2%% increase")
+	}
+	sig3 := detectBaselineDrift(nil, drift)
+	if sig3 != nil {
+		t.Fatalf("expected nil drift with empty baseline")
+	}
+}
+
+func TestFindCandidateRun(t *testing.T) {
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
+	makeRun := func(path string, ts time.Time) TrendRun {
+		return TrendRun{
+			Path:      path,
+			StartedAt: ts,
+			Summary: SummaryReport{
+				Provenance: &RunProvenance{
+					Mode:         string(ExecutionModeLive),
+					Scale:        string(ScaleSmall),
+					Distribution: string(DistributionUniform),
+					TierProfile:  DefaultTierMixProfile().Name,
+				},
+				OracleModes: map[string]string{"q1": string(OracleModeLoadedState), "q2": string(OracleModeLoadedState)},
+				Workloads:   []WorkloadSummary{{Name: "q1"}, {Name: "q2"}},
+			},
+		}
+	}
+	runs := []TrendRun{
+		makeRun("/a/summary.json", ts1),
+		makeRun("/b/summary.json", ts2),
+	}
+	key := buildComparabilityIdentity(runs[0].Summary)
+	candidate, _, err := findCandidateRun(runs, "", key)
+	if err != nil {
+		t.Fatalf("findCandidateRun failed: %v", err)
+	}
+	if candidate.Path != "/b/summary.json" {
+		t.Fatalf("expected newest run as candidate, got %s", candidate.Path)
+	}
+	candidate2, _, err := findCandidateRun(runs, "/a/summary.json", key)
+	if err != nil {
+		t.Fatalf("findCandidateRun with explicit path failed: %v", err)
+	}
+	if candidate2.Path != "/a/summary.json" {
+		t.Fatalf("expected specified candidate, got %s", candidate2.Path)
+	}
+}
+
+func TestAnalyzeTrend(t *testing.T) {
+	dir := t.TempDir()
+	makeSummary := func(id string, ts time.Time, p95 time.Duration, qps float64, correctnessFailures int, passed bool) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		summary := SummaryReport{
+			Metadata: ArtifactMetadata{BenchmarkID: id},
+			Provenance: &RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Channel:      "ci",
+				Mode:         string(ExecutionModeLive),
+				Scale:        string(ScaleSmall),
+				Distribution: string(DistributionUniform),
+				TierProfile:  DefaultTierMixProfile().Name,
+			},
+			Passed: passed,
+			Workloads: []WorkloadSummary{
+				{
+					Name:                "baseline-page-1",
+					TargetSchema:        "trade",
+					P95:                 p95,
+					QPS:                 qps,
+					CorrectnessFailures: correctnessFailures,
+					Passed:              passed,
+				},
+			},
+		}
+		data, _ := json.MarshalIndent(summary, "", "  ")
+		os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	ts3 := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
+	ts4 := time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	ts5 := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+	ts6 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	makeSummary("bench-1", ts1, 100*time.Millisecond, 10, 0, true)
+	makeSummary("bench-2", ts2, 105*time.Millisecond, 9.8, 0, true)
+	makeSummary("bench-3", ts3, 102*time.Millisecond, 10.1, 0, true)
+	makeSummary("bench-4", ts4, 108*time.Millisecond, 9.9, 0, true)
+	makeSummary("bench-5", ts5, 104*time.Millisecond, 10.0, 0, true)
+	makeSummary("bench-6", ts6, 100*time.Millisecond, 10, 0, true)
+	protected := []string{"baseline-page-1"}
+	report, err := AnalyzeTrend(dir, "", 5, 0, protected)
+	if err != nil {
+		t.Fatalf("AnalyzeTrend failed: %v", err)
+	}
+	if report.Status != TrendStatusPass {
+		t.Fatalf("expected pass status, got %q", report.Status)
+	}
+	if len(report.BaselineWindow) != 5 {
+		t.Fatalf("expected 5 baseline runs, got %d", len(report.BaselineWindow))
+	}
+	if len(report.WorkloadTrends) != 1 {
+		t.Fatalf("expected 1 workload trend, got %d", len(report.WorkloadTrends))
+	}
+}
+
+func TestAnalyzeTrendWithCorrectnessRegression(t *testing.T) {
+	dir := t.TempDir()
+	makeSummary := func(id string, ts time.Time, correctnessFailures int, passed bool) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		summary := SummaryReport{
+			Metadata: ArtifactMetadata{BenchmarkID: id},
+			Provenance: &RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Mode:         string(ExecutionModeLive),
+				Scale:        string(ScaleSmall),
+				Distribution: string(DistributionUniform),
+				TierProfile:  DefaultTierMixProfile().Name,
+			},
+			Passed: passed,
+			Workloads: []WorkloadSummary{
+				{
+					Name:                "baseline-page-1",
+					TargetSchema:        "trade",
+					P95:                 100 * time.Millisecond,
+					QPS:                 10,
+					CorrectnessFailures: correctnessFailures,
+					Passed:              passed,
+				},
+			},
+		}
+		data, _ := json.MarshalIndent(summary, "", "  ")
+		os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	makeSummary("bench-1", ts1, 0, true)
+	makeSummary("bench-2", ts2, 1, false)
+	protected := []string{"baseline-page-1"}
+	report, err := AnalyzeTrend(dir, "", 5, 0, protected)
+	if err != nil {
+		t.Fatalf("AnalyzeTrend failed: %v", err)
+	}
+	if report.Status != TrendStatusHardStopRegression {
+		t.Fatalf("expected hard stop status, got %q", report.Status)
+	}
+	if len(report.Regressions) < 1 {
+		t.Fatalf("expected at least 1 regression")
+	}
+}
+
+func TestAnalyzeTrendWithMethodologyChange(t *testing.T) {
+	dir := t.TempDir()
+	makeSummary := func(id string, ts time.Time, oracleMode string) {
+		subDir := filepath.Join(dir, "run-"+id)
+		os.MkdirAll(subDir, 0o755)
+		summary := SummaryReport{
+			Metadata: ArtifactMetadata{BenchmarkID: id},
+			OracleModes: map[string]string{"q1": oracleMode},
+			Provenance: &RunProvenance{
+				StartedAt:    ts,
+				CompletedAt:  ts.Add(5 * time.Second),
+				Mode:         string(ExecutionModeLive),
+				Scale:        string(ScaleSmall),
+				Distribution: string(DistributionUniform),
+				TierProfile:  DefaultTierMixProfile().Name,
+			},
+			Passed: true,
+			Workloads: []WorkloadSummary{
+				{Name: "q1", P95: 100 * time.Millisecond, QPS: 10, Passed: true},
+			},
+		}
+		data, _ := json.MarshalIndent(summary, "", "  ")
+		os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
+	}
+	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	makeSummary("bench-1", ts1, string(OracleModeLoadedState))
+	makeSummary("bench-2", ts2, string(OracleModeTruthPass))
+	protected := []string{"q1"}
+	report, err := AnalyzeTrend(dir, "", 5, 0, protected)
+	if err != nil {
+		t.Fatalf("AnalyzeTrend failed: %v", err)
+	}
+	if report.Status != TrendStatusMethodology {
+		t.Fatalf("expected methodology status, got %q", report.Status)
+	}
+	if len(report.MethodologyChanges) == 0 {
+		t.Fatalf("expected methodology changes")
+	}
+}
+
+func TestFormatTrendSummary(t *testing.T) {
+	report := TrendReport{
+		Candidate: TrendRun{
+			Summary: SummaryReport{
+				Metadata:   ArtifactMetadata{BenchmarkID: "bench-cand"},
+				Provenance: &RunProvenance{Mode: string(ExecutionModeLive), Scale: string(ScaleSmall)},
+			},
+		},
+		BaselineWindow:    make([]TrendRun, 5),
+		ComparabilityKey:  "live|small|uniform|balanced|q1",
+		Status:            TrendStatusPass,
+		ProtectedWorkloads: []string{"q1"},
+		WorkloadTrends: []WorkloadTrend{
+			{
+				Name:         "q1",
+				TargetSchema: "trade",
+				BaselineP95:  100 * time.Millisecond,
+				CandidateP95: 105 * time.Millisecond,
+				P95Delta:     5 * time.Millisecond,
+				Classification: TrendClassStable,
+			},
+		},
+	}
+	formatted := FormatTrendSummary(report)
+	if !strings.Contains(formatted, "Benchmark Trend Analysis") {
+		t.Fatalf("expected trend header: %s", formatted)
+	}
+	if !strings.Contains(formatted, "status=pass") {
+		t.Fatalf("expected pass status: %s", formatted)
+	}
+	if !strings.Contains(formatted, "q1") {
+		t.Fatalf("expected workload name: %s", formatted)
+	}
+}
+
+func TestWriteAndReadTrendReport(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trend.json")
+	report := &TrendReport{
+		Candidate: TrendRun{
+			Summary: SummaryReport{
+				Metadata: ArtifactMetadata{BenchmarkID: "bench-cand"},
+			},
+		},
+		BaselineWindow:    make([]TrendRun, 3),
+		ComparabilityKey:  "test-key",
+		Status:            TrendStatusPass,
+		ProtectedWorkloads: []string{"q1"},
+	}
+	if err := WriteTrendReport(path, report); err != nil {
+		t.Fatalf("WriteTrendReport failed: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected trend report to exist: %v", err)
+	}
+}
+
+func TestWriteTrendReportNil(t *testing.T) {
+	err := WriteTrendReport("/dev/null", nil)
+	if err == nil {
+		t.Fatalf("expected error for nil report")
+	}
+}
+
+func TestIsWorkloadInstabilityChanged(t *testing.T) {
+	base := WorkloadSummary{
+		AssertionStats: map[string]AssertionStat{
+			"repeated-run-failure-kind-stable": {Passed: 0, Failed: 1},
+		},
+	}
+	cand := WorkloadSummary{
+		AssertionStats: map[string]AssertionStat{
+			"repeated-run-failure-kind-stable": {Passed: 1, Failed: 0},
+		},
+	}
+	if !isWorkloadInstabilityChanged(base, cand) {
+		t.Fatalf("expected instability change to be detected")
+	}
+}
+
+func TestMedianP95FromTrendRuns(t *testing.T) {
+	runs := []TrendRun{
+		{Summary: SummaryReport{Workloads: []WorkloadSummary{{P95: 100 * time.Millisecond}, {P95: 200 * time.Millisecond}}}},
+		{Summary: SummaryReport{Workloads: []WorkloadSummary{{P95: 300 * time.Millisecond}}}},
+	}
+	med := medianP95FromTrendRuns(runs)
+	if med != 200*time.Millisecond {
+		t.Fatalf("expected median 200ms, got %s", med)
+	}
+	med2 := medianP95FromTrendRuns(nil)
+	if med2 != 0 {
+		t.Fatalf("expected 0 for nil, got %s", med2)
+	}
+}
+
+func TestReadTrendHistorySkipsInvalid(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "benchmark-summary.json"), []byte("not json"), 0o644)
+	runs, err := ReadTrendHistory(dir)
+	if err != nil {
+		t.Fatalf("ReadTrendHistory should not error on invalid files: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("expected 0 runs for invalid json, got %d", len(runs))
+	}
+}
+
+func TestReadTrendHistorySkipsNoTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	summary := SummaryReport{
+		Metadata:   ArtifactMetadata{BenchmarkID: "bench"},
+		Provenance: &RunProvenance{Mode: string(ExecutionModeLive)},
+		Passed:     true,
+	}
+	data, _ := json.MarshalIndent(summary, "", "  ")
+	os.WriteFile(filepath.Join(dir, "benchmark-summary.json"), data, 0o644)
+	runs, err := ReadTrendHistory(dir)
+	if err != nil {
+		t.Fatalf("ReadTrendHistory failed: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("expected 0 runs for missing timestamp, got %d", len(runs))
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -955,7 +955,7 @@ func TestMedianP95FromTrendRuns(t *testing.T) {
 
 func TestReadTrendHistorySkipsInvalid(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "benchmark-summary.json"), []byte("not json"), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "benchmark-summary.json"), []byte("not json"), 0o644)
 	runs, err := ReadTrendHistory(dir)
 	if err != nil {
 		t.Fatalf("ReadTrendHistory should not error on invalid files: %v", err)
@@ -973,7 +973,7 @@ func TestReadTrendHistorySkipsNoTimestamp(t *testing.T) {
 		Passed:     true,
 	}
 	data, _ := json.MarshalIndent(summary, "", "  ")
-	os.WriteFile(filepath.Join(dir, "benchmark-summary.json"), data, 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "benchmark-summary.json"), data, 0o644)
 	runs, err := ReadTrendHistory(dir)
 	if err != nil {
 		t.Fatalf("ReadTrendHistory failed: %v", err)

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -403,7 +403,7 @@ func TestReadTrendHistory(t *testing.T) {
 	dir := t.TempDir()
 	makeSummary := func(id string, ts time.Time, preset string, mode, scale string, workloads []string) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		workloadSummaries := make([]WorkloadSummary, 0, len(workloads))
 		for _, name := range workloads {
 			workloadSummaries = append(workloadSummaries, WorkloadSummary{
@@ -429,7 +429,7 @@ func TestReadTrendHistory(t *testing.T) {
 			Workloads: workloadSummaries,
 		}
 		data, _ := json.MarshalIndent(summary, "", "  ")
-		os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
+		_ = os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
 	}
 	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
@@ -715,7 +715,7 @@ func TestAnalyzeTrend(t *testing.T) {
 	dir := t.TempDir()
 	makeSummary := func(id string, ts time.Time, p95 time.Duration, qps float64, correctnessFailures int, passed bool) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		summary := SummaryReport{
 			Metadata: ArtifactMetadata{BenchmarkID: id},
 			Provenance: &RunProvenance{
@@ -740,7 +740,7 @@ func TestAnalyzeTrend(t *testing.T) {
 			},
 		}
 		data, _ := json.MarshalIndent(summary, "", "  ")
-		os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
+		_ = os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
 	}
 	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
@@ -774,7 +774,7 @@ func TestAnalyzeTrendWithCorrectnessRegression(t *testing.T) {
 	dir := t.TempDir()
 	makeSummary := func(id string, ts time.Time, correctnessFailures int, passed bool) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		summary := SummaryReport{
 			Metadata: ArtifactMetadata{BenchmarkID: id},
 			Provenance: &RunProvenance{
@@ -798,7 +798,7 @@ func TestAnalyzeTrendWithCorrectnessRegression(t *testing.T) {
 			},
 		}
 		data, _ := json.MarshalIndent(summary, "", "  ")
-		os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
+		_ = os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
 	}
 	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
@@ -821,7 +821,7 @@ func TestAnalyzeTrendWithMethodologyChange(t *testing.T) {
 	dir := t.TempDir()
 	makeSummary := func(id string, ts time.Time, oracleMode string) {
 		subDir := filepath.Join(dir, "run-"+id)
-		os.MkdirAll(subDir, 0o755)
+		_ = os.MkdirAll(subDir, 0o755)
 		summary := SummaryReport{
 			Metadata: ArtifactMetadata{BenchmarkID: id},
 			OracleModes: map[string]string{"q1": oracleMode},
@@ -839,7 +839,7 @@ func TestAnalyzeTrendWithMethodologyChange(t *testing.T) {
 			},
 		}
 		data, _ := json.MarshalIndent(summary, "", "  ")
-		os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
+		_ = os.WriteFile(filepath.Join(subDir, "benchmark-summary.json"), data, 0o644)
 	}
 	ts1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -21,6 +21,7 @@ type RunResult struct {
 	Config         Config               `json:"config"`
 	Generator      GeneratorConfig      `json:"generator"`
 	Metadata       ArtifactMetadata     `json:"metadata"`
+	Provenance     *RunProvenance       `json:"provenance,omitempty"`
 	StartedAt      time.Time            `json:"started_at"`
 	CompletedAt    time.Time            `json:"completed_at"`
 	ValidationOnly bool                 `json:"validation_only"`


### PR DESCRIPTION
## Summary
- Add provenance metadata to benchmark summary artifacts for self-sufficient trend analysis
- Introduce `TrendReport`, `RegressionCandidate`, `DriftSignal`, `WorkloadTrend` types
- Add `benchmark trend` CLI subcommand with rolling-window regression detection
- Hard-stop on protected-workload correctness regressions; report-only for latency initially
- Update CI to upload smoke benchmark artifacts (14-day retention)
- Document trend capture/analysis workflow in runbook and ops guide

## Scope
- `benchmark trend -history-dir <dir>` scans stored `benchmark-summary.json` files
- Groups comparable runs by mode/scale/distribution/tier-profile/workload-set
- Detects correctness regressions, instability changes, p95/QPS regressions
- Distinguishes feature impact vs baseline drift vs methodology changes
- Non-zero exit code only for hard-stop (correctness/instability) regressions

## Files
| File | Change |
|---|---|
| `internal/e2e_harness/federated/benchmark/report.go` | +632 lines: provenance, trend types, history loading, analysis engine, formatters |
| `internal/e2e_harness/federated/benchmark/report_test.go` | +685 lines: 20 new tests |
| `cmd/benchmark/main.go` | +92 lines: trend subcommand, provenance flags |
| `cmd/benchmark/main_test.go` | +219 lines: 6 new CLI tests |
| `docs/...-baseline-runbook.md` | +39 lines: historical trend section |
| `docs/...-ci-and-ops-guide.md` | +51/−7 lines: trend replaces deferred work |
| `.github/workflows/ci.yml` | +7 lines: upload smoke artifacts |
| `Makefile` | +19 lines: benchmark-trend target, provenance flags |
| `internal/.../runner.go` | +1 line: Provenance field on RunResult |

## Verification
- All existing tests pass unchanged
- 20 new unit tests for trend engine (history loading, comparability, regression, drift, methodology)
- 6 new CLI tests (missing args, valid scan, candidate selection, regression exit code, JSON output, file output)
- Full `go test ./...` passes