### PR TITLE
fix: P1 CRUD data-path findings from forma#109 review

### DIFF
--- a/internal/postgres_persistent_repository.go
+++ b/internal/postgres_persistent_repository.go
@@ -202,8 +202,12 @@ func (r *DBPersistentRecordRepository) DeletePersistentRecord(ctx context.Contex
 	defer func() { _ = tx.Rollback(ctx) }() // no-op if committed
 
 	deleteMain := fmt.Sprintf("DELETE FROM %s WHERE ltbase_schema_id = $1 AND ltbase_row_id = $2", sanitizeIdentifier(tables.EntityMain))
-	if _, err := tx.Exec(ctx, deleteMain, schemaID, rowID); err != nil {
+	tag, err := tx.Exec(ctx, deleteMain, schemaID, rowID)
+	if err != nil {
 		return fmt.Errorf("delete entity_main row: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("entity not found (schema=%d row=%s): %w", schemaID, rowID, forma.ErrNotFound)
 	}
 
 	deleteEAV := fmt.Sprintf("DELETE FROM %s WHERE schema_id = $1 AND row_id = $2", sanitizeIdentifier(tables.EAVData))

--- a/internal/postgres_persistent_repository_batch.go
+++ b/internal/postgres_persistent_repository_batch.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/lychee-technology/forma"
 )
 
 func (r *DBPersistentRecordRepository) BatchInsertPersistentRecords(ctx context.Context, tables StorageTables, records []*PersistentRecord) error {
@@ -117,8 +118,12 @@ func (r *DBPersistentRecordRepository) BatchDeletePersistentRecords(ctx context.
 			return fmt.Errorf("key[%d] has empty row id", i)
 		}
 
-		if _, err := tx.Exec(ctx, deleteMain, key.SchemaID, key.RowID); err != nil {
+		tag, err := tx.Exec(ctx, deleteMain, key.SchemaID, key.RowID)
+		if err != nil {
 			return fmt.Errorf("delete entity_main row for key[%d]: %w", i, err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("entity not found for key[%d] (schema=%d row=%s): %w", i, key.SchemaID, key.RowID, forma.ErrNotFound)
 		}
 		if _, err := tx.Exec(ctx, deleteEAV, key.SchemaID, key.RowID); err != nil {
 			return fmt.Errorf("delete eav row for key[%d]: %w", i, err)

--- a/internal/postgres_persistent_repository_main_table.go
+++ b/internal/postgres_persistent_repository_main_table.go
@@ -176,8 +176,12 @@ func (r *DBPersistentRecordRepository) updateMainRow(ctx context.Context, tx pgx
 	if err != nil {
 		return err
 	}
-	if _, err := tx.Exec(ctx, query, args...); err != nil {
+	tag, err := tx.Exec(ctx, query, args...)
+	if err != nil {
 		return fmt.Errorf("update entity_main: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("entity not found (schema=%d row=%s): %w", record.SchemaID, record.RowID, forma.ErrNotFound)
 	}
 	return nil
 }

--- a/internal/postgres_persistent_repository_repo_test.go
+++ b/internal/postgres_persistent_repository_repo_test.go
@@ -563,6 +563,75 @@ func TestQueryPersistentRecordsMissingCache(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestBatchDeletePersistentRecords_WhenRowMissing_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	mock.MatchExpectationsInOrder(true)
+
+	repo := NewDBPersistentRecordRepository(mock, nil, nil, forma.DuckDBConfig{})
+
+	rowID1 := uuid.MustParse("dddddddd-dddd-dddd-dddd-dddddddddddd")
+	rowID2 := uuid.MustParse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+	keys := []PersistentRecordKey{
+		{SchemaID: 1, RowID: rowID1},
+		{SchemaID: 1, RowID: rowID2},
+	}
+	tables := StorageTables{EntityMain: "entity_main", EAVData: "eav_table", ChangeLog: "change_log"}
+
+	mock.ExpectBegin()
+	// First key deletes successfully.
+	mock.ExpectExec(`^DELETE FROM "entity_main"`).
+		WithArgs(int16(1), rowID1).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	mock.ExpectExec(`^DELETE FROM "eav_table"`).
+		WithArgs(int16(1), rowID1).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+	mock.ExpectExec(`^INSERT INTO "change_log"`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	// Second key row does not exist — 0 rows affected.
+	mock.ExpectExec(`^DELETE FROM "entity_main"`).
+		WithArgs(int16(1), rowID2).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectRollback()
+
+	err = repo.BatchDeletePersistentRecords(ctx, tables, keys)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrNotFound)
+	require.Contains(t, err.Error(), "key[1]")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBatchDeletePersistentRecords_WhenRowMissing_DoesNotWriteEAVOrChangelog(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	mock.MatchExpectationsInOrder(true)
+
+	repo := NewDBPersistentRecordRepository(mock, nil, nil, forma.DuckDBConfig{})
+
+	rowID := uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
+	keys := []PersistentRecordKey{{SchemaID: 1, RowID: rowID}}
+	tables := StorageTables{EntityMain: "entity_main", EAVData: "eav_table", ChangeLog: "change_log"}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`^DELETE FROM "entity_main"`).
+		WithArgs(int16(1), rowID).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	// No EAV delete, no changelog upsert expected — transaction rolls back.
+	mock.ExpectRollback()
+
+	err = repo.BatchDeletePersistentRecords(ctx, tables, keys)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrNotFound)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestParseEAVAttribute_NilSchemaID_ReturnsError(t *testing.T) {
 	_, err := parseEAVAttribute(map[string]any{
 		"schema_id": nil,

--- a/internal/postgres_persistent_repository_repo_test.go
+++ b/internal/postgres_persistent_repository_repo_test.go
@@ -185,6 +185,133 @@ func TestDeletePersistentRecordWithMockPool(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestDeletePersistentRecord_WhenRowMissing_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	mock.MatchExpectationsInOrder(true)
+
+	repo := NewDBPersistentRecordRepository(mock, nil, nil, forma.DuckDBConfig{})
+	rowID := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	tables := StorageTables{EntityMain: "entity_main", EAVData: "eav_table", ChangeLog: "change_log"}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`^DELETE FROM "entity_main"`).
+		WithArgs(int16(1), rowID).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0)) // 0 rows affected
+	mock.ExpectRollback()
+
+	err = repo.DeletePersistentRecord(ctx, tables, 1, rowID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrNotFound)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeletePersistentRecord_WhenRowMissing_DoesNotWriteChangelog(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	mock.MatchExpectationsInOrder(true)
+
+	repo := NewDBPersistentRecordRepository(mock, nil, nil, forma.DuckDBConfig{})
+	rowID := uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc")
+	tables := StorageTables{EntityMain: "entity_main", EAVData: "eav_table", ChangeLog: "change_log"}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`^DELETE FROM "entity_main"`).
+		WithArgs(int16(1), rowID).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	// No EAV delete, no changelog upsert expected — transaction rolls back
+	mock.ExpectRollback()
+
+	err = repo.DeletePersistentRecord(ctx, tables, 1, rowID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrNotFound)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdatePersistentRecord_WhenRowMissing_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	mock.MatchExpectationsInOrder(true)
+
+	repo := NewDBPersistentRecordRepository(mock, nil, nil, forma.DuckDBConfig{})
+	fixed := time.Date(2024, 4, 5, 6, 7, 8, 0, time.UTC)
+	repo.withClock(func() time.Time { return fixed })
+	fixedMillis := fixed.UnixMilli()
+
+	rowID := uuid.MustParse("99999999-9999-9999-9999-999999999999")
+	record := &PersistentRecord{
+		SchemaID:  1,
+		RowID:     rowID,
+		UpdatedAt: fixedMillis,
+		TextItems: map[string]string{"text_01": "hello"},
+	}
+	tables := StorageTables{EntityMain: "entity_main", EAVData: "eav_table", ChangeLog: "change_log"}
+
+	updateQuery, updateArgs, err := buildUpdateMainStatement(tables.EntityMain, record)
+	require.NoError(t, err)
+
+	mock.ExpectBegin()
+	// UPDATE affects 0 rows — row does not exist
+	mock.ExpectExec("^" + regexp.QuoteMeta(updateQuery) + "$").
+		WithArgs(updateArgs...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectRollback()
+
+	err = repo.UpdatePersistentRecord(ctx, tables, record)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrNotFound)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdatePersistentRecord_WhenRowMissing_DoesNotWriteEAVOrChangelog(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	mock.MatchExpectationsInOrder(true)
+
+	repo := NewDBPersistentRecordRepository(mock, nil, nil, forma.DuckDBConfig{})
+	fixed := time.Date(2024, 4, 5, 6, 7, 8, 0, time.UTC)
+	repo.withClock(func() time.Time { return fixed })
+	fixedMillis := fixed.UnixMilli()
+
+	rowID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	text := "v"
+	record := &PersistentRecord{
+		SchemaID:        1,
+		RowID:           rowID,
+		UpdatedAt:       fixedMillis,
+		TextItems:       map[string]string{"text_01": "hello"},
+		OtherAttributes: []EAVRecord{{SchemaID: 1, RowID: rowID, AttrID: 5, ValueText: &text}},
+	}
+	tables := StorageTables{EntityMain: "entity_main", EAVData: "eav_table", ChangeLog: "change_log"}
+
+	updateQuery, updateArgs, err := buildUpdateMainStatement(tables.EntityMain, record)
+	require.NoError(t, err)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("^" + regexp.QuoteMeta(updateQuery) + "$").
+		WithArgs(updateArgs...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	// No EAV delete, no EAV insert, no changelog upsert expected — transaction rolls back
+	mock.ExpectRollback()
+
+	err = repo.UpdatePersistentRecord(ctx, tables, record)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrNotFound)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestBatchInsertPersistentRecordsWithMockPool(t *testing.T) {
 	ctx := context.Background()
 	mock, err := pgxmock.NewPool()
@@ -434,4 +561,64 @@ func TestQueryPersistentRecordsMissingCache(t *testing.T) {
 		SchemaID: 1,
 	})
 	require.Error(t, err)
+}
+
+func TestParseEAVAttribute_NilSchemaID_ReturnsError(t *testing.T) {
+	_, err := parseEAVAttribute(map[string]any{
+		"schema_id": nil,
+		"attr_id":   float64(10),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema_id")
+}
+
+func TestParseEAVAttribute_NilAttrID_ReturnsError(t *testing.T) {
+	_, err := parseEAVAttribute(map[string]any{
+		"schema_id": float64(1),
+		"attr_id":   nil,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "attr_id")
+}
+
+func TestParseEAVAttribute_WrongTypeSchemaID_ReturnsError(t *testing.T) {
+	_, err := parseEAVAttribute(map[string]any{
+		"schema_id": "not-a-number",
+		"attr_id":   float64(10),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema_id")
+}
+
+func TestParseEAVAttribute_ValidFields_Succeeds(t *testing.T) {
+	rowID := uuid.New()
+	valueText := "hello"
+	valueNumeric := float64(42)
+
+	attr, err := parseEAVAttribute(map[string]any{
+		"schema_id":     float64(5),
+		"attr_id":       float64(11),
+		"row_id":        rowID.String(),
+		"array_indices": "0,1",
+		"value_text":    valueText,
+		"value_numeric": valueNumeric,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int16(5), attr.SchemaID)
+	assert.Equal(t, int16(11), attr.AttrID)
+	assert.Equal(t, rowID, attr.RowID)
+	assert.Equal(t, "0,1", attr.ArrayIndices)
+	require.NotNil(t, attr.ValueText)
+	assert.Equal(t, "hello", *attr.ValueText)
+	require.NotNil(t, attr.ValueNumeric)
+	assert.Equal(t, float64(42), *attr.ValueNumeric)
+}
+
+func TestParseAttributesJSON_MalformedAttribute_ReturnsError(t *testing.T) {
+	record := &PersistentRecord{}
+	// schema_id is null in the JSON blob
+	malformed := []byte(`[{"schema_id":null,"attr_id":10,"row_id":"00000000-0000-0000-0000-000000000001","array_indices":"","value_text":"x","value_numeric":null}]`)
+	err := parseAttributesJSON(malformed, record)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema_id")
 }

--- a/internal/postgres_row_scanner.go
+++ b/internal/postgres_row_scanner.go
@@ -204,7 +204,10 @@ func parseAttributesJSON(attrsJSON []byte, record *PersistentRecord) error {
 
 	record.OtherAttributes = make([]EAVRecord, 0, len(attributes))
 	for _, attrObj := range attributes {
-		attr := parseEAVAttribute(attrObj)
+		attr, err := parseEAVAttribute(attrObj)
+		if err != nil {
+			return fmt.Errorf("parse eav attribute: %w", err)
+		}
 		record.OtherAttributes = append(record.OtherAttributes, attr)
 	}
 
@@ -212,10 +215,18 @@ func parseAttributesJSON(attrsJSON []byte, record *PersistentRecord) error {
 }
 
 // parseEAVAttribute converts a JSON object to an EAVRecord
-func parseEAVAttribute(attrObj map[string]any) EAVRecord {
+func parseEAVAttribute(attrObj map[string]any) (EAVRecord, error) {
+	schemaIDRaw, ok := attrObj["schema_id"].(float64)
+	if !ok {
+		return EAVRecord{}, fmt.Errorf("schema_id is missing or not a number: %v", attrObj["schema_id"])
+	}
+	attrIDRaw, ok := attrObj["attr_id"].(float64)
+	if !ok {
+		return EAVRecord{}, fmt.Errorf("attr_id is missing or not a number: %v", attrObj["attr_id"])
+	}
 	attr := EAVRecord{
-		SchemaID: int16(attrObj["schema_id"].(float64)),
-		AttrID:   int16(attrObj["attr_id"].(float64)),
+		SchemaID: int16(schemaIDRaw),
+		AttrID:   int16(attrIDRaw),
 	}
 
 	if rowIDStr, ok := attrObj["row_id"].(string); ok {
@@ -235,7 +246,7 @@ func parseEAVAttribute(attrObj map[string]any) EAVRecord {
 		attr.ValueNumeric = &valueNumeric
 	}
 
-	return attr
+	return attr, nil
 }
 
 // cleanupEmptyMaps removes empty maps from the record to avoid nil-map checks

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -262,7 +262,7 @@ func (t *transformer) flattenToAttributes(
 			if value == nil {
 				candidateName := strings.Join(append(path, key), ".")
 				if isKnownAttributeOrParent(candidateName, cache) {
-					return fmt.Errorf("attribute '%s' cannot be set to null; omit the key to preserve its current value", candidateName)
+					return fmt.Errorf("attribute '%s' cannot be set to null; omit the key to preserve its current value: %w", candidateName, forma.ErrInvalidInput)
 				}
 				continue
 			}
@@ -273,6 +273,13 @@ func (t *transformer) flattenToAttributes(
 		}
 	case []any:
 		for i, item := range v {
+			if item == nil {
+				attrName := strings.Join(path, ".")
+				if isKnownAttributeOrParent(attrName, cache) {
+					return fmt.Errorf("attribute '%s' cannot be set to null (array index %d); omit the element to preserve its current value: %w", attrName, i, forma.ErrInvalidInput)
+				}
+				continue
+			}
 			newIndices := append(indices, i)
 			if err := t.flattenToAttributes(schemaID, rowID, path, item, newIndices, cache, result); err != nil {
 				return err

--- a/internal/transformer.go
+++ b/internal/transformer.go
@@ -226,6 +226,21 @@ func (t *transformer) ValidateAgainstSchema(ctx context.Context, jsonSchema any,
 	return nil
 }
 
+// isKnownAttributeOrParent returns true if name is a leaf attribute in the cache
+// or is a parent path prefix of at least one cached attribute.
+func isKnownAttributeOrParent(name string, cache forma.SchemaAttributeCache) bool {
+	if _, ok := cache[name]; ok {
+		return true
+	}
+	prefix := name + "."
+	for attrName := range cache {
+		if strings.HasPrefix(attrName, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *transformer) flattenToAttributes(
 	schemaID int16,
 	rowID uuid.UUID,
@@ -245,6 +260,10 @@ func (t *transformer) flattenToAttributes(
 		for _, key := range keys {
 			value := v[key]
 			if value == nil {
+				candidateName := strings.Join(append(path, key), ".")
+				if isKnownAttributeOrParent(candidateName, cache) {
+					return fmt.Errorf("attribute '%s' cannot be set to null; omit the key to preserve its current value", candidateName)
+				}
 				continue
 			}
 			newPath := append(path, key)

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -534,3 +534,73 @@ func TestPopulateTypedValueOptionalSkipsOnError(t *testing.T) {
 	require.NotEmpty(t, entries)
 	assert.Equal(t, "optional", entries[0].ContextMap()["attribute"])
 }
+
+// F3: null-clear divergence tests
+
+// Setting a known leaf attribute to null must return an error, not silently skip it.
+func TestTransformer_ToAttributes_NullLeafAttribute_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry()
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	_, err = tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{
+		"name": nil,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
+	assert.Contains(t, err.Error(), "null")
+}
+
+// Setting a known nested leaf attribute to null must return an error.
+func TestTransformer_ToAttributes_NullNestedAttribute_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry()
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	_, err = tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{
+		"person": map[string]any{
+			"name": nil,
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "person.name")
+	assert.Contains(t, err.Error(), "null")
+}
+
+// Setting a parent object key to null (which would clear its entire subtree in EAV)
+// must return an error because one or more child attributes are schema-defined.
+func TestTransformer_ToAttributes_NullParentObject_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry()
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	_, err = tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{
+		"person": nil, // parent of person.name and person.age
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "person")
+	assert.Contains(t, err.Error(), "null")
+}
+
+// A null value for a key that is not in the schema must be silently skipped.
+func TestTransformer_ToAttributes_NullUnknownField_IsSilentlySkipped(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry()
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	attrs, err := tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{
+		"name":          "Alice",
+		"unknown_field": nil, // not in schema — should be skipped without error
+	})
+	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+	assert.Equal(t, int16(1), attrs[0].AttrID) // name
+}

--- a/internal/transformer_test.go
+++ b/internal/transformer_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"testing"
@@ -601,6 +602,109 @@ func TestTransformer_ToAttributes_NullUnknownField_IsSilentlySkipped(t *testing.
 		"unknown_field": nil, // not in schema — should be skipped without error
 	})
 	require.NoError(t, err)
+	require.Len(t, attrs, 1)
+	assert.Equal(t, int16(1), attrs[0].AttrID) // name
+}
+
+// F3 null errors must be classified as ErrInvalidInput so callers get HTTP 400.
+
+func TestTransformer_ToAttributes_NullLeafAttribute_WrapsErrInvalidInput(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry()
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	_, err = tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{"name": nil})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, forma.ErrInvalidInput), "expected ErrInvalidInput, got: %v", err)
+}
+
+func TestTransformer_ToAttributes_NullNestedAttribute_WrapsErrInvalidInput(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry()
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	_, err = tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{
+		"person": map[string]any{"name": nil},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, forma.ErrInvalidInput), "expected ErrInvalidInput, got: %v", err)
+}
+
+func TestTransformer_ToAttributes_NullParentObject_WrapsErrInvalidInput(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry()
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	_, err = tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{"person": nil})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, forma.ErrInvalidInput), "expected ErrInvalidInput, got: %v", err)
+}
+
+// F2: null elements inside arrays must also be rejected.
+
+// A null primitive inside a schema-defined array leaf must return an error.
+func TestTransformer_ToAttributes_NullPrimitiveArrayItem_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry() // "items" is a schema-defined text leaf
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	_, err = tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{
+		"items": []any{"valid", nil}, // null at index 1
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "items")
+	assert.Contains(t, err.Error(), "null")
+	assert.True(t, errors.Is(err, forma.ErrInvalidInput), "expected ErrInvalidInput, got: %v", err)
+}
+
+// A null object inside a schema-defined array must return an error.
+func TestTransformer_ToAttributes_NullObjectArrayItem_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	reg := &stubSchemaRegistry{
+		schemaID:   305,
+		schemaName: "contacts_schema",
+		cache: forma.SchemaAttributeCache{
+			"contacts.name": {AttributeID: 1, ValueType: forma.ValueTypeText},
+		},
+	}
+	tr := NewTransformer(reg)
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("contacts_schema")
+	require.NoError(t, err)
+
+	_, err = tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{
+		"contacts": []any{
+			map[string]any{"name": "Alice"},
+			nil, // null object at index 1
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contacts")
+	assert.Contains(t, err.Error(), "null")
+	assert.True(t, errors.Is(err, forma.ErrInvalidInput), "expected ErrInvalidInput, got: %v", err)
+}
+
+// A null inside an array whose path is NOT in the schema must be silently skipped.
+func TestTransformer_ToAttributes_NullUnknownArrayItem_IsSilentlySkipped(t *testing.T) {
+	ctx := context.Background()
+	reg := newStubSchemaRegistry() // "unknown_list" is not in schema
+	schemaID, _, err := reg.GetSchemaAttributeCacheByName("test")
+	require.NoError(t, err)
+	tr := NewTransformer(reg)
+
+	attrs, err := tr.ToAttributes(ctx, schemaID, uuid.New(), map[string]any{
+		"name":         "Alice",
+		"unknown_list": []any{"x", nil},
+	})
+	require.NoError(t, err)
+	// Only "name" should be stored; unknown_list is skipped entirely.
 	require.Len(t, attrs, 1)
 	assert.Equal(t, int16(1), attrs[0].AttrID) // name
 }


### PR DESCRIPTION
## Summary

Implements all four P1 fixes identified in the `forma#109` CRUD data-path code review.

Closes #109

---

### F1 — `updateMainRow` discards `CommandTag` (P1)

**File:** `internal/postgres_persistent_repository_main_table.go`

Checks `RowsAffected()` on the UPDATE result. Returns `ErrNotFound` when the row is absent, preventing orphaned EAV rows and spurious changelog entries that would otherwise be written after a concurrent delete.

**Tests added:** `TestUpdatePersistentRecord_WhenRowMissing_ReturnsNotFound`, `TestUpdatePersistentRecord_WhenRowMissing_DoesNotWriteEAVOrChangelog`

---

### F2 — `DeletePersistentRecord` discards `CommandTag` (P1)

**File:** `internal/postgres_persistent_repository.go`

Checks `RowsAffected()` on the main-table DELETE. Returns `ErrNotFound` before any EAV or changelog writes when the row does not exist.

**Tests added:** `TestDeletePersistentRecord_WhenRowMissing_ReturnsNotFound`, `TestDeletePersistentRecord_WhenRowMissing_DoesNotWriteChangelog`

---

### F3 — Divergent null-clear semantics (P1)

**File:** `internal/transformer.go`

Previously, passing `null` for a schema-defined field silently skipped it during `flattenToAttributes`. Because `replaceEAVAttributes` does a delete-all then re-insert, the EAV row was cleared, while a hot-table column with the same field retained its old value — silent asymmetric behavior.

Fix: `flattenToAttributes` now returns an explicit error when a caller passes `nil` for any schema-defined leaf attribute or parent path prefix. Unknown fields with `nil` values continue to be silently skipped. Also added `isKnownAttributeOrParent` helper.

**Tests added:** `TestTransformer_ToAttributes_NullLeafAttribute_ReturnsError`, `TestTransformer_ToAttributes_NullNestedAttribute_ReturnsError`, `TestTransformer_ToAttributes_NullParentObject_ReturnsError`, `TestTransformer_ToAttributes_NullUnknownField_IsSilentlySkipped`

---

### F4 — Bare type assertions in `parseEAVAttribute` (P1)

**File:** `internal/postgres_row_scanner.go`

Replaced bare `.(float64)` assertions on `schema_id` and `attr_id` with ok-form assertions. Returns a typed error instead of panicking on NULL or unexpected types from the DB JSON blob.

**Tests added:** `TestParseEAVAttribute_NilSchemaID_ReturnsError`, `TestParseEAVAttribute_NilAttrID_ReturnsError`, `TestParseEAVAttribute_WrongTypeSchemaID_ReturnsError`, `TestParseEAVAttribute_ValidFields_Succeeds`, `TestParseAttributesJSON_MalformedAttribute_ReturnsError`

---

## Test results

```
make test-unit → all packages PASS
```