### PR TITLE
refactor: typed predicate IR — parse-once normalization layer in front of sqlgen (#143)

### DIFF
--- a/internal/sqlgen/condition_walker.go
+++ b/internal/sqlgen/condition_walker.go
@@ -25,6 +25,18 @@ type compositeGuard interface {
 
 type CompositeGuard = compositeGuard
 
+// typedLeafEmitter renders a typed predicate leaf into SQL and args. The
+// skip contract matches leafEmitter: ("", nil, nil) drops the leaf.
+type typedLeafEmitter interface {
+	EmitTypedLeaf(leaf *PredicateLeaf) (sql string, args []any, err error)
+}
+
+// typedGuard optionally intercepts a PredicateGroup before traversing its
+// children, mirroring compositeGuard on the typed tree.
+type typedGuard interface {
+	SkipGroup(g *PredicateGroup) bool
+}
+
 type allEmptyBehavior int
 
 const (
@@ -83,14 +95,45 @@ var (
 
 var HybridStyle = hybridStyle
 
+// legacyLeafAdapter feeds the original KvCondition of a typed leaf to a
+// legacy leafEmitter, so untyped consumers (hybrid builder) share the typed
+// traversal instead of a second walker.
+type legacyLeafAdapter struct{ emit leafEmitter }
+
+func (a legacyLeafAdapter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, error) {
+	return a.emit.EmitLeaf(leaf.Source)
+}
+
+// legacyGuardAdapter feeds the source composite of a typed group to a legacy
+// compositeGuard.
+type legacyGuardAdapter struct{ guard compositeGuard }
+
+func (a legacyGuardAdapter) SkipGroup(g *PredicateGroup) bool {
+	return a.guard.SkipComposite(g.Source)
+}
+
 func WalkCondition(cond forma.Condition, style compositeStyle, guard CompositeGuard, emit LeafEmitter) (string, []any, error) {
 	return walkCondition(cond, style, guard, emit)
 }
 
-// walkCondition traverses a forma.Condition AST and emits SQL via the leafEmitter.
-// Composite traversal (empty handling, parens, joins, guard) is parameterised by style.
+// walkCondition traverses a forma.Condition AST and emits SQL via the legacy
+// leafEmitter. The traversal itself is the typed predicate walker over a
+// structure-only normalization (no target payloads), so composite semantics
+// exist exactly once.
 func walkCondition(cond forma.Condition, style compositeStyle, guard compositeGuard, emit leafEmitter) (string, []any, error) {
-	if cond == nil {
+	var g typedGuard
+	if guard != nil {
+		g = legacyGuardAdapter{guard: guard}
+	}
+	return walkPredicate(normalizePredicates(cond, nil, targetsNone), style, g, legacyLeafAdapter{emit: emit})
+}
+
+// walkPredicate traverses a typed predicate tree and emits SQL via the
+// typedLeafEmitter. Composite traversal (empty handling, parens, joins,
+// guard) is parameterised by style.
+func walkPredicate(node PredicateNode, style compositeStyle, guard typedGuard, emit typedLeafEmitter) (string, []any, error) {
+	switch n := node.(type) {
+	case predicateNilNode:
 		switch style.nilNode {
 		case nilNodeError:
 			return "", nil, fmt.Errorf("nil condition not allowed")
@@ -101,23 +144,22 @@ func walkCondition(cond forma.Condition, style compositeStyle, guard compositeGu
 		default:
 			return "", nil, fmt.Errorf("unknown nilNode behavior")
 		}
-	}
-
-	switch c := cond.(type) {
-	case *forma.CompositeCondition:
-		return walkComposite(c, style, guard, emit)
-	case *forma.KvCondition:
-		return emit.EmitLeaf(c)
+	case *PredicateGroup:
+		return walkPredicateGroup(n, style, guard, emit)
+	case *PredicateLeaf:
+		return emit.EmitTypedLeaf(n)
+	case predicateInvalidNode:
+		return "", nil, n.err
 	default:
-		return "", nil, fmt.Errorf("unsupported condition type %T", cond)
+		return "", nil, fmt.Errorf("unsupported predicate node %T", node)
 	}
 }
 
-func walkComposite(c *forma.CompositeCondition, style compositeStyle, guard compositeGuard, emit leafEmitter) (string, []any, error) {
+func walkPredicateGroup(g *PredicateGroup, style compositeStyle, guard typedGuard, emit typedLeafEmitter) (string, []any, error) {
 	// Empty composite produces identity value BEFORE guard check (empty OR must
 	// yield "1=0", not be silently vetoed).
-	if len(c.Conditions) == 0 {
-		if c.Logic == forma.LogicOr {
+	if len(g.Children) == 0 {
+		if g.Logic == forma.LogicOr {
 			return style.emptyOr, nil, nil
 		}
 		return style.emptyAnd, nil, nil
@@ -125,27 +167,27 @@ func walkComposite(c *forma.CompositeCondition, style compositeStyle, guard comp
 
 	// strictLogic: error on unknown Logic
 	joiner := " AND "
-	switch c.Logic {
+	switch g.Logic {
 	case forma.LogicAnd:
 		joiner = " AND "
 	case forma.LogicOr:
 		joiner = " OR "
 	default:
 		if style.strictLogic {
-			return "", nil, fmt.Errorf("unknown logic: %s", c.Logic)
+			return "", nil, fmt.Errorf("unknown logic: %s", g.Logic)
 		}
 	}
 
-	// guard: ask compositeGuard whether to skip this node entirely
-	if guard != nil && guard.SkipComposite(c) {
+	// guard: ask typedGuard whether to skip this node entirely
+	if guard != nil && guard.SkipGroup(g) {
 		return "", nil, nil
 	}
 
 	var parts []string
 	var allArgs []any
 
-	for _, child := range c.Conditions {
-		childSQL, childArgs, err := walkCondition(child, style, guard, emit)
+	for _, child := range g.Children {
+		childSQL, childArgs, err := walkPredicate(child, style, guard, emit)
 		if err != nil {
 			return "", nil, err
 		}
@@ -162,7 +204,7 @@ func walkComposite(c *forma.CompositeCondition, style compositeStyle, guard comp
 		case allEmptyOmit:
 			return "", nil, nil
 		case allEmptyIdentity:
-			if c.Logic == forma.LogicOr {
+			if g.Logic == forma.LogicOr {
 				return "1=0", nil, nil
 			}
 			return "1=1", nil, nil

--- a/internal/sqlgen/dual_clause_plan.go
+++ b/internal/sqlgen/dual_clause_plan.go
@@ -40,19 +40,22 @@ func PlanDualClauses(condition forma.Condition, eavTable string, schemaID int16,
 // Bind produces the per-request DualClauses for a condition tree with the
 // same shape the plan was compiled from: cached skeletons plus freshly bound
 // args. paramIndex is advanced by the plan's span, mirroring ToDualClauses.
+// The condition is normalized into the typed predicate tree once; all three
+// arg slices bind from that shared tree.
 func (p *DualClausePlan) Bind(condition forma.Condition, cache forma.SchemaAttributeCache, paramIndex *int) (DualClauses, error) {
 	if p == nil {
 		return DualClauses{}, fmt.Errorf("dual clause plan is nil")
 	}
-	pgMainArgs, err := bindPgMainArgs(condition, cache)
+	tree := normalizePredicates(condition, cache, targetsAll)
+	pgMainArgs, err := bindArgsFromTree(tree, pgMainStyle, pgMainTypedGuard{}, bindPgMainValues)
 	if err != nil {
 		return DualClauses{}, fmt.Errorf("pg main binding: %w", err)
 	}
-	pgArgs, err := bindPgEavArgs(condition, cache)
+	pgArgs, err := bindArgsFromTree(tree, pgEavStyle, nil, bindPgEavValues)
 	if err != nil {
 		return DualClauses{}, fmt.Errorf("pg eav binding: %w", err)
 	}
-	duckArgs, err := bindDuckArgs(condition, cache)
+	duckArgs, err := bindArgsFromTree(tree, duckStyle, nil, bindDuckValues)
 	if err != nil {
 		return DualClauses{}, fmt.Errorf("duck binding: %w", err)
 	}
@@ -69,63 +72,53 @@ func (p *DualClausePlan) Bind(condition forma.Condition, cache forma.SchemaAttri
 	}, nil
 }
 
-// bindEmitter adapts a value core to the walker's leafEmitter contract: the
-// dummy non-empty SQL keeps the walker's skip/veto accounting identical to
-// the string-producing emitters, so args accumulate in the same order.
-type bindEmitter struct {
-	values func(kv *forma.KvCondition) ([]any, bool, error)
+// typedBindEmitter adapts a typed-leaf value function to the walker's
+// emitter contract: the dummy non-empty SQL keeps the walker's skip/veto
+// accounting identical to the string-producing emitters, so args accumulate
+// in the same order.
+type typedBindEmitter struct {
+	values func(leaf *PredicateLeaf) ([]any, bool, error)
 }
 
-func (b *bindEmitter) EmitLeaf(kv *forma.KvCondition) (string, []any, error) {
-	args, emit, err := b.values(kv)
+func (b *typedBindEmitter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, error) {
+	args, emit, err := b.values(leaf)
 	if err != nil || !emit {
 		return "", nil, err
 	}
 	return "x", args, nil
 }
 
-func bindPgMainArgs(cond forma.Condition, cache forma.SchemaAttributeCache) ([]any, error) {
-	if cond == nil {
+// bindArgsFromTree re-walks an already-normalized tree with a value-only
+// emitter. A top-level nil condition binds no args (matching the generation
+// entrypoints, which skip nil before walking).
+func bindArgsFromTree(tree PredicateNode, style compositeStyle, guard typedGuard, values func(leaf *PredicateLeaf) ([]any, bool, error)) ([]any, error) {
+	if _, ok := tree.(predicateNilNode); ok {
 		return nil, nil
 	}
-	guard := &pgMainGuard{cache: cache}
-	emitter := &bindEmitter{values: func(kv *forma.KvCondition) ([]any, bool, error) {
-		val, emit, err := pgMainLeafValue(kv, cache)
-		if err != nil || !emit {
-			return nil, false, err
-		}
-		return []any{val}, true, nil
-	}}
-	_, args, err := walkCondition(cond, pgMainStyle, guard, emitter)
+	_, args, err := walkPredicate(tree, style, guard, &typedBindEmitter{values: values})
 	return args, err
 }
 
-func bindPgEavArgs(cond forma.Condition, cache forma.SchemaAttributeCache) ([]any, error) {
-	if cond == nil {
-		return nil, nil
+func bindPgMainValues(leaf *PredicateLeaf) ([]any, bool, error) {
+	p := leaf.PgMain
+	if p.Err != nil || p.Skip {
+		return nil, false, p.Err
 	}
-	emitter := &bindEmitter{values: func(kv *forma.KvCondition) ([]any, bool, error) {
-		attrID, val, _, _, err := pgEavLeafValue(kv, cache)
-		if err != nil {
-			return nil, false, err
-		}
-		return []any{attrID, val}, true, nil
-	}}
-	_, args, err := walkCondition(cond, pgEavStyle, nil, emitter)
-	return args, err
+	return []any{p.Value}, true, nil
 }
 
-func bindDuckArgs(cond forma.Condition, cache forma.SchemaAttributeCache) ([]any, error) {
-	if cond == nil {
-		return nil, nil
+func bindPgEavValues(leaf *PredicateLeaf) ([]any, bool, error) {
+	p := leaf.PgEav
+	if p.Err != nil {
+		return nil, false, p.Err
 	}
-	emitter := &bindEmitter{values: func(kv *forma.KvCondition) ([]any, bool, error) {
-		parts, err := duckLeafValue(kv, cache)
-		if err != nil {
-			return nil, false, err
-		}
-		return []any{parts.param}, true, nil
-	}}
-	_, args, err := walkCondition(cond, duckStyle, nil, emitter)
-	return args, err
+	return []any{p.AttrID, p.Value}, true, nil
+}
+
+func bindDuckValues(leaf *PredicateLeaf) ([]any, bool, error) {
+	p := leaf.Duck
+	if p.Err != nil {
+		return nil, false, p.Err
+	}
+	return []any{p.Param}, true, nil
 }

--- a/internal/sqlgen/dualpath_sql_generator.go
+++ b/internal/sqlgen/dualpath_sql_generator.go
@@ -2,7 +2,6 @@ package sqlgen
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/lychee-technology/forma"
 )
@@ -23,6 +22,9 @@ type DualClauses struct {
 // - PgMainClause contains predicates suitable for entity_main pushdown.
 // - DuckClause maps attributes to column names when available and emits a simple DuckDB-style clause.
 // Note: DuckDB placeholders are "?" and args are returned in order. Postgres uses $n placeholders.
+//
+// The condition tree is normalized into the typed predicate IR exactly once
+// (#143); the three emitters below consume that shared tree.
 func ToDualClauses(
 	condition forma.Condition,
 	eavTable string,
@@ -30,21 +32,27 @@ func ToDualClauses(
 	cache forma.SchemaAttributeCache,
 	paramIndex *int,
 ) (DualClauses, error) {
+	tree := normalizePredicates(condition, cache, targetsAll)
+
 	// Build pushdown-capable main table predicates first so placeholders ($n) align.
-	pgMainClause, pgMainArgs, err := buildPgMainClause(condition, cache, paramIndex)
+	pgMainClause, pgMainArgs, err := pgMainClauseFromTree(tree, paramIndex)
 	if err != nil {
 		return DualClauses{}, fmt.Errorf("pg main generation: %w", err)
 	}
 
-	// Postgres EAV side: reuse existing SQL generator for full condition
-	pgGen := NewSQLGenerator()
-	pgClause, pgArgs, err := pgGen.ToSQLClauses(condition, eavTable, schemaID, cache, paramIndex)
-	if err != nil {
-		return DualClauses{}, fmt.Errorf("pg sql generation: %w", err)
+	// Postgres EAV side: full condition as EXISTS expressions. A nil
+	// top-level condition is skipped (only nested nils are an error).
+	var pgClause string
+	var pgArgs []any
+	if condition != nil {
+		pgClause, pgArgs, err = pgEavClausesFromTree(tree, eavTable, paramIndex)
+		if err != nil {
+			return DualClauses{}, fmt.Errorf("pg sql generation: %w", err)
+		}
 	}
 
-	// DuckDB side: generate simple column-based predicates using attribute metadata
-	duckClause, duckArgs, err := buildDuckClause(condition, cache)
+	// DuckDB side: simple column-based predicates using attribute metadata
+	duckClause, duckArgs, err := duckClauseFromTree(tree)
 	if err != nil {
 		return DualClauses{}, fmt.Errorf("duck sql generation: %w", err)
 	}
@@ -59,153 +67,44 @@ func ToDualClauses(
 	}, nil
 }
 
-// classifyPredicate returns whether a KvCondition can be pushed to main table based on metadata.
-func classifyPredicate(kv *forma.KvCondition, meta forma.AttributeMetadata) (bool, string) {
-	if meta.ColumnBinding == nil {
-		return false, "no column binding"
-	}
+// pgMainTypedGuard vetoes OR groups that are not fully pushable to
+// entity_main: pushing a partial OR would silently drop rows matched only
+// by the non-pushable branch. Pushability is precomputed per group by the
+// normalizer.
+type pgMainTypedGuard struct{}
 
-	// Simple operator extraction
-	opPart := ""
-	valPart := ""
-	if idx := strings.Index(kv.Value, ":"); idx >= 0 {
-		opPart = kv.Value[:idx]
-		valPart = kv.Value[idx+1:]
-	}
-	opStr := "equals"
-	if opPart != "" && valPart != "" {
-		opStr = opPart
-	}
-
-	// Decide based on value type and operator
-	switch meta.ValueType {
-	case forma.ValueTypeText, forma.ValueTypeUUID:
-		if opStr == "equals" || opStr == "starts_with" || opStr == "contains" {
-			return true, "text supported"
-		}
-		return false, "text operator not supported"
-	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
-		switch opStr {
-		case "equals", "gt", "gte", "lt", "lte", "not_equals":
-			return true, "numeric supported"
-		default:
-			return false, "numeric operator not supported"
-		}
-	case forma.ValueTypeDate, forma.ValueTypeDateTime:
-		switch opStr {
-		case "equals", "gt", "gte", "lt", "lte", "not_equals":
-			return true, "date supported"
-		default:
-			return false, "date operator not supported"
-		}
-	case forma.ValueTypeBool:
-		if opStr == "equals" || opStr == "not_equals" {
-			return true, "bool supported"
-		}
-		return false, "bool operator not supported"
-	default:
-		return false, "unknown value type"
-	}
-}
-
-// isFullyPushableToMain returns true iff every leaf KvCondition in the tree
-// has a column binding and a supported operator, so the whole tree can be
-// pushed to the Postgres entity_main table. Used to guard OR composites:
-// pushing a partial OR would silently drop rows matched only by the
-// non-pushable branch, so the entire OR must be skipped when any child fails.
-func isFullyPushableToMain(cond forma.Condition, cache forma.SchemaAttributeCache) bool {
-	switch c := cond.(type) {
-	case *forma.CompositeCondition:
-		for _, child := range c.Conditions {
-			if !isFullyPushableToMain(child, cache) {
-				return false
-			}
-		}
-		return true
-	case *forma.KvCondition:
-		meta, ok := cache[c.Attr]
-		if !ok || meta.ColumnBinding == nil {
-			return false
-		}
-		pushable, _ := classifyPredicate(c, meta)
-		return pushable
-	default:
-		return false
-	}
-}
-
-// pgMainGuard implements compositeGuard with OR veto for pg-main.
-type pgMainGuard struct {
-	cache forma.SchemaAttributeCache
-}
-
-func (g *pgMainGuard) SkipComposite(c *forma.CompositeCondition) bool {
-	if c.Logic == forma.LogicOr {
-		return !isFullyPushableToMain(c, g.cache)
+func (pgMainTypedGuard) SkipGroup(g *PredicateGroup) bool {
+	if g.Logic == forma.LogicOr {
+		return !g.FullyPushable
 	}
 	return false
 }
 
-// pgMainLeafEmitter renders KvCondition leaves for PG main table pushdown.
-type pgMainLeafEmitter struct {
-	cache      forma.SchemaAttributeCache
+// pgMainTypedEmitter renders typed predicate leaves for PG main table pushdown.
+type pgMainTypedEmitter struct {
 	paramIndex *int
 }
 
-// pgMainLeafValue is the value core shared by the string emitter and the
-// plan binder (#142): every pushability decision and conversion lives here
-// exactly once so bound args cannot diverge from emitted clauses.
-func pgMainLeafValue(c *forma.KvCondition, cache forma.SchemaAttributeCache) (any, bool, error) {
-	meta, ok := cache[c.Attr]
-	if !ok {
-		// unknown attribute -> cannot push
-		return nil, false, nil
+func (e *pgMainTypedEmitter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, error) {
+	p := leaf.PgMain
+	if p.Err != nil {
+		return "", nil, p.Err
 	}
-
-	opVal := parseOperatorValue(c.Value)
-
-	// Check if we can push to main table
-	useMain, _ := classifyPredicate(c, meta)
-	if !useMain {
-		if meta.ColumnBinding == nil {
-			return nil, false, nil
-		}
-		return nil, false, fmt.Errorf("unsupported operator: %s", opVal.op)
+	if p.Skip {
+		return "", nil, nil
 	}
-	if meta.ColumnBinding == nil {
-		return nil, false, nil
-	}
-
-	sqlOpResult, err := toSQLOperator(opVal.op, opVal.value)
-	if err != nil {
-		return nil, false, err
-	}
-
-	parsedValue, err := ConvertPgMainValue(sqlOpResult.value, c.Attr, meta)
-	if err != nil {
-		return nil, false, err
-	}
-	return parsedValue, true, nil
-}
-
-func (e *pgMainLeafEmitter) EmitLeaf(c *forma.KvCondition) (string, []any, error) {
-	parsedValue, emit, err := pgMainLeafValue(c, e.cache)
-	if err != nil || !emit {
-		return "", nil, err
-	}
-
-	meta := e.cache[c.Attr]
-	opVal := parseOperatorValue(c.Value)
-	sqlOpResult, err := toSQLOperator(opVal.op, opVal.value)
-	if err != nil {
-		return "", nil, err
-	}
-	colName := resolveMainTableColumn(c.Attr, meta)
 
 	*e.paramIndex++
 	ph := fmt.Sprintf("$%d", *e.paramIndex)
-	sql := fmt.Sprintf("%s %s %s", colName, sqlOpResult.sqlOp, ph)
-	return sql, []any{parsedValue}, nil
+	sql := fmt.Sprintf("%s %s %s", p.Column, p.SQLOp, ph)
+	return sql, []any{p.Value}, nil
+}
+
+// pgMainClauseFromTree walks an already-normalized predicate tree and emits
+// a WHERE fragment targeting entity_main (m.*), advancing paramIndex.
+func pgMainClauseFromTree(tree PredicateNode, paramIndex *int) (string, []any, error) {
+	emitter := &pgMainTypedEmitter{paramIndex: paramIndex}
+	return walkPredicate(tree, pgMainStyle, pgMainTypedGuard{}, emitter)
 }
 
 // buildPgMainClause traverses the condition tree and emits a WHERE fragment targeting entity_main (m.*)
@@ -214,88 +113,36 @@ func buildPgMainClause(cond forma.Condition, cache forma.SchemaAttributeCache, p
 	if cond == nil {
 		return "", nil, nil
 	}
-	guard := &pgMainGuard{cache: cache}
-	emitter := &pgMainLeafEmitter{cache: cache, paramIndex: paramIndex}
-	return walkCondition(cond, pgMainStyle, guard, emitter)
+	return pgMainClauseFromTree(normalizePredicates(cond, cache, targetPgMain), paramIndex)
 }
 
 func BuildPgMainClause(cond forma.Condition, cache forma.SchemaAttributeCache, paramIndex *int) (string, []any, error) {
 	return buildPgMainClause(cond, cache, paramIndex)
 }
 
-// duckLeafEmitter renders KvCondition leaves for DuckDB with ? placeholders and CAST expressions.
-type duckLeafEmitter struct {
-	cache forma.SchemaAttributeCache
+// duckTypedEmitter renders typed predicate leaves for DuckDB with ? placeholders and CAST expressions.
+type duckTypedEmitter struct{}
+
+func (duckTypedEmitter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, error) {
+	p := leaf.Duck
+	if p.Err != nil {
+		return "", nil, p.Err
+	}
+
+	if p.TextLike {
+		clause := fmt.Sprintf("%s %s ?", p.Column, p.SQLOp)
+		return clause, []any{p.Param}, nil
+	}
+
+	castExpr := CastExpression("?", p.ValueType)
+	clause := fmt.Sprintf("%s %s %s", p.Column, p.SQLOp, castExpr)
+	return clause, []any{p.Param}, nil
 }
 
-// duckLeafParts is the shape/value decomposition of a DuckDB leaf shared by
-// the string emitter and the plan binder (#142).
-type duckLeafParts struct {
-	sqlOp     string
-	valueType forma.ValueType
-	textLike  bool // emit `col op ?` with the string value (LIKE or text type)
-	param     any
-}
-
-// duckLeafValue is the value core shared by the string emitter and the plan
-// binder: operator/type/param decisions live here exactly once.
-func duckLeafValue(c *forma.KvCondition, cache forma.SchemaAttributeCache) (duckLeafParts, error) {
-	opVal := parseOperatorValue(c.Value)
-
-	sqlOpResult, err := toSQLOperator(opVal.op, opVal.value)
-	if err != nil {
-		return duckLeafParts{}, err
-	}
-
-	var meta forma.AttributeMetadata
-	var hasMeta bool
-	if m, ok := cache[c.Attr]; ok {
-		meta = m
-		hasMeta = true
-	}
-
-	if sqlOpResult.sqlOp == "LIKE" {
-		return duckLeafParts{sqlOp: sqlOpResult.sqlOp, textLike: true, param: sqlOpResult.value}, nil
-	}
-
-	var valueType forma.ValueType
-	if hasMeta {
-		valueType = meta.ValueType
-	} else {
-		valueType = detectValueType(sqlOpResult.value)
-	}
-
-	if valueType == forma.ValueTypeText {
-		return duckLeafParts{sqlOp: sqlOpResult.sqlOp, valueType: valueType, textLike: true, param: sqlOpResult.value}, nil
-	}
-
-	rawParam, err := parseDuckDBRawParam(sqlOpResult.value, c.Attr, valueType)
-	if err != nil {
-		return duckLeafParts{}, err
-	}
-	param, err := ToDuckDBParam(rawParam, valueType)
-	if err != nil {
-		return duckLeafParts{}, fmt.Errorf("to duckdb param: %w", err)
-	}
-	return duckLeafParts{sqlOp: sqlOpResult.sqlOp, valueType: valueType, param: param}, nil
-}
-
-func (e *duckLeafEmitter) EmitLeaf(c *forma.KvCondition) (string, []any, error) {
-	parts, err := duckLeafValue(c, e.cache)
-	if err != nil {
-		return "", nil, err
-	}
-
-	colName := resolveDuckDBColumn(c.Attr, e.cache)
-
-	if parts.textLike {
-		clause := fmt.Sprintf("%s %s ?", colName, parts.sqlOp)
-		return clause, []any{parts.param}, nil
-	}
-
-	castExpr := CastExpression("?", parts.valueType)
-	clause := fmt.Sprintf("%s %s %s", colName, parts.sqlOp, castExpr)
-	return clause, []any{parts.param}, nil
+// duckClauseFromTree walks an already-normalized predicate tree and produces
+// a DuckDB-compatible WHERE clause.
+func duckClauseFromTree(tree PredicateNode) (string, []any, error) {
+	return walkPredicate(tree, duckStyle, nil, duckTypedEmitter{})
 }
 
 // buildDuckClause traverses the condition tree and produces a DuckDB-compatible WHERE clause.
@@ -303,8 +150,7 @@ func buildDuckClause(cond forma.Condition, cache forma.SchemaAttributeCache) (st
 	if cond == nil {
 		return "1=1", nil, nil
 	}
-	emitter := &duckLeafEmitter{cache: cache}
-	return walkCondition(cond, duckStyle, nil, emitter)
+	return duckClauseFromTree(normalizePredicates(cond, cache, targetDuck))
 }
 
 func BuildDuckClause(cond forma.Condition, cache forma.SchemaAttributeCache) (string, []any, error) {

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -10,50 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
-	"github.com/lychee-technology/forma/internal/conditionexpr"
 )
-
-// operatorValuePair holds a parsed operator and value from a kv condition value string.
-type operatorValuePair struct {
-	op    string
-	value string
-}
-
-// parseOperatorValue extracts operator and value from "op:value" format.
-// If no colon is found, defaults to "equals" operator with full string as value.
-func parseOperatorValue(kvValue string) operatorValuePair {
-	parsed := conditionexpr.ParseOperatorValueLenient(kvValue)
-	return operatorValuePair{op: parsed.Operator, value: parsed.Value}
-}
-
-// parseOperatorValueStrict validates "op:value" format when a separator is present.
-// It returns an error when either side is empty to avoid ambiguous predicates.
-func parseOperatorValueStrict(kvValue string) (operatorValuePair, error) {
-	parsed, err := conditionexpr.ParseOperatorValueStrict(kvValue)
-	if err != nil {
-		return operatorValuePair{}, err
-	}
-	return operatorValuePair{op: parsed.Operator, value: parsed.Value}, nil
-}
-
-// sqlOperatorResult holds the SQL operator and possibly modified value for LIKE patterns.
-type sqlOperatorResult struct {
-	sqlOp string
-	value string
-}
-
-// toSQLOperator converts a string operator to SQL operator syntax.
-// For LIKE operators, it also modifies the value to include wildcards.
-func toSQLOperator(op, value string) (sqlOperatorResult, error) {
-	normalized, err := conditionexpr.ToSQLOperator(op, value)
-	if err != nil {
-		return sqlOperatorResult{}, err
-	}
-	return sqlOperatorResult{
-		sqlOp: normalized.SQLOperator,
-		value: normalized.Value,
-	}, nil
-}
 
 // ConvertPgMainValue converts a string value to the appropriate Go type based
 // on attribute metadata. It is the canonical value converter for Postgres

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -1,0 +1,434 @@
+package sqlgen
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// characterizationCache covers every storage/encoding combination the three
+// emitters treat differently: bound/unbound text, integer, numeric, bool
+// (int/text encodings), date (unix-ms/ISO8601 encodings), datetime, uuid.
+func characterizationCache() forma.SchemaAttributeCache {
+	return forma.SchemaAttributeCache{
+		"username": {AttributeID: 1, ValueType: forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_01")}},
+		"age": {AttributeID: 2, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("integer_01")}},
+		"score": {AttributeID: 3, ValueType: forma.ValueTypeNumeric},
+		"tag":   {AttributeID: 4, ValueType: forma.ValueTypeText},
+		"active": {AttributeID: 5, ValueType: forma.ValueTypeBool,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("bool_01"), Encoding: forma.MainColumnEncodingBoolInt}},
+		"verified": {AttributeID: 6, ValueType: forma.ValueTypeBool,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_02"), Encoding: forma.MainColumnEncodingBoolText}},
+		"flag": {AttributeID: 7, ValueType: forma.ValueTypeBool},
+		"born": {AttributeID: 8, ValueType: forma.ValueTypeDate,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("bigint_01"), Encoding: forma.MainColumnEncodingUnixMs}},
+		"joined": {AttributeID: 9, ValueType: forma.ValueTypeDateTime,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_03"), Encoding: forma.MainColumnEncodingISO8601}},
+		"seen": {AttributeID: 10, ValueType: forma.ValueTypeDateTime},
+		"ref":  {AttributeID: 11, ValueType: forma.ValueTypeUUID},
+	}
+}
+
+func charKv(attr, value string) forma.Condition { return &forma.KvCondition{Attr: attr, Value: value} }
+
+func charAnd(cs ...forma.Condition) forma.Condition {
+	return &forma.CompositeCondition{Logic: forma.LogicAnd, Conditions: cs}
+}
+
+func charOr(cs ...forma.Condition) forma.Condition {
+	return &forma.CompositeCondition{Logic: forma.LogicOr, Conditions: cs}
+}
+
+const charEXISTS = "EXISTS (SELECT 1 FROM eav_table x WHERE x.schema_id = e.schema_id AND x.row_id = e.row_id AND x.attr_id = "
+
+func charEavClause(attrPh, valueColumn, sqlOp, valuePh string) string {
+	return charEXISTS + attrPh + " AND x." + valueColumn + " " + sqlOp + " " + valuePh + ")"
+}
+
+// TestToDualClauses_Characterization locks the exact clause bytes, argument
+// values (including Go types), and paramIndex advancement of the three
+// emitters for the full storage/encoding matrix. Any parse-once refactor
+// must keep every case byte- and type-identical.
+func TestToDualClauses_Characterization(t *testing.T) {
+	cache := characterizationCache()
+
+	iso := "2024-01-02T03:04:05Z"
+	isoTime := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		cond forma.Condition
+		want DualClauses
+		span int // expected paramIndex advancement
+	}{
+		{
+			name: "text equals bound",
+			cond: charKv("username", "equals:Alice"),
+			want: DualClauses{
+				PgMainClause: "m.text_01 = $1", PgMainArgs: []any{"Alice"},
+				PgClause: charEavClause("$2", "value_text", "=", "$3"), PgArgs: []any{int16(1), "Alice"},
+				DuckClause: "text_01 = ?", DuckArgs: []any{"Alice"},
+			},
+			span: 3,
+		},
+		{
+			name: "text bare value defaults to equals",
+			cond: charKv("username", "Alice"),
+			want: DualClauses{
+				PgMainClause: "m.text_01 = $1", PgMainArgs: []any{"Alice"},
+				PgClause: charEavClause("$2", "value_text", "=", "$3"), PgArgs: []any{int16(1), "Alice"},
+				DuckClause: "text_01 = ?", DuckArgs: []any{"Alice"},
+			},
+			span: 3,
+		},
+		{
+			name: "text equals unbound goes EAV only",
+			cond: charKv("tag", "equals:x"),
+			want: DualClauses{
+				PgMainClause: "", PgMainArgs: nil,
+				PgClause: charEavClause("$1", "value_text", "=", "$2"), PgArgs: []any{int16(4), "x"},
+				DuckClause: "tag = ?", DuckArgs: []any{"x"},
+			},
+			span: 2,
+		},
+		{
+			name: "starts_with wildcards suffix",
+			cond: charKv("username", "starts_with:Al"),
+			want: DualClauses{
+				PgMainClause: "m.text_01 LIKE $1", PgMainArgs: []any{"Al%"},
+				PgClause: charEavClause("$2", "value_text", "LIKE", "$3"), PgArgs: []any{int16(1), "Al%"},
+				DuckClause: "text_01 LIKE ?", DuckArgs: []any{"Al%"},
+			},
+			span: 3,
+		},
+		{
+			name: "contains wildcards both sides",
+			cond: charKv("tag", "contains:mid"),
+			want: DualClauses{
+				PgMainClause: "", PgMainArgs: nil,
+				PgClause: charEavClause("$1", "value_text", "LIKE", "$2"), PgArgs: []any{int16(4), "%mid%"},
+				DuckClause: "tag LIKE ?", DuckArgs: []any{"%mid%"},
+			},
+			span: 2,
+		},
+		{
+			name: "integer gt: main int64, eav float64, duck float64",
+			cond: charKv("age", "gt:30"),
+			want: DualClauses{
+				PgMainClause: "m.integer_01 > $1", PgMainArgs: []any{int64(30)},
+				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), float64(30)},
+				DuckClause: "integer_01 > CAST(? AS INTEGER)", DuckArgs: []any{float64(30)},
+			},
+			span: 3,
+		},
+		{
+			name: "numeric unbound: duck binds decimal string",
+			cond: charKv("score", "lt:3.5"),
+			want: DualClauses{
+				PgMainClause: "", PgMainArgs: nil,
+				PgClause: charEavClause("$1", "value_numeric", "<", "$2"), PgArgs: []any{int16(3), 3.5},
+				DuckClause: "score < CAST(? AS DECIMAL(38,10))", DuckArgs: []any{"3.5"},
+			},
+			span: 2,
+		},
+		{
+			name: "big integral: main keeps int64 beyond 2^53, eav/duck lose to float64",
+			cond: charKv("age", "equals:9007199254740993"),
+			want: DualClauses{
+				PgMainClause: "m.integer_01 = $1", PgMainArgs: []any{int64(9007199254740993)},
+				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), float64(9007199254740992)},
+				DuckClause: "integer_01 = CAST(? AS INTEGER)", DuckArgs: []any{float64(9007199254740992)},
+			},
+			span: 3,
+		},
+		{
+			name: "bool bool-int encoding: main int64(1), eav float64(1), duck true",
+			cond: charKv("active", "equals:1"),
+			want: DualClauses{
+				PgMainClause: "m.bool_01 = $1", PgMainArgs: []any{int64(1)},
+				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(5), float64(1)},
+				DuckClause: "bool_01 = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
+			},
+			span: 3,
+		},
+		{
+			name: "bool bool-text encoding zero: main \"0\", eav float64(0), duck false",
+			cond: charKv("verified", "equals:0"),
+			want: DualClauses{
+				PgMainClause: "m.text_02 = $1", PgMainArgs: []any{"0"},
+				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(6), float64(0)},
+				DuckClause: "text_02 = CAST(? AS BOOLEAN)", DuckArgs: []any{false},
+			},
+			span: 3,
+		},
+		{
+			name: "bool unbound: eav float64, duck true",
+			cond: charKv("flag", "equals:1"),
+			want: DualClauses{
+				PgMainClause: "", PgMainArgs: nil,
+				PgClause: charEavClause("$1", "value_numeric", "=", "$2"), PgArgs: []any{int16(7), float64(1)},
+				DuckClause: "flag = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
+			},
+			span: 2,
+		},
+		{
+			name: "date unix-ms encoding: main/eav int64 ms, duck time.Time",
+			cond: charKv("born", "gte:1700000000000"),
+			want: DualClauses{
+				PgMainClause: "m.bigint_01 >= $1", PgMainArgs: []any{int64(1700000000000)},
+				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(8), int64(1700000000000)},
+				DuckClause: "bigint_01 >= CAST(? AS TIMESTAMP)", DuckArgs: []any{time.UnixMilli(1700000000000).UTC()},
+			},
+			span: 3,
+		},
+		{
+			name: "datetime ISO8601 encoding: main/eav bind ISO string, duck time.Time",
+			cond: charKv("joined", "gte:" + iso),
+			want: DualClauses{
+				PgMainClause: "m.text_03 >= $1", PgMainArgs: []any{iso},
+				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(9), iso},
+				DuckClause: "text_03 >= CAST(? AS TIMESTAMP)", DuckArgs: []any{isoTime},
+			},
+			span: 3,
+		},
+		{
+			name: "datetime unbound: eav unix-ms int64, duck time.Time",
+			cond: charKv("seen", "gte:" + iso),
+			want: DualClauses{
+				PgMainClause: "", PgMainArgs: nil,
+				PgClause: charEavClause("$1", "value_numeric", ">=", "$2"), PgArgs: []any{int16(10), int64(1704164645000)},
+				DuckClause: "seen >= CAST(? AS TIMESTAMP)", DuckArgs: []any{isoTime},
+			},
+			span: 2,
+		},
+		{
+			name: "uuid equals unbound: eav value_text, duck VARCHAR cast",
+			cond: charKv("ref", "equals:0b210f52-1f4d-4f47-9799-1e2f2c0efc07"),
+			want: DualClauses{
+				PgMainClause: "", PgMainArgs: nil,
+				PgClause: charEavClause("$1", "value_text", "=", "$2"), PgArgs: []any{int16(11), "0b210f52-1f4d-4f47-9799-1e2f2c0efc07"},
+				DuckClause: "ref = CAST(? AS VARCHAR)", DuckArgs: []any{"0b210f52-1f4d-4f47-9799-1e2f2c0efc07"},
+			},
+			span: 2,
+		},
+		{
+			name: "AND(main leaf, vetoed OR): pg-main keeps only pushable branch",
+			cond: charAnd(charKv("username", "equals:Alice"), charOr(charKv("age", "gt:18"), charKv("tag", "equals:x"))),
+			want: DualClauses{
+				PgMainClause: "(m.text_01 = $1)", PgMainArgs: []any{"Alice"},
+				PgClause: "((" + charEavClause("$2", "value_text", "=", "$3") + ") AND (((" +
+					charEavClause("$4", "value_numeric", ">", "$5") + ") OR (" +
+					charEavClause("$6", "value_text", "=", "$7") + "))))",
+				PgArgs:     []any{int16(1), "Alice", int16(2), float64(18), int16(4), "x"},
+				DuckClause: "(text_01 = ?) AND ((integer_01 > CAST(? AS INTEGER)) OR (tag = ?))",
+				DuckArgs:   []any{"Alice", float64(18), "x"},
+			},
+			span: 7,
+		},
+		{
+			name: "OR all pushable emits pg-main prefilter",
+			cond: charOr(charKv("username", "equals:A"), charKv("age", "gt:5")),
+			want: DualClauses{
+				PgMainClause: "((m.text_01 = $1) OR (m.integer_01 > $2))", PgMainArgs: []any{"A", int64(5)},
+				PgClause: "((" + charEavClause("$3", "value_text", "=", "$4") + ") OR (" +
+					charEavClause("$5", "value_numeric", ">", "$6") + "))",
+				PgArgs:     []any{int16(1), "A", int16(2), float64(5)},
+				DuckClause: "(text_01 = ?) OR (integer_01 > CAST(? AS INTEGER))",
+				DuckArgs:   []any{"A", float64(5)},
+			},
+			span: 6,
+		},
+		{
+			name: "AND of two main predicates on same column",
+			cond: charAnd(charKv("age", "gt:10"), charKv("age", "lt:90")),
+			want: DualClauses{
+				PgMainClause: "((m.integer_01 > $1) AND (m.integer_01 < $2))", PgMainArgs: []any{int64(10), int64(90)},
+				PgClause: "((" + charEavClause("$3", "value_numeric", ">", "$4") + ") AND (" +
+					charEavClause("$5", "value_numeric", "<", "$6") + "))",
+				PgArgs:     []any{int16(2), float64(10), int16(2), float64(90)},
+				DuckClause: "(integer_01 > CAST(? AS INTEGER)) AND (integer_01 < CAST(? AS INTEGER))",
+				DuckArgs:   []any{float64(10), float64(90)},
+			},
+			span: 6,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			paramIndex := 0
+			dc, err := ToDualClauses(tc.cond, "eav_table", 7, cache, &paramIndex)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, dc)
+			require.Equal(t, tc.span, paramIndex, "paramIndex advancement")
+
+			// Plan+Bind must reproduce the direct path exactly for every case.
+			plan, err := PlanDualClauses(tc.cond, "eav_table", 7, cache, 0)
+			require.NoError(t, err)
+			bound := 0
+			got, err := plan.Bind(tc.cond, cache, &bound)
+			require.NoError(t, err)
+			require.Equal(t, dc, got)
+			require.Equal(t, paramIndex, bound)
+		})
+	}
+}
+
+// TestToDualClauses_Characterization_Errors locks the error surface: which
+// generator reports first (pg-main runs before EAV), the exact message, and
+// the strict-vs-lenient parse split between entrypoints.
+func TestToDualClauses_Characterization_Errors(t *testing.T) {
+	cache := characterizationCache()
+
+	cases := []struct {
+		name    string
+		cond    forma.Condition
+		wantErr string
+	}{
+		{
+			// classifyPredicate splits the raw value at the first colon, so a
+			// bare ISO timestamp reads as an unknown operator and vetoes the
+			// bound date column with an error (not a silent skip).
+			name:    "bare ISO on bound date errors in pg-main",
+			cond:    charKv("born", "2024-01-02T03:04:05Z"),
+			wantErr: "pg main generation: unsupported operator: equals",
+		},
+		{
+			// neq is canonicalized by ToSQLOperator but NOT by
+			// classifyPredicate, so it is unpushable on a bound column.
+			name:    "neq alias on bound column errors in pg-main",
+			cond:    charKv("age", "neq:7"),
+			wantErr: "pg main generation: unsupported operator: neq",
+		},
+		{
+			// Strict parse splits at the colon: op "2024-01-02T03" passes the
+			// non-empty check, then the value "04:05Z" fails date parsing.
+			name:    "bare ISO on unbound datetime errors in EAV date parse",
+			cond:    charKv("seen", "2024-01-02T03:04:05Z"),
+			wantErr: "pg sql generation: invalid date value for 'seen': invalid date value: expected ISO 8601 format or unix milliseconds, got '04:05Z'",
+		},
+		{
+			name:    "empty value after operator fails strict EAV parse",
+			cond:    charKv("tag", "equals:"),
+			wantErr: "pg sql generation: invalid KvCondition value format: equals:",
+		},
+		{
+			name:    "unknown attribute errors in EAV",
+			cond:    charKv("ghost", "equals:1"),
+			wantErr: "pg sql generation: attribute not found in cache: ghost",
+		},
+		{
+			name:    "LIKE on uuid rejected by EAV whitelist",
+			cond:    charKv("ref", "starts_with:0b"),
+			wantErr: "pg sql generation: operator 'starts_with' only supported for text attributes, not 'uuid'",
+		},
+		{
+			name:    "gt on unbound bool rejected by EAV whitelist",
+			cond:    charKv("flag", "gt:1"),
+			wantErr: "pg sql generation: operator 'gt' not supported for boolean attributes",
+		},
+		{
+			name:    "gt on bound bool rejected by pg-main",
+			cond:    charKv("active", "gt:1"),
+			wantErr: "pg main generation: unsupported operator: gt",
+		},
+		{
+			name:    "nil child in composite errors in EAV",
+			cond:    charAnd(charKv("username", "equals:Alice"), nil),
+			wantErr: "pg sql generation: nil condition not allowed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			paramIndex := 0
+			_, err := ToDualClauses(tc.cond, "eav_table", 7, cache, &paramIndex)
+			require.Error(t, err)
+			require.Equal(t, tc.wantErr, err.Error())
+		})
+	}
+}
+
+// TestStandaloneBuilders_Characterization locks the lenient semantics of the
+// standalone BuildDuckClause / BuildPgMainClause entrypoints, which must NOT
+// inherit the EAV path's strict parse or its error surface.
+func TestStandaloneBuilders_Characterization(t *testing.T) {
+	cache := characterizationCache()
+	isoTime := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+	t.Run("duck lenient keeps malformed pair as equals(raw)", func(t *testing.T) {
+		clause, args, err := BuildDuckClause(charKv("tag", "equals:"), cache)
+		require.NoError(t, err)
+		require.Equal(t, "tag = ?", clause)
+		require.Equal(t, []any{"equals:"}, args)
+	})
+
+	t.Run("duck nil child renders 1=1", func(t *testing.T) {
+		clause, args, err := BuildDuckClause(charAnd(charKv("username", "equals:Alice"), nil), cache)
+		require.NoError(t, err)
+		require.Equal(t, "(text_01 = ?) AND (1=1)", clause)
+		require.Equal(t, []any{"Alice"}, args)
+	})
+
+	t.Run("duck no-metadata inference matrix", func(t *testing.T) {
+		cases := []struct {
+			name       string
+			value      string
+			wantClause string
+			wantArgs   []any
+		}{
+			{"numeric literal", "equals:42", "ghost = CAST(? AS DECIMAL(38,10))", []any{"42"}},
+			{"bool literal", "equals:true", "ghost = CAST(? AS BOOLEAN)", []any{true}},
+			{"uuid literal", "equals:0b210f52-1f4d-4f47-9799-1e2f2c0efc07", "ghost = CAST(? AS VARCHAR)", []any{"0b210f52-1f4d-4f47-9799-1e2f2c0efc07"}},
+			{"iso literal", "gte:2024-01-02T03:04:05Z", "ghost >= CAST(? AS TIMESTAMP)", []any{isoTime}},
+			{"bare iso literal", "2024-01-02T03:04:05Z", "ghost = CAST(? AS TIMESTAMP)", []any{isoTime}},
+			{"text literal", "equals:hello", "ghost = ?", []any{"hello"}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				clause, args, err := BuildDuckClause(charKv("ghost", tc.value), cache)
+				require.NoError(t, err)
+				require.Equal(t, tc.wantClause, clause)
+				require.Equal(t, tc.wantArgs, args)
+			})
+		}
+	})
+
+	t.Run("pg-main nil child skipped silently", func(t *testing.T) {
+		idx := 0
+		clause, args, err := BuildPgMainClause(charAnd(charKv("username", "equals:Alice"), nil), cache, &idx)
+		require.NoError(t, err)
+		require.Equal(t, "(m.text_01 = $1)", clause)
+		require.Equal(t, []any{"Alice"}, args)
+		require.Equal(t, 1, idx)
+	})
+
+	t.Run("pg-main unbound attr with strict-invalid value skipped without error", func(t *testing.T) {
+		idx := 0
+		clause, args, err := BuildPgMainClause(charKv("tag", "equals:"), cache, &idx)
+		require.NoError(t, err)
+		require.Equal(t, "", clause)
+		require.Nil(t, args)
+		require.Equal(t, 0, idx)
+	})
+
+	t.Run("pg-main nested OR veto cascades from inner AND", func(t *testing.T) {
+		idx := 0
+		cond := charOr(charKv("age", "gt:18"), charAnd(charKv("username", "equals:A"), charKv("tag", "equals:x")))
+		clause, args, err := BuildPgMainClause(cond, cache, &idx)
+		require.NoError(t, err)
+		require.Equal(t, "", clause)
+		require.Nil(t, args)
+		require.Equal(t, 0, idx)
+	})
+
+	t.Run("pg-main bound bool gt surfaces error", func(t *testing.T) {
+		idx := 0
+		_, _, err := BuildPgMainClause(charKv("active", "gt:1"), cache, &idx)
+		require.Error(t, err)
+		require.Equal(t, "unsupported operator: gt", err.Error())
+	})
+}

--- a/internal/sqlgen/predicate_ir.go
+++ b/internal/sqlgen/predicate_ir.go
@@ -1,0 +1,136 @@
+package sqlgen
+
+import (
+	"github.com/lychee-technology/forma"
+)
+
+// PredicateNode is a node in the typed predicate tree produced by
+// normalizePredicates (#143). The tree mirrors the forma.Condition AST
+// one-to-one — composites become PredicateGroup, KvCondition leaves become
+// PredicateLeaf, and nil / unknown-type nodes keep dedicated markers — so
+// each walk style retains its distinct handling (error, skip, identity).
+type PredicateNode interface{ isPredicateNode() }
+
+// PredicateOperator is the canonical logical operator of a leaf, derived
+// from the lenient "op:value" parse. Unknown tokens are kept verbatim; the
+// per-target payloads carry any resulting error.
+type PredicateOperator string
+
+const (
+	PredicateOpEquals     PredicateOperator = "equals"
+	PredicateOpNotEquals  PredicateOperator = "not_equals"
+	PredicateOpGt         PredicateOperator = "gt"
+	PredicateOpGte        PredicateOperator = "gte"
+	PredicateOpLt         PredicateOperator = "lt"
+	PredicateOpLte        PredicateOperator = "lte"
+	PredicateOpStartsWith PredicateOperator = "starts_with"
+	PredicateOpContains   PredicateOperator = "contains"
+)
+
+// PatternKind classifies the LIKE wildcard normalization applied to a value.
+type PatternKind int
+
+const (
+	PatternKindNone     PatternKind = iota
+	PatternKindPrefix               // starts_with -> "value%"
+	PatternKindContains             // contains -> "%value%"
+)
+
+// PredicateStorage says which physical storage a leaf resolves to.
+type PredicateStorage int
+
+const (
+	PredicateStorageEAV PredicateStorage = iota
+	PredicateStorageMain
+)
+
+// PredicateGroup mirrors a CompositeCondition.
+type PredicateGroup struct {
+	Logic    forma.Logic
+	Children []PredicateNode
+	// FullyPushable reports whether every leaf under this group can be
+	// pushed to entity_main. The pg-main walker reads it to veto partial
+	// OR branches without re-walking the subtree.
+	FullyPushable bool
+	// Source is the composite this group was normalized from, kept for the
+	// legacy CompositeGuard contract.
+	Source *forma.CompositeCondition
+}
+
+func (*PredicateGroup) isPredicateNode() {}
+
+// PredicateLeaf is a KvCondition parsed exactly once: attribute metadata,
+// operator normalization, and the converted values for all three emission
+// targets. Target payloads are computed per the entrypoint's target set and
+// keep their own error so strict/lenient parse policies stay per-target.
+type PredicateLeaf struct {
+	// Attr is the original attribute name; Source the leaf it came from.
+	Attr   string
+	Source *forma.KvCondition
+
+	// HasMeta / Meta carry the schema cache lookup result (AttributeID,
+	// ValueType, ColumnBinding).
+	HasMeta bool
+	Meta    forma.AttributeMetadata
+
+	// Operator is the canonical lenient-parse operator; SQLOperator its SQL
+	// form and Pattern the LIKE wildcarding, both zero when the operator is
+	// unknown (the payloads carry the error).
+	Operator    PredicateOperator
+	SQLOperator string
+	Pattern     PatternKind
+
+	// Storage and Pushable summarize main-table placement: Storage is where
+	// the leaf's value lives, Pushable whether pg-main may push it down.
+	Storage  PredicateStorage
+	Pushable bool
+
+	PgEav  PgEavLeafPayload
+	PgMain PgMainLeafPayload
+	Duck   DuckLeafPayload
+}
+
+func (*PredicateLeaf) isPredicateNode() {}
+
+// PgEavLeafPayload is the EAV EXISTS emission payload (strict parse policy).
+type PgEavLeafPayload struct {
+	Err         error
+	AttrID      int16
+	ValueColumn string
+	SQLOp       string
+	Value       any
+}
+
+// PgMainLeafPayload is the entity_main pushdown payload (lenient parse
+// policy). Skip marks leaves pg-main silently drops (unknown attribute or
+// no column binding).
+type PgMainLeafPayload struct {
+	Err    error
+	Skip   bool
+	Column string
+	SQLOp  string
+	Value  any
+}
+
+// DuckLeafPayload is the DuckDB emission payload (lenient parse policy).
+// TextLike leaves bind the string value without a CAST wrapper.
+type DuckLeafPayload struct {
+	Err       error
+	Column    string
+	SQLOp     string
+	ValueType forma.ValueType
+	TextLike  bool
+	Param     any
+}
+
+// predicateNilNode marks a nil condition (top-level or composite child);
+// each style resolves it via its nilNode behavior.
+type predicateNilNode struct{}
+
+func (predicateNilNode) isPredicateNode() {}
+
+// predicateInvalidNode preserves the walker's lazy "unsupported condition
+// type" error for condition implementations the normalizer does not know.
+type predicateInvalidNode struct{ err error }
+
+func (predicateInvalidNode) isPredicateNode() {}

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -1,0 +1,316 @@
+package sqlgen
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/conditionexpr"
+	"github.com/lychee-technology/forma/internal/numutil"
+)
+
+// normalizeTargets selects which per-target payloads normalizePredicates
+// computes, so standalone entrypoints do not pay for backends they never
+// emit.
+type normalizeTargets uint8
+
+const (
+	targetPgEav normalizeTargets = 1 << iota
+	targetPgMain
+	targetDuck
+
+	targetsNone normalizeTargets = 0
+	targetsAll                   = targetPgEav | targetPgMain | targetDuck
+)
+
+// normalizePredicates converts a forma.Condition into the typed predicate
+// tree consumed by walkPredicate. It is the parse-once layer of #143: every
+// "op:value" parse, metadata lookup, operator whitelist check, and target
+// value conversion happens here exactly once per leaf. Structural oddities
+// (nil nodes, unknown condition types) are preserved as dedicated nodes so
+// each walk style keeps its lazy, per-target semantics.
+func normalizePredicates(cond forma.Condition, cache forma.SchemaAttributeCache, targets normalizeTargets) PredicateNode {
+	if cond == nil {
+		return predicateNilNode{}
+	}
+	switch c := cond.(type) {
+	case *forma.CompositeCondition:
+		group := &PredicateGroup{Logic: c.Logic, Source: c, FullyPushable: true}
+		for _, child := range c.Conditions {
+			node := normalizePredicates(child, cache, targets)
+			group.Children = append(group.Children, node)
+			if !nodeFullyPushable(node) {
+				group.FullyPushable = false
+			}
+		}
+		return group
+	case *forma.KvCondition:
+		return normalizeLeaf(c, cache, targets)
+	default:
+		return predicateInvalidNode{err: fmt.Errorf("unsupported condition type %T", cond)}
+	}
+}
+
+func nodeFullyPushable(node PredicateNode) bool {
+	switch n := node.(type) {
+	case *PredicateGroup:
+		return n.FullyPushable
+	case *PredicateLeaf:
+		return n.Pushable
+	default:
+		return false
+	}
+}
+
+func normalizeLeaf(kv *forma.KvCondition, cache forma.SchemaAttributeCache, targets normalizeTargets) *PredicateLeaf {
+	leaf := &PredicateLeaf{Attr: kv.Attr, Source: kv}
+
+	meta, hasMeta := cache[kv.Attr]
+	leaf.HasMeta = hasMeta
+	leaf.Meta = meta
+	if hasMeta && meta.ColumnBinding != nil {
+		leaf.Storage = PredicateStorageMain
+	}
+
+	lenient := conditionexpr.ParseOperatorValueLenient(kv.Value)
+	leaf.Operator = PredicateOperator(conditionexpr.CanonicalOperator(lenient.Operator))
+	lenientSQL, lenientSQLErr := conditionexpr.ToSQLOperator(lenient.Operator, lenient.Value)
+	if lenientSQLErr == nil {
+		leaf.SQLOperator = lenientSQL.SQLOperator
+		switch leaf.Operator {
+		case PredicateOpStartsWith:
+			leaf.Pattern = PatternKindPrefix
+		case PredicateOpContains:
+			leaf.Pattern = PatternKindContains
+		}
+	}
+
+	var classifyOK bool
+	if hasMeta {
+		classifyOK, _ = classifyPredicate(kv, meta)
+	}
+	leaf.Pushable = hasMeta && meta.ColumnBinding != nil && classifyOK
+
+	if targets&targetPgEav != 0 {
+		leaf.PgEav = normalizePgEavPayload(kv, meta, hasMeta)
+	}
+	if targets&targetPgMain != 0 {
+		leaf.PgMain = normalizePgMainPayload(kv, meta, hasMeta, classifyOK, lenient, lenientSQL, lenientSQLErr)
+	}
+	if targets&targetDuck != 0 {
+		leaf.Duck = normalizeDuckPayload(kv, cache, meta, hasMeta, lenientSQL, lenientSQLErr)
+	}
+	return leaf
+}
+
+// classifyPredicate returns whether a KvCondition can be pushed to main table based on metadata.
+// Note it splits the raw value at the first colon itself (no lenient date
+// fallback, no alias canonicalization) — bare ISO timestamps and alias
+// operators like "neq" therefore classify as unpushable.
+func classifyPredicate(kv *forma.KvCondition, meta forma.AttributeMetadata) (bool, string) {
+	if meta.ColumnBinding == nil {
+		return false, "no column binding"
+	}
+
+	// Simple operator extraction
+	opPart := ""
+	valPart := ""
+	if idx := strings.Index(kv.Value, ":"); idx >= 0 {
+		opPart = kv.Value[:idx]
+		valPart = kv.Value[idx+1:]
+	}
+	opStr := "equals"
+	if opPart != "" && valPart != "" {
+		opStr = opPart
+	}
+
+	// Decide based on value type and operator
+	switch meta.ValueType {
+	case forma.ValueTypeText, forma.ValueTypeUUID:
+		if opStr == "equals" || opStr == "starts_with" || opStr == "contains" {
+			return true, "text supported"
+		}
+		return false, "text operator not supported"
+	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
+		switch opStr {
+		case "equals", "gt", "gte", "lt", "lte", "not_equals":
+			return true, "numeric supported"
+		default:
+			return false, "numeric operator not supported"
+		}
+	case forma.ValueTypeDate, forma.ValueTypeDateTime:
+		switch opStr {
+		case "equals", "gt", "gte", "lt", "lte", "not_equals":
+			return true, "date supported"
+		default:
+			return false, "date operator not supported"
+		}
+	case forma.ValueTypeBool:
+		if opStr == "equals" || opStr == "not_equals" {
+			return true, "bool supported"
+		}
+		return false, "bool operator not supported"
+	default:
+		return false, "unknown value type"
+	}
+}
+
+// normalizePgEavPayload converts a leaf for the EAV EXISTS emitter: strict
+// parse, EAV value-column selection, type conversion, and the text/bool
+// operator whitelist.
+func normalizePgEavPayload(kv *forma.KvCondition, meta forma.AttributeMetadata, hasMeta bool) PgEavLeafPayload {
+	if !hasMeta {
+		return PgEavLeafPayload{Err: fmt.Errorf("attribute not found in cache: %s", kv.Attr)}
+	}
+
+	operator, err := conditionexpr.ParseOperatorValueStrict(kv.Value)
+	if err != nil {
+		return PgEavLeafPayload{Err: err}
+	}
+	opStr := operator.Operator
+	valStr := operator.Value
+
+	var valueColumn string
+	var parsedValue any
+
+	switch meta.ValueType {
+	case forma.ValueTypeText, forma.ValueTypeUUID:
+		valueColumn = "value_text"
+		parsedValue = valStr
+	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
+		valueColumn = "value_numeric"
+		parsed := numutil.TryParseNumber(valStr)
+		switch v := parsed.(type) {
+		case int64:
+			parsedValue = float64(v)
+		case float64:
+			parsedValue = v
+		default:
+			return PgEavLeafPayload{Err: fmt.Errorf("invalid numeric value for '%s': %s", kv.Attr, valStr)}
+		}
+	case forma.ValueTypeDate, forma.ValueTypeDateTime:
+		valueColumn = "value_numeric"
+		var err error
+		parsedValue, err = parseDateValue(valStr, meta)
+		if err != nil {
+			return PgEavLeafPayload{Err: fmt.Errorf("invalid date value for '%s': %w", kv.Attr, err)}
+		}
+	case forma.ValueTypeBool:
+		valueColumn = "value_numeric"
+		parsedInt, err := strconv.Atoi(valStr)
+		if err != nil {
+			return PgEavLeafPayload{Err: fmt.Errorf("invalid boolean value for '%s': %s", kv.Attr, valStr)}
+		}
+		if parsedInt > 0 {
+			parsedValue = float64(1)
+		} else {
+			parsedValue = float64(0)
+		}
+	default:
+		return PgEavLeafPayload{Err: fmt.Errorf("unsupported value_type '%s' for attribute '%s'", meta.ValueType, kv.Attr)}
+	}
+
+	sqlOperator, err := conditionexpr.ToSQLOperator(opStr, valStr)
+	if err != nil {
+		return PgEavLeafPayload{Err: err}
+	}
+	sqlOp := sqlOperator.SQLOperator
+	if sqlOp == "LIKE" {
+		parsedValue = sqlOperator.Value
+	}
+
+	if meta.ValueType != forma.ValueTypeText && sqlOp == "LIKE" {
+		return PgEavLeafPayload{Err: fmt.Errorf("operator '%s' only supported for text attributes, not '%s'", opStr, meta.ValueType)}
+	}
+	if meta.ValueType == forma.ValueTypeBool && sqlOp != "=" && sqlOp != "!=" {
+		return PgEavLeafPayload{Err: fmt.Errorf("operator '%s' not supported for boolean attributes", opStr)}
+	}
+
+	return PgEavLeafPayload{
+		AttrID:      meta.AttributeID,
+		ValueColumn: valueColumn,
+		SQLOp:       sqlOp,
+		Value:       parsedValue,
+	}
+}
+
+// normalizePgMainPayload converts a leaf for entity_main pushdown: unknown
+// attributes and unbound columns skip silently, bound-but-unclassifiable
+// operators error, and values convert per column encoding.
+func normalizePgMainPayload(
+	kv *forma.KvCondition,
+	meta forma.AttributeMetadata,
+	hasMeta bool,
+	classifyOK bool,
+	lenient conditionexpr.OperatorValue,
+	lenientSQL conditionexpr.SQLOperatorResult,
+	lenientSQLErr error,
+) PgMainLeafPayload {
+	if !hasMeta {
+		// unknown attribute -> cannot push
+		return PgMainLeafPayload{Skip: true}
+	}
+	if !classifyOK {
+		if meta.ColumnBinding == nil {
+			return PgMainLeafPayload{Skip: true}
+		}
+		return PgMainLeafPayload{Err: fmt.Errorf("unsupported operator: %s", lenient.Operator)}
+	}
+	if lenientSQLErr != nil {
+		return PgMainLeafPayload{Err: lenientSQLErr}
+	}
+
+	parsedValue, err := ConvertPgMainValue(lenientSQL.Value, kv.Attr, meta)
+	if err != nil {
+		return PgMainLeafPayload{Err: err}
+	}
+	return PgMainLeafPayload{
+		Column: resolveMainTableColumn(kv.Attr, meta),
+		SQLOp:  lenientSQL.SQLOperator,
+		Value:  parsedValue,
+	}
+}
+
+// normalizeDuckPayload converts a leaf for the DuckDB emitter, keeping the
+// no-metadata fallback inference (detectValueType) and the text/LIKE
+// no-cast emission.
+func normalizeDuckPayload(
+	kv *forma.KvCondition,
+	cache forma.SchemaAttributeCache,
+	meta forma.AttributeMetadata,
+	hasMeta bool,
+	lenientSQL conditionexpr.SQLOperatorResult,
+	lenientSQLErr error,
+) DuckLeafPayload {
+	if lenientSQLErr != nil {
+		return DuckLeafPayload{Err: lenientSQLErr}
+	}
+
+	column := resolveDuckDBColumn(kv.Attr, cache)
+
+	if lenientSQL.SQLOperator == "LIKE" {
+		return DuckLeafPayload{Column: column, SQLOp: lenientSQL.SQLOperator, TextLike: true, Param: lenientSQL.Value}
+	}
+
+	var valueType forma.ValueType
+	if hasMeta {
+		valueType = meta.ValueType
+	} else {
+		valueType = detectValueType(lenientSQL.Value)
+	}
+
+	if valueType == forma.ValueTypeText {
+		return DuckLeafPayload{Column: column, SQLOp: lenientSQL.SQLOperator, ValueType: valueType, TextLike: true, Param: lenientSQL.Value}
+	}
+
+	rawParam, err := parseDuckDBRawParam(lenientSQL.Value, kv.Attr, valueType)
+	if err != nil {
+		return DuckLeafPayload{Err: err}
+	}
+	param, err := ToDuckDBParam(rawParam, valueType)
+	if err != nil {
+		return DuckLeafPayload{Err: fmt.Errorf("to duckdb param: %w", err)}
+	}
+	return DuckLeafPayload{Column: column, SQLOp: lenientSQL.SQLOperator, ValueType: valueType, Param: param}
+}

--- a/internal/sqlgen/sql_generator.go
+++ b/internal/sqlgen/sql_generator.go
@@ -63,7 +63,7 @@ func (e *pgEavTypedEmitter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, e
 	var args []any
 
 	*e.paramIndex++
-	attrIdPlaceholder := fmt.Sprintf("$%d", *e.paramIndex)
+	attrIDPlaceholder := fmt.Sprintf("$%d", *e.paramIndex)
 	args = append(args, p.AttrID)
 
 	*e.paramIndex++
@@ -73,7 +73,7 @@ func (e *pgEavTypedEmitter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, e
 	sql := fmt.Sprintf(
 		"EXISTS (SELECT 1 FROM %s x WHERE x.schema_id = e.schema_id AND x.row_id = e.row_id AND x.attr_id = %s AND x.%s %s %s)",
 		e.eavTable,
-		attrIdPlaceholder,
+		attrIDPlaceholder,
 		p.ValueColumn,
 		p.SQLOp,
 		valuePlaceholder,

--- a/internal/sqlgen/sql_generator.go
+++ b/internal/sqlgen/sql_generator.go
@@ -2,10 +2,7 @@ package sqlgen
 
 import (
 	"fmt"
-	"strconv"
 	"time"
-
-	"github.com/lychee-technology/forma/internal/numutil"
 
 	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/conditionexpr"
@@ -49,118 +46,47 @@ func NewSQLGenerator() *SQLGenerator {
 	return &SQLGenerator{}
 }
 
-// pgEavLeafEmitter renders KvCondition leaves as EAV EXISTS subqueries with $N placeholders.
-type pgEavLeafEmitter struct {
+// pgEavTypedEmitter renders typed predicate leaves as EAV EXISTS subqueries
+// with $N placeholders. All parsing and value conversion happened in the
+// normalizer; the emitter only assigns placeholders and formats the shell.
+type pgEavTypedEmitter struct {
 	eavTable   string
-	schemaID   int16
-	cache      forma.SchemaAttributeCache
 	paramIndex *int
 }
 
-// pgEavLeafValue is the value core shared by the string emitter and the plan
-// binder (#142): parsing, type conversion, and operator validation live here
-// exactly once. It returns the two bound args (attr_id, value) plus the
-// clause ingredients the string shell needs.
-func pgEavLeafValue(kv *forma.KvCondition, cache forma.SchemaAttributeCache) (int16, any, string, string, error) {
-	meta, ok := cache[kv.Attr]
-	if !ok {
-		return 0, nil, "", "", fmt.Errorf("attribute not found in cache: %s", kv.Attr)
-	}
-
-	operator, err := parseOperatorValueStrict(kv.Value)
-	if err != nil {
-		return 0, nil, "", "", err
-	}
-	opStr := operator.op
-	valStr := operator.value
-
-	var valueColumn string
-	var parsedValue any
-
-	switch meta.ValueType {
-	case forma.ValueTypeText, forma.ValueTypeUUID:
-		valueColumn = "value_text"
-		parsedValue = valStr
-	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
-		valueColumn = "value_numeric"
-		parsed := numutil.TryParseNumber(valStr)
-		switch v := parsed.(type) {
-		case int64:
-			parsedValue = float64(v)
-		case float64:
-			parsedValue = v
-		default:
-			return 0, nil, "", "", fmt.Errorf("invalid numeric value for '%s': %s", kv.Attr, valStr)
-		}
-	case forma.ValueTypeDate, forma.ValueTypeDateTime:
-		valueColumn = "value_numeric"
-		var err error
-		parsedValue, err = parseDateValue(valStr, meta)
-		if err != nil {
-			return 0, nil, "", "", fmt.Errorf("invalid date value for '%s': %w", kv.Attr, err)
-		}
-	case forma.ValueTypeBool:
-		valueColumn = "value_numeric"
-		parsedInt, err := strconv.Atoi(valStr)
-		if err != nil {
-			return 0, nil, "", "", fmt.Errorf("invalid boolean value for '%s': %s", kv.Attr, valStr)
-		}
-		if parsedInt > 0 {
-			parsedValue = float64(1)
-		} else {
-			parsedValue = float64(0)
-		}
-	default:
-		return 0, nil, "", "", fmt.Errorf("unsupported value_type '%s' for attribute '%s'", meta.ValueType, kv.Attr)
-	}
-
-	sqlOperator, err := toSQLOperator(opStr, valStr)
-	if err != nil {
-		return 0, nil, "", "", err
-	}
-	sqlOp := sqlOperator.sqlOp
-	if sqlOp == "LIKE" {
-		parsedValue = sqlOperator.value
-	}
-
-	if meta.ValueType != forma.ValueTypeText && sqlOp == "LIKE" {
-		return 0, nil, "", "", fmt.Errorf("operator '%s' only supported for text attributes, not '%s'", opStr, meta.ValueType)
-	}
-	if meta.ValueType == forma.ValueTypeBool && sqlOp != "=" && sqlOp != "!=" {
-		return 0, nil, "", "", fmt.Errorf("operator '%s' not supported for boolean attributes", opStr)
-	}
-
-	return meta.AttributeID, parsedValue, valueColumn, sqlOp, nil
-}
-
-func (e *pgEavLeafEmitter) EmitLeaf(kv *forma.KvCondition) (string, []any, error) {
-	_ = e.schemaID
-
-	attrID, parsedValue, valueColumn, sqlOp, err := pgEavLeafValue(kv, e.cache)
-	if err != nil {
-		return "", nil, err
+func (e *pgEavTypedEmitter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, error) {
+	p := leaf.PgEav
+	if p.Err != nil {
+		return "", nil, p.Err
 	}
 
 	var args []any
 
 	*e.paramIndex++
 	attrIdPlaceholder := fmt.Sprintf("$%d", *e.paramIndex)
-	args = append(args, attrID)
+	args = append(args, p.AttrID)
 
 	*e.paramIndex++
 	valuePlaceholder := fmt.Sprintf("$%d", *e.paramIndex)
-	args = append(args, parsedValue)
+	args = append(args, p.Value)
 
 	sql := fmt.Sprintf(
 		"EXISTS (SELECT 1 FROM %s x WHERE x.schema_id = e.schema_id AND x.row_id = e.row_id AND x.attr_id = %s AND x.%s %s %s)",
 		e.eavTable,
 		attrIdPlaceholder,
-		valueColumn,
-		sqlOp,
+		p.ValueColumn,
+		p.SQLOp,
 		valuePlaceholder,
 	)
 
 	return sql, args, nil
+}
+
+// pgEavClausesFromTree walks an already-normalized predicate tree for the
+// EAV target, letting ToDualClauses share one normalization pass.
+func pgEavClausesFromTree(tree PredicateNode, eavTable string, paramIndex *int) (string, []any, error) {
+	emitter := &pgEavTypedEmitter{eavTable: eavTable, paramIndex: paramIndex}
+	return walkPredicate(tree, pgEavStyle, nil, emitter)
 }
 
 // ToSQLClauses builds the SQL clause and arguments for a condition tree.
@@ -174,13 +100,7 @@ func (g *SQLGenerator) ToSQLClauses(
 	if condition == nil {
 		return "", nil, nil
 	}
-	emitter := &pgEavLeafEmitter{
-		eavTable:   eavTable,
-		schemaID:   schemaID,
-		cache:      cache,
-		paramIndex: paramIndex,
-	}
-	return walkCondition(condition, pgEavStyle, nil, emitter)
+	return pgEavClausesFromTree(normalizePredicates(condition, cache, targetPgEav), eavTable, paramIndex)
 }
 
 // ToSqlClauses is kept for backward compatibility.


### PR DESCRIPTION
## Summary

按 #143 修订版方案实现 typed predicate IR:在 `sqlgen` 前加 parse-once 归一化层,`forma.Condition` → typed predicate tree → 现有三个 SQL 发射器。SQL 输出逐字节不变、args 值与 Go 类型不变、错误面不变。

## 实现

**新增**

- `internal/sqlgen/predicate_ir.go` — `PredicateNode` / `PredicateGroup` / `PredicateLeaf` / `PredicateOperator` / `PatternKind` / `PredicateStorage`;每个叶子携带原始 attr、`AttributeID`、`ValueType`、规范化操作符与 SQL operator、LIKE `PatternKind`、`Storage`、column binding、**三套 target-specific 已转换值**(PG EAV / PG main / DuckDB 各自 payload,各带独立 error)与 pushability。
- `internal/sqlgen/predicate_normalizer.go` — `normalizePredicates`:operator parsing、metadata lookup、LIKE wildcarding、类型×操作符白名单、target value conversion 全部迁入,每叶恰好解析一次;group 级 `FullyPushable` 自底向上预计算。

**入口语义逐项保留**

- strict(EAV)vs lenient(pg-main / duck)parse 差异按 target payload 各自建模,包括 `classifyPredicate` 原始冒号切分的怪癖(裸 ISO 时间戳、`neq` 别名在 bound 列上报错而非下推);
- nil 顶层 / nil 子节点 / empty composite / unknown attr / unknown condition type 的分路径行为(error / skip / identity)由归一化层保留为专用节点,walker 按 style 惰性处理;
- `ToDualClauses` 的错误包装顺序(pg main → pg eav → duck)与 paramIndex 推进不变。

**遍历唯一化**

- `walkPredicate` 成为唯一 composite 遍历实现;legacy `WalkCondition`(hybrid builder 在用)通过 structure-only 归一化 + 适配器复用同一遍历,**没有第二套 walker 语义**。
- PG main OR veto 改读预计算的 `FullyPushable`,不再每个 OR 重扫子树。

**发射器迁移**

- PG EAV / PG main / DuckDB 三个发射器缩减为占位符分配 + 字符串壳,消费 typed leaf;DuckDB 保留 no-metadata fallback 推断(`detectValueType`)。
- `DualClausePlan.Bind` 归一化一次,从同一棵树绑定三组 args。

**死代码清理**

`pgEavLeafValue` / `pgMainLeafValue` / `duckLeafValue` / `isFullyPushableToMain` / `pgMainGuard` / `bindEmitter` / `operatorValuePair` / `sqlOperatorResult` 及 wrapper 均删除;normalizer 直接调用 `conditionexpr` 正典 helper。

## Hybrid builder(计划 step 10:拆出后续)

hybrid builder 本 PR 未迁移叶子发射,理由:其叶子形态独特(`useMainTableAsAnchor` 双 SQL 形态、EXISTS 别名重写、`resolveLeafMeta` descriptor 契约),需要第四套 payload,风险应隔离。经本 PR 它的 composite 遍历已通过 `WalkCondition` → `walkPredicate` 共享 typed walker,叶子仍走 `conditionexpr` + `ConvertPgMainValue` 正典栈,**不构成平行 normalizer**。

后续迁移 tracking issue:#154。

## 验收对照

- [x] 条件树解析每查询一次;三个发射器消费同一棵 typed tree(`ToDualClauses` / `Bind` 单次 `normalizePredicates(targetsAll)`)
- [x] metadata lookup / operator normalization / LIKE normalization / 白名单集中于 normalizer
- [x] SQL 逐字节不变:现有金标准测试零改动全绿;新增 characterization 矩阵(存储×编码×操作符、错误面、strict/lenient 分口)在重构前对主线捕获、重构后不变
- [x] `PlanDualClauses.Bind` ≡ `ToDualClauses`(clause / args / paramIndex;等价断言并入 characterization 矩阵每个用例)
- [x] `BuildPgMainClause` OR veto 语义不变(含嵌套 veto 级联用例)
- [x] standalone `BuildDuckClause` no-metadata fallback 不变(推断矩阵用例)
- [x] 无 queryoptimizer 式平行体系:唯一遍历实现,payload 计算按 target 掩码裁剪

## 验证

- [x] `go test ./internal/sqlgen` 绿
- [x] `go test ./internal -run "TestHybrid_|TestBuildHybridConditions"` 绿
- [x] `make test` 25 包全绿
- [x] `make lint` exit 0
- [x] `go test -race ./internal/sqlgen ./internal` 绿

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

