### PR TITLE
fix: address issue #114 coverage gaps

### DIFF
--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -127,19 +127,7 @@ func RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectClient, dryRun
 		manifestResolver: manifestResolver,
 	}
 
-	var schemaErrs []error
-	for _, sid := range schemaIDs {
-		schemaID := int16(sid)
-		if err := flushCtx.processSchema(ctx, schemaID); err != nil {
-			logger.Sugar().Errorw("process schema failed", "schema_id", schemaID, "err", err)
-			schemaErrs = append(schemaErrs, fmt.Errorf("schema %d: %w", schemaID, err))
-		}
-	}
-	if len(schemaErrs) > 0 {
-		return errors.Join(schemaErrs...)
-	}
-
-	return nil
+	return flushCtx.processSchemas(ctx, schemaIDs)
 }
 
 // setupAWSClient initializes the AWS credentials and S3 client.
@@ -263,6 +251,32 @@ type schemaFlushContext struct {
 	releaseLock      func(context.Context, *sql.DB, int16) error
 	executeSingle    func(*flushBatchExecutor, []uuid.UUID) error
 	executeInChunks  func(*flushBatchExecutor, []uuid.UUID, int) error
+	processSchemaFn  func(context.Context, int16) error
+}
+
+func (c *schemaFlushContext) processSchemas(ctx context.Context, schemaIDs []int64) error {
+	if len(schemaIDs) == 0 {
+		return nil
+	}
+
+	processSchema := c.processSchemaFn
+	if processSchema == nil {
+		processSchema = c.processSchema
+	}
+
+	var schemaErrs []error
+	for _, sid := range schemaIDs {
+		schemaID := int16(sid)
+		if err := processSchema(ctx, schemaID); err != nil {
+			c.logger.Sugar().Errorw("process schema failed", "schema_id", schemaID, "err", err)
+			schemaErrs = append(schemaErrs, fmt.Errorf("schema %d: %w", schemaID, err))
+		}
+	}
+	if len(schemaErrs) > 0 {
+		return errors.Join(schemaErrs...)
+	}
+
+	return nil
 }
 
 // processSchema handles the flush process for a single schema.

--- a/internal/cdc/flusher_test.go
+++ b/internal/cdc/flusher_test.go
@@ -311,6 +311,58 @@ func TestGetUnflushedSchemaIDs_CanceledContext(t *testing.T) {
 	require.Contains(t, err.Error(), "query distinct schema ids")
 }
 
+func TestProcessSchemas_ContinuesAcrossFailuresAndJoinsErrors(t *testing.T) {
+	processed := make([]int16, 0, 3)
+	flushCtx := &schemaFlushContext{
+		logger: zap.NewNop(),
+		processSchemaFn: func(_ context.Context, schemaID int16) error {
+			processed = append(processed, schemaID)
+			if schemaID == 2 {
+				return errors.New("boom")
+			}
+			return nil
+		},
+	}
+
+	err := flushCtx.processSchemas(context.Background(), []int64{1, 2, 3})
+	require.Error(t, err)
+	require.Equal(t, []int16{1, 2, 3}, processed)
+	require.Contains(t, err.Error(), "schema 2")
+	require.Contains(t, err.Error(), "boom")
+}
+
+func TestProcessSchemas_ReturnsNilForNilOrEmptySchemaIDsWithoutProcessing(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		calls := 0
+		flushCtx := &schemaFlushContext{
+			logger: zap.NewNop(),
+			processSchemaFn: func(context.Context, int16) error {
+				calls++
+				return nil
+			},
+		}
+
+		err := flushCtx.processSchemas(context.Background(), nil)
+		require.NoError(t, err)
+		require.Zero(t, calls)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		calls := 0
+		flushCtx := &schemaFlushContext{
+			logger: zap.NewNop(),
+			processSchemaFn: func(context.Context, int16) error {
+				calls++
+				return nil
+			},
+		}
+
+		err := flushCtx.processSchemas(context.Background(), []int64{})
+		require.NoError(t, err)
+		require.Zero(t, calls)
+	})
+}
+
 func TestExecuteFlush_NoSelectedRowIDsReturnsWithoutExportWork(t *testing.T) {
 	db, err := sql.Open("duckdb", ":memory:")
 	require.NoError(t, err)

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -16,6 +16,7 @@ import (
 type mockEntityManager struct {
 	advancedResult    *forma.QueryResult
 	advancedErr       error
+	advancedReq       *forma.QueryRequest
 	getResult         *forma.DataRecord
 	getErr            error
 	batchCreateResult *forma.BatchResult
@@ -46,6 +47,7 @@ func (m *mockEntityManager) Delete(ctx context.Context, req *forma.EntityOperati
 }
 
 func (m *mockEntityManager) Query(ctx context.Context, req *forma.QueryRequest) (*forma.QueryResult, error) {
+	m.advancedReq = req
 	if m.advancedResult != nil || m.advancedErr != nil {
 		return m.advancedResult, m.advancedErr
 	}
@@ -126,6 +128,37 @@ func TestHandleAdvancedQueryValidation(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleAdvancedQueryURLAttrsOverrideBodyAttrs(t *testing.T) {
+	manager := &mockEntityManager{
+		advancedResult: &forma.QueryResult{Data: []*forma.DataRecord{}},
+	}
+	server := &Server{manager: manager}
+
+	payload := []byte(`{
+		"schema_name": "lead",
+		"condition": {"l": "and", "c": [{"a": "status", "v": "equals:hot"}]},
+		"attrs": ["body_attr"],
+		"page": 1,
+		"items_per_page": 10
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/advanced_query?attrs=url_one,url_two", bytes.NewReader(payload))
+	rec := httptest.NewRecorder()
+	server.handleAdvancedQuery(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if manager.advancedReq == nil {
+		t.Fatalf("expected Query request to be captured")
+	}
+
+	expectedAttrs := []string{"url_one", "url_two"}
+	if !reflect.DeepEqual(expectedAttrs, manager.advancedReq.Attrs) {
+		t.Fatalf("expected attrs %v, got %v", expectedAttrs, manager.advancedReq.Attrs)
 	}
 }
 

--- a/internal/postgres_persistent_repository_main_table.go
+++ b/internal/postgres_persistent_repository_main_table.go
@@ -178,7 +178,7 @@ func (r *DBPersistentRecordRepository) updateMainRow(ctx context.Context, tx pgx
 	}
 	tag, err := tx.Exec(ctx, query, args...)
 	if err != nil {
-		return fmt.Errorf("update entity_main: %w", err)
+		return fmt.Errorf("update entity_main: %w", classifyPgError(err))
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("entity not found (schema=%d row=%s): %w", record.SchemaID, record.RowID, forma.ErrNotFound)

--- a/internal/postgres_persistent_repository_main_table_test.go
+++ b/internal/postgres_persistent_repository_main_table_test.go
@@ -2,10 +2,12 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/lychee-technology/forma"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
@@ -148,4 +150,50 @@ func TestInsertAndUpdateMainRow(t *testing.T) {
 	require.NoError(t, repo.updateMainRow(ctx, mock, "entity_main", record))
 
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdateMainRowClassifiesUniqueViolationAsConflict(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	rowID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	record := &PersistentRecord{
+		SchemaID:  1,
+		RowID:     rowID,
+		UpdatedAt: 20,
+		TextItems: map[string]string{"text_01": "hello"},
+	}
+
+	updateQuery, updateArgs, err := buildUpdateMainStatement("entity_main", record)
+	require.NoError(t, err)
+	mock.ExpectExec("^" + regexp.QuoteMeta(updateQuery) + "$").
+		WithArgs(updateArgs...).
+		WillReturnError(&pgconn.PgError{Code: "23505", Detail: "duplicate key value violates unique constraint"})
+
+	repo := &DBPersistentRecordRepository{}
+	err = repo.updateMainRow(ctx, mock, "entity_main", record)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, forma.ErrConflict)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestClassifyPgError(t *testing.T) {
+	t.Run("maps 23505 to conflict", func(t *testing.T) {
+		err := classifyPgError(&pgconn.PgError{Code: "23505", Detail: "duplicate key value violates unique constraint"})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, forma.ErrConflict)
+	})
+
+	t.Run("leaves other pg errors unchanged", func(t *testing.T) {
+		original := &pgconn.PgError{Code: "23503", Detail: "violates foreign key constraint"}
+		assert.Same(t, original, classifyPgError(original))
+	})
+
+	t.Run("leaves non pg errors unchanged", func(t *testing.T) {
+		original := errors.New("boom")
+		assert.Same(t, original, classifyPgError(original))
+	})
 }

--- a/internal/postgres_persistent_repository_repo_test.go
+++ b/internal/postgres_persistent_repository_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/google/uuid"
@@ -518,6 +519,66 @@ func TestQueryPersistentRecordsWithMockPool(t *testing.T) {
 	require.NotNil(t, page)
 	require.Len(t, page.Records, 1)
 
+	assert.Equal(t, int64(1), page.TotalRecords)
+	assert.Equal(t, 1, page.TotalPages)
+	assert.Equal(t, 1, page.CurrentPage)
+	assert.Equal(t, rowID, page.Records[0].RowID)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestQueryPersistentRecordsFederated_FallsBackToPostgresWhenDuckDBCircuitBreakerOpen(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	duck, err := NewDuckDBClient(forma.DuckDBConfig{Enabled: true, DBPath: ":memory:"})
+	require.NoError(t, err)
+	defer duck.Close()
+
+	prevBreaker := GetDuckDBCircuitBreaker()
+	breaker := NewCircuitBreaker(1, time.Minute, time.Minute)
+	breaker.RecordFailure()
+	SetGlobalDuckDBCircuitBreaker(breaker)
+	defer SetGlobalDuckDBCircuitBreaker(prevBreaker)
+
+	repo := NewDBPersistentRecordRepository(mock, nil, duck, forma.DuckDBConfig{Enabled: true})
+	repo.fetchDirtyIDs = func(ctx context.Context, table string, schemaID int16) ([]uuid.UUID, error) {
+		return nil, nil
+	}
+	repo.buildDuckSQL = func(tpl *template.Template, params any, q *FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *DualClauses) (string, []any, error) {
+		return `SELECT
+			1::SMALLINT AS ltbase_schema_id,
+			'11111111-1111-1111-1111-111111111111'::TEXT AS ltbase_row_id,
+			100::BIGINT AS ltbase_created_at,
+			200::BIGINT AS ltbase_updated_at,
+			NULL::BIGINT AS ltbase_deleted_at,
+			'[]'::TEXT AS attributes_json,
+			1::BIGINT AS total_records,
+			1::BIGINT AS total_pages,
+			1 AS current_page`, nil, nil
+	}
+
+	rowID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, 1)
+	rows := pgxmock.NewRows(columns).AddRow(values...)
+	mock.ExpectQuery("WITH anchor").WithArgs(int16(1), 50, 0).WillReturnRows(rows)
+
+	page, err := repo.QueryPersistentRecordsFederated(ctx, StorageTables{EntityMain: "main_table", EAVData: "eav_table"}, &FederatedAttributeQuery{
+		AttributeQuery: AttributeQuery{
+			SchemaID: 1,
+			Limit:    50,
+			Offset:   0,
+		},
+		PreferredTiers: []DataTier{DataTierHot, DataTierCold},
+	}, &FederatedQueryOptions{AllowPartialDegradedMode: true})
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	require.Len(t, page.Records, 1)
 	assert.Equal(t, int64(1), page.TotalRecords)
 	assert.Equal(t, 1, page.TotalPages)
 	assert.Equal(t, 1, page.CurrentPage)

--- a/internal/postgres_persistent_repository_repo_test.go
+++ b/internal/postgres_persistent_repository_repo_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 	"text/template"
@@ -550,21 +551,22 @@ func TestQueryPersistentRecordsFederated_FallsBackToPostgresWhenDuckDBCircuitBre
 	repo.fetchDirtyIDs = func(ctx context.Context, table string, schemaID int16) ([]uuid.UUID, error) {
 		return nil, nil
 	}
+	duckRowID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	repo.buildDuckSQL = func(tpl *template.Template, params any, q *FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *DualClauses) (string, []any, error) {
-		return `SELECT
+		return fmt.Sprintf(`SELECT
 			1::SMALLINT AS ltbase_schema_id,
-			'11111111-1111-1111-1111-111111111111'::TEXT AS ltbase_row_id,
+			'%s'::TEXT AS ltbase_row_id,
 			100::BIGINT AS ltbase_created_at,
 			200::BIGINT AS ltbase_updated_at,
 			NULL::BIGINT AS ltbase_deleted_at,
 			'[]'::TEXT AS attributes_json,
-			1::BIGINT AS total_records,
+			99::BIGINT AS total_records,
 			1::BIGINT AS total_pages,
-			1 AS current_page`, nil, nil
+			1 AS current_page`, duckRowID), nil, nil
 	}
 
-	rowID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, 1)
+	pgRowID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	columns, values := optimizedQueryFixtureColumnsAndValues(pgRowID, 1)
 	rows := pgxmock.NewRows(columns).AddRow(values...)
 	mock.ExpectQuery("WITH anchor").WithArgs(int16(1), 50, 0).WillReturnRows(rows)
 
@@ -582,7 +584,7 @@ func TestQueryPersistentRecordsFederated_FallsBackToPostgresWhenDuckDBCircuitBre
 	assert.Equal(t, int64(1), page.TotalRecords)
 	assert.Equal(t, 1, page.TotalPages)
 	assert.Equal(t, 1, page.CurrentPage)
-	assert.Equal(t, rowID, page.Records[0].RowID)
+	assert.Equal(t, pgRowID, page.Records[0].RowID)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
## Summary
- apply `classifyPgError` to `updateMainRow` and add focused contract tests
- add a repository test for circuit-breaker-open federated fallback to Postgres when degraded mode is enabled
- add coverage for advanced query `?attrs=` override and CDC multi-schema loop error aggregation

## Test Plan
- [x] `go test ./internal ./internal/httpapi ./internal/cdc`

Closes #114
