### PR TITLE
refactor: deglobalize factory DuckDB seams

### DIFF
--- a/config.go
+++ b/config.go
@@ -158,20 +158,22 @@ type MetricsConfig struct {
 
 // DuckDBConfig contains DuckDB connection and S3 settings for federated queries
 type DuckDBConfig struct {
-	Enabled                 bool          `json:"enabled"`
-	DBPath                  string        `json:"dbPath"`        // path to local DuckDB file (or ":memory:")
-	MemoryLimitMB           int           `json:"memoryLimitMB"` // memory limit for DuckDB in MB
-	EnableS3                bool          `json:"enableS3"`      // enable S3/http file system
-	S3Endpoint              string        `json:"s3Endpoint"`    // custom S3 endpoint (for MinIO)
-	S3AccessKey             string        `json:"s3AccessKey"`
-	S3SecretKey             string        `json:"s3SecretKey"`
-	S3Region                string        `json:"s3Region"`
-	EnableParquet           bool          `json:"enableParquet"` // enable parquet extension
-	Extensions              []string      `json:"extensions"`    // additional extensions to load
-	MaxConnections          int           `json:"maxConnections"`
-	QueryTimeout            time.Duration `json:"queryTimeout"`            // per-query timeout for DuckDB access
-	MaxParallelism          int           `json:"maxParallelism"`          // max threads/pragmas for DuckDB
-	CircuitBreakerThreshold float64       `json:"circuitBreakerThreshold"` // Deprecated: ignored failure-rate threshold; use CircuitBreakerFailureThreshold instead.
+	Enabled        bool          `json:"enabled"`
+	DBPath         string        `json:"dbPath"`        // path to local DuckDB file (or ":memory:")
+	MemoryLimitMB  int           `json:"memoryLimitMB"` // memory limit for DuckDB in MB
+	EnableS3       bool          `json:"enableS3"`      // enable S3/http file system
+	S3Endpoint     string        `json:"s3Endpoint"`    // custom S3 endpoint (for MinIO)
+	S3AccessKey    string        `json:"s3AccessKey"`
+	S3SecretKey    string        `json:"s3SecretKey"`
+	S3Region       string        `json:"s3Region"`
+	EnableParquet  bool          `json:"enableParquet"` // enable parquet extension
+	Extensions     []string      `json:"extensions"`    // additional extensions to load
+	MaxConnections int           `json:"maxConnections"`
+	QueryTimeout   time.Duration `json:"queryTimeout"`   // per-query timeout for DuckDB access
+	MaxParallelism int           `json:"maxParallelism"` // max threads/pragmas for DuckDB
+	// Deprecated: ignored failure-rate threshold; use
+	// CircuitBreakerFailureThreshold instead.
+	CircuitBreakerThreshold float64 `json:"circuitBreakerThreshold"`
 
 	// CircuitBreakerFailureThreshold is the number of consecutive failures that
 	// opens the DuckDB circuit breaker. Zero means use the built-in default.

--- a/config.go
+++ b/config.go
@@ -171,8 +171,19 @@ type DuckDBConfig struct {
 	MaxConnections          int           `json:"maxConnections"`
 	QueryTimeout            time.Duration `json:"queryTimeout"`            // per-query timeout for DuckDB access
 	MaxParallelism          int           `json:"maxParallelism"`          // max threads/pragmas for DuckDB
-	CircuitBreakerThreshold float64       `json:"circuitBreakerThreshold"` // failure rate to trip circuit breaker (0..1)
-	Routing                 RoutingPolicy `json:"routing"`                 // routing policy for federated queries
+	CircuitBreakerThreshold float64       `json:"circuitBreakerThreshold"` // Deprecated: ignored failure-rate threshold; use CircuitBreakerFailureThreshold instead.
+
+	// CircuitBreakerFailureThreshold is the number of consecutive failures that
+	// opens the DuckDB circuit breaker. Zero means use the built-in default.
+	CircuitBreakerFailureThreshold int `json:"circuitBreakerFailureThreshold"`
+	// CircuitBreakerWindow is the sliding window for counting DuckDB failures.
+	// Zero means use the built-in default.
+	CircuitBreakerWindow time.Duration `json:"circuitBreakerWindow"`
+	// CircuitBreakerOpenDuration is how long the DuckDB breaker stays open after
+	// tripping. Zero means use the built-in default.
+	CircuitBreakerOpenDuration time.Duration `json:"circuitBreakerOpenDuration"`
+
+	Routing RoutingPolicy `json:"routing"` // routing policy for federated queries
 }
 
 // RoutingStrategy specifies the federated query routing algorithm.
@@ -493,16 +504,19 @@ func defaultReferenceConfig() ReferenceConfig {
 // defaultDuckDBConfig returns default DuckDB configuration.
 func defaultDuckDBConfig() DuckDBConfig {
 	return DuckDBConfig{
-		Enabled:                 false,
-		DBPath:                  ":memory:",
-		MemoryLimitMB:           0,
-		EnableS3:                false,
-		EnableParquet:           false,
-		Extensions:              []string{},
-		MaxConnections:          1,
-		QueryTimeout:            30 * time.Second,
-		MaxParallelism:          1,
-		CircuitBreakerThreshold: 0.5,
+		Enabled:                        false,
+		DBPath:                         ":memory:",
+		MemoryLimitMB:                  0,
+		EnableS3:                       false,
+		EnableParquet:                  false,
+		Extensions:                     []string{},
+		MaxConnections:                 1,
+		QueryTimeout:                   30 * time.Second,
+		MaxParallelism:                 1,
+		CircuitBreakerThreshold:        0,
+		CircuitBreakerFailureThreshold: 5,
+		CircuitBreakerWindow:           time.Minute,
+		CircuitBreakerOpenDuration:     time.Minute,
 		Routing: RoutingPolicy{
 			Strategy:          RoutingStrategyHybrid,
 			HotTTL:            5 * time.Minute,
@@ -544,6 +558,15 @@ func (c *Config) Validate() error {
 	}
 	if c.DuckDB.QueryTimeout < 0 {
 		return &ConfigError{Field: "duckdb.queryTimeout", Message: "must be greater than or equal to 0"}
+	}
+	if c.DuckDB.CircuitBreakerFailureThreshold < 0 {
+		return &ConfigError{Field: "duckdb.circuitBreakerFailureThreshold", Message: "must be greater than or equal to 0"}
+	}
+	if c.DuckDB.CircuitBreakerWindow < 0 {
+		return &ConfigError{Field: "duckdb.circuitBreakerWindow", Message: "must be greater than or equal to 0"}
+	}
+	if c.DuckDB.CircuitBreakerOpenDuration < 0 {
+		return &ConfigError{Field: "duckdb.circuitBreakerOpenDuration", Message: "must be greater than or equal to 0"}
 	}
 	allowed := map[RoutingStrategy]bool{
 		RoutingStrategyFreshnessFirst: true,

--- a/config_test.go
+++ b/config_test.go
@@ -132,6 +132,90 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestDuckDBBreakerConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultDuckDBConfig()
+
+	if cfg.CircuitBreakerThreshold != 0 {
+		t.Errorf("Expected deprecated circuit breaker threshold to default to 0, got %v", cfg.CircuitBreakerThreshold)
+	}
+	if cfg.CircuitBreakerFailureThreshold != 5 {
+		t.Errorf("Expected circuit breaker failure threshold to be 5, got %d", cfg.CircuitBreakerFailureThreshold)
+	}
+	if cfg.CircuitBreakerWindow != time.Minute {
+		t.Errorf("Expected circuit breaker window to be 1m, got %v", cfg.CircuitBreakerWindow)
+	}
+	if cfg.CircuitBreakerOpenDuration != time.Minute {
+		t.Errorf("Expected circuit breaker open duration to be 1m, got %v", cfg.CircuitBreakerOpenDuration)
+	}
+}
+
+func TestDuckDBBreakerConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		duckDB     DuckDBConfig
+		errorField string
+	}{
+		{
+			name:       "zero breaker values are allowed for runtime default fallback",
+			duckDB:     DuckDBConfig{},
+			errorField: "",
+		},
+		{
+			name: "negative failure threshold",
+			duckDB: DuckDBConfig{
+				CircuitBreakerFailureThreshold: -1,
+			},
+			errorField: "duckdb.circuitBreakerFailureThreshold",
+		},
+		{
+			name: "negative window",
+			duckDB: DuckDBConfig{
+				CircuitBreakerWindow: -time.Second,
+			},
+			errorField: "duckdb.circuitBreakerWindow",
+		},
+		{
+			name: "negative open duration",
+			duckDB: DuckDBConfig{
+				CircuitBreakerOpenDuration: -time.Second,
+			},
+			errorField: "duckdb.circuitBreakerOpenDuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := DefaultConfig(NewMockSchemaRegistry())
+			config.DuckDB = tt.duckDB
+
+			err := config.Validate()
+			if tt.errorField == "" {
+				if err != nil {
+					t.Fatalf("Expected no validation error, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("Expected validation error, got nil")
+			}
+			configErr, ok := err.(*ConfigError)
+			if !ok {
+				t.Fatalf("Expected ConfigError, got %T", err)
+			}
+			if configErr.Field != tt.errorField {
+				t.Errorf("Expected error field %s, got %s", tt.errorField, configErr.Field)
+			}
+		})
+	}
+}
+
 func TestConfigValidationDetailed(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -157,8 +157,10 @@ func newEntityManagerWithConfigContext(ctx context.Context, config *forma.Config
 }
 
 func newDuckDBCircuitBreaker(cfg forma.DuckDBConfig) *internal.CircuitBreaker {
-	if cfg.CircuitBreakerThreshold > 0 {
-		zap.S().Warnw("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead", "oldValue", cfg.CircuitBreakerThreshold)
+	// This is the one sanctioned reader of the deprecated field: it exists to
+	// warn callers who still set it.
+	if cfg.CircuitBreakerThreshold > 0 { //nolint:staticcheck // SA1019: intentional migration-warning read
+		zap.S().Warnw("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead", "oldValue", cfg.CircuitBreakerThreshold) //nolint:staticcheck // SA1019: intentional migration-warning read
 	}
 
 	defaults := forma.DefaultConfig(nil).DuckDB

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -26,28 +25,26 @@ type metadataLoader interface {
 	LoadMetadata(ctx context.Context) (*internal.MetadataCache, error)
 }
 
-// defaultMetadataLoaderFactory is the default factory function for creating metadata loaders.
-// It can be overridden in tests for injection.
-var defaultMetadataLoaderFactory = func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
-	return internal.NewMetadataLoader(pool, schemaTable, schemaDir)
+// entityManagerDependencies carries factory seams for EntityManager construction.
+// Only add fields that are strictly construction dependencies of the factory.
+// Business-logic seams belong on the EntityManager interface, not here.
+type entityManagerDependencies struct {
+	collectTables     func(context.Context, queryPool, string) ([]string, error)
+	newMetadataLoader func(*pgxpool.Pool, string, string) metadataLoader
+	newDuckDBClient   func(context.Context, forma.DuckDBConfig) (*internal.DuckDBClient, error)
 }
 
-var defaultDuckDBClientFactory = internal.NewDuckDBClientContext
-
-// tableCollector is a test hook for table discovery.
-var tableCollector = collectTablesFromPool
+func defaultEntityManagerDependencies() entityManagerDependencies {
+	return entityManagerDependencies{
+		collectTables: collectTablesFromPool,
+		newMetadataLoader: func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
+			return internal.NewMetadataLoader(pool, schemaTable, schemaDir)
+		},
+		newDuckDBClient: internal.NewDuckDBClientContext,
+	}
+}
 
 const defaultDatabaseSchema = "public"
-
-// DuckDB circuit-breaker parameters for the federated query engine. The
-// breaker is count-based (consecutive failures within a sliding window);
-// forma.DuckDBConfig.CircuitBreakerThreshold is a failure *rate* (0..1) and
-// does not map onto it — making these configurable is tracked in #129.
-const (
-	duckDBBreakerFailureThreshold = 5
-	duckDBBreakerWindow           = time.Minute
-	duckDBBreakerOpenDuration     = time.Minute
-)
 
 // collectTablesFromPool queries information_schema for table/view names and returns the list.
 func collectTablesFromPool(ctx context.Context, pool queryPool, schema string) ([]string, error) {
@@ -85,9 +82,13 @@ UNION SELECT table_name FROM information_schema.views v WHERE table_schema = $1;
 //
 // See NewEntityManagerWithConfig for usage examples.
 func NewEntityManagerWithConfigContext(ctx context.Context, config *forma.Config, pool *pgxpool.Pool) (forma.EntityManager, error) {
+	return newEntityManagerWithConfigContext(ctx, config, pool, defaultEntityManagerDependencies())
+}
+
+func newEntityManagerWithConfigContext(ctx context.Context, config *forma.Config, pool *pgxpool.Pool, deps entityManagerDependencies) (forma.EntityManager, error) {
 	schemaName := normalizeSchemaName(config.Database.Schema)
 	effectiveConfig := configWithQualifiedTables(config, schemaName)
-	tables, err := tableCollector(ctx, pool, schemaName)
+	tables, err := deps.collectTables(ctx, pool, schemaName)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func NewEntityManagerWithConfigContext(ctx context.Context, config *forma.Config
 
 	// Load metadata from database at startup
 	zap.S().Info("Loading metadata from database...")
-	loader := defaultMetadataLoaderFactory(
+	loader := deps.newMetadataLoader(
 		pool,
 		effectiveConfig.Database.TableNames.SchemaRegistry,
 		effectiveConfig.Entity.SchemaDirectory,
@@ -134,7 +135,7 @@ func NewEntityManagerWithConfigContext(ctx context.Context, config *forma.Config
 	// Initialize DuckDB client if enabled in config
 	if effectiveConfig.DuckDB.Enabled {
 		zap.S().Infow("initializing DuckDB client", "dbPath", effectiveConfig.DuckDB.DBPath)
-		duckClient, err = defaultDuckDBClientFactory(ctx, effectiveConfig.DuckDB)
+		duckClient, err = deps.newDuckDBClient(ctx, effectiveConfig.DuckDB)
 		if err != nil {
 			zap.S().Warnw("failed to initialize DuckDB client; continuing without DuckDB", "err", err)
 		} else {
@@ -146,13 +147,35 @@ func NewEntityManagerWithConfigContext(ctx context.Context, config *forma.Config
 		repository,
 		internal.NewPostgresDirtyIDFetcher(pool),
 		internal.NewDuckDBClientQueryExecutor(duckClient),
-		internal.NewCircuitBreaker(duckDBBreakerFailureThreshold, duckDBBreakerWindow, duckDBBreakerOpenDuration),
+		newDuckDBCircuitBreaker(effectiveConfig.DuckDB),
 		effectiveConfig.DuckDB,
 		metadataCache,
 		internal.DuckDBPostgresConnStringFromPool(pool),
 	)
 	// Create and return entity manager
 	return internal.NewEntityManager(transformer, repository, federatedEngine, registry, effectiveConfig), nil
+}
+
+func newDuckDBCircuitBreaker(cfg forma.DuckDBConfig) *internal.CircuitBreaker {
+	if cfg.CircuitBreakerThreshold > 0 {
+		zap.S().Warnw("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead", "oldValue", cfg.CircuitBreakerThreshold)
+	}
+
+	defaults := forma.DefaultConfig(nil).DuckDB
+	failureThreshold := cfg.CircuitBreakerFailureThreshold
+	if failureThreshold <= 0 {
+		failureThreshold = defaults.CircuitBreakerFailureThreshold
+	}
+	window := cfg.CircuitBreakerWindow
+	if window <= 0 {
+		window = defaults.CircuitBreakerWindow
+	}
+	openDuration := cfg.CircuitBreakerOpenDuration
+	if openDuration <= 0 {
+		openDuration = defaults.CircuitBreakerOpenDuration
+	}
+
+	return internal.NewCircuitBreaker(failureThreshold, window, openDuration)
 }
 
 // NewEntityManagerWithConfig creates a new EntityManager with the provided configuration and database pool.

--- a/factory/factory_test.go
+++ b/factory/factory_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // ---------------------------------------------------------------------------
@@ -275,50 +277,40 @@ func (m *mockMetadataLoader) LoadMetadata(ctx context.Context) (*internal.Metada
 	return m.cache, m.err
 }
 
-func withTableCollector(t *testing.T, collector func(context.Context, queryPool, string) ([]string, error)) {
-	t.Helper()
-	original := tableCollector
-	tableCollector = collector
-	t.Cleanup(func() {
-		tableCollector = original
-	})
-}
-
-func withMetadataLoaderFactory(t *testing.T, factory func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader) {
-	t.Helper()
-	original := defaultMetadataLoaderFactory
-	defaultMetadataLoaderFactory = factory
-	t.Cleanup(func() {
-		defaultMetadataLoaderFactory = original
-	})
-}
-
-func withDuckDBClientFactory(t *testing.T, factory func(context.Context, forma.DuckDBConfig) (*internal.DuckDBClient, error)) {
-	t.Helper()
-	original := defaultDuckDBClientFactory
-	defaultDuckDBClientFactory = factory
-	t.Cleanup(func() {
-		defaultDuckDBClientFactory = original
-	})
+func unitEntityManagerDeps(cache *internal.MetadataCache) entityManagerDependencies {
+	deps := defaultEntityManagerDependencies()
+	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
+		return []string{"schema_registry", "eav_data", "entity_main"}, nil
+	}
+	deps.newMetadataLoader = func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
+		return &mockMetadataLoader{cache: cache, err: nil}
+	}
+	return deps
 }
 
 func TestNewEntityManagerWithConfig_Unit_TableCollectorError(t *testing.T) {
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
+	t.Parallel()
+
+	deps := defaultEntityManagerDependencies()
+	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		return nil, assert.AnError
-	})
+	}
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 
-	em, err := NewEntityManagerWithConfig(config, nil)
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
 	assert.Nil(t, em)
 	assert.Error(t, err)
 }
 
 func TestNewEntityManagerWithConfig_Unit_MissingRequiredTables(t *testing.T) {
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
+	t.Parallel()
+
+	deps := defaultEntityManagerDependencies()
+	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		return []string{"schema_registry"}, nil
-	})
+	}
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.TableNames = forma.TableNames{
@@ -327,7 +319,7 @@ func TestNewEntityManagerWithConfig_Unit_MissingRequiredTables(t *testing.T) {
 		EntityMain:     "entity_main",
 	}
 
-	em, err := NewEntityManagerWithConfig(config, nil)
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
 	assert.Nil(t, em)
 	assert.Error(t, err)
@@ -335,10 +327,13 @@ func TestNewEntityManagerWithConfig_Unit_MissingRequiredTables(t *testing.T) {
 }
 
 func TestNewEntityManagerWithConfig_Unit_MissingEntityMainTable(t *testing.T) {
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
+	t.Parallel()
+
+	deps := defaultEntityManagerDependencies()
+	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		// schema_registry and eav_data present, but entity_main is absent
 		return []string{"schema_registry", "eav_data"}, nil
-	})
+	}
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.TableNames = forma.TableNames{
@@ -347,7 +342,7 @@ func TestNewEntityManagerWithConfig_Unit_MissingEntityMainTable(t *testing.T) {
 		EntityMain:     "entity_main",
 	}
 
-	em, err := NewEntityManagerWithConfig(config, nil)
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
 	assert.Nil(t, em)
 	assert.Error(t, err)
@@ -355,13 +350,13 @@ func TestNewEntityManagerWithConfig_Unit_MissingEntityMainTable(t *testing.T) {
 }
 
 func TestNewEntityManagerWithConfig_Unit_MetadataLoaderError(t *testing.T) {
+	t.Parallel()
+
 	cache := internal.NewMetadataCache()
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
-		return []string{"schema_registry", "eav_data", "entity_main"}, nil
-	})
-	withMetadataLoaderFactory(t, func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
+	deps := unitEntityManagerDeps(cache)
+	deps.newMetadataLoader = func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
 		return &mockMetadataLoader{cache: cache, err: fmt.Errorf("simulated loader error")}
-	})
+	}
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.TableNames = forma.TableNames{
@@ -371,7 +366,7 @@ func TestNewEntityManagerWithConfig_Unit_MetadataLoaderError(t *testing.T) {
 	}
 	config.Entity.SchemaDirectory = t.TempDir()
 
-	em, err := NewEntityManagerWithConfig(config, nil)
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
 	assert.Nil(t, em)
 	assert.Error(t, err)
@@ -379,13 +374,10 @@ func TestNewEntityManagerWithConfig_Unit_MetadataLoaderError(t *testing.T) {
 }
 
 func TestNewEntityManagerWithConfig_Unit_NilSchemaRegistry(t *testing.T) {
+	t.Parallel()
+
 	cache := internal.NewMetadataCache()
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
-		return []string{"schema_registry", "eav_data", "entity_main"}, nil
-	})
-	withMetadataLoaderFactory(t, func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
-		return &mockMetadataLoader{cache: cache, err: nil}
-	})
+	deps := unitEntityManagerDeps(cache)
 
 	config := forma.DefaultConfig(nil)
 	config.Database.TableNames = forma.TableNames{
@@ -395,7 +387,7 @@ func TestNewEntityManagerWithConfig_Unit_NilSchemaRegistry(t *testing.T) {
 	}
 	config.Entity.SchemaDirectory = t.TempDir()
 
-	em, err := NewEntityManagerWithConfig(config, nil)
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
 	assert.Nil(t, em)
 	assert.Error(t, err)
@@ -403,13 +395,10 @@ func TestNewEntityManagerWithConfig_Unit_NilSchemaRegistry(t *testing.T) {
 }
 
 func TestNewEntityManagerWithConfig_Unit_Success(t *testing.T) {
+	t.Parallel()
+
 	cache := internal.NewMetadataCache()
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
-		return []string{"schema_registry", "eav_data", "entity_main"}, nil
-	})
-	withMetadataLoaderFactory(t, func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
-		return &mockMetadataLoader{cache: cache, err: nil}
-	})
+	deps := unitEntityManagerDeps(cache)
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.TableNames = forma.TableNames{
@@ -419,22 +408,25 @@ func TestNewEntityManagerWithConfig_Unit_Success(t *testing.T) {
 	}
 	config.Entity.SchemaDirectory = t.TempDir()
 
-	em, err := NewEntityManagerWithConfig(config, nil)
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
 	assert.NotNil(t, em)
 	assert.NoError(t, err)
 }
 
 func TestNewEntityManagerWithConfig_Unit_SchemaQualifiedTableNames(t *testing.T) {
+	t.Parallel()
+
 	cache := internal.NewMetadataCache()
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
+	deps := unitEntityManagerDeps(cache)
+	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		assert.Equal(t, "tenant", schema)
 		return []string{"schema_registry", "eav_data", "entity_main"}, nil
-	})
-	withMetadataLoaderFactory(t, func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
+	}
+	deps.newMetadataLoader = func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
 		assert.Equal(t, "tenant.schema_registry", schemaTable)
 		return &mockMetadataLoader{cache: cache, err: nil}
-	})
+	}
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.Schema = "tenant"
@@ -445,22 +437,25 @@ func TestNewEntityManagerWithConfig_Unit_SchemaQualifiedTableNames(t *testing.T)
 	}
 	config.Entity.SchemaDirectory = t.TempDir()
 
-	em, err := NewEntityManagerWithConfig(config, nil)
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
 	assert.NotNil(t, em)
 	assert.NoError(t, err)
 }
 
 func TestNewEntityManagerWithConfig_Unit_SchemaParamQualifiesUnqualifiedTableNames(t *testing.T) {
+	t.Parallel()
+
 	cache := internal.NewMetadataCache()
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
+	deps := unitEntityManagerDeps(cache)
+	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		assert.Equal(t, "tenant", schema)
 		return []string{"schema_registry", "eav_data", "entity_main"}, nil
-	})
-	withMetadataLoaderFactory(t, func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
+	}
+	deps.newMetadataLoader = func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
 		assert.Equal(t, "tenant.schema_registry", schemaTable)
 		return &mockMetadataLoader{cache: cache, err: nil}
-	})
+	}
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.Schema = "tenant"
@@ -472,24 +467,24 @@ func TestNewEntityManagerWithConfig_Unit_SchemaParamQualifiesUnqualifiedTableNam
 	}
 	config.Entity.SchemaDirectory = t.TempDir()
 
-	em, err := NewEntityManagerWithConfig(config, nil)
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
 	assert.NotNil(t, em)
 	assert.NoError(t, err)
 }
 
 func TestNewEntityManagerWithConfigContext_Unit_PropagatesContextToTableCollector(t *testing.T) {
+	t.Parallel()
+
 	cache := internal.NewMetadataCache()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
+	deps := unitEntityManagerDeps(cache)
+	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		assert.ErrorIs(t, ctx.Err(), context.Canceled)
 		return []string{"schema_registry", "eav_data", "entity_main"}, nil
-	})
-	withMetadataLoaderFactory(t, func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
-		return &mockMetadataLoader{cache: cache, err: nil}
-	})
+	}
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.TableNames = forma.TableNames{
@@ -499,27 +494,24 @@ func TestNewEntityManagerWithConfigContext_Unit_PropagatesContextToTableCollecto
 	}
 	config.Entity.SchemaDirectory = t.TempDir()
 
-	em, err := NewEntityManagerWithConfigContext(ctx, config, nil)
+	em, err := newEntityManagerWithConfigContext(ctx, config, nil, deps)
 
 	assert.NotNil(t, em)
 	assert.NoError(t, err)
 }
 
 func TestNewEntityManagerWithConfigContext_Unit_PropagatesContextToDuckDBFactory(t *testing.T) {
+	t.Parallel()
+
 	cache := internal.NewMetadataCache()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	withTableCollector(t, func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
-		return []string{"schema_registry", "eav_data", "entity_main"}, nil
-	})
-	withMetadataLoaderFactory(t, func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
-		return &mockMetadataLoader{cache: cache, err: nil}
-	})
-	withDuckDBClientFactory(t, func(ctx context.Context, cfg forma.DuckDBConfig) (*internal.DuckDBClient, error) {
+	deps := unitEntityManagerDeps(cache)
+	deps.newDuckDBClient = func(ctx context.Context, cfg forma.DuckDBConfig) (*internal.DuckDBClient, error) {
 		assert.ErrorIs(t, ctx.Err(), context.Canceled)
 		return nil, context.Canceled
-	})
+	}
 
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.TableNames = forma.TableNames{
@@ -530,10 +522,60 @@ func TestNewEntityManagerWithConfigContext_Unit_PropagatesContextToDuckDBFactory
 	config.Entity.SchemaDirectory = t.TempDir()
 	config.DuckDB.Enabled = true
 
-	em, err := NewEntityManagerWithConfigContext(ctx, config, nil)
+	em, err := newEntityManagerWithConfigContext(ctx, config, nil, deps)
 
 	assert.NotNil(t, em)
 	assert.NoError(t, err)
+}
+
+func TestNewDuckDBCircuitBreakerUsesDefaultParametersForZeroConfig(t *testing.T) {
+	t.Parallel()
+
+	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{})
+
+	for i := 0; i < 4; i++ {
+		breaker.RecordFailure()
+		assert.False(t, breaker.IsOpen())
+	}
+	breaker.RecordFailure()
+	assert.True(t, breaker.IsOpen())
+}
+
+func TestNewDuckDBCircuitBreakerUsesConfiguredParameters(t *testing.T) {
+	t.Parallel()
+
+	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{
+		CircuitBreakerFailureThreshold: 2,
+		CircuitBreakerWindow:           time.Minute,
+		CircuitBreakerOpenDuration:     time.Minute,
+	})
+
+	breaker.RecordFailure()
+	assert.False(t, breaker.IsOpen())
+	breaker.RecordFailure()
+	assert.True(t, breaker.IsOpen())
+}
+
+func TestNewDuckDBCircuitBreakerDoesNotWarnForDefaultThreshold(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	breaker := newDuckDBCircuitBreaker(forma.DefaultConfig(nil).DuckDB)
+
+	require.NotNil(t, breaker)
+	assert.Equal(t, 0, logs.FilterMessage("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead").Len())
+}
+
+func TestNewDuckDBCircuitBreakerWarnsForDeprecatedThreshold(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{CircuitBreakerThreshold: 0.5})
+
+	require.NotNil(t, breaker)
+	assert.Equal(t, 1, logs.FilterMessage("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead").Len())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace factory package-level test hooks with private per-call EntityManager construction dependencies.
- Add count-based DuckDB circuit-breaker config fields and use them when constructing the federated engine breaker.
- Keep deprecated `CircuitBreakerThreshold` defaulting to zero and warn only when callers explicitly set it.

## Test Plan
- [x] `go test -race ./factory`
- [x] `make test`
- [x] `make lint`

Closes #129