### PR TITLE
refactor: fold parseKvConditionForColumnWithMeta into the unified operator stack

### DIFF
--- a/internal/hybrid_condition_builder_characterization_test.go
+++ b/internal/hybrid_condition_builder_characterization_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemameta"
@@ -38,6 +39,36 @@ func newHybridTestHelper(useMainAnchor bool) hybridTestHelper {
 		"tag": {
 			AttributeID: 9,
 			ValueType:   forma.ValueTypeText,
+		},
+		"created": {
+			AttributeID:   10,
+			ValueType:     forma.ValueTypeDateTime,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("bigint_01"), Encoding: forma.MainColumnEncodingUnixMs},
+		},
+		"created_iso": {
+			AttributeID:   11,
+			ValueType:     forma.ValueTypeDateTime,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_02"), Encoding: forma.MainColumnEncodingISO8601},
+		},
+		"active_int": {
+			AttributeID:   12,
+			ValueType:     forma.ValueTypeBool,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("smallint_01"), Encoding: forma.MainColumnEncodingBoolInt},
+		},
+		"active_text": {
+			AttributeID:   13,
+			ValueType:     forma.ValueTypeBool,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_03"), Encoding: forma.MainColumnEncodingBoolText},
+		},
+		"score": {
+			AttributeID:   14,
+			ValueType:     forma.ValueTypeNumeric,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("double_01")},
+		},
+		"badcol": {
+			AttributeID:   15,
+			ValueType:     forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_99")},
 		},
 	}); err != nil {
 		panic(err)
@@ -221,4 +252,93 @@ func TestHybrid_MainTableLikeOperator(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "m.\"text_01\" LIKE $2", clause)
 	require.Equal(t, []any{"A%"}, args)
+}
+
+// --- #140 characterization: pin main-table leaf conversion semantics before
+// switching to the canonical conditionexpr/sqlgen stack. ---
+
+func TestHybrid_DateTimeUnixMsEncoding(t *testing.T) {
+	h := newHybridTestHelper(true)
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	cond := &forma.KvCondition{Attr: "created", Value: "equals:" + date.Format(time.RFC3339)}
+	clause, args, err := h.build(cond)
+	require.NoError(t, err)
+	require.Equal(t, "m.\"bigint_01\" = $2", clause)
+	require.Equal(t, []any{date.UnixMilli()}, args)
+}
+
+func TestHybrid_DateTimeISO8601Encoding(t *testing.T) {
+	h := newHybridTestHelper(true)
+	cond := &forma.KvCondition{Attr: "created_iso", Value: "equals:2024-01-02T03:04:05Z"}
+	clause, args, err := h.build(cond)
+	require.NoError(t, err)
+	require.Equal(t, "m.\"text_02\" = $2", clause)
+	require.Equal(t, []any{"2024-01-02T03:04:05Z"}, args)
+}
+
+func TestHybrid_BoolIntEncoding(t *testing.T) {
+	h := newHybridTestHelper(true)
+	cond := &forma.KvCondition{Attr: "active_int", Value: "equals:1"}
+	clause, args, err := h.build(cond)
+	require.NoError(t, err)
+	require.Equal(t, "m.\"smallint_01\" = $2", clause)
+	require.Equal(t, []any{int64(1)}, args)
+}
+
+func TestHybrid_BoolTextEncoding(t *testing.T) {
+	h := newHybridTestHelper(true)
+	cond := &forma.KvCondition{Attr: "active_text", Value: "equals:1"}
+	clause, args, err := h.build(cond)
+	require.NoError(t, err)
+	require.Equal(t, "m.\"text_03\" = $2", clause)
+	require.Equal(t, []any{"1"}, args)
+}
+
+func TestHybrid_UnsupportedOperatorErrors(t *testing.T) {
+	h := newHybridTestHelper(true)
+	cond := &forma.KvCondition{Attr: "age", Value: "nope:1"}
+	_, _, err := h.build(cond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported operator")
+}
+
+func TestHybrid_RawColumnComposite(t *testing.T) {
+	h := newHybridTestHelper(true)
+	root := &forma.CompositeCondition{
+		Logic: forma.LogicAnd,
+		Conditions: []forma.Condition{
+			&forma.KvCondition{Attr: "text_01", Value: "hello"},
+			&forma.KvCondition{Attr: "bigint_01", Value: "gt:42"},
+		},
+	}
+	clause, args, err := h.build(root)
+	require.NoError(t, err)
+	require.Equal(t, "(m.\"text_01\" = $2) AND (m.\"bigint_01\" > $3)", clause)
+	require.Equal(t, []any{"hello", int64(42)}, args)
+}
+
+func TestHybrid_EqAliasNormalization(t *testing.T) {
+	h := newHybridTestHelper(true)
+	cond := &forma.KvCondition{Attr: "age", Value: "eq:10"}
+	clause, args, err := h.build(cond)
+	require.NoError(t, err)
+	require.Equal(t, "m.\"integer_01\" = $2", clause)
+	require.Equal(t, []any{int64(10)}, args)
+}
+
+func TestHybrid_DoubleColumnIntegerLiteral(t *testing.T) {
+	h := newHybridTestHelper(true)
+	cond := &forma.KvCondition{Attr: "score", Value: "equals:25"}
+	clause, args, err := h.build(cond)
+	require.NoError(t, err)
+	require.Equal(t, "m.\"double_01\" = $2", clause)
+	require.Equal(t, []any{int64(25)}, args)
+}
+
+func TestHybrid_UnknownBoundColumnErrors(t *testing.T) {
+	h := newHybridTestHelper(true)
+	cond := &forma.KvCondition{Attr: "badcol", Value: "equals:x"}
+	_, _, err := h.build(cond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown main table column")
 }

--- a/internal/hybrid_condition_builder_characterization_test.go
+++ b/internal/hybrid_condition_builder_characterization_test.go
@@ -342,3 +342,29 @@ func TestHybrid_UnknownBoundColumnErrors(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown main table column")
 }
+
+// --- #140 post-switch semantics (disclosed behavior changes vs the retired
+// private parser; see issue #140 AC). ---
+
+// gt: (empty value) is treated by the lenient parser as equals(raw), where the
+// retired SplitN parser produced "> ”".
+func TestHybrid_EmptyOperatorValueFallsBackToEquals(t *testing.T) {
+	h := newHybridTestHelper(true)
+	cond := &forma.KvCondition{Attr: "text_01", Value: "gt:"}
+	clause, args, err := h.build(cond)
+	require.NoError(t, err)
+	require.Equal(t, "m.\"text_01\" = $2", clause)
+	require.Equal(t, []any{"gt:"}, args)
+}
+
+// A bare RFC3339 value is recognized as an equals literal (the retired SplitN
+// parser mis-split it at "T03:" and errored).
+func TestHybrid_BareRFC3339ValueIsEquals(t *testing.T) {
+	h := newHybridTestHelper(true)
+	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	cond := &forma.KvCondition{Attr: "created", Value: date.Format(time.RFC3339)}
+	clause, args, err := h.build(cond)
+	require.NoError(t, err)
+	require.Equal(t, "m.\"bigint_01\" = $2", clause)
+	require.Equal(t, []any{date.UnixMilli()}, args)
+}

--- a/internal/model/columns.go
+++ b/internal/model/columns.go
@@ -1,6 +1,10 @@
 package model
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/lychee-technology/forma"
+)
 
 // Column slices define the physical hot-storage columns available in entity_main.
 // These are declared once and treated as read-only after package init.
@@ -152,4 +156,25 @@ func GetMainColumnDescriptor(name string) *ColumnDescriptor {
 		}
 	}
 	return nil
+}
+
+// ColumnKindToValueType maps a physical column kind to the forma value type
+// used when a raw main-table column is referenced without schema metadata.
+func ColumnKindToValueType(kind ColumnKind) forma.ValueType {
+	switch kind {
+	case ColumnKindText:
+		return forma.ValueTypeText
+	case ColumnKindSmallint:
+		return forma.ValueTypeSmallInt
+	case ColumnKindInteger:
+		return forma.ValueTypeInteger
+	case ColumnKindBigint:
+		return forma.ValueTypeBigInt
+	case ColumnKindDouble:
+		return forma.ValueTypeNumeric
+	case ColumnKindUUID:
+		return forma.ValueTypeUUID
+	default:
+		return forma.ValueTypeText
+	}
 }

--- a/internal/postgres_condition_helpers.go
+++ b/internal/postgres_condition_helpers.go
@@ -1,15 +1,8 @@
 package internal
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/lychee-technology/forma/internal/model"
-	"github.com/lychee-technology/forma/internal/numutil"
-
 	"github.com/lychee-technology/forma"
-	"github.com/lychee-technology/forma/internal/conditionexpr"
-	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/lychee-technology/forma/internal/model"
 )
 
 // hasMainTableCondition checks if a condition contains predicates on main table columns
@@ -49,82 +42,4 @@ func hasMainTableCondition(cond forma.Condition, cache forma.SchemaAttributeCach
 	default:
 		return false
 	}
-}
-
-// parseKvConditionForColumnWithMeta parses a KvCondition for a specific column name with metadata
-// The meta parameter is used to determine the encoding for date/time values
-func parseKvConditionForColumnWithMeta(kv *forma.KvCondition, colName string, meta *forma.AttributeMetadata) (string, any, error) {
-	opStr, valStr := parseOperatorAndValue(kv.Value)
-
-	sqlOp, err := operatorToSQL(opStr)
-	if err != nil {
-		return "", nil, err
-	}
-
-	// Adjust value for pattern operators
-	switch opStr {
-	case "starts_with":
-		valStr = valStr + "%"
-	case "contains":
-		valStr = "%" + valStr + "%"
-	}
-
-	desc := model.GetMainColumnDescriptor(colName)
-	if desc == nil {
-		return "", nil, fmt.Errorf("unknown main table column: %s", colName)
-	}
-
-	parsedValue, err := parseColumnValue(desc, valStr, meta)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return sqlOp, parsedValue, nil
-}
-
-// parseOperatorAndValue extracts operator and value from a condition value string
-func parseOperatorAndValue(value string) (string, string) {
-	parts := strings.SplitN(value, ":", 2)
-	if len(parts) == 1 {
-		return "equals", value
-	}
-	return parts[0], parts[1]
-}
-
-// operatorToSQL converts a string operator to its SQL equivalent
-func operatorToSQL(opStr string) (string, error) {
-	sqlOp, err := conditionexpr.ToSQLOperator(opStr, "")
-	if err != nil {
-		return "", err
-	}
-	return sqlOp.SQLOperator, nil
-}
-
-// parseColumnValue parses and converts a value string based on column type
-func parseColumnValue(desc *model.ColumnDescriptor, valStr string, meta *forma.AttributeMetadata) (any, error) {
-	switch desc.Kind {
-	case model.ColumnKindText:
-		return valStr, nil
-	case model.ColumnKindSmallint, model.ColumnKindInteger, model.ColumnKindBigint, model.ColumnKindDouble:
-		// Check if this is a date/time field that needs conversion
-		if meta != nil && (meta.ValueType == forma.ValueTypeDate || meta.ValueType == forma.ValueTypeDateTime) {
-			return convertDateValueForQuery(valStr, meta)
-		}
-		return numutil.TryParseNumber(valStr), nil
-	case model.ColumnKindUUID:
-		return valStr, nil
-	default:
-		return valStr, nil
-	}
-}
-
-// convertDateValueForQuery converts a date value string to the appropriate format for querying.
-// It supports both ISO 8601 format strings and Unix millisecond timestamps as input.
-// The output format is determined by the storage encoding in metadata.
-func convertDateValueForQuery(valStr string, meta *forma.AttributeMetadata) (any, error) {
-	if meta == nil {
-		emptyMeta := forma.AttributeMetadata{}
-		return sqlgen.ParseDateValue(valStr, emptyMeta)
-	}
-	return sqlgen.ParseDateValue(valStr, *meta)
 }

--- a/internal/postgres_persistent_repository_query.go
+++ b/internal/postgres_persistent_repository_query.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lychee-technology/forma/internal/conditionexpr"
 	"github.com/lychee-technology/forma/internal/model"
 
 	"github.com/lychee-technology/forma"
@@ -152,8 +153,7 @@ func (r *DBPersistentRecordRepository) RunOptimizedQuery(
 
 // scanOptimizedRow is implemented in postgres_row_scanner.go
 
-// hasMainTableCondition, parseKvConditionForColumnWithMeta, and convertDateValueForQuery
-// are implemented in postgres_condition_helpers.go
+// hasMainTableCondition is implemented in postgres_condition_helpers.go
 
 // hybridConditionBuilder encapsulates the state needed for building hybrid SQL conditions.
 type hybridConditionBuilder struct {
@@ -233,13 +233,17 @@ func (b *hybridConditionBuilder) resolveColumnName(attr string) string {
 }
 
 func (b *hybridConditionBuilder) buildMainTableCondition(cond *forma.KvCondition, colName string) (string, []any, error) {
-	var attrMeta *forma.AttributeMetadata
-	if b.cache != nil {
-		if meta, ok := b.cache[cond.Attr]; ok {
-			attrMeta = &meta
-		}
+	parsed := conditionexpr.ParseOperatorValueLenient(cond.Value)
+	sqlOpResult, err := conditionexpr.ToSQLOperator(parsed.Operator, parsed.Value)
+	if err != nil {
+		return "", nil, err
 	}
-	op, val, err := parseKvConditionForColumnWithMeta(cond, colName, attrMeta)
+
+	meta, err := b.resolveLeafMeta(cond, colName)
+	if err != nil {
+		return "", nil, err
+	}
+	parsedValue, err := sqlgen.ConvertPgMainValue(sqlOpResult.Value, cond.Attr, meta)
 	if err != nil {
 		return "", nil, err
 	}
@@ -248,10 +252,34 @@ func (b *hybridConditionBuilder) buildMainTableCondition(cond *forma.KvCondition
 	placeholder := fmt.Sprintf("$%d", b.argCounter)
 
 	if b.useMainTableAsAnchor {
-		return fmt.Sprintf("m.%s %s %s", sanitizeIdentifier(colName), op, placeholder), []any{val}, nil
+		return fmt.Sprintf("m.%s %s %s", sanitizeIdentifier(colName), sqlOpResult.SQLOperator, placeholder), []any{parsedValue}, nil
 	}
 	return fmt.Sprintf("EXISTS (SELECT 1 FROM %s m WHERE m.ltbase_row_id = t.row_id AND m.%s %s %s)",
-		sanitizeIdentifier(b.mainTable), sanitizeIdentifier(colName), op, placeholder), []any{val}, nil
+		sanitizeIdentifier(b.mainTable), sanitizeIdentifier(colName), sqlOpResult.SQLOperator, placeholder), []any{parsedValue}, nil
+}
+
+// resolveLeafMeta returns the attribute metadata driving value conversion for
+// a main-table leaf. The physical column is always validated against the
+// entity_main descriptors (preserving the pre-#140 "unknown main table
+// column" contract even for cache-bound attributes); raw column references
+// without schema metadata derive a minimal metadata from the descriptor kind.
+func (b *hybridConditionBuilder) resolveLeafMeta(cond *forma.KvCondition, colName string) (forma.AttributeMetadata, error) {
+	desc := model.GetMainColumnDescriptor(colName)
+	if desc == nil {
+		return forma.AttributeMetadata{}, fmt.Errorf("unknown main table column: %s", colName)
+	}
+	if b.cache != nil {
+		if meta, ok := b.cache[cond.Attr]; ok {
+			// Bound attributes may omit value_type (e.g. audit columns); the
+			// pre-#140 implementation converted by physical column kind, so
+			// derive the missing type from the descriptor to keep that contract.
+			if meta.ValueType == "" {
+				meta.ValueType = model.ColumnKindToValueType(desc.Kind)
+			}
+			return meta, nil
+		}
+	}
+	return forma.AttributeMetadata{ValueType: model.ColumnKindToValueType(desc.Kind)}, nil
 }
 
 func (b *hybridConditionBuilder) buildEAVCondition(cond *forma.KvCondition) (string, []any, error) {

--- a/internal/postgres_persistent_repository_test.go
+++ b/internal/postgres_persistent_repository_test.go
@@ -243,63 +243,6 @@ func TestComputeTotalPages(t *testing.T) {
 	assert.Equal(t, 3, model.ComputeTotalPages(11, 5))
 }
 
-func TestParseKvConditionForColumnWithMeta(t *testing.T) {
-	textCond := &forma.KvCondition{Attr: "text_01", Value: "starts_with:hello"}
-	op, val, err := parseKvConditionForColumnWithMeta(textCond, "text_01", nil)
-	require.NoError(t, err)
-	assert.Equal(t, "LIKE", op)
-	assert.Equal(t, "hello%", val)
-
-	numericCond := &forma.KvCondition{Attr: "bigint_01", Value: "gt:42"}
-	op, val, err = parseKvConditionForColumnWithMeta(numericCond, "bigint_01", nil)
-	require.NoError(t, err)
-	assert.Equal(t, ">", op)
-	assert.Equal(t, int64(42), val)
-
-	date := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
-	meta := &forma.AttributeMetadata{
-		ValueType: forma.ValueTypeDateTime,
-		ColumnBinding: &forma.MainColumnBinding{
-			ColumnName: "bigint_01",
-			Encoding:   forma.MainColumnEncodingUnixMs,
-		},
-	}
-	dateCond := &forma.KvCondition{Attr: "bigint_01", Value: "equals:" + date.Format(time.RFC3339)}
-	op, val, err = parseKvConditionForColumnWithMeta(dateCond, "bigint_01", meta)
-	require.NoError(t, err)
-	assert.Equal(t, "=", op)
-	assert.Equal(t, date.UnixMilli(), val)
-
-	badCond := &forma.KvCondition{Attr: "text_01", Value: "nope:1"}
-	_, _, err = parseKvConditionForColumnWithMeta(badCond, "text_01", nil)
-	require.Error(t, err)
-
-	_, _, err = parseKvConditionForColumnWithMeta(textCond, "missing", nil)
-	require.Error(t, err)
-}
-
-func TestConvertDateValueForQuery(t *testing.T) {
-	when := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
-	meta := &forma.AttributeMetadata{
-		ColumnBinding: &forma.MainColumnBinding{
-			ColumnName: "bigint_01",
-			Encoding:   forma.MainColumnEncodingUnixMs,
-		},
-	}
-
-	val, err := convertDateValueForQuery(when.Format(time.RFC3339), meta)
-	require.NoError(t, err)
-	assert.Equal(t, when.UnixMilli(), val)
-
-	meta.ColumnBinding.Encoding = forma.MainColumnEncodingISO8601
-	val, err = convertDateValueForQuery("1700000000000", meta)
-	require.NoError(t, err)
-	assert.Equal(t, time.UnixMilli(1700000000000).Format(time.RFC3339), val)
-
-	_, err = convertDateValueForQuery("not-a-date", meta)
-	require.Error(t, err)
-}
-
 func TestHasMainTableCondition(t *testing.T) {
 	assert.True(t, hasMainTableCondition(nil, nil))
 

--- a/internal/sqlgen/dualpath_sql_generator.go
+++ b/internal/sqlgen/dualpath_sql_generator.go
@@ -184,7 +184,7 @@ func (e *pgMainLeafEmitter) EmitLeaf(c *forma.KvCondition) (string, []any, error
 	colName := resolveMainTableColumn(c.Attr, meta)
 
 	// Convert value based on metadata
-	parsedValue, err := convertPgMainValue(sqlOpResult.value, c.Attr, meta)
+	parsedValue, err := ConvertPgMainValue(sqlOpResult.value, c.Attr, meta)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/sqlgen/dualpath_sql_generator_test.go
+++ b/internal/sqlgen/dualpath_sql_generator_test.go
@@ -523,3 +523,18 @@ func TestBuildDuckClause_OR_AllNonPushable_Returns1_0(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1=0", clause)
 }
+
+// Migrated from the retired TestConvertDateValueForQuery (#140): ParseDateValue
+// must convert a UnixMs literal to an RFC3339 string for ISO8601-encoded
+// columns, and reject non-date input.
+func TestParseDateValue_ISO8601EncodingFromUnixMs(t *testing.T) {
+	meta := forma.AttributeMetadata{
+		ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_02"), Encoding: forma.MainColumnEncodingISO8601},
+	}
+	val, err := ParseDateValue("1700000000000", meta)
+	require.NoError(t, err)
+	require.Equal(t, time.UnixMilli(1700000000000).Format(time.RFC3339), val)
+
+	_, err = ParseDateValue("not-a-date", meta)
+	require.Error(t, err)
+}

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -55,18 +55,21 @@ func toSQLOperator(op, value string) (sqlOperatorResult, error) {
 	}, nil
 }
 
-// convertPgMainValue converts a string value to the appropriate Go type based on attribute metadata.
-// This is used for Postgres main table pushdown predicates.
-func convertPgMainValue(valStr string, attr string, meta forma.AttributeMetadata) (any, error) {
+// ConvertPgMainValue converts a string value to the appropriate Go type based
+// on attribute metadata. It is the canonical value converter for Postgres
+// main-table predicates, shared by the dual-path generator and the hybrid
+// condition builder. Numeric-family literals keep their own type via
+// TryParseNumber (integral → int64, lossless for bigint beyond 2^53;
+// fractional → float64).
+func ConvertPgMainValue(valStr string, attr string, meta forma.AttributeMetadata) (any, error) {
 	switch meta.ValueType {
 	case forma.ValueTypeText, forma.ValueTypeUUID:
 		return valStr, nil
 
 	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
-		parsed := numutil.TryParseNumber(valStr)
-		switch v := parsed.(type) {
+		switch v := numutil.TryParseNumber(valStr).(type) {
 		case int64:
-			return float64(v), nil
+			return v, nil
 		case float64:
 			return v, nil
 		default:


### PR DESCRIPTION
## Summary

按 #140 修订版设计实施：hybrid 主表叶子切换到正典栈（`conditionexpr.ToSQLOperator` + 导出的 `sqlgen.ConvertPgMainValue`），私有实现五函数全删。操作符 DSL→SQL 映射回到唯一实现。

## 实施要点

- **Characterization-first**：commit 1 先以 9 个新测试钉住私有实现语义（datetime 两种 encoding、bool 两种 encoding、raw composite、eq alias、double 列整数字面量 int64 保型、不支持操作符、未知绑定列），全部对旧实现一次通过后才动代码。
- **`ConvertPgMainValue` 导出并校准**：numeric family 经 `TryParseNumber` 保持字面量原型（整数 → int64、浮点 → float64）。共享消费者 dual-path 的整数参数由此获得 2^53 以上无损（原恒 float64 有损）；pgx 编码层两种类型均安全，dual-path 测试零改动通过。
- **特征化网抓到第四处差异**（设计评审的三处之外）：绑定属性 `ValueType` 为空（审计列 `createdBy`）在私有实现按列 kind 转换、新流程会流入 default 分支报错——`resolveLeafMeta` 现从列描述符派生缺失类型，且**先**校验物理列（保留 "unknown main table column" 契约，含 cache 命中路径）。

## 已披露的行为变化（#140 AC 限定的三处，均有 post-switch 测试钉住）

| 输入 | 旧（私有 SplitN） | 新（lenient） |
|---|---|---|
| `gt:`（空值） | `> ''` | `= 'gt:'` |
| 裸 RFC3339 值 | 在 `T03:` 误切报错 | equals 整值（修复） |
| UnixMs 字面量 vs ISO8601 text 列 | 原样传串，永不匹配（潜在 bug） | 正确转 RFC3339（修复；迁移的 `TestParseDateValue_ISO8601EncodingFromUnixMs` 钉住） |

## Verification

- [x] 9 个 pre-switch 特征化测试在新旧实现下均绿（零翻转）
- [x] `git grep` 五个私有函数零残留
- [x] `make test` 24 包全绿、`make lint` 干净

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)