### PR TITLE
fix: bool EAV filter and pivot column use value_numeric

### DIFF
--- a/internal/duckdb_schema_projection.go
+++ b/internal/duckdb_schema_projection.go
@@ -215,7 +215,8 @@ func (sp *SchemaProjection) buildEAVPivot(attrs []attrProjectionInfo) {
 func eavValueColumn(vt forma.ValueType) string {
 	switch vt {
 	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt,
-		forma.ValueTypeSmallInt, forma.ValueTypeDate, forma.ValueTypeDateTime:
+		forma.ValueTypeSmallInt, forma.ValueTypeDate, forma.ValueTypeDateTime,
+		forma.ValueTypeBool:
 		return "value_numeric"
 	default:
 		return "value_text"

--- a/internal/duckdb_schema_projection.go
+++ b/internal/duckdb_schema_projection.go
@@ -178,8 +178,18 @@ func (sp *SchemaProjection) buildPGProjection(attrs []attrProjectionInfo) {
 	for _, a := range attrs {
 		if a.isColumn {
 			colName := string(a.meta.ColumnBinding.ColumnName)
-			expr := fmt.Sprintf("COALESCE(hot_vals.%s, m.%s) AS %s",
-				a.name, colName, a.name)
+			var expr string
+			if a.meta.ValueType == forma.ValueTypeBool {
+				// Normalize the main column to BOOLEAN so both sides of COALESCE
+				// are the same type. hot_vals.<attr> is already BOOLEAN (from the
+				// EAV pivot fix); m.<col> must be normalized by encoding.
+				mainBoolExpr := mainColBoolExpr(colName, a.meta.ColumnBinding.Encoding)
+				expr = fmt.Sprintf("COALESCE(hot_vals.%s, %s) AS %s",
+					a.name, mainBoolExpr, a.name)
+			} else {
+				expr = fmt.Sprintf("COALESCE(hot_vals.%s, m.%s) AS %s",
+					a.name, colName, a.name)
+			}
 			selectParts = append(selectParts, expr)
 			groupParts = append(groupParts, "m."+colName)
 		} else {
@@ -198,9 +208,19 @@ func (sp *SchemaProjection) buildEAVPivot(attrs []attrProjectionInfo) {
 	sort.Slice(attrs, func(i, j int) bool { return attrs[i].name < attrs[j].name })
 	for _, a := range attrs {
 		attrIDParts = append(attrIDParts, fmt.Sprintf("%d", a.attrID))
-		pivotParts = append(pivotParts, fmt.Sprintf(
-			"\t\t\t\tMAX(CASE WHEN attr_id = %d THEN %s END) AS %s",
-			a.attrID, eavValueColumn(a.meta.ValueType), a.name))
+		var pivotExpr string
+		if a.meta.ValueType == forma.ValueTypeBool {
+			// Wrap in <> 0 so the pivot column is BOOLEAN, not DOUBLE.
+			// DuckDB WHERE uses CAST(? AS BOOLEAN); the pivot output must match.
+			pivotExpr = fmt.Sprintf(
+				"(MAX(CASE WHEN attr_id = %d THEN value_numeric END) <> 0)",
+				a.attrID)
+		} else {
+			pivotExpr = fmt.Sprintf(
+				"MAX(CASE WHEN attr_id = %d THEN %s END)",
+				a.attrID, eavValueColumn(a.meta.ValueType))
+		}
+		pivotParts = append(pivotParts, fmt.Sprintf("\t\t\t\t%s AS %s", pivotExpr, a.name))
 	}
 
 	if len(pivotParts) > 0 {
@@ -221,6 +241,18 @@ func eavValueColumn(vt forma.ValueType) string {
 	default:
 		return "value_text"
 	}
+}
+
+// mainColBoolExpr returns a DuckDB boolean expression that normalises a
+// column-bound bool main-table column to a BOOLEAN value.
+// bool_text encoding stores "1"/"0" as text; bool_smallint stores 0/1 as SMALLINT.
+// Both must produce a BOOLEAN so that COALESCE(hot_vals.<attr>, <expr>) is type-safe.
+func mainColBoolExpr(colName string, enc forma.MainColumnEncoding) string {
+	if enc == forma.MainColumnEncodingBoolText {
+		return fmt.Sprintf("m.%s = '1'", colName)
+	}
+	// Default covers MainColumnEncodingBoolInt and any other numeric-like encoding.
+	return fmt.Sprintf("m.%s <> 0", colName)
 }
 
 func (sp *SchemaProjection) buildOuterSelect(schemaID int16, sortedAttrs []string) {

--- a/internal/duckdb_sql_generator_test.go
+++ b/internal/duckdb_sql_generator_test.go
@@ -392,3 +392,12 @@ func TestGenerateDuckDBWhereClause_GivenNestedAndOrConditions_WhenClauseBuilt_Th
 	require.Equal(t, "(status = ?) AND ((score > CAST(? AS DOUBLE)) OR (email LIKE ?))", clause)
 	require.Equal(t, []any{"active", 10.0, "ops%"}, args)
 }
+
+// TestEAVValueColumn_BoolUsesValueNumeric verifies that eavValueColumn returns
+// "value_numeric" for ValueTypeBool, matching the storage path where booleans
+// are written as float64 into value_numeric (see attribute_converter.go).
+func TestEAVValueColumn_BoolUsesValueNumeric(t *testing.T) {
+	got := eavValueColumn(forma.ValueTypeBool)
+	require.Equal(t, "value_numeric", got,
+		"bool EAV values are stored as float64 in value_numeric, not value_text")
+}

--- a/internal/duckdb_sql_generator_test.go
+++ b/internal/duckdb_sql_generator_test.go
@@ -401,3 +401,81 @@ func TestEAVValueColumn_BoolUsesValueNumeric(t *testing.T) {
 	require.Equal(t, "value_numeric", got,
 		"bool EAV values are stored as float64 in value_numeric, not value_text")
 }
+
+// TestBuildSchemaProjection_BoolEAVOnly_PivotReturnsBoolExpr verifies that an
+// EAV-only bool attribute produces a boolean-typed pivot expression
+// "(MAX(CASE WHEN attr_id = X THEN value_numeric END) <> 0) AS active" so that
+// the unified column type is BOOLEAN and DuckDB WHERE comparisons are type-safe.
+func TestBuildSchemaProjection_BoolEAVOnly_PivotReturnsBoolExpr(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"active": forma.AttributeMetadata{
+			AttributeID: 7,
+			ValueType:   forma.ValueTypeBool,
+			// No ColumnBinding → EAV-only
+		},
+	}
+	sp, err := BuildSchemaProjection(1, cache)
+	require.NoError(t, err)
+
+	// EAV pivot must use a boolean comparison, not raw value_numeric
+	require.Contains(t, sp.EAVPivotSelect,
+		"(MAX(CASE WHEN attr_id = 7 THEN value_numeric END) <> 0) AS active",
+		"bool EAV pivot expression must be boolean-typed via <> 0 comparison")
+
+	// Must NOT contain a raw (non-wrapped) value_numeric for active
+	require.NotContains(t, sp.EAVPivotSelect,
+		"THEN value_numeric END) AS active",
+		"raw value_numeric pivot must not be used for bool; wrap with <> 0")
+}
+
+// TestBuildSchemaProjection_BoolColumnBound_SmallintCOALESCE verifies that a
+// bool_smallint column-bound attribute emits a type-safe COALESCE expression
+// "COALESCE(hot_vals.active, m.smallint_01 <> 0) AS active" in PGSourceSelect,
+// so that both sides of the COALESCE are BOOLEAN and there is no type mismatch.
+func TestBuildSchemaProjection_BoolColumnBound_SmallintCOALESCE(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"active": forma.AttributeMetadata{
+			AttributeID: 7,
+			ValueType:   forma.ValueTypeBool,
+			ColumnBinding: &forma.MainColumnBinding{
+				ColumnName: forma.MainColumn("smallint_01"),
+				Encoding:   forma.MainColumnEncodingBoolInt,
+			},
+		},
+	}
+	sp, err := BuildSchemaProjection(1, cache)
+	require.NoError(t, err)
+
+	// PGSourceSelect must normalize the main col to BOOLEAN via <> 0
+	require.Contains(t, sp.PGSourceSelect,
+		"COALESCE(hot_vals.active, m.smallint_01 <> 0) AS active",
+		"bool_smallint column-bound COALESCE must normalize main col to boolean")
+
+	// EAV pivot must also produce a boolean expression for this attribute
+	require.Contains(t, sp.EAVPivotSelect,
+		"(MAX(CASE WHEN attr_id = 7 THEN value_numeric END) <> 0) AS active",
+		"bool column-bound EAV pivot must also be boolean-typed")
+}
+
+// TestBuildSchemaProjection_BoolColumnBound_TextCOALESCE verifies that a
+// bool_text column-bound attribute emits "COALESCE(hot_vals.active, m.text_01 = '1')
+// AS active" in PGSourceSelect, normalising the text main column to BOOLEAN.
+func TestBuildSchemaProjection_BoolColumnBound_TextCOALESCE(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"active": forma.AttributeMetadata{
+			AttributeID: 7,
+			ValueType:   forma.ValueTypeBool,
+			ColumnBinding: &forma.MainColumnBinding{
+				ColumnName: forma.MainColumn("text_01"),
+				Encoding:   forma.MainColumnEncodingBoolText,
+			},
+		},
+	}
+	sp, err := BuildSchemaProjection(1, cache)
+	require.NoError(t, err)
+
+	// PGSourceSelect must normalize the text main col to BOOLEAN via = '1'
+	require.Contains(t, sp.PGSourceSelect,
+		"COALESCE(hot_vals.active, m.text_01 = '1') AS active",
+		"bool_text column-bound COALESCE must normalize main col to boolean")
+}

--- a/internal/sql_generator.go
+++ b/internal/sql_generator.go
@@ -189,15 +189,15 @@ func (g *SQLGenerator) buildKv(
 			return "", nil, fmt.Errorf("invalid date value for '%s': %w", kv.Attr, err)
 		}
 	case forma.ValueTypeBool:
-		valueColumn = "value_text"
+		valueColumn = "value_numeric"
 		parsedInt, err := strconv.Atoi(valStr)
 		if err != nil {
 			return "", nil, fmt.Errorf("invalid boolean value for '%s': %s", kv.Attr, valStr)
 		}
 		if parsedInt > 0 {
-			parsedValue = "1"
+			parsedValue = float64(1)
 		} else {
-			parsedValue = "0"
+			parsedValue = float64(0)
 		}
 	default:
 		return "", nil, fmt.Errorf("unsupported value_type '%s' for attribute '%s'", meta.ValueType, kv.Attr)

--- a/internal/sql_generator_test.go
+++ b/internal/sql_generator_test.go
@@ -139,3 +139,46 @@ func TestBuildHybridConditions_EmptyComposite_OR(t *testing.T) {
 	require.Equal(t, "1=0", clause)
 	require.Empty(t, args)
 }
+
+// TestSQLGenerator_BoolEAV_UsesValueNumeric verifies that a bool EAV filter generates
+// a predicate against value_numeric (not value_text) and binds float64(1)/float64(0)
+// arguments, matching the storage path in attribute_converter.go.
+func TestSQLGenerator_BoolEAV_UsesValueNumeric(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"active": forma.AttributeMetadata{
+			AttributeID: 20,
+			ValueType:   forma.ValueTypeBool,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		value     string
+		wantArg   float64
+		wantOp    string
+	}{
+		{name: "truthy value=1", value: "1", wantArg: float64(1), wantOp: "="},
+		{name: "falsy value=0", value: "0", wantArg: float64(0), wantOp: "="},
+		{name: "not-equal truthy neq:1", value: "neq:1", wantArg: float64(1), wantOp: "!="},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cond := &forma.CompositeCondition{
+				Logic: forma.LogicAnd,
+				Conditions: []forma.Condition{
+					&forma.KvCondition{Attr: "active", Value: tc.value},
+				},
+			}
+			paramIndex := 1
+			gen := NewSQLGenerator()
+			clause, args, err := gen.ToSQLClauses(cond, "eav_data", 1, cache, &paramIndex)
+			require.NoError(t, err)
+			require.Contains(t, clause, "value_numeric", "bool filter must use value_numeric column")
+			require.NotContains(t, clause, "value_text", "bool filter must not use value_text column")
+			require.Len(t, args, 2)
+			require.Equal(t, int16(20), args[0], "first arg must be attr_id as int16")
+			require.Equal(t, tc.wantArg, args[1], "second arg must be float64")
+		})
+	}
+}

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -78,7 +78,7 @@ type MainColumnEncoding string
 
 const (
 	MainColumnEncodingDefault  MainColumnEncoding = "default"
-	MainColumnEncodingBoolText MainColumnEncoding = "bool_text" // "true"/"false" string
+	MainColumnEncodingBoolText MainColumnEncoding = "bool_text" // "1"/"0" string in a text column
 	MainColumnEncodingUnixMs   MainColumnEncoding = "unix_ms"
 	MainColumnEncodingBoolInt  MainColumnEncoding = "bool_smallint"
 	MainColumnEncodingISO8601  MainColumnEncoding = "iso8601"


### PR DESCRIPTION
## Summary

Two paths were querying `value_text` for boolean EAV attributes, but booleans are stored as `float64` in `value_numeric` (see `attribute_converter.go:74-80`). This caused bool EAV filters to never match and federated sort projections to produce NULL sort columns for bool attributes.

### Changes

**`internal/sql_generator.go` — EAV filter path**
- `ValueTypeBool` branch: switch `valueColumn` from `value_text` to `value_numeric`
- Bind `float64(1)`/`float64(0)` instead of string `"1"`/`"0"`

**`internal/duckdb_schema_projection.go` — EAV pivot projection path**
- Add `forma.ValueTypeBool` to the `value_numeric` case in `eavValueColumn()`, keeping it in sync with `types.go ValueColumn()` (already fixed in #118)
- `buildEAVPivot`: wrap the bool pivot expression in `(<> 0)` so the pivoted column is BOOLEAN-typed, not DOUBLE. This is required for type-safe `CAST(? AS BOOLEAN)` comparisons in the federated WHERE clause.
- `buildPGProjection`: for column-bound bool attributes, replace `COALESCE(hot_vals.x, m.col)` with `COALESCE(hot_vals.x, m.col = '1')` (bool_text) or `COALESCE(hot_vals.x, m.col <> 0)` (bool_smallint) so both sides of the COALESCE are BOOLEAN. Without this, DuckDB must coerce DOUBLE/SMALLINT to BOOLEAN implicitly, which is type-unsafe and breaks outer-select `CAST(x AS BOOLEAN)`.
- New helper `mainColBoolExpr` encapsulates the encoding-aware normalization.

**`schema_registry.go`**
- Correct the stale doc comment on `MainColumnEncodingBoolText`: it stores `"1"`/`"0"` in a text column, not `"true"`/`"false"`. The previous comment contradicted `persistent_transformer.go:173-179` and would have led to a future writer "fixing" the encoding to `"true"`/`"false"`, silently breaking the `mainColBoolExpr` comparison.

### Tests

All fixes follow TDD: failing tests written first, then minimal implementation.

- `TestSQLGenerator_BoolEAV_UsesValueNumeric` (3 subtests: truthy, falsy, not-equal)
- `TestEAVValueColumn_BoolUsesValueNumeric`
- `TestBuildSchemaProjection_BoolEAVOnly_PivotReturnsBoolExpr`
- `TestBuildSchemaProjection_BoolColumnBound_SmallintCOALESCE`
- `TestBuildSchemaProjection_BoolColumnBound_TextCOALESCE`

All 11 test packages pass.

## Context

These two bugs were identified during review of #118 but the fix commit was not pushed before that PR was merged. This PR carries the work forward.

Closes #110