### PR TITLE
docs: add schema consistency migration tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit lint coverage build build-tools build-benchmark benchmark-smoke benchmark-regression benchmark-heavy build-all build-lambda clean all create-build-dir link
+.PHONY: test test-unit lint coverage build build-tools build-benchmark benchmark-smoke benchmark-regression benchmark-heavy build-all build-lambda clean all create-build-dir link validate-schema-consistency
 
 # Binary names
 BINARY_SERVER=server
@@ -97,6 +97,19 @@ build-tools: create-build-dir
 	@echo "Building $(GOOS)-$(GOARCH) -> $(BUILD_DIR)/$(BINARY_TOOLS)-$(GOOS)-$(GOARCH)"
 	@$(GOENV) go build -ldflags="-s -w" -o $(BUILD_DIR)/$(BINARY_TOOLS)-$(GOOS)-$(GOARCH) $(MAIN_TOOLS)
 	@echo "Tools build complete."
+
+validate-schema-consistency: build-tools link
+	@echo "Running schema consistency validator..."
+	@./$(BUILD_DIR)/$(BINARY_TOOLS) validate-schema-consistency \
+		--db-host $${DB_HOST:-localhost} \
+		--db-port $${DB_PORT:-5432} \
+		--db-user $${DB_USER:-postgres} \
+		--db-password $${DB_PASSWORD:-postgres} \
+		--db-name $${DB_NAME:-forma} \
+		--db-ssl-mode $${DB_SSL_MODE:-disable} \
+		--schema-registry-table $${SCHEMA_TABLE:-schema_registry_dev} \
+		--schema-dir $${SCHEMA_DIR:-cmd/server/schemas} \
+		--eav-table $${EAV_TABLE:-eav_data_dev}
 
 # Build sample for current platform
 build-sample: create-build-dir

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ make benchmark-heavy       # Heavy planning set
 
 - [Documentation Index](docs/index.md)
 - [Error Handling](docs/error-handling.md)
+- [Schema Consistency Migration Guide](docs/schema-consistency-migration.md)
 - [E2E Test Matrix](docs/e2e-tests-en.md)
 - [Integration Test Cases](docs/integ-tests-en.md)
 - [Go E2E Harness README](internal/e2e_harness/README.md)

--- a/cmd/tools/main.go
+++ b/cmd/tools/main.go
@@ -15,6 +15,8 @@ type toolCommand struct {
 	exitOnError bool
 }
 
+var runValidateSchemaConsistencyFn = runValidateSchemaConsistency
+
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -58,6 +60,7 @@ func toolCommands() []toolCommand {
 		{name: "generate-attributes", run: runGenerateAttributes},
 		{name: "init-db", run: runInitDB},
 		{name: "inline-schema", run: runInlineSchema},
+		{name: "validate-schema-consistency", run: runValidateSchemaConsistencyFn, exitOnError: true},
 		{name: "cdc-flush", run: runCDCFlush, exitOnError: true},
 		{name: "cdc-init", run: runCDCInit, exitOnError: true},
 		{name: "compactor", run: runCompactor, exitOnError: true},
@@ -71,6 +74,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  generate-attributes   Generate <schema>_attributes.json from a JSON schema file")
 	fmt.Fprintln(out, "  init-db               Create PostgreSQL tables and indexes for Forma")
 	fmt.Fprintln(out, "  inline-schema         Inline $ref references and remove x-* extension properties from a JSON schema")
+	fmt.Fprintln(out, "  validate-schema-consistency Validate schema metadata and EAV storage before upgrade")
 	fmt.Fprintln(out, "  cdc-flush             Run CDC change_log flush to S3 parquet files")
 	fmt.Fprintln(out, "  cdc-init              Initialize S3 parquet base files from existing data")
 	fmt.Fprintln(out, "  compactor             Run compaction on parquet files for a schema")

--- a/cmd/tools/main_test.go
+++ b/cmd/tools/main_test.go
@@ -58,3 +58,26 @@ func TestRunToolMain_Success(t *testing.T) {
 		t.Fatalf("expected output file: %v", err)
 	}
 }
+
+func TestRunToolMain_ValidateSchemaConsistencySuccess(t *testing.T) {
+	old := runValidateSchemaConsistencyFn
+	defer func() { runValidateSchemaConsistencyFn = old }()
+
+	called := false
+	runValidateSchemaConsistencyFn = func(ctx context.Context, args []string) error {
+		called = true
+		if len(args) != 1 || args[0] != "-h" {
+			t.Fatalf("unexpected args: %v", args)
+		}
+		return nil
+	}
+
+	var out bytes.Buffer
+	exitCode := runToolMain(context.Background(), []string{"validate-schema-consistency", "-h"}, &out)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d output=%q", exitCode, out.String())
+	}
+	if !called {
+		t.Fatal("expected validate-schema-consistency command to run")
+	}
+}

--- a/cmd/tools/tool_bootstrap.go
+++ b/cmd/tools/tool_bootstrap.go
@@ -5,6 +5,7 @@ import (
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal"
@@ -13,12 +14,20 @@ import (
 )
 
 var (
-	toolLoggerFactoryDev  = zap.NewDevelopment
-	toolLoggerFactoryProd = zap.NewProduction
-	toolPostgresPoolFn    = bootstrap.NewPostgresPoolFromConfigContext
-	toolSchemaRegistryFn  = internal.NewFileSchemaRegistryContext
-	toolLoadAWSConfigFn   = awsconfig.LoadDefaultConfig
+	toolLoggerFactoryDev    = zap.NewDevelopment
+	toolLoggerFactoryProd   = zap.NewProduction
+	toolPostgresPoolFn      = bootstrap.NewPostgresPoolFromConfigContext
+	toolSchemaRegistryFn    = internal.NewFileSchemaRegistryContext
+	toolLoadAWSConfigFn     = awsconfig.LoadDefaultConfig
+	buildToolPostgresPoolFn = func(ctx context.Context, cfg forma.DatabaseConfig) (toolDBPool, error) {
+		return toolPostgresPoolFn(ctx, cfg)
+	}
 )
+
+type toolDBPool interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	Close()
+}
 
 func buildToolLogger(dev bool) (*zap.Logger, error) {
 	if dev {
@@ -29,6 +38,10 @@ func buildToolLogger(dev bool) (*zap.Logger, error) {
 
 func buildToolPostgresPool(ctx context.Context, cfg forma.DatabaseConfig) (*pgxpool.Pool, error) {
 	return toolPostgresPoolFn(ctx, cfg)
+}
+
+func buildSchemaConsistencyPool(ctx context.Context, cfg forma.DatabaseConfig) (toolDBPool, error) {
+	return buildToolPostgresPoolFn(ctx, cfg)
 }
 
 func buildToolS3Client(ctx context.Context, region, endpoint string, usePath bool) (*s3.Client, error) {

--- a/cmd/tools/validate_schema_consistency.go
+++ b/cmd/tools/validate_schema_consistency.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal"
+	"github.com/lychee-technology/forma/internal/bootstrap"
+)
+
+var runValidateSchemaConsistencyOutFn = runValidateSchemaConsistencyOut
+
+type schemaConsistencyValidator struct {
+	pool        toolDBPool
+	schemaDir   string
+	schemaTable string
+	eavTable    string
+	out         io.Writer
+}
+
+type validationIssue struct {
+	category string
+	details  string
+}
+
+func runValidateSchemaConsistency(ctx context.Context, args []string) error {
+	return runValidateSchemaConsistencyOutFn(ctx, args, os.Stdout)
+}
+
+func runValidateSchemaConsistencyOut(ctx context.Context, args []string, out io.Writer) error {
+	flags := flag.NewFlagSet("validate-schema-consistency", flag.ContinueOnError)
+	flags.SetOutput(out)
+	flags.Usage = func() {
+		fmt.Fprintln(out, "Usage: forma-tools validate-schema-consistency [options]")
+		fmt.Fprintln(out, "")
+		fmt.Fprintln(out, "Options:")
+		flags.PrintDefaults()
+	}
+
+	var pg postgresFlags
+	pg.register(flags, postgresFlagOptions{
+		hostFlag:        "db-host",
+		portFlag:        "db-port",
+		userFlag:        "db-user",
+		passwordFlag:    "db-password",
+		databaseFlag:    "db-name",
+		sslModeFlag:     "db-ssl-mode",
+		hostDefault:     bootstrap.Env("DB_HOST", "localhost"),
+		portDefault:     bootstrap.EnvInt("DB_PORT", 5432),
+		userDefault:     bootstrap.Env("DB_USER", "postgres"),
+		passwordDefault: bootstrap.Env("DB_PASSWORD", "postgres"),
+		databaseDefault: bootstrap.Env("DB_NAME", "forma"),
+		sslModeDefault:  bootstrap.Env("DB_SSL_MODE", "disable"),
+		hostUsage:       "database host",
+		portUsage:       "database port",
+		userUsage:       "database user",
+		passwordUsage:   "database password",
+		databaseUsage:   "database name",
+		sslModeUsage:    "database sslmode",
+	})
+
+	var schemaRegistry schemaRegistryFlags
+	schemaRegistry.register(flags, true)
+	eavTable := flags.String("eav-table", bootstrap.Env("EAV_TABLE", "eav_data_dev"), "EAV data table to validate")
+
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	if err := schemaRegistry.validate(true); err != nil {
+		return err
+	}
+
+	pool, err := buildSchemaConsistencyPool(ctx, pg.databaseConfig("DB_PASSWORD", toolPostgresPoolSettings{
+		maxConnections: 4,
+		timeout:        30 * time.Second,
+	}))
+	if err != nil {
+		return fmt.Errorf("create connection pool: %w", err)
+	}
+	defer pool.Close()
+
+	validator := schemaConsistencyValidator{
+		pool:        pool,
+		schemaDir:   schemaRegistry.dir,
+		schemaTable: schemaRegistry.table,
+		eavTable:    *eavTable,
+		out:         out,
+	}
+	return validator.run(ctx)
+}
+
+func (v schemaConsistencyValidator) run(ctx context.Context) error {
+	loader := internal.NewMetadataLoader(v.pool, v.schemaTable, v.schemaDir)
+	cache, err := loader.LoadMetadata(ctx)
+	if err != nil {
+		return fmt.Errorf("load schema metadata: %w", err)
+	}
+
+	issues, err := v.collectIssues(ctx, cache)
+	if err != nil {
+		return err
+	}
+
+	if len(issues) == 0 {
+		fmt.Fprintf(v.out, "schema consistency checks passed for %d schema(s)\n", len(cache.ListSchemas()))
+		return nil
+	}
+
+	for _, issue := range issues {
+		fmt.Fprintf(v.out, "- %s: %s\n", issue.category, issue.details)
+	}
+	return fmt.Errorf("schema consistency validation failed with %d issue(s)", len(issues))
+}
+
+func (v schemaConsistencyValidator) collectIssues(ctx context.Context, cache *internal.MetadataCache) ([]validationIssue, error) {
+	var issues []validationIssue
+
+	unknownIssues, err := v.checkUnknownAttributeIDs(ctx, cache)
+	if err != nil {
+		return nil, err
+	}
+	issues = append(issues, unknownIssues...)
+
+	storageIssues, err := v.checkStorageMismatches(ctx, cache)
+	if err != nil {
+		return nil, err
+	}
+	issues = append(issues, storageIssues...)
+
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].category == issues[j].category {
+			return issues[i].details < issues[j].details
+		}
+		return issues[i].category < issues[j].category
+	})
+	return issues, nil
+}
+
+func (v schemaConsistencyValidator) checkUnknownAttributeIDs(ctx context.Context, cache *internal.MetadataCache) ([]validationIssue, error) {
+	knownAttrIDs := make(map[int16]map[int16]struct{})
+	for _, schemaName := range cache.ListSchemas() {
+		schemaID, ok := cache.GetSchemaID(schemaName)
+		if !ok {
+			continue
+		}
+		schemaCache, ok := cache.GetSchemaCache(schemaName)
+		if !ok {
+			continue
+		}
+		ids := make(map[int16]struct{}, len(schemaCache))
+		for _, meta := range schemaCache {
+			ids[meta.AttributeID] = struct{}{}
+		}
+		knownAttrIDs[schemaID] = ids
+	}
+
+	query := fmt.Sprintf(`
+SELECT e.schema_id, e.attr_id, COUNT(*) AS record_count
+FROM %s AS e
+GROUP BY e.schema_id, e.attr_id
+ORDER BY e.schema_id, e.attr_id`, quoteIdentifier(v.eavTable))
+
+	rows, err := v.pool.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("query unknown attribute ids: %w", err)
+	}
+	defer rows.Close()
+
+	var issues []validationIssue
+	for rows.Next() {
+		var schemaID, attrID int16
+		var count int64
+		if err := rows.Scan(&schemaID, &attrID, &count); err != nil {
+			return nil, fmt.Errorf("scan unknown attribute ids: %w", err)
+		}
+		if ids, ok := knownAttrIDs[schemaID]; ok {
+			if _, exists := ids[attrID]; exists {
+				continue
+			}
+		}
+		issues = append(issues, validationIssue{
+			category: "unknown attribute IDs in " + v.eavTable,
+			details:  fmt.Sprintf("schema_id=%d attr_id=%d rows=%d", schemaID, attrID, count),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate unknown attribute ids: %w", err)
+	}
+	return issues, nil
+}
+
+func (v schemaConsistencyValidator) checkStorageMismatches(ctx context.Context, cache *internal.MetadataCache) ([]validationIssue, error) {
+	textBacked := make(map[int16]map[int16]struct{})
+	numericBacked := make(map[int16]map[int16]struct{})
+
+	for _, schemaName := range cache.ListSchemas() {
+		schemaID, ok := cache.GetSchemaID(schemaName)
+		if !ok {
+			continue
+		}
+		schemaCache, ok := cache.GetSchemaCache(schemaName)
+		if !ok {
+			continue
+		}
+		for _, meta := range schemaCache {
+			if valueTypeUsesNumericColumn(meta.ValueType) {
+				if numericBacked[schemaID] == nil {
+					numericBacked[schemaID] = make(map[int16]struct{})
+				}
+				numericBacked[schemaID][meta.AttributeID] = struct{}{}
+			} else {
+				if textBacked[schemaID] == nil {
+					textBacked[schemaID] = make(map[int16]struct{})
+				}
+				textBacked[schemaID][meta.AttributeID] = struct{}{}
+			}
+		}
+	}
+
+	textQuery := fmt.Sprintf(`
+SELECT e.schema_id, e.attr_id, COUNT(*) AS record_count
+FROM %s AS e WHERE e.value_text IS NOT NULL
+GROUP BY e.schema_id, e.attr_id
+ORDER BY e.schema_id, e.attr_id`, quoteIdentifier(v.eavTable))
+	textIssues, err := v.scanStorageIssueRows(ctx, textQuery, func(schemaID, attrID int16, count int64) *validationIssue {
+		if ids, ok := numericBacked[schemaID]; ok {
+			if _, exists := ids[attrID]; exists {
+				return &validationIssue{
+					category: "numeric/date/bool attributes stored in value_text",
+					details:  fmt.Sprintf("schema_id=%d attr_id=%d rows=%d", schemaID, attrID, count),
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	numericQuery := fmt.Sprintf(`
+SELECT e.schema_id, e.attr_id, COUNT(*) AS record_count
+FROM %s AS e WHERE e.value_numeric IS NOT NULL
+GROUP BY e.schema_id, e.attr_id
+ORDER BY e.schema_id, e.attr_id`, quoteIdentifier(v.eavTable))
+	numericIssues, err := v.scanStorageIssueRows(ctx, numericQuery, func(schemaID, attrID int16, count int64) *validationIssue {
+		if ids, ok := textBacked[schemaID]; ok {
+			if _, exists := ids[attrID]; exists {
+				return &validationIssue{
+					category: "text/uuid/list attributes stored in value_numeric",
+					details:  fmt.Sprintf("schema_id=%d attr_id=%d rows=%d", schemaID, attrID, count),
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return append(textIssues, numericIssues...), nil
+}
+
+func (v schemaConsistencyValidator) scanStorageIssueRows(ctx context.Context, query string, classify func(schemaID, attrID int16, count int64) *validationIssue) ([]validationIssue, error) {
+	rows, err := v.pool.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("query storage mismatches: %w", err)
+	}
+	defer rows.Close()
+
+	var issues []validationIssue
+	for rows.Next() {
+		var schemaID, attrID int16
+		var count int64
+		if err := rows.Scan(&schemaID, &attrID, &count); err != nil {
+			return nil, fmt.Errorf("scan storage mismatches: %w", err)
+		}
+		if issue := classify(schemaID, attrID, count); issue != nil {
+			issues = append(issues, *issue)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate storage mismatches: %w", err)
+	}
+	return issues, nil
+}
+
+func valueTypeUsesNumericColumn(valueType forma.ValueType) bool {
+	switch valueType {
+	case forma.ValueTypeNumeric,
+		forma.ValueTypeInteger,
+		forma.ValueTypeBigInt,
+		forma.ValueTypeSmallInt,
+		forma.ValueTypeBool,
+		forma.ValueTypeDate,
+		forma.ValueTypeDateTime:
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/tools/validate_schema_consistency_test.go
+++ b/cmd/tools/validate_schema_consistency_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/pashagolub/pgxmock/v4"
+)
+
+func TestRunValidateSchemaConsistencyHelpFlag(t *testing.T) {
+	if err := runValidateSchemaConsistency(context.Background(), []string{"-h"}); err != nil {
+		t.Fatalf("expected no error with -h flag, got %v", err)
+	}
+}
+
+func TestRunValidateSchemaConsistencyRequiresSchemaRegistryPair(t *testing.T) {
+	err := runValidateSchemaConsistency(context.Background(), []string{"-schema-dir", "/tmp/schemas"})
+	if err == nil || !strings.Contains(err.Error(), "--schema-registry-table is required") {
+		t.Fatalf("expected schema registry pair validation error, got %v", err)
+	}
+}
+
+func TestValueTypeUsesNumericColumn(t *testing.T) {
+	tests := []struct {
+		name      string
+		valueType forma.ValueType
+		want      bool
+	}{
+		{name: "numeric", valueType: forma.ValueTypeNumeric, want: true},
+		{name: "bool", valueType: forma.ValueTypeBool, want: true},
+		{name: "text", valueType: forma.ValueTypeText, want: false},
+		{name: "uuid", valueType: forma.ValueTypeUUID, want: false},
+		{name: "unknown defaults to text", valueType: forma.ValueType("custom_future_type"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := valueTypeUsesNumericColumn(tt.valueType); got != tt.want {
+				t.Fatalf("valueTypeUsesNumericColumn(%q)=%v want %v", tt.valueType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateSchemaConsistencyReportsSuccess(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("create mock pool: %v", err)
+	}
+	defer mock.Close()
+
+	schemaDir := t.TempDir()
+	writeSchemaConsistencyArtifacts(t, schemaDir, "contact", `{"type":"object","properties":{"id":{"type":"string"}}}`, `{"id":{"attributeID":1,"valueType":"text"}}`)
+
+	mock.ExpectQuery(`SELECT schema_name, schema_id FROM "schema_registry_dev"`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_name", "schema_id"}).AddRow("contact", int16(100)))
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}))
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e WHERE e\.value_text IS NOT NULL`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}))
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e WHERE e\.value_numeric IS NOT NULL`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}))
+
+	var out strings.Builder
+	validator := schemaConsistencyValidator{
+		pool:        mock,
+		schemaDir:   schemaDir,
+		schemaTable: "schema_registry_dev",
+		eavTable:    "eav_data_dev",
+		out:         &out,
+	}
+
+	if err := validator.run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "schema consistency checks passed") {
+		t.Fatalf("expected success output, got %q", out.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}
+
+func TestValidateSchemaConsistencyReportsIssues(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("create mock pool: %v", err)
+	}
+	defer mock.Close()
+
+	schemaDir := t.TempDir()
+	writeSchemaConsistencyArtifacts(t, schemaDir, "contact", `{"type":"object","properties":{"id":{"type":"string"},"score":{"type":"number"}}}`, `{"id":{"attributeID":1,"valueType":"text"},"score":{"attributeID":2,"valueType":"numeric"}}`)
+
+	mock.ExpectQuery(`SELECT schema_name, schema_id FROM "schema_registry_dev"`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_name", "schema_id"}).AddRow("contact", int16(100)))
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}).AddRow(int16(100), int16(99), int64(2)))
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e WHERE e\.value_text IS NOT NULL`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}).AddRow(int16(100), int16(2), int64(3)))
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e WHERE e\.value_numeric IS NOT NULL`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}))
+
+	var out strings.Builder
+	validator := schemaConsistencyValidator{
+		pool:        mock,
+		schemaDir:   schemaDir,
+		schemaTable: "schema_registry_dev",
+		eavTable:    "eav_data_dev",
+		out:         &out,
+	}
+
+	err = validator.run(context.Background())
+	if err == nil {
+		t.Fatal("expected validation failure")
+	}
+	if !strings.Contains(err.Error(), "2 issue(s)") {
+		t.Fatalf("expected issue count in error, got %v", err)
+	}
+	if !strings.Contains(out.String(), "unknown attribute IDs in eav_data_dev") {
+		t.Fatalf("expected unknown attribute issue output, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), "numeric/date/bool attributes stored in value_text") {
+		t.Fatalf("expected storage mismatch output, got %q", out.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}
+
+func TestValidateSchemaConsistencyBuildPoolFailure(t *testing.T) {
+	oldBuildPool := buildToolPostgresPoolFn
+	oldValidate := runValidateSchemaConsistencyOutFn
+	defer func() {
+		buildToolPostgresPoolFn = oldBuildPool
+		runValidateSchemaConsistencyOutFn = oldValidate
+	}()
+
+	buildToolPostgresPoolFn = func(ctx context.Context, cfg forma.DatabaseConfig) (toolDBPool, error) {
+		return nil, errors.New("boom")
+	}
+	runValidateSchemaConsistencyOutFn = func(ctx context.Context, args []string, out io.Writer) error {
+		return runValidateSchemaConsistencyOut(ctx, args, out)
+	}
+
+	err := runValidateSchemaConsistency(context.Background(), []string{
+		"-db-host", "localhost",
+		"-db-port", "5432",
+		"-db-user", "postgres",
+		"-db-name", "forma",
+		"-db-ssl-mode", "disable",
+		"-schema-registry-table", "schema_registry_dev",
+		"-schema-dir", t.TempDir(),
+		"-eav-table", "eav_data_dev",
+	})
+	if err == nil || !strings.Contains(err.Error(), "create connection pool") {
+		t.Fatalf("expected pool creation error, got %v", err)
+	}
+}
+
+func writeSchemaConsistencyArtifacts(t *testing.T, dir, schemaName, schemaJSON, attrsJSON string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, schemaName+".json"), []byte(schemaJSON), 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, schemaName+"_attributes.json"), []byte(attrsJSON), 0o644); err != nil {
+		t.Fatalf("write attrs: %v", err)
+	}
+}

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -1,0 +1,212 @@
+# Schema Consistency Migration Guide
+
+This guide covers the upgrade to the schema/metadata consistency hardening introduced in PR `#121` (`709c31a`).
+
+## What Changed
+
+Older releases tolerated several schema and metadata inconsistencies by logging warnings or silently skipping bad records. The hardened release turns those cases into startup or request-time errors.
+
+The new checks fail on:
+
+- duplicate `schema_id` values in the schema registry table
+- duplicate `attributeID` values inside a single `<schema>_attributes.json`
+- duplicate hot-column bindings inside a single `<schema>_attributes.json`
+- EAV rows whose `attr_id` is not present in metadata for that schema
+- EAV rows whose value is stored in the wrong physical column (`value_text` vs `value_numeric`)
+- writes that reference attributes not defined in schema metadata
+
+## Recommended Migration Flow
+
+1. Stop writes to the target environment.
+2. Back up the database.
+3. Run the checked-in SQL script for DB-level sanity checks.
+4. Run the checked-in Go validator for full metadata-aware validation.
+5. Fix all reported issues.
+6. Deploy the hardened release.
+7. Run the validator again after deploy.
+
+For development and staging, a 5-15 minute maintenance window is usually enough.
+
+## Quick Commands
+
+DB-level SQL check:
+
+```bash
+psql "$DATABASE_URL" \
+  -v schema_table=schema_registry_dev \
+  -v eav_table=eav_data_dev \
+  -v entity_main_table=entity_main_dev \
+  -f scripts/validate_schema_consistency.sql
+```
+
+Full validation:
+
+```bash
+make validate-schema-consistency \
+  DB_HOST=localhost \
+  DB_PORT=5432 \
+  DB_USER=postgres \
+  DB_PASSWORD=postgres \
+  DB_NAME=forma \
+  DB_SSL_MODE=disable \
+  SCHEMA_TABLE=schema_registry_dev \
+  SCHEMA_DIR=cmd/server/schemas \
+  EAV_TABLE=eav_data_dev
+```
+
+Direct tool invocation:
+
+```bash
+./build/tools validate-schema-consistency \
+  --db-host localhost \
+  --db-port 5432 \
+  --db-user postgres \
+  --db-password postgres \
+  --db-name forma \
+  --db-ssl-mode disable \
+  --schema-registry-table schema_registry_dev \
+  --schema-dir cmd/server/schemas \
+  --eav-table eav_data_dev
+```
+
+## What Each Checker Covers
+
+### SQL Script
+
+`scripts/validate_schema_consistency.sql` is useful when you want a fast database-only pass in `psql`.
+
+It checks:
+
+- duplicate `schema_id` values in the schema registry table
+- duplicate `schema_name` rows in the schema registry table
+- `eav_data.schema_id` values that do not exist in the registry
+- `entity_main.ltbase_schema_id` values that do not exist in the registry
+- rows with both `value_text` and `value_numeric` populated
+- rows with neither `value_text` nor `value_numeric` populated
+- duplicate logical primary keys in `entity_main`
+- duplicate logical primary keys in `eav_data`
+
+### Go Validator
+
+The Go validator reuses the same metadata loading path the server uses at runtime. That means it will catch the same startup failures before you deploy.
+
+It validates:
+
+- schema registry rows can be loaded without duplicate schema IDs
+- every referenced `<schema>_attributes.json` parses successfully
+- each schema’s metadata has unique `attributeID` values
+- each schema’s metadata has unique `column_binding.col_name` values
+- `eav_data.attr_id` values all map to known metadata IDs for the same `schema_id`
+- numeric/date/bool values are not incorrectly stored in `value_text`
+- text/uuid/list values are not incorrectly stored in `value_numeric`
+
+Use both checks before upgrading. The SQL script gives quick database facts; the Go validator gives the final runtime-compatible answer.
+
+## Interpreting Failures
+
+### Duplicate schema IDs
+
+Example validator failure:
+
+```text
+validate-schema-consistency: load schema metadata: failed to load schema registry: duplicate schema id 100 for contact and lead
+```
+
+Fix by assigning one schema a new unused ID and updating the corresponding `schema_id` foreign keys in:
+
+- `eav_data_*`
+- `entity_main_*`
+- `change_log_*`
+
+### Duplicate attribute IDs in metadata
+
+Example startup failure:
+
+```text
+schema contact has duplicate attribute id 7 for email and phone
+```
+
+Fix the conflicting `<schema>_attributes.json` file and re-run the validator.
+
+### Duplicate column bindings
+
+Example startup failure:
+
+```text
+schema contact has duplicate column binding text_01 for email and phone
+```
+
+Only one attribute may own a given hot column inside a schema. Remove or change one binding.
+
+### Unknown attribute IDs in EAV
+
+Example validator output:
+
+```text
+- unknown attribute IDs in eav_data_dev: schema_id=100 attr_id=99 rows=12
+```
+
+That means the table contains rows that current metadata cannot decode. Fix by either:
+
+1. restoring the missing attribute metadata if the data is legitimate, or
+2. deleting the orphaned EAV rows if they were produced by a bad deployment or test data.
+
+### Storage-column mismatches
+
+Example validator output:
+
+```text
+- numeric/date/bool attributes stored in value_text: schema_id=100 attr_id=2 rows=3
+```
+
+This means the row uses the wrong physical value column for the declared `valueType`.
+
+Fix by rewriting the bad rows into the correct column and clearing the wrong one.
+
+## Suggested SQL Fix Workflow
+
+Inspect a bad attribute:
+
+```sql
+SELECT schema_id, row_id, attr_id, array_indices, value_text, value_numeric
+FROM eav_data_dev
+WHERE schema_id = 100 AND attr_id = 99
+LIMIT 50;
+```
+
+Delete orphaned rows if you have confirmed they are invalid:
+
+```sql
+DELETE FROM eav_data_dev
+WHERE schema_id = 100 AND attr_id = 99;
+```
+
+Inspect value-column mismatches:
+
+```sql
+SELECT schema_id, row_id, attr_id, array_indices, value_text, value_numeric
+FROM eav_data_dev
+WHERE schema_id = 100 AND attr_id = 2 AND value_text IS NOT NULL
+LIMIT 50;
+```
+
+## Deployment Checklist
+
+- database backup taken
+- `scripts/validate_schema_consistency.sql` returns no duplicate schema IDs
+- `make validate-schema-consistency` returns success
+- hardened release deployed
+- validator re-run after deploy
+- smoke CRUD tests pass against existing schemas
+
+## Rollback
+
+If deploy fails because of newly enforced checks:
+
+1. restore the previous server binary or image
+2. keep the database unchanged unless you already applied manual cleanup SQL
+3. fix the reported metadata or EAV inconsistencies
+4. re-run the validator
+5. retry the upgrade
+
+The validator is safe to run repeatedly and is intended to be part of your pre-upgrade checklist.

--- a/scripts/validate_schema_consistency.sql
+++ b/scripts/validate_schema_consistency.sql
@@ -1,0 +1,124 @@
+\if :{?schema_table}
+\else
+\set schema_table schema_registry_dev
+\endif
+
+\if :{?eav_table}
+\else
+\set eav_table eav_data_dev
+\endif
+
+\if :{?entity_main_table}
+\else
+\set entity_main_table entity_main_dev
+\endif
+
+\echo '=== Forma schema consistency validation ==='
+\echo ''
+\echo 'Tables:'
+\echo '  schema_table      = ' :schema_table
+\echo '  eav_table         = ' :eav_table
+\echo '  entity_main_table = ' :entity_main_table
+\echo ''
+\echo 'Notes:'
+\echo '- This script checks DB-level consistency only.'
+\echo '- Run `make validate-schema-consistency` for metadata-aware checks against *_attributes.json files.'
+\echo ''
+
+\echo '1. Duplicate schema IDs'
+SELECT
+  schema_id,
+  array_agg(schema_name ORDER BY schema_name) AS conflicting_schemas,
+  COUNT(*) AS duplicate_count
+FROM :schema_table
+GROUP BY schema_id
+HAVING COUNT(*) > 1
+ORDER BY schema_id;
+
+\echo ''
+\echo '2. Duplicate schema names'
+SELECT
+  schema_name,
+  array_agg(schema_id ORDER BY schema_id) AS conflicting_schema_ids,
+  COUNT(*) AS duplicate_count
+FROM :schema_table
+GROUP BY schema_name
+HAVING COUNT(*) > 1
+ORDER BY schema_name;
+
+\echo ''
+\echo '3. EAV schema IDs missing from registry'
+SELECT
+  e.schema_id,
+  COUNT(*) AS orphan_rows
+FROM :eav_table AS e
+LEFT JOIN :schema_table AS s ON s.schema_id = e.schema_id
+WHERE s.schema_id IS NULL
+GROUP BY e.schema_id
+ORDER BY e.schema_id;
+
+\echo ''
+\echo '4. entity_main schema IDs missing from registry'
+SELECT
+  m.ltbase_schema_id AS schema_id,
+  COUNT(*) AS orphan_rows
+FROM :entity_main_table AS m
+LEFT JOIN :schema_table AS s ON s.schema_id = m.ltbase_schema_id
+WHERE s.schema_id IS NULL
+GROUP BY m.ltbase_schema_id
+ORDER BY m.ltbase_schema_id;
+
+\echo ''
+\echo '5. change-log style entity references missing from entity_main primary key'
+\echo '   Skipped here because change_log table name is deployment-specific and not provided to this script.'
+
+\echo ''
+\echo '6. EAV rows with both value columns populated'
+SELECT
+  schema_id,
+  attr_id,
+  COUNT(*) AS affected_rows
+FROM :eav_table
+WHERE value_text IS NOT NULL
+  AND value_numeric IS NOT NULL
+GROUP BY schema_id, attr_id
+ORDER BY schema_id, attr_id;
+
+\echo ''
+\echo '7. EAV rows with neither value column populated'
+SELECT
+  schema_id,
+  attr_id,
+  COUNT(*) AS affected_rows
+FROM :eav_table
+WHERE value_text IS NULL
+  AND value_numeric IS NULL
+GROUP BY schema_id, attr_id
+ORDER BY schema_id, attr_id;
+
+\echo ''
+\echo '8. Duplicate entity_main primary keys (should be impossible unless constraints were bypassed)'
+SELECT
+  ltbase_schema_id,
+  ltbase_row_id,
+  COUNT(*) AS duplicate_count
+FROM :entity_main_table
+GROUP BY ltbase_schema_id, ltbase_row_id
+HAVING COUNT(*) > 1
+ORDER BY ltbase_schema_id, ltbase_row_id;
+
+\echo ''
+\echo '9. Duplicate EAV primary keys (should be impossible unless constraints were bypassed)'
+SELECT
+  schema_id,
+  row_id,
+  attr_id,
+  array_indices,
+  COUNT(*) AS duplicate_count
+FROM :eav_table
+GROUP BY schema_id, row_id, attr_id, array_indices
+HAVING COUNT(*) > 1
+ORDER BY schema_id, row_id, attr_id, array_indices;
+
+\echo ''
+\echo '=== Validation complete ==='


### PR DESCRIPTION
## Summary
- add a `forma-tools validate-schema-consistency` command for metadata-aware pre-upgrade checks
- add a richer SQL validation script and a documented migration runbook for existing deployments
- add a `make validate-schema-consistency` workflow and README link for operators

## Related Issues
- Related to #112

## Test Plan
- [x] `go test ./cmd/tools/...`
- [x] `go test ./internal/...`
- [x] `make build-tools`