### PR TITLE
fix: restore small-live benchmark green — zero-UUID row ids and window oracles (#147)

### DIFF
--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -1872,12 +1872,13 @@ var benchmarkTradeFilterColumns = map[string]string{
 }
 
 var benchmarkTradeFilterEAVAttrs = map[string]int16{
-	"exchange": 8,
+	"exchange":     8,
+	"orderChannel": 12,
 }
 
 func recordMatchesFilter(record *model.PersistentRecord, attribute, expected string) bool {
 	switch attribute {
-	case "symbol", "exchange", "region", "name":
+	case "symbol", "exchange", "region", "name", "orderChannel":
 		value, ok := benchmarkRecordTextValue(record, attribute)
 		return ok && value == expected
 	case "tradeType":
@@ -1889,7 +1890,9 @@ func recordMatchesFilter(record *model.PersistentRecord, attribute, expected str
 		}
 		return false
 	default:
-		return true
+		// Fail closed: an unmapped filter attribute means the oracle cannot
+		// verify the row, and silently passing would mask filter regressions.
+		return false
 	}
 }
 

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -215,11 +215,11 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 	executions := make([]WorkloadRunResult, 0, len(r.workloads)*r.config.Iterations*r.config.Concurrency)
 	pageRuns := make(map[string]WorkloadRunResult)
 	previousRuns := make(map[string]WorkloadRunResult)
-	loadedRecords, err := buildLoadedStateSnapshot(ctx, h, tiered)
+	loadedRecords, hotKeys, err := buildLoadedStateSnapshot(ctx, h, tiered)
 	if err != nil {
 		return nil, fmt.Errorf("build loaded state snapshot: %w", err)
 	}
-	expectedByWorkload, oracleModes, oracleNotes, err := r.buildExpectedResults(ctx, h, loadedRecords)
+	expectedByWorkload, oracleModes, oracleNotes, err := r.buildExpectedResults(ctx, h, loadedRecords, hotKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -343,8 +343,8 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 	return result, nil
 }
 
-func (r *Runner) buildExpectedResults(ctx context.Context, h *federated.FederatedTestHarness, loadedRecords []GeneratedRecord) (map[string]expectedWorkloadResult, map[string]string, string, error) {
-	results := buildExpectedWorkloadResultsFromRecords(loadedRecords, r.workloads, r.config.PageSize, r.genConfig)
+func (r *Runner) buildExpectedResults(ctx context.Context, h *federated.FederatedTestHarness, loadedRecords []GeneratedRecord, hotKeys map[string]struct{}) (map[string]expectedWorkloadResult, map[string]string, string, error) {
+	results := buildExpectedWorkloadResultsFromRecords(loadedRecords, r.workloads, r.config.PageSize, r.genConfig, hotKeys)
 	oracleModes := make(map[string]string, len(r.workloads))
 	loadedStateCount := 0
 	truthPassCount := 0
@@ -432,7 +432,7 @@ func (r *Runner) executeWorkload(ctx context.Context, h *federated.FederatedTest
 		h.SchemaID = previousSchemaID
 	}()
 	opts := queryOptionsForWorkloadWithConfig(workload, r.config.PageSize, r.genConfig)
-	opts.PreferHot = workload.PreferHot && workload.Category == WorkloadCategoryTierMix
+	opts.PreferHot = workloadExecutesPostgresOnly(workload)
 	if conditions := workload.ResolvedFilterConditions(); len(conditions) > 0 {
 		opts.Filter = &federated.Filter{Conditions: conditions}
 	}
@@ -1095,14 +1095,34 @@ func buildExpectedWorkloadResults(dataset *GeneratedDataset, workloads []Workloa
 	if dataset == nil {
 		return map[string]expectedWorkloadResult{}
 	}
-	return buildExpectedWorkloadResultsFromRecords(dataset.Records, workloads, defaultPageSize, dataset.Config)
+	return buildExpectedWorkloadResultsFromRecords(dataset.Records, workloads, defaultPageSize, dataset.Config, nil)
 }
 
-func buildExpectedWorkloadResultsFromRecords(records []GeneratedRecord, workloads []WorkloadDefinition, defaultPageSize int, genCfg GeneratorConfig) map[string]expectedWorkloadResult {
+// workloadExecutesPostgresOnly mirrors the execution override in executeWorkload:
+// prefer-hot tier-mix workloads run against the Postgres hot buffer only, so
+// their loaded-state oracle must be restricted to hot-tier records.
+func workloadExecutesPostgresOnly(workload WorkloadDefinition) bool {
+	return workload.PreferHot && workload.Category == WorkloadCategoryTierMix
+}
+
+func buildExpectedWorkloadResultsFromRecords(records []GeneratedRecord, workloads []WorkloadDefinition, defaultPageSize int, genCfg GeneratorConfig, hotKeys map[string]struct{}) map[string]expectedWorkloadResult {
 	results := make(map[string]expectedWorkloadResult, len(workloads))
 	visible := expectedVisibleRecords(records)
+	var hotVisible []GeneratedRecord
+	if hotKeys != nil {
+		hotVisible = make([]GeneratedRecord, 0, len(hotKeys))
+		for _, record := range visible {
+			if _, ok := hotKeys[schemaRowKey(record.SchemaID, record.RowID)]; ok {
+				hotVisible = append(hotVisible, record)
+			}
+		}
+	}
 	for _, workload := range workloads {
-		matching := filterExpectedRecordsForWorkload(visible, workload, semanticsForWorkload(workload, genCfg))
+		source := visible
+		if hotKeys != nil && workloadExecutesPostgresOnly(workload) {
+			source = hotVisible
+		}
+		matching := filterExpectedRecordsForWorkload(source, workload, semanticsForWorkload(workload, genCfg))
 		sortExpectedRecordsForWorkload(matching, workload)
 		pageSize := workload.PageSize
 		if pageSize <= 0 {
@@ -1115,13 +1135,13 @@ func buildExpectedWorkloadResultsFromRecords(records []GeneratedRecord, workload
 	return results
 }
 
-func buildLoadedStateSnapshot(ctx context.Context, h *federated.FederatedTestHarness, dataset *TieredDataset) ([]GeneratedRecord, error) {
+func buildLoadedStateSnapshot(ctx context.Context, h *federated.FederatedTestHarness, dataset *TieredDataset) ([]GeneratedRecord, map[string]struct{}, error) {
 	if h == nil || dataset == nil {
-		return nil, fmt.Errorf("harness and dataset are required")
+		return nil, nil, fmt.Errorf("harness and dataset are required")
 	}
 	hotRecords, hotKeys, err := loadHotStateRecords(ctx, h)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	records := make([]GeneratedRecord, 0, len(dataset.Base)+len(dataset.Delta)+len(hotRecords))
 	for _, bucket := range [][]GeneratedRecord{dataset.Base, dataset.Delta} {
@@ -1133,7 +1153,7 @@ func buildLoadedStateSnapshot(ctx context.Context, h *federated.FederatedTestHar
 		}
 	}
 	records = append(records, hotRecords...)
-	return records, nil
+	return records, hotKeys, nil
 }
 
 func loadHotStateRecords(ctx context.Context, h *federated.FederatedTestHarness) ([]GeneratedRecord, map[string]struct{}, error) {

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -1861,15 +1861,58 @@ func validateSortOrder(records []*model.PersistentRecord, attribute string, desc
 	return AssertionResult{Name: "sorted-by-tradeTime-desc", Passed: true, Message: fmt.Sprintf("comparable_rows=%d", len(values))}
 }
 
+// benchmarkTradeFilterColumns and benchmarkTradeFilterEAVAttrs map trade filter
+// attributes to their storage layout (see schemas/trade_attributes.json):
+// service-path records are rebuilt via transform.ToPersistentRecord, which
+// stores column-bound attributes under entity_main column names and EAV-only
+// attributes as OtherAttributes entries.
+var benchmarkTradeFilterColumns = map[string]string{
+	"symbol": "text_01",
+	"region": "text_02",
+}
+
+var benchmarkTradeFilterEAVAttrs = map[string]int16{
+	"exchange": 8,
+}
+
 func recordMatchesFilter(record *model.PersistentRecord, attribute, expected string) bool {
 	switch attribute {
 	case "symbol", "exchange", "region", "name":
-		return record.TextItems[attribute] == expected
+		value, ok := benchmarkRecordTextValue(record, attribute)
+		return ok && value == expected
 	case "tradeType":
-		return fmt.Sprintf("%d", record.Int64Items[attribute]) == expected
+		if value, ok := record.Int64Items[attribute]; ok {
+			return fmt.Sprintf("%d", value) == expected
+		}
+		if value, ok := record.Int16Items["smallint_01"]; ok {
+			return fmt.Sprintf("%d", value) == expected
+		}
+		return false
 	default:
 		return true
 	}
+}
+
+// benchmarkRecordTextValue reads a benchmark text attribute from either record
+// shape: harness-path records carry attribute names directly, service-path
+// records carry the storage layout.
+func benchmarkRecordTextValue(record *model.PersistentRecord, attribute string) (string, bool) {
+	if value, ok := record.TextItems[attribute]; ok {
+		return value, true
+	}
+	if column, ok := benchmarkTradeFilterColumns[attribute]; ok {
+		if value, ok := record.TextItems[column]; ok {
+			return value, true
+		}
+	}
+	if attrID, ok := benchmarkTradeFilterEAVAttrs[attribute]; ok {
+		for _, eav := range record.OtherAttributes {
+			if eav.AttrID == attrID && eav.ValueText != nil {
+				return *eav.ValueText, true
+			}
+		}
+	}
+	return "", false
 }
 
 func persistentRecordIDs(records []*model.PersistentRecord) []string {

--- a/internal/e2e_harness/federated/benchmark/runner_test.go
+++ b/internal/e2e_harness/federated/benchmark/runner_test.go
@@ -573,3 +573,41 @@ func TestBuildExpectedWorkloadResultsRestrictsPostgresOnlyWorkloadsToHotKeys(t *
 		t.Fatalf("expected nil hot keys to keep all records, got %+v", unrestricted["hot-only-window"])
 	}
 }
+
+func TestRecordMatchesFilterHandlesStorageLayoutRecords(t *testing.T) {
+	// Issue #147: service-path workloads rebuild records in storage layout
+	// (column bindings + EAV entries) while harness-path records carry
+	// attribute names directly; the filter oracle must read both shapes.
+	nyse := "NYSE"
+	serviceShaped := &model.PersistentRecord{
+		SchemaID:   SchemaIDTrade,
+		TextItems:  map[string]string{"text_01": "SYM00001", "text_02": "EU"},
+		Int16Items: map[string]int16{"smallint_01": 3},
+		OtherAttributes: []model.EAVRecord{
+			{AttrID: 8, ValueText: &nyse},
+		},
+	}
+	harnessShaped := &model.PersistentRecord{
+		SchemaID:   SchemaIDTrade,
+		TextItems:  map[string]string{"symbol": "SYM00001", "exchange": "NYSE", "region": "EU"},
+		Int64Items: map[string]int64{"tradeType": 3},
+	}
+
+	for name, record := range map[string]*model.PersistentRecord{"service": serviceShaped, "harness": harnessShaped} {
+		if !recordMatchesFilter(record, "symbol", "SYM00001") {
+			t.Fatalf("%s record should match symbol filter", name)
+		}
+		if !recordMatchesFilter(record, "exchange", "NYSE") {
+			t.Fatalf("%s record should match exchange filter", name)
+		}
+		if !recordMatchesFilter(record, "region", "EU") {
+			t.Fatalf("%s record should match region filter", name)
+		}
+		if !recordMatchesFilter(record, "tradeType", "3") {
+			t.Fatalf("%s record should match tradeType filter", name)
+		}
+		if recordMatchesFilter(record, "symbol", "SYM99999") {
+			t.Fatalf("%s record should reject wrong symbol", name)
+		}
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/runner_test.go
+++ b/internal/e2e_harness/federated/benchmark/runner_test.go
@@ -261,7 +261,7 @@ func TestBuildExpectedWorkloadResultsFromRecordsUsesLoadedTierState(t *testing.T
 		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 1, ChangedAt: 100, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "2026-01-01T00:00:00Z"}},
 		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 2, ChangedAt: 200, Attributes: map[string]any{"symbol": "SYM99999", "tradeTime": "2026-01-01T00:01:00Z"}},
 	}
-	results := buildExpectedWorkloadResultsFromRecords([]GeneratedRecord{original[0]}, workloads, 20, DefaultGeneratorConfig())
+	results := buildExpectedWorkloadResultsFromRecords([]GeneratedRecord{original[0]}, workloads, 20, DefaultGeneratorConfig(), nil)
 	expected := results["hot-selective-page"]
 	if expected.TotalRecords != 1 {
 		t.Fatalf("expected loaded tier state to include visible row, got %+v", expected)
@@ -282,7 +282,7 @@ func TestBuildExpectedWorkloadResultsFromRecordsExcludesDeletedHotSelectiveRows(
 		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 1, ChangedAt: 100, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "2026-01-01T00:00:00Z"}},
 		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 2, ChangedAt: 200, DeletedAt: 205, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "2026-01-01T00:01:00Z"}},
 	}
-	results := buildExpectedWorkloadResultsFromRecords(records, workloads, 20, DefaultGeneratorConfig())
+	results := buildExpectedWorkloadResultsFromRecords(records, workloads, 20, DefaultGeneratorConfig(), nil)
 	if results["hot-selective-page"].TotalRecords != 0 {
 		t.Fatalf("expected deleted latest trade row to be excluded, got %+v", results["hot-selective-page"])
 	}
@@ -293,11 +293,11 @@ func TestExpectedWorkloadResultsCanUseLoadedHotStateSnapshot(t *testing.T) {
 	workloads := []WorkloadDefinition{{Name: "hot-selective-page", TargetSchema: "trade", FilterAttribute: "symbol", FilterValue: "SYM00001", PageSize: 20, PageNumber: 1}}
 	syntheticTiered := []GeneratedRecord{{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 2, ChangedAt: 200, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "2026-01-01T00:01:00Z"}}}
 	loadedHotSnapshot := []GeneratedRecord{{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: rowID, Version: 0, ChangedAt: 200, DeletedAt: 205, Attributes: map[string]any{"symbol": "SYM00001", "tradeTime": "1735689660000"}}}
-	fromSynthetic := buildExpectedWorkloadResultsFromRecords(syntheticTiered, workloads, 20, DefaultGeneratorConfig())
+	fromSynthetic := buildExpectedWorkloadResultsFromRecords(syntheticTiered, workloads, 20, DefaultGeneratorConfig(), nil)
 	if fromSynthetic["hot-selective-page"].TotalRecords != 1 {
 		t.Fatalf("expected synthetic tiered record to match filter, got %+v", fromSynthetic["hot-selective-page"])
 	}
-	fromLoaded := buildExpectedWorkloadResultsFromRecords(loadedHotSnapshot, workloads, 20, DefaultGeneratorConfig())
+	fromLoaded := buildExpectedWorkloadResultsFromRecords(loadedHotSnapshot, workloads, 20, DefaultGeneratorConfig(), nil)
 	if fromLoaded["hot-selective-page"].TotalRecords != 0 {
 		t.Fatalf("expected loaded hot snapshot to exclude deleted row, got %+v", fromLoaded["hot-selective-page"])
 	}
@@ -315,7 +315,7 @@ func TestBuildExpectedWorkloadResultsFromRecordsHonorsMixedTierWindow(t *testing
 		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: before, Version: 1, ChangedAt: semantics.TradeTimeStart - 1000, Attributes: map[string]any{"tradeTime": strconv.FormatInt(semantics.TradeTimeStart-1000, 10)}},
 		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: after, Version: 1, ChangedAt: semantics.TradeTimeEnd + 1000, Attributes: map[string]any{"tradeTime": strconv.FormatInt(semantics.TradeTimeEnd+1000, 10)}},
 	}
-	results := buildExpectedWorkloadResultsFromRecords(records, workloads, 20, genCfg)
+	results := buildExpectedWorkloadResultsFromRecords(records, workloads, 20, genCfg, nil)
 	expected := results["mixed-tier-window"]
 	if expected.TotalRecords != 1 {
 		t.Fatalf("expected one in-window record, got %+v", expected)
@@ -534,5 +534,42 @@ func TestExecuteWorkloadWithRetry_ReturnsLastErrorAfterRetries(t *testing.T) {
 	}
 	if attempts != maxInfraRetries+1 {
 		t.Fatalf("expected %d attempts, got %d", maxInfraRetries+1, attempts)
+	}
+}
+
+func TestBuildExpectedWorkloadResultsRestrictsPostgresOnlyWorkloadsToHotKeys(t *testing.T) {
+	// Issue #147: prefer-hot tier-mix workloads execute against the Postgres
+	// hot buffer only, so their loaded-state oracle must exclude records that
+	// live in parquet tiers even when those records fall inside the window.
+	genCfg := GeneratorConfig{Scale: ScaleSmall, Distribution: DistributionUniform, TimeWindowDays: 30, BaseTime: defaultBaseTime}.WithDefaults()
+	semantics := semanticsForWorkload(WorkloadDefinition{Name: "hot-only-window", TargetSchema: "trade"}, genCfg)
+	hotRow := deterministicRowID(8, "trade", 1)
+	coldRow := deterministicRowID(8, "trade", 2)
+	workloads := []WorkloadDefinition{{
+		Name:         "hot-only-window",
+		Category:     WorkloadCategoryTierMix,
+		TargetSchema: "trade",
+		PageSize:     50,
+		PageNumber:   1,
+		PreferHot:    true,
+	}}
+	records := []GeneratedRecord{
+		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: hotRow, Version: 1, ChangedAt: semantics.TradeTimeStart + 1000, Attributes: map[string]any{"tradeTime": strconv.FormatInt(semantics.TradeTimeStart+1000, 10)}},
+		{SchemaID: SchemaIDTrade, SchemaName: "trade", RowID: coldRow, Version: 1, ChangedAt: semantics.TradeTimeStart + 2000, Attributes: map[string]any{"tradeTime": strconv.FormatInt(semantics.TradeTimeStart+2000, 10)}},
+	}
+	hotKeys := map[string]struct{}{schemaRowKey(SchemaIDTrade, hotRow): {}}
+
+	results := buildExpectedWorkloadResultsFromRecords(records, workloads, 20, genCfg, hotKeys)
+	expected := results["hot-only-window"]
+	if expected.TotalRecords != 1 {
+		t.Fatalf("expected only the hot-tier record, got %+v", expected)
+	}
+	if len(expected.RowIDs) != 1 || expected.RowIDs[0] != hotRow.String() {
+		t.Fatalf("unexpected hot-only row ids: %+v", expected.RowIDs)
+	}
+
+	unrestricted := buildExpectedWorkloadResultsFromRecords(records, workloads, 20, genCfg, nil)
+	if unrestricted["hot-only-window"].TotalRecords != 2 {
+		t.Fatalf("expected nil hot keys to keep all records, got %+v", unrestricted["hot-only-window"])
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/runner_test.go
+++ b/internal/e2e_harness/federated/benchmark/runner_test.go
@@ -611,3 +611,28 @@ func TestRecordMatchesFilterHandlesStorageLayoutRecords(t *testing.T) {
 		}
 	}
 }
+
+func TestRecordMatchesFilterFailsClosedForUnsupportedAttributes(t *testing.T) {
+	// PR #149 review: the filter oracle must not silently pass attributes it
+	// cannot resolve — that would mask filter regressions (#147 intent).
+	web := "web"
+	serviceShaped := &model.PersistentRecord{
+		SchemaID: SchemaIDTrade,
+		OtherAttributes: []model.EAVRecord{
+			{AttrID: 12, ValueText: &web},
+		},
+	}
+
+	if !recordMatchesFilter(serviceShaped, "orderChannel", "web") {
+		t.Fatal("service record should match orderChannel filter via EAV attr 12")
+	}
+	if recordMatchesFilter(serviceShaped, "orderChannel", "branch") {
+		t.Fatal("service record should reject wrong orderChannel value")
+	}
+	if recordMatchesFilter(serviceShaped, "brokerId", "BRK-0001") {
+		t.Fatal("unsupported filter attribute must fail closed")
+	}
+	if recordMatchesFilter(&model.PersistentRecord{SchemaID: SchemaIDTrade}, "orderChannel", "web") {
+		t.Fatal("record without the attribute must not match")
+	}
+}

--- a/internal/e2e_harness/federated/seeding.go
+++ b/internal/e2e_harness/federated/seeding.go
@@ -300,6 +300,11 @@ func nullableUnixMillis(value any) sql.NullInt64 {
 	}
 	switch v := value.(type) {
 	case string:
+		// Benchmark generators emit datetime attributes as unix-millis digit
+		// strings (issue #147); accept both that and RFC3339 text.
+		if millis, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return sql.NullInt64{Int64: millis, Valid: true}
+		}
 		if parsed, err := time.Parse(time.RFC3339, v); err == nil {
 			return sql.NullInt64{Int64: parsed.UnixMilli(), Valid: true}
 		}

--- a/internal/e2e_harness/federated/seeding_test.go
+++ b/internal/e2e_harness/federated/seeding_test.go
@@ -122,3 +122,31 @@ func TestDeterministicAttributeIDStable(t *testing.T) {
 		t.Fatalf("expected different attributes to hash differently")
 	}
 }
+
+func TestNullableUnixMillisParsesUnixMillisStrings(t *testing.T) {
+	// The benchmark trade generator emits tradeTime as a unix-millis digit
+	// string (issue #147); seeding must land it in entity_main.bigint_02.
+	got := nullableUnixMillis("1748736000000")
+	if !got.Valid || got.Int64 != 1748736000000 {
+		t.Fatalf("expected unix-millis string to parse, got %+v", got)
+	}
+
+	got = nullableUnixMillis("2026-05-31T12:00:00Z")
+	if !got.Valid {
+		t.Fatalf("expected RFC3339 string to keep parsing, got %+v", got)
+	}
+
+	got = nullableUnixMillis("not-a-time")
+	if got.Valid {
+		t.Fatalf("expected invalid string to stay NULL, got %+v", got)
+	}
+}
+
+func TestBenchmarkMainColumnValuesPopulatesTradeTime(t *testing.T) {
+	_, _, _, _, bigint02, _, _ := benchmarkMainColumnValues(TestRecord{
+		Attributes: map[string]any{"tradeTime": "1748736000000"},
+	})
+	if !bigint02.Valid || bigint02.Int64 != 1748736000000 {
+		t.Fatalf("expected trade tradeTime to populate bigint_02, got %+v", bigint02)
+	}
+}

--- a/internal/federated/duckdb_query_helpers.go
+++ b/internal/federated/duckdb_query_helpers.go
@@ -11,6 +11,51 @@ import (
 	"github.com/lychee-technology/forma/internal/sqlutil"
 )
 
+// nullDuckDBUUID scans a nullable UUID column from DuckDB. The duckdb-go
+// driver returns UUID values as 16 raw bytes (not their text form), so a
+// plain sql.NullString silently yields an unparseable value and the record
+// ends up with a zero row id (#147).
+type nullDuckDBUUID struct {
+	UUID  uuid.UUID
+	Valid bool
+}
+
+// Scan implements sql.Scanner for text, raw-byte, and native UUID sources.
+func (n *nullDuckDBUUID) Scan(src any) error {
+	n.UUID, n.Valid = uuid.Nil, false
+	switch v := src.(type) {
+	case nil:
+		return nil
+	case string:
+		parsed, err := uuid.Parse(v)
+		if err != nil {
+			return fmt.Errorf("scan duckdb uuid %q: %w", v, err)
+		}
+		n.UUID, n.Valid = parsed, true
+		return nil
+	case []byte:
+		if len(v) == 16 {
+			parsed, err := uuid.FromBytes(v)
+			if err != nil {
+				return fmt.Errorf("scan duckdb uuid bytes: %w", err)
+			}
+			n.UUID, n.Valid = parsed, true
+			return nil
+		}
+		parsed, err := uuid.ParseBytes(v)
+		if err != nil {
+			return fmt.Errorf("scan duckdb uuid %q: %w", string(v), err)
+		}
+		n.UUID, n.Valid = parsed, true
+		return nil
+	case uuid.UUID:
+		n.UUID, n.Valid = v, true
+		return nil
+	default:
+		return fmt.Errorf("scan duckdb uuid: unsupported source type %T", src)
+	}
+}
+
 // duckDBScanBuffers holds pre-allocated scan buffers for DuckDB row scanning.
 type duckDBScanBuffers struct {
 	textVals   []sql.NullString
@@ -18,7 +63,7 @@ type duckDBScanBuffers struct {
 	intVals    []sql.NullInt64
 	bigVals    []sql.NullInt64
 	doubleVals []sql.NullFloat64
-	uuidVals   []sql.NullString
+	uuidVals   []nullDuckDBUUID
 }
 
 // newDuckDBScanBuffers creates scan buffers sized according to model.EntityMainColumnDescriptors.
@@ -47,7 +92,7 @@ func newDuckDBScanBuffers() *duckDBScanBuffers {
 		intVals:    make([]sql.NullInt64, intCount),
 		bigVals:    make([]sql.NullInt64, bigCount),
 		doubleVals: make([]sql.NullFloat64, doubleCount),
-		uuidVals:   make([]sql.NullString, uuidCount),
+		uuidVals:   make([]nullDuckDBUUID, uuidCount),
 	}
 }
 
@@ -75,7 +120,6 @@ func (b *duckDBScanBuffers) buildScanArgs() ([]any, *sql.NullString, *sql.NullIn
 			scanArgs = append(scanArgs, &b.doubleVals[doubleIdx])
 			doubleIdx++
 		case model.ColumnKindUUID:
-			// DuckDB will typically return UUID as text; use NullString and parse
 			scanArgs = append(scanArgs, &b.uuidVals[uuidIdx])
 			uuidIdx++
 		default:
@@ -157,12 +201,10 @@ func (b *duckDBScanBuffers) buildRecordFromBuffers() *model.PersistentRecord {
 		case model.ColumnKindUUID:
 			val := b.uuidVals[uuidIdx]
 			if val.Valid {
-				if parsed, err := uuid.Parse(val.String); err == nil {
-					if desc.Name == "ltbase_row_id" {
-						record.RowID = parsed
-					} else {
-						record.UUIDItems[desc.Name] = parsed
-					}
+				if desc.Name == "ltbase_row_id" {
+					record.RowID = val.UUID
+				} else {
+					record.UUIDItems[desc.Name] = val.UUID
 				}
 			}
 			uuidIdx++

--- a/internal/federated/duckdb_uuid_scan_test.go
+++ b/internal/federated/duckdb_uuid_scan_test.go
@@ -1,0 +1,91 @@
+package federated
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// duckDBLiteralTypeForKind mirrors the DuckDB column types produced by the
+// federated outer SELECT for each entity_main column kind.
+func duckDBLiteralTypeForKind(kind model.ColumnKind) string {
+	switch kind {
+	case model.ColumnKindText:
+		return "VARCHAR"
+	case model.ColumnKindSmallint:
+		return "SMALLINT"
+	case model.ColumnKindInteger:
+		return "INTEGER"
+	case model.ColumnKindBigint:
+		return "BIGINT"
+	case model.ColumnKindDouble:
+		return "DOUBLE"
+	case model.ColumnKindUUID:
+		return "UUID"
+	default:
+		return "VARCHAR"
+	}
+}
+
+// TestStreamDuckDBRows_RealDriver_UUIDColumnsScan pins issue #147: the
+// duckdb-go driver returns UUID columns as 16 raw bytes, and the scan buffers
+// must decode them instead of silently leaving uuid.Nil row ids.
+func TestStreamDuckDBRows_RealDriver_UUIDColumnsScan(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	rowID := uuid.MustParse("1a0f337e-0f82-5679-b842-1254f95c0642")
+	customerID := uuid.MustParse("c79ae7be-710b-5540-9c05-19c2dec9950b")
+
+	parts := make([]string, 0, len(model.EntityMainColumnDescriptors)+4)
+	for _, desc := range model.EntityMainColumnDescriptors {
+		switch desc.Name {
+		case "ltbase_schema_id":
+			parts = append(parts, "102::SMALLINT AS ltbase_schema_id")
+		case "ltbase_row_id":
+			parts = append(parts, fmt.Sprintf("CAST('%s' AS UUID) AS ltbase_row_id", rowID))
+		case "ltbase_created_at":
+			parts = append(parts, "11::BIGINT AS ltbase_created_at")
+		case "ltbase_updated_at":
+			parts = append(parts, "22::BIGINT AS ltbase_updated_at")
+		case "uuid_01":
+			parts = append(parts, fmt.Sprintf("CAST('%s' AS UUID) AS uuid_01", customerID))
+		default:
+			parts = append(parts, fmt.Sprintf("NULL::%s AS %s", duckDBLiteralTypeForKind(desc.Kind), desc.Name))
+		}
+	}
+	parts = append(parts,
+		"'[]'::VARCHAR AS attributes_json",
+		"1::BIGINT AS total_records",
+		"1::BIGINT AS total_pages",
+		"1::BIGINT AS current_page",
+	)
+
+	rows, err := db.Query("SELECT " + strings.Join(parts, ", "))
+	require.NoError(t, err)
+	defer rows.Close()
+
+	engine := &DBFederatedQueryEngine{}
+	var records []*model.PersistentRecord
+	total, rowCount, err := engine.streamDuckDBRows(context.Background(), rows, func(_ context.Context, record *model.PersistentRecord) error {
+		records = append(records, record)
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Equal(t, int64(1), rowCount)
+	require.Len(t, records, 1)
+	require.Equal(t, rowID, records[0].RowID, "ltbase_row_id must survive the DuckDB UUID scan")
+	require.Equal(t, customerID, records[0].UUIDItems["uuid_01"], "uuid_01 must survive the DuckDB UUID scan")
+	require.Equal(t, int16(102), records[0].SchemaID)
+}

--- a/internal/federated/stream_rows_test.go
+++ b/internal/federated/stream_rows_test.go
@@ -128,9 +128,9 @@ func populateDuckDBRow(dest []any, schemaID int16, rowID uuid.UUID, createdAt in
 
 	for i, scanDest := range dest[:len(model.EntityMainColumnDescriptors)] {
 		switch typed := scanDest.(type) {
-		case *sql.NullString:
+		case *nullDuckDBUUID:
 			if model.EntityMainColumnDescriptors[i].Name == "ltbase_row_id" {
-				typed.String = rowID.String()
+				typed.UUID = rowID
 				typed.Valid = true
 			}
 		case *sql.NullInt64:

--- a/internal/sqlgen/duckdb_outer_select_order_test.go
+++ b/internal/sqlgen/duckdb_outer_select_order_test.go
@@ -1,0 +1,81 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// outerSelectAliases extracts the output column aliases from an outer SELECT
+// fragment as produced by buildOuterSelect / BuildBenchmarkOuterSelect (parts
+// joined with ",\n\t\t\t").
+func outerSelectAliases(t *testing.T, outerSelect string) []string {
+	t.Helper()
+	parts := strings.Split(outerSelect, ",\n\t\t\t")
+	aliases := make([]string, 0, len(parts))
+	for _, part := range parts {
+		idx := strings.LastIndex(part, " AS ")
+		require.GreaterOrEqual(t, idx, 0, "outer select part %q must carry an alias", part)
+		aliases = append(aliases, strings.TrimSpace(part[idx+len(" AS "):]))
+	}
+	return aliases
+}
+
+// expectedOuterSelectAliases is the scan contract: streamDuckDBRows scans rows
+// positionally in model.EntityMainColumnDescriptors order, then attributes_json.
+func expectedOuterSelectAliases() []string {
+	expected := make([]string, 0, len(model.EntityMainColumnDescriptors)+1)
+	for _, desc := range model.EntityMainColumnDescriptors {
+		expected = append(expected, desc.Name)
+	}
+	return append(expected, "attributes_json")
+}
+
+// TestBuildBenchmarkOuterSelect_ColumnOrderMatchesScanContract pins issue #147:
+// the outer SELECT column order must match the positional scan order used by
+// the DuckDB scan buffers, otherwise attribute values land in wrong columns.
+func TestBuildBenchmarkOuterSelect_ColumnOrderMatchesScanContract(t *testing.T) {
+	for _, schemaID := range []int16{100, 101, 102} {
+		aliases := outerSelectAliases(t, BuildBenchmarkOuterSelect(schemaID))
+		require.Equal(t, expectedOuterSelectAliases(), aliases, "schema %d outer select order", schemaID)
+	}
+}
+
+func TestBuildSchemaProjection_OuterSelectOrderMatchesScanContract(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"customerId": {
+			AttributeID: 6,
+			ValueType:   forma.ValueTypeUUID,
+			ColumnBinding: &forma.MainColumnBinding{
+				ColumnName: "uuid_01",
+			},
+		},
+		"symbol": {
+			AttributeID: 1,
+			ValueType:   forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{
+				ColumnName: "text_01",
+			},
+		},
+		"quantity": {
+			AttributeID: 3,
+			ValueType:   forma.ValueTypeBigInt,
+			ColumnBinding: &forma.MainColumnBinding{
+				ColumnName: "bigint_01",
+			},
+		},
+		"exchange": {
+			AttributeID: 8,
+			ValueType:   forma.ValueTypeText,
+		},
+	}
+
+	sp, err := BuildSchemaProjection(42, cache)
+	require.NoError(t, err)
+	aliases := outerSelectAliases(t, sp.OuterSelect)
+	require.Equal(t, expectedOuterSelectAliases(), aliases)
+}

--- a/internal/sqlgen/duckdb_schema_projection.go
+++ b/internal/sqlgen/duckdb_schema_projection.go
@@ -294,23 +294,14 @@ func (sp *SchemaProjection) buildOuterSelect(schemaID int16, sortedAttrs []strin
 		eavOnlySelects[attr] = true
 	}
 
-	for _, attr := range sortedAttrs {
-		col, isColumn := sp.AttrToMainColumn[attr]
-		if isColumn {
-			// Map attribute to its entity_main column with appropriate CAST
-			parts = append(parts, fmt.Sprintf("%s AS %s",
-				duckDBAttrCast(attr, sp.UnifiedColumnTypes[attr]), col))
-		}
-	}
-
-	// For entity_main columns not mapped to any attribute, emit NULL
+	// Emit EAV columns in descriptor order: streamDuckDBRows scans rows
+	// positionally against model.EntityMainColumnDescriptors, so any other
+	// order lands attribute values in the wrong record fields (#147).
 	allMainCols := model.EntityMainColumnDescriptors[len(model.SystemColumnDescriptors):]
-	mappedCols := make(map[string]bool)
-	for _, col := range sp.AttrToMainColumn {
-		mappedCols[col] = true
-	}
 	for _, desc := range allMainCols {
-		if mappedCols[desc.Name] {
+		if attr, ok := mainColToAttr[desc.Name]; ok {
+			parts = append(parts, fmt.Sprintf("%s AS %s",
+				duckDBAttrCast(attr, sp.UnifiedColumnTypes[attr]), desc.Name))
 			continue
 		}
 		parts = append(parts, fmt.Sprintf("NULL::%s AS %s",
@@ -498,99 +489,64 @@ func BuildBenchmarkOuterSelect(schemaID int16) string {
 		"deleted_ts AS ltbase_deleted_at",
 	}
 
-	// Map known benchmark attributes to entity_main columns
+	// Map known benchmark attributes to entity_main column cast expressions.
+	var boundCols map[string]string
+	var eavJSON string
 	switch schemaID {
 	case 102: // trade
-		// text_01 = symbol
-		parts = append(parts, "CAST(symbol AS VARCHAR) AS text_01")
-		// text_02 = region
-		parts = append(parts, "CAST(region AS VARCHAR) AS text_02")
-		// smallint_01 = tradeType
-		parts = append(parts, "CAST(tradeType AS SMALLINT) AS smallint_01")
-		// bigint_01 = quantity
-		parts = append(parts, "CAST(quantity AS BIGINT) AS bigint_01")
-		// bigint_02 = tradeTime
-		parts = append(parts, "CAST(tradeTime AS BIGINT) AS bigint_02")
-		// double_01 = price
-		parts = append(parts, "CAST(price AS DOUBLE) AS double_01")
-		// uuid_01 = customerId
-		parts = append(parts, "CAST(customerId AS UUID) AS uuid_01")
-		// NULL for remaining entity_main columns
-		remaining := restMainColumnNames([]string{
-			"text_01", "text_02", "smallint_01", "bigint_01", "bigint_02",
-			"double_01", "uuid_01",
-		})
-		for _, col := range remaining {
-			desc := model.GetMainColumnDescriptor(col)
-			if desc == nil {
-				parts = append(parts, fmt.Sprintf("NULL::VARCHAR AS %s", col))
-				continue
-			}
-			parts = append(parts, fmt.Sprintf("NULL::%s AS %s", duckDBColumnType(desc.Kind), col))
+		boundCols = map[string]string{
+			"text_01":     "CAST(symbol AS VARCHAR)",
+			"text_02":     "CAST(region AS VARCHAR)",
+			"smallint_01": "CAST(tradeType AS SMALLINT)",
+			"bigint_01":   "CAST(quantity AS BIGINT)",
+			"bigint_02":   "CAST(tradeTime AS BIGINT)",
+			"double_01":   "CAST(price AS DOUBLE)",
+			"uuid_01":     "CAST(customerId AS UUID)",
 		}
-		// attributes_json from EAV-only attributes
-		parts = append(parts, fmt.Sprintf("%s::TEXT AS attributes_json",
-			benchmarkEAVJSONArray(schemaID, 102, "",
-				eavJSONAttr{id: 8, name: "exchange", type_: "text"},
-				eavJSONAttr{id: 9, name: "commission", type_: "numeric"},
-				eavJSONAttr{id: 10, name: "isCash", type_: "numeric"},
-				eavJSONAttr{id: 11, name: "brokerId", type_: "text"},
-				eavJSONAttr{id: 12, name: "orderChannel", type_: "text"},
-			)))
+		eavJSON = benchmarkEAVJSONArray(schemaID, 102, "",
+			eavJSONAttr{id: 8, name: "exchange", type_: "text"},
+			eavJSONAttr{id: 9, name: "commission", type_: "numeric"},
+			eavJSONAttr{id: 10, name: "isCash", type_: "numeric"},
+			eavJSONAttr{id: 11, name: "brokerId", type_: "text"},
+			eavJSONAttr{id: 12, name: "orderChannel", type_: "text"},
+		)
 	case 100: // customer
-		parts = append(parts, "CAST(taxId AS VARCHAR) AS text_01")
-		parts = append(parts, "CAST(region AS VARCHAR) AS text_02")
-		parts = append(parts, "CAST(status AS SMALLINT) AS smallint_01")
-		remaining := restMainColumnNames([]string{"text_01", "text_02", "smallint_01"})
-		for _, col := range remaining {
-			desc := model.GetMainColumnDescriptor(col)
-			if desc == nil {
-				parts = append(parts, fmt.Sprintf("NULL::VARCHAR AS %s", col))
-				continue
-			}
-			parts = append(parts, fmt.Sprintf("NULL::%s AS %s", duckDBColumnType(desc.Kind), col))
+		boundCols = map[string]string{
+			"text_01":     "CAST(taxId AS VARCHAR)",
+			"text_02":     "CAST(region AS VARCHAR)",
+			"smallint_01": "CAST(status AS SMALLINT)",
 		}
-		parts = append(parts, fmt.Sprintf("%s::TEXT AS attributes_json",
-			benchmarkEAVJSONArray(schemaID, 100, "",
-				eavJSONAttr{id: 5, name: "email", type_: "text"},
-				eavJSONAttr{id: 6, name: "creditRating", type_: "numeric"},
-			)))
+		eavJSON = benchmarkEAVJSONArray(schemaID, 100, "",
+			eavJSONAttr{id: 5, name: "email", type_: "text"},
+			eavJSONAttr{id: 6, name: "creditRating", type_: "numeric"},
+		)
 	case 101: // security
-		parts = append(parts, "CAST(symbol AS VARCHAR) AS text_01")
-		parts = append(parts, "CAST(sector AS SMALLINT) AS smallint_01")
-		remaining := restMainColumnNames([]string{"text_01", "smallint_01"})
-		for _, col := range remaining {
-			desc := model.GetMainColumnDescriptor(col)
-			if desc == nil {
-				parts = append(parts, fmt.Sprintf("NULL::VARCHAR AS %s", col))
-				continue
-			}
-			parts = append(parts, fmt.Sprintf("NULL::%s AS %s", duckDBColumnType(desc.Kind), col))
+		boundCols = map[string]string{
+			"text_01":     "CAST(symbol AS VARCHAR)",
+			"smallint_01": "CAST(sector AS SMALLINT)",
 		}
-		parts = append(parts, fmt.Sprintf("%s::TEXT AS attributes_json",
-			benchmarkEAVJSONArray(schemaID, 101, "",
-				eavJSONAttr{id: 3, name: "companyName", type_: "text"},
-				eavJSONAttr{id: 4, name: "dividend", type_: "numeric"},
-				eavJSONAttr{id: 5, name: "marketCap", type_: "numeric"},
-			)))
+		eavJSON = benchmarkEAVJSONArray(schemaID, 101, "",
+			eavJSONAttr{id: 3, name: "companyName", type_: "text"},
+			eavJSONAttr{id: 4, name: "dividend", type_: "numeric"},
+			eavJSONAttr{id: 5, name: "marketCap", type_: "numeric"},
+		)
 	}
+
+	// Emit EAV columns in descriptor order: streamDuckDBRows scans rows
+	// positionally against model.EntityMainColumnDescriptors (#147).
+	for _, desc := range model.EntityMainColumnDescriptors[len(model.SystemColumnDescriptors):] {
+		if expr, ok := boundCols[desc.Name]; ok {
+			parts = append(parts, fmt.Sprintf("%s AS %s", expr, desc.Name))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("NULL::%s AS %s", duckDBColumnType(desc.Kind), desc.Name))
+	}
+	if eavJSON == "" {
+		eavJSON = "'[]'"
+	}
+	parts = append(parts, fmt.Sprintf("%s::TEXT AS attributes_json", eavJSON))
 
 	return strings.Join(parts, ",\n\t\t\t")
-}
-
-// restMainColumnNames returns all entity_main EAV column names except those listed in exclude.
-func restMainColumnNames(exclude []string) []string {
-	excludeSet := make(map[string]bool)
-	for _, col := range exclude {
-		excludeSet[col] = true
-	}
-	var result []string
-	for _, desc := range model.EntityMainColumnDescriptors[len(model.SystemColumnDescriptors):] {
-		if !excludeSet[desc.Name] {
-			result = append(result, desc.Name)
-		}
-	}
-	return result
 }
 
 // benchmarkAttr describes a benchmark attribute used to build matching S3 and PG projections.
@@ -642,7 +598,7 @@ func BuildBenchmarkProjections(schemaID int16) *SchemaProjection {
 			{name: "quantity", colName: "bigint_01", eavJSON: false, attrID: 3, s3Expr: "quantity"},
 			{name: "region", colName: "text_02", eavJSON: false, attrID: 7, s3Expr: "region"},
 			{name: "symbol", colName: "text_01", eavJSON: false, attrID: 1, s3Expr: "symbol"},
-			{name: "tradeTime", colName: "bigint_02", eavJSON: false, attrID: 5, s3Expr: "epoch_ms(try_cast(tradeTime AS TIMESTAMP)) as tradeTime"},
+			{name: "tradeTime", colName: "bigint_02", eavJSON: false, attrID: 5, s3Expr: "COALESCE(try_cast(tradeTime AS BIGINT), epoch_ms(try_cast(tradeTime AS TIMESTAMP))) as tradeTime"},
 			{name: "tradeType", colName: "smallint_01", eavJSON: false, attrID: 2, s3Expr: "tradeType"},
 		}
 	}

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -354,7 +354,7 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 			return handleConversionError(err)
 		}
 		attr.ValueNumeric = &numVal
-	case forma.ValueTypeDate:
+	case forma.ValueTypeDate, forma.ValueTypeDateTime:
 		timeVal, err := toTime(value)
 		if err != nil {
 			return handleConversionError(err)

--- a/internal/transform/transformer_test.go
+++ b/internal/transform/transformer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strconv"
 	"testing"
 	"time"
 
@@ -730,4 +731,23 @@ func TestTransformer_ToAttributes_NullUnknownArrayItem_ReturnsError(t *testing.T
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown_list")
 	assert.True(t, errors.Is(err, forma.ErrInvalidInput), "expected ErrInvalidInput, got: %v", err)
+}
+
+func TestPopulateTypedValueDateTimeStoresUnixMillisNumeric(t *testing.T) {
+	// Issue #147: datetime attributes (e.g. benchmark tradeTime) must round-trip
+	// through populateTypedValue exactly like date attributes do.
+	meta := forma.AttributeMetadata{
+		AttributeID: 5,
+		ValueType:   forma.ValueTypeDateTime,
+	}
+	when := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+
+	for _, value := range []any{when, strconv.FormatInt(when.UnixMilli(), 10), when.Format(time.RFC3339)} {
+		attr := model.EAVRecord{}
+		set, err := populateTypedValue(&attr, "tradeTime", value, meta)
+		require.NoError(t, err, "value %v", value)
+		require.True(t, set)
+		require.NotNil(t, attr.ValueNumeric)
+		assert.Equal(t, float64(when.UnixMilli()), *attr.ValueNumeric, "value %v", value)
+	}
 }


### PR DESCRIPTION
Closes #147

## 根因定位(AC 1)

零 UUID 产生在**服务响应侧的 DuckDB 扫描层**,不是 harness 重建层。共定位到五个相互叠加的缺陷,其中前两个是生产代码 bug:

| # | 层 | 缺陷 | 症状 |
|---|----|------|------|
| A | `internal/federated` 引擎扫描 | duckdb-go/v2 驱动把 UUID 列以 **16 字节 raw binary** 返回;`sql.NullString` + `uuid.Parse` 解析失败后被**静默吞掉**,`RowID` 保持 `uuid.Nil` | service path 三个 workload 全零 UUID(`unique-row-ids-within-page` 等 24 项失败的主体) |
| B | `internal/sqlgen` 投影 | `buildOuterSelect` / `BuildBenchmarkOuterSelect` 输出列序是"绑定列在前、NULL 列在后",而 `streamDuckDBRows` 按 `EntityMainColumnDescriptors` **位置**扫描 → 属性值落错字段(symbol 进 `ltbase_created_by`、quantity 进 `text_01`…) | `filter-results-match-request` 失败;任何有 column binding 的 schema 走 DuckDB 引擎都受影响 |
| B2 | `internal/sqlgen` 投影 | benchmark s3 侧 `tradeTime` 只做 `epoch_ms(try_cast(... AS TIMESTAMP))`,对 harness Parquet 的 BIGINT 列恒为 NULL | `tradeTime DESC` 排序把全部 parquet 行排到 pg 行之后,页序错乱 |
| C | `internal/transform` | `populateTypedValue` 缺 `ValueTypeDateTime` 分支(同包 `AttributeConverter` 早已 Date/DateTime 同治) | 列序修复后 tradeTime 首次真正到达重建层,直接报 `unsupported value type 'datetime'` |
| D | e2e harness seeding | `nullableUnixMillis` 不解析数字字符串 → hot 层 `bigint_02` 全 NULL,EAV 侧存 `value_text` 而查询读 `value_numeric` → `COALESCE(...)=0` | `hot-only-window` count=0;`mixed-tier-window` 缺失全部 hot 层记录 |
| E | benchmark oracle | prefer-hot tier-mix workload 执行侧是 postgres-only override,oracle 却对**全部层**的窗口记录计数 | `hot-only-window` 永远无法匹配(执行只能看到 hot buffer) |
| F | benchmark oracle | `recordMatchesFilter` 只按属性名读记录,而 service path 重建的记录是**存储布局**(symbol→`text_01`、exchange→EAV `OtherAttributes`) | `filter-results-match-request` 对 service workload 结构性失败 |

**修正 issue 评论中的两个前提**:artifact 显示 `mixed-tier-window` 的 row_ids 一直是正常 UUID(它失败在 total 数);零 UUID 只出现在 service path 三个 workload——它们恰好都是 trade,而 customer/security 从未走 service path,所以"按 schema 维度分裂"是取样偏差,真实维度是**执行路径**。

## 修复

每个根因一个提交,均先落失败回归测试再修复:

1. `fix(federated)`: `nullDuckDBUUID` scanner,解码 text / 16-byte raw / `uuid.UUID` 三种形态,不可解码时**报错而非静默置 Nil**;附真实驱动端到端测试钉住
2. `fix(sqlgen)`: 两个 outer SELECT 改为按描述符规范序逐列输出(绑定 cast 或类型化 NULL);s3 `tradeTime` 用 `COALESCE(BIGINT, epoch_ms(TIMESTAMP))` 兼容 harness/CDC 两种 Parquet 形态;附列序契约测试
3. `fix(transform)`: `populateTypedValue` 的 Date 分支扩展为 `Date, DateTime`,对齐同包既有约定
4. `fix(e2e)`: `nullableUnixMillis` 支持 unix-millis 数字字符串
5. `fix(benchmark)`: `buildLoadedStateSnapshot` 返回 hotKeys;oracle 与执行侧共用 `workloadExecutesPostgresOnly` 谓词,postgres-only workload 的期望限定 hot 层记录
6. `fix(benchmark)`: `recordMatchesFilter` 形态感知——同时支持 harness 直查形态与 service 重建的存储布局形态(text_01 / OtherAttributes)

## 验证(AC 2)

- `make test` 全绿;`make lint` 干净
- `go test ./internal/e2e_harness/federated/... -tags=e2e -short`(CI 同款命令)全绿,exit 0
- 小规模诊断复现(300 trades):`baseline-page-1` / `customer-region-page` / `mixed-tier-window` / `hot-only-window` 断言全部通过,row_ids 与 oracle 精确一致;修复 F 后 `hot-selective-page` / `eav-selective-page`(truth-pass)同样全绿
- `make benchmark-regression`(small-live preset)首轮完整 run:失败从 main 的 **24 → 4**(仅剩 F 的 filter 断言);F 修复后完整复跑进行中,failures=0 结果将以 PR 评论补充

⚠️ 运行时间注意:small-live 的 truth-pass oracle(`hot-selective-page`/`eav-selective-page`)会**逐候选记录**发真实联邦查询(uniform 分布下 eav-selective 约 2.4 万条),整个 run 在负载中的机器上需 3-4 小时(空闲机器约 35 分钟)。这是既有设计成本,非本 PR 引入。

## 备注

- `TestBenchmarkWorkloadExecution_RunWithHarness` 不断言 `execution.Passed`,这是 main 上 oracle 失败长期未被发现的原因;本 PR 未改动该断言(避免扩散范围),建议后续 issue 讨论收紧
- `fallbackOuterSelect`(无 metadata cache 的兜底路径)引用了不存在的 `bigint_04`/`boolean_01` 列,与描述符不符,但该路径不被 benchmark 触发,超出本 issue 范围

🤖 Generated with [Claude Code](https://claude.com/claude-code)
