### PR TITLE
ci: update GitHub Actions major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -79,7 +79,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -98,7 +98,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/publish-module.yml
+++ b/.github/workflows/publish-module.yml
@@ -23,7 +23,7 @@ jobs:
       GOPROXY: https://proxy.golang.org
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve version
         id: resolve


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v6 in CI and publish workflows
- keep workflow behavior unchanged
- align GitHub Actions majors with current supported versions

## Test Plan
- [x] run `git diff --check -- .github/workflows`
- [x] confirm no `actions/checkout@v4` matches remain in workspace