### PR TITLE
feat: DuckDB resource config single source + concurrency benchmark evidence (#104)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,26 @@ benchmark-trend: create-build-dir
 	@echo "Running benchmark trend analysis..."
 	@$(GOENV) go run ./cmd/benchmark trend -history-dir .artifacts/benchmark
 
+# Concurrency evidence sweep (#104): full small-live at C=1/2/4/8 plus the
+# aggregated report. Each level is a complete live run (~35min+ on an idle
+# machine, hours under load) — operator-initiated only, never CI.
+benchmark-concurrency: create-build-dir
+	@echo "Running concurrency evidence sweep (C=1,2,4,8; several hours)..."
+	@mkdir -p .artifacts/benchmark/concurrency
+	@for c in 1 2 4 8; do \
+		$(GOENV) go run ./cmd/benchmark baseline -preset small-live \
+			-concurrency $$c \
+			-output-dir .artifacts/benchmark/concurrency \
+			-channel manual -label concurrency-sweep-c$$c \
+			-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
+			-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "") || exit 1; \
+	done
+	@$(GOENV) go run ./cmd/benchmark concurrency-report \
+		-input-dir .artifacts/benchmark/concurrency \
+		-md-out .artifacts/benchmark/concurrency/concurrency-report.md \
+		-json-out .artifacts/benchmark/concurrency/concurrency-report.json
+	@echo "Concurrency report written to .artifacts/benchmark/concurrency/concurrency-report.md"
+
 benchmark-heavy: create-build-dir
 	@echo "Running benchmark heavy planning set..."
 	@mkdir -p .artifacts/benchmark/heavy

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -138,6 +138,9 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 	gitSHA := flags.String("git-sha", "", "Provenance git commit SHA")
 	gitRef := flags.String("git-ref", "", "Provenance git ref")
 	label := flags.String("label", "", "Provenance human-readable label")
+	concurrency := flags.Int("concurrency", 0, "Override preset concurrency (0 = preset value)")
+	duckDBThreads := flags.Int("duckdb-threads", 0, "Override DuckDB threads for live runs (0 = harness default)")
+	duckDBMemoryMB := flags.Int("duckdb-memory-mb", 0, "Override DuckDB memory limit in MB for live runs (0 = harness default)")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -145,6 +148,17 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 	if err != nil {
 		fmt.Fprintf(errOut, "baseline setup failed: %v\n", err)
 		return 1
+	}
+	if *concurrency > 0 {
+		config.Concurrency = *concurrency
+	}
+	config.DuckDBThreads = *duckDBThreads
+	config.DuckDBMemoryLimitMB = *duckDBMemoryMB
+	// Concurrent baselines get their own artifact directory (-c{N}); C<=1
+	// keeps the preset directory so existing capture paths (and the
+	// make benchmark-regression contract) are untouched.
+	if config.Concurrency > 1 {
+		dirName = fmt.Sprintf("%s-c%d", dirName, config.Concurrency)
 	}
 	outputs := runOutputs{
 		baselineDir: filepath.Join(*outputDir, dirName),
@@ -278,6 +292,8 @@ func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, 
 	tierProfile := flags.String("tier-profile", bench.DefaultTierMixProfile().Name, "Tier mix profile: balanced, high-hot, long-history, or explicit profile name")
 	seed := flags.Int64("seed", 42, "Deterministic benchmark seed")
 	tradeCount := flags.Int("trade-count", 0, "Override generated trade row count")
+	duckDBThreads := flags.Int("duckdb-threads", 0, "Override DuckDB threads for live runs (0 = harness default)")
+	duckDBMemoryMB := flags.Int("duckdb-memory-mb", 0, "Override DuckDB memory limit in MB for live runs (0 = harness default)")
 	customerCount := flags.Int("customer-count", 0, "Override generated customer row count")
 	securityCount := flags.Int("security-count", 0, "Override generated security row count")
 	overlapRatio := flags.Float64("overlap-ratio", 0, "Override overlap ratio")
@@ -308,6 +324,9 @@ func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, 
 		OverlapRatio:  *overlapRatio,
 		DeleteRatio:   *deleteRatio,
 		Workloads:     parseWorkloads(*workloads),
+
+		DuckDBThreads:       *duckDBThreads,
+		DuckDBMemoryLimitMB: *duckDBMemoryMB,
 	}.WithDefaults()
 	outputs := runOutputs{jsonOut: *jsonOut, mdOut: *mdOut, baselineDir: *baselineDir}
 	outputs.channel = *channel
@@ -346,6 +365,7 @@ func executeBenchmarkRun(ctx context.Context, cfg bench.Config, outputs runOutpu
 			Scale:        string(result.Config.Scale),
 			Distribution: string(result.Config.Distribution),
 			TierProfile:  result.Config.TierProfile,
+			Concurrency:  result.Config.Concurrency,
 		}
 	}
 	if outputs.jsonOut != "" {

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -78,6 +78,8 @@ func runBenchmarkMain(ctx context.Context, args []string, out, errOut io.Writer)
 		return runBenchmark(ctx, args[1:], out, errOut)
 	case "trend":
 		return runTrend(args[1:], out, errOut)
+	case "concurrency-report":
+		return runConcurrencyReport(args[1:], out, errOut)
 	default:
 		fmt.Fprintf(errOut, "unknown command %q\n", args[0])
 		printUsage(out)
@@ -94,6 +96,7 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  baseline   Capture a baseline artifact set for a preset")
 	fmt.Fprintln(out, "  run        Execute benchmark validation or live runtime")
 	fmt.Fprintln(out, "  trend      Analyze longitudinal benchmark trends and regressions")
+	fmt.Fprintln(out, "  concurrency-report  Aggregate per-concurrency summaries into one p50/p95/p99 matrix")
 }
 
 func runDescribe(out io.Writer) int {
@@ -217,6 +220,67 @@ func compareSummaryFiles(baselinePath, candidatePath string, out, errOut io.Writ
 	}
 	fmt.Fprintln(errOut, bench.FormatDiffSummary(diff))
 	return writeJSON(out, diff)
+}
+
+// runConcurrencyReport aggregates one benchmark-summary.json per concurrency
+// level into a single publishable markdown/JSON artifact (#104).
+func runConcurrencyReport(args []string, out, errOut io.Writer) int {
+	flags := flag.NewFlagSet("concurrency-report", flag.ContinueOnError)
+	flags.SetOutput(errOut)
+	inputs := flags.String("inputs", "", "Comma-separated benchmark-summary.json paths (one per concurrency level)")
+	inputDir := flags.String("input-dir", "", "Directory tree scanned for benchmark-summary.json files")
+	mdOut := flags.String("md-out", "", "Path for the markdown report (omit to print to stdout)")
+	jsonOut := flags.String("json-out", "", "Optional path for the JSON report")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	var summaries []bench.SummaryReport
+	if *inputDir != "" {
+		runs, err := bench.ReadTrendHistory(*inputDir)
+		if err != nil {
+			fmt.Fprintf(errOut, "concurrency-report failed: %v\n", err)
+			return 1
+		}
+		for _, run := range runs {
+			summaries = append(summaries, run.Summary)
+		}
+	}
+	for _, path := range strings.Split(*inputs, ",") {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		summary, err := bench.ReadSummaryReport(path)
+		if err != nil {
+			fmt.Fprintf(errOut, "concurrency-report failed: %v\n", err)
+			return 1
+		}
+		summaries = append(summaries, summary)
+	}
+	if len(summaries) == 0 {
+		fmt.Fprintln(errOut, "concurrency-report requires -inputs or -input-dir")
+		return 1
+	}
+
+	report, err := bench.BuildConcurrencyReport(summaries)
+	if err != nil {
+		fmt.Fprintf(errOut, "concurrency-report failed: %v\n", err)
+		return 1
+	}
+	if err := bench.WriteConcurrencyReport(*jsonOut, *mdOut, report); err != nil {
+		fmt.Fprintf(errOut, "concurrency-report failed: %v\n", err)
+		return 1
+	}
+	if *mdOut == "" {
+		fmt.Fprint(out, bench.FormatConcurrencyMarkdown(report))
+	} else {
+		fmt.Fprintf(out, "concurrency report written to %s\n", *mdOut)
+	}
+	if !report.Comparable {
+		fmt.Fprintln(errOut, "warning: runs are not directly comparable; see report warnings")
+	}
+	return 0
 }
 
 func runTrend(args []string, out, errOut io.Writer) int {

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -237,14 +237,12 @@ func runConcurrencyReport(args []string, out, errOut io.Writer) int {
 
 	var summaries []bench.SummaryReport
 	if *inputDir != "" {
-		runs, err := bench.ReadTrendHistory(*inputDir)
+		collected, err := bench.CollectConcurrencySummaries(*inputDir)
 		if err != nil {
 			fmt.Fprintf(errOut, "concurrency-report failed: %v\n", err)
 			return 1
 		}
-		for _, run := range runs {
-			summaries = append(summaries, run.Summary)
-		}
+		summaries = append(summaries, collected...)
 	}
 	for _, path := range strings.Split(*inputs, ",") {
 		path = strings.TrimSpace(path)

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -36,7 +36,8 @@ var (
 		if err != nil {
 			return nil, err
 		}
-		h, err := federated.NewFederatedTestHarness(ctx)
+		h, err := federated.NewFederatedTestHarness(ctx,
+			federated.WithDuckDBResources(cfg.DuckDBThreads, cfg.DuckDBMemoryLimitMB, 0))
 		if err != nil {
 			return nil, fmt.Errorf("create federated harness: %w", err)
 		}

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -198,6 +198,74 @@ func writeSummaryFixture(t *testing.T, path string, summary bench.SummaryReport)
 	}
 }
 
+func TestRunBenchmarkMainConcurrencyReport(t *testing.T) {
+	dir := t.TempDir()
+	mkSummary := func(concurrency int, p99 time.Duration) bench.SummaryReport {
+		return bench.SummaryReport{
+			Metadata: bench.ArtifactMetadata{BenchmarkID: "bench"},
+			Provenance: &bench.RunProvenance{
+				Mode:         string(bench.ExecutionModeLive),
+				Scale:        string(bench.ScaleSmall),
+				Distribution: string(bench.DistributionUniform),
+				TierProfile:  bench.DefaultTierMixProfile().Name,
+				Concurrency:  concurrency,
+			},
+			Passed: true,
+			P50:    10 * time.Millisecond,
+			P95:    p99 / 2,
+			P99:    p99,
+			Workloads: []bench.WorkloadSummary{
+				{Name: "baseline-page-1", TargetSchema: "trade", P99: p99, Passed: true},
+			},
+		}
+	}
+	c1Path := filepath.Join(dir, "c1-summary.json")
+	c4Path := filepath.Join(dir, "c4-summary.json")
+	writeSummaryFixture(t, c1Path, mkSummary(1, 20*time.Millisecond))
+	writeSummaryFixture(t, c4Path, mkSummary(4, 80*time.Millisecond))
+	mdPath := filepath.Join(dir, "concurrency-report.md")
+	jsonPath := filepath.Join(dir, "concurrency-report.json")
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{
+		"concurrency-report", "-inputs", c1Path + "," + c4Path, "-md-out", mdPath, "-json-out", jsonPath,
+	}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("concurrency-report returned exit code %d: %s", exitCode, errOut.String())
+	}
+	md, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatalf("expected markdown report: %v", err)
+	}
+	if !bytes.Contains(md, []byte("# Concurrency Benchmark Report")) || !bytes.Contains(md, []byte("| 4 |")) {
+		t.Fatalf("unexpected markdown content:\n%s", md)
+	}
+	var report bench.ConcurrencyReport
+	raw, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("expected json report: %v", err)
+	}
+	if err := json.Unmarshal(raw, &report); err != nil {
+		t.Fatalf("unmarshal json report: %v", err)
+	}
+	if len(report.Levels) != 2 || report.Levels[1] != 4 {
+		t.Fatalf("unexpected levels in json report: %v", report.Levels)
+	}
+}
+
+func TestRunBenchmarkMainConcurrencyReportRequiresInputs(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"concurrency-report"}, &out, &errOut)
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1 without inputs, got %d", exitCode)
+	}
+	if !bytes.Contains(errOut.Bytes(), []byte("requires -inputs or -input-dir")) {
+		t.Fatalf("expected usage error, got: %s", errOut.String())
+	}
+}
+
 func TestRunBenchmarkMainTrendMissingHistoryDir(t *testing.T) {
 	var out bytes.Buffer
 	var errOut bytes.Buffer

--- a/config_duckdb.go
+++ b/config_duckdb.go
@@ -65,15 +65,19 @@ type RoutingPolicy struct {
 // defaultDuckDBConfig returns default DuckDB configuration.
 func defaultDuckDBConfig() DuckDBConfig {
 	return DuckDBConfig{
-		Enabled:                        false,
-		DBPath:                         ":memory:",
-		MemoryLimitMB:                  0,
-		EnableS3:                       false,
-		EnableParquet:                  false,
-		Extensions:                     []string{},
+		Enabled:       false,
+		DBPath:        ":memory:",
+		EnableS3:      false,
+		EnableParquet: false,
+		Extensions:    []string{},
+		// MemoryLimitMB / MaxParallelism defaults mirror the PRAGMAs the
+		// federated query template used to hardcode (memory_limit='4GB',
+		// threads=4); connection-level pragmas are now the single source of
+		// truth, so these defaults keep the effective behavior unchanged.
+		MemoryLimitMB:                  4096,
 		MaxConnections:                 1,
 		QueryTimeout:                   30 * time.Second,
-		MaxParallelism:                 1,
+		MaxParallelism:                 4,
 		CircuitBreakerThreshold:        0,
 		CircuitBreakerFailureThreshold: 5,
 		CircuitBreakerWindow:           time.Minute,
@@ -97,6 +101,9 @@ func (c *Config) validateDuckDBConfig() error {
 	}
 	if c.DuckDB.QueryTimeout < 0 {
 		return &ConfigError{Field: "duckdb.queryTimeout", Message: "must be greater than or equal to 0"}
+	}
+	if c.DuckDB.MaxParallelism < 0 {
+		return &ConfigError{Field: "duckdb.maxParallelism", Message: "must be greater than or equal to 0"}
 	}
 	if c.DuckDB.CircuitBreakerFailureThreshold < 0 {
 		return &ConfigError{Field: "duckdb.circuitBreakerFailureThreshold", Message: "must be greater than or equal to 0"}

--- a/config_duckdb_test.go
+++ b/config_duckdb_test.go
@@ -24,6 +24,19 @@ func TestDuckDBBreakerConfigDefaults(t *testing.T) {
 	}
 }
 
+func TestDuckDBResourceConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultDuckDBConfig()
+
+	if cfg.MaxParallelism != 4 {
+		t.Errorf("Expected max parallelism to default to 4 (parity with the removed template PRAGMA threads=4), got %d", cfg.MaxParallelism)
+	}
+	if cfg.MemoryLimitMB != 4096 {
+		t.Errorf("Expected memory limit to default to 4096MB (parity with the removed template PRAGMA memory_limit='4GB'), got %d", cfg.MemoryLimitMB)
+	}
+}
+
 func TestDuckDBBreakerConfigValidation(t *testing.T) {
 	t.Parallel()
 
@@ -57,6 +70,20 @@ func TestDuckDBBreakerConfigValidation(t *testing.T) {
 				CircuitBreakerOpenDuration: -time.Second,
 			},
 			errorField: "duckdb.circuitBreakerOpenDuration",
+		},
+		{
+			name: "negative max parallelism",
+			duckDB: DuckDBConfig{
+				MaxParallelism: -1,
+			},
+			errorField: "duckdb.maxParallelism",
+		},
+		{
+			name: "negative memory limit",
+			duckDB: DuckDBConfig{
+				MemoryLimitMB: -1,
+			},
+			errorField: "duckdb.memoryLimitMB",
 		},
 	}
 

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -147,6 +147,34 @@ go run ./cmd/benchmark baseline \
   -output-dir .artifacts/benchmark
 ```
 
+### Concurrency Evidence Sweep (#104)
+
+```bash
+make benchmark-concurrency
+```
+
+Runs the full small-live preset at `Concurrency=1,2,4,8` and aggregates the
+four runs into `.artifacts/benchmark/concurrency/concurrency-report.md`
+(overall and per-workload p50/p95/p99/QPS per level, plus the
+`concurrent-run-*` stability assertion pass rates from PR #94). Each level is
+a complete live run (~35 minutes on an idle machine, hours under load):
+operator-initiated only, never CI. Concurrent baselines write to `-c{N}`
+suffixed directories and form their own trend comparability group, so they
+never pollute the sequential (`C=1`) baseline window.
+
+Individual pieces compose too:
+
+```bash
+go run ./cmd/benchmark baseline -preset small-live -concurrency 4 \
+  -output-dir .artifacts/benchmark/concurrency
+go run ./cmd/benchmark concurrency-report \
+  -input-dir .artifacts/benchmark/concurrency -md-out report.md
+```
+
+DuckDB resources are connection-level configuration (the query template no
+longer hardcodes PRAGMAs); override per run with `-duckdb-threads` /
+`-duckdb-memory-mb` on either `baseline` or `run`.
+
 ## CI Guidance
 
 Use these rules in CI and automation for the current benchmark model.

--- a/internal/e2e_harness/federated/benchmark/concurrency_report.go
+++ b/internal/e2e_harness/federated/benchmark/concurrency_report.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -33,6 +34,8 @@ type ConcurrencyReport struct {
 }
 
 // ConcurrencyLevelSummary is one whole-run row of the concurrency matrix.
+// The *DeltaVsBase fields carry the delta against the lowest concurrency
+// level in the report (zero on that baseline row itself).
 type ConcurrencyLevelSummary struct {
 	Concurrency         int                      `json:"concurrency"`
 	ExecutionCount      int                      `json:"execution_count"`
@@ -41,6 +44,9 @@ type ConcurrencyLevelSummary struct {
 	P50                 time.Duration            `json:"p50"`
 	P95                 time.Duration            `json:"p95"`
 	P99                 time.Duration            `json:"p99"`
+	P50DeltaVsBase      time.Duration            `json:"p50_delta_vs_base,omitempty"`
+	P95DeltaVsBase      time.Duration            `json:"p95_delta_vs_base,omitempty"`
+	P99DeltaVsBase      time.Duration            `json:"p99_delta_vs_base,omitempty"`
 	QPS                 float64                  `json:"qps"`
 	StabilityAssertions map[string]AssertionStat `json:"stability_assertions,omitempty"`
 }
@@ -53,6 +59,8 @@ type WorkloadConcurrencyTrend struct {
 }
 
 // WorkloadConcurrencyLevel is one workload row at one concurrency level.
+// The *DeltaVsBase fields carry the delta against the workload's own row at
+// its lowest concurrency level (zero on that baseline row itself).
 type WorkloadConcurrencyLevel struct {
 	Concurrency         int                      `json:"concurrency"`
 	ExecutionCount      int                      `json:"execution_count"`
@@ -60,6 +68,9 @@ type WorkloadConcurrencyLevel struct {
 	P50                 time.Duration            `json:"p50"`
 	P95                 time.Duration            `json:"p95"`
 	P99                 time.Duration            `json:"p99"`
+	P50DeltaVsBase      time.Duration            `json:"p50_delta_vs_base,omitempty"`
+	P95DeltaVsBase      time.Duration            `json:"p95_delta_vs_base,omitempty"`
+	P99DeltaVsBase      time.Duration            `json:"p99_delta_vs_base,omitempty"`
 	QPS                 float64                  `json:"qps"`
 	StabilityAssertions map[string]AssertionStat `json:"stability_assertions,omitempty"`
 }
@@ -137,7 +148,64 @@ func BuildConcurrencyReport(summaries []SummaryReport) (ConcurrencyReport, error
 		}
 	}
 
+	applyConcurrencyDeltas(&report)
+
 	return report, nil
+}
+
+// applyConcurrencyDeltas fills the *DeltaVsBase fields against the lowest
+// concurrency level present (overall) and each workload's own lowest-level
+// row. The baseline rows keep zero deltas.
+func applyConcurrencyDeltas(report *ConcurrencyReport) {
+	if len(report.Summary) > 0 {
+		base := report.Summary[0]
+		for i := range report.Summary[1:] {
+			row := &report.Summary[i+1]
+			row.P50DeltaVsBase = row.P50 - base.P50
+			row.P95DeltaVsBase = row.P95 - base.P95
+			row.P99DeltaVsBase = row.P99 - base.P99
+		}
+	}
+	for w := range report.Workloads {
+		levels := report.Workloads[w].Levels
+		if len(levels) == 0 {
+			continue
+		}
+		base := levels[0]
+		for i := range levels[1:] {
+			row := &levels[i+1]
+			row.P50DeltaVsBase = row.P50 - base.P50
+			row.P95DeltaVsBase = row.P95 - base.P95
+			row.P99DeltaVsBase = row.P99 - base.P99
+		}
+	}
+}
+
+// CollectConcurrencySummaries walks dir for benchmark-summary.json files for
+// evidence aggregation. Unlike ReadTrendHistory it fails loudly on unreadable
+// or malformed files (a silently dropped file would silently drop a
+// concurrency level from the evidence) and does not require provenance
+// timestamps (provenance-less artifacts count as C=1).
+func CollectConcurrencySummaries(dir string) ([]SummaryReport, error) {
+	var summaries []SummaryReport
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || info.Name() != "benchmark-summary.json" {
+			return nil
+		}
+		summary, readErr := ReadSummaryReport(path)
+		if readErr != nil {
+			return fmt.Errorf("read summary %s: %w", path, readErr)
+		}
+		summaries = append(summaries, summary)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return summaries, nil
 }
 
 func summaryConcurrency(summary SummaryReport) int {
@@ -202,11 +270,15 @@ func FormatConcurrencyMarkdown(report ConcurrencyReport) string {
 	}
 
 	b.WriteString("\n## Overall\n\n")
-	b.WriteString("| Concurrency | P50 | P95 | P99 | QPS | Executions | Passed |\n")
-	b.WriteString("|---|---|---|---|---|---|---|\n")
-	for _, row := range report.Summary {
-		b.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %.2f | %d | %t |\n",
-			row.Concurrency, row.P50, row.P95, row.P99, row.QPS, row.ExecutionCount, row.Passed))
+	b.WriteString("| Concurrency | P50 | P95 | P99 | P50Δ | P95Δ | P99Δ | QPS | Executions | Passed |\n")
+	b.WriteString("|---|---|---|---|---|---|---|---|---|---|\n")
+	for i, row := range report.Summary {
+		b.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %s | %s | %s | %.2f | %d | %t |\n",
+			row.Concurrency, row.P50, row.P95, row.P99,
+			formatDeltaCell(row.P50DeltaVsBase, i == 0),
+			formatDeltaCell(row.P95DeltaVsBase, i == 0),
+			formatDeltaCell(row.P99DeltaVsBase, i == 0),
+			row.QPS, row.ExecutionCount, row.Passed))
 	}
 
 	for _, workload := range report.Workloads {
@@ -214,19 +286,43 @@ func FormatConcurrencyMarkdown(report ConcurrencyReport) string {
 		if workload.TargetSchema != "" {
 			b.WriteString(fmt.Sprintf("target schema: %s\n\n", workload.TargetSchema))
 		}
-		b.WriteString("| Concurrency | P50 | P95 | P99 | QPS | Executions | Passed | Stability |\n")
-		b.WriteString("|---|---|---|---|---|---|---|---|\n")
-		for _, row := range workload.Levels {
-			b.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %.2f | %d | %t | %s |\n",
-				row.Concurrency, row.P50, row.P95, row.P99, row.QPS, row.ExecutionCount, row.Passed,
+		b.WriteString("| Concurrency | P50 | P95 | P99 | P50Δ | P95Δ | P99Δ | QPS | Executions | Passed | Stability |\n")
+		b.WriteString("|---|---|---|---|---|---|---|---|---|---|---|\n")
+		for i, row := range workload.Levels {
+			b.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %s | %s | %s | %.2f | %d | %t | %s |\n",
+				row.Concurrency, row.P50, row.P95, row.P99,
+				formatDeltaCell(row.P50DeltaVsBase, i == 0),
+				formatDeltaCell(row.P95DeltaVsBase, i == 0),
+				formatDeltaCell(row.P99DeltaVsBase, i == 0),
+				row.QPS, row.ExecutionCount, row.Passed,
 				formatStabilityCell(row.StabilityAssertions)))
 		}
 	}
 
+	writeStabilitySection(&b, report)
+
+	return b.String()
+}
+
+// writeStabilitySection reports the concurrency stability assertion outcome
+// in three distinct states: failures, missing evidence (a C>1 row without
+// assertion stats is NOT a pass), and all-passed.
+func writeStabilitySection(b *strings.Builder, report ConcurrencyReport) {
 	b.WriteString("\n## Concurrency Stability Assertions\n\n")
+
 	unstable := false
+	observed := 0
+	var missing []string
 	for _, workload := range report.Workloads {
 		for _, row := range workload.Levels {
+			if row.Concurrency <= 1 {
+				continue
+			}
+			if len(row.StabilityAssertions) == 0 {
+				missing = append(missing, fmt.Sprintf("%s @ C=%d", workload.Name, row.Concurrency))
+				continue
+			}
+			observed++
 			for _, name := range concurrencyStabilityAssertions {
 				if stat, ok := row.StabilityAssertions[name]; ok && stat.Failed > 0 {
 					b.WriteString(fmt.Sprintf("- FAIL %s @ C=%d: %s %d/%d passed\n",
@@ -236,11 +332,28 @@ func FormatConcurrencyMarkdown(report ConcurrencyReport) string {
 			}
 		}
 	}
-	if !unstable {
-		b.WriteString("All concurrency stability assertions passed at every level (C=1 rows are n/a: the assertions only fire at C>=2).\n")
+
+	for _, m := range missing {
+		b.WriteString(fmt.Sprintf("- MISSING evidence: %s has no concurrency stability assertion stats\n", m))
 	}
 
-	return b.String()
+	switch {
+	case observed == 0 && len(missing) == 0:
+		b.WriteString("n/a: all runs are sequential (C=1); the assertions only fire at C>=2.\n")
+	case !unstable && len(missing) == 0:
+		b.WriteString("All concurrency stability assertions passed at every level (C=1 rows are n/a: the assertions only fire at C>=2).\n")
+	}
+}
+
+// formatDeltaCell renders a signed delta; the baseline row shows "—".
+func formatDeltaCell(d time.Duration, isBase bool) string {
+	if isBase {
+		return "—"
+	}
+	if d > 0 {
+		return "+" + d.String()
+	}
+	return d.String()
 }
 
 func joinLevels(levels []int) string {

--- a/internal/e2e_harness/federated/benchmark/concurrency_report.go
+++ b/internal/e2e_harness/federated/benchmark/concurrency_report.go
@@ -1,0 +1,290 @@
+package benchmark
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// concurrencyStabilityAssertions are the PR #94 fixed-concurrency assertions
+// whose pass rates the concurrency report surfaces. They only fire when a
+// batch runs with concurrency >= 2.
+var concurrencyStabilityAssertions = []string{
+	"concurrent-run-total-records-stable",
+	"concurrent-run-page-row-ids-stable",
+	"concurrent-run-failure-kind-stable",
+	"concurrent-run-route-engine-stable",
+}
+
+// ConcurrencyReport aggregates N single-concurrency benchmark summaries into
+// one publishable artifact comparing latency percentiles and concurrency
+// stability assertions across concurrency levels (#104).
+type ConcurrencyReport struct {
+	Metadata   ArtifactMetadata           `json:"metadata"`
+	Provenance *RunProvenance             `json:"provenance,omitempty"`
+	Levels     []int                      `json:"levels"`
+	Comparable bool                       `json:"comparable"`
+	Warnings   []string                   `json:"warnings,omitempty"`
+	Summary    []ConcurrencyLevelSummary  `json:"summary"`
+	Workloads  []WorkloadConcurrencyTrend `json:"workloads,omitempty"`
+}
+
+// ConcurrencyLevelSummary is one whole-run row of the concurrency matrix.
+type ConcurrencyLevelSummary struct {
+	Concurrency         int                      `json:"concurrency"`
+	ExecutionCount      int                      `json:"execution_count"`
+	Passed              bool                     `json:"passed"`
+	FailureCount        int                      `json:"failure_count,omitempty"`
+	P50                 time.Duration            `json:"p50"`
+	P95                 time.Duration            `json:"p95"`
+	P99                 time.Duration            `json:"p99"`
+	QPS                 float64                  `json:"qps"`
+	StabilityAssertions map[string]AssertionStat `json:"stability_assertions,omitempty"`
+}
+
+// WorkloadConcurrencyTrend tracks one workload across concurrency levels.
+type WorkloadConcurrencyTrend struct {
+	Name         string                     `json:"name"`
+	TargetSchema string                     `json:"target_schema,omitempty"`
+	Levels       []WorkloadConcurrencyLevel `json:"levels"`
+}
+
+// WorkloadConcurrencyLevel is one workload row at one concurrency level.
+type WorkloadConcurrencyLevel struct {
+	Concurrency         int                      `json:"concurrency"`
+	ExecutionCount      int                      `json:"execution_count"`
+	Passed              bool                     `json:"passed"`
+	P50                 time.Duration            `json:"p50"`
+	P95                 time.Duration            `json:"p95"`
+	P99                 time.Duration            `json:"p99"`
+	QPS                 float64                  `json:"qps"`
+	StabilityAssertions map[string]AssertionStat `json:"stability_assertions,omitempty"`
+}
+
+// BuildConcurrencyReport aggregates one summary per concurrency level into a
+// ConcurrencyReport. Summaries missing a provenance concurrency count as
+// level 1 (pre-#104 artifacts); duplicate levels are an input error.
+func BuildConcurrencyReport(summaries []SummaryReport) (ConcurrencyReport, error) {
+	if len(summaries) == 0 {
+		return ConcurrencyReport{}, fmt.Errorf("no summaries provided")
+	}
+
+	ordered := make([]SummaryReport, len(summaries))
+	copy(ordered, summaries)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return summaryConcurrency(ordered[i]) < summaryConcurrency(ordered[j])
+	})
+
+	seen := map[int]bool{}
+	report := ConcurrencyReport{
+		Metadata:   ordered[0].Metadata,
+		Provenance: ordered[0].Provenance,
+		Comparable: true,
+	}
+	baseIdentity := concurrencyAgnosticIdentity(ordered[0])
+
+	workloadIndex := map[string]int{}
+
+	for _, summary := range ordered {
+		level := summaryConcurrency(summary)
+		if seen[level] {
+			return ConcurrencyReport{}, fmt.Errorf("duplicate concurrency level %d", level)
+		}
+		seen[level] = true
+		report.Levels = append(report.Levels, level)
+
+		if identity := concurrencyAgnosticIdentity(summary); identity != baseIdentity {
+			report.Comparable = false
+			report.Warnings = append(report.Warnings,
+				fmt.Sprintf("run at concurrency %d is not comparable to the first run: %s vs %s", level, identity, baseIdentity))
+		}
+
+		report.Summary = append(report.Summary, ConcurrencyLevelSummary{
+			Concurrency:         level,
+			ExecutionCount:      summary.ExecutionCount,
+			Passed:              summary.Passed,
+			FailureCount:        summary.FailureCount,
+			P50:                 summary.P50,
+			P95:                 summary.P95,
+			P99:                 summary.P99,
+			QPS:                 summary.QPS,
+			StabilityAssertions: filterStabilityAssertions(summary.AssertionStats),
+		})
+
+		for _, w := range summary.Workloads {
+			idx, ok := workloadIndex[w.Name]
+			if !ok {
+				idx = len(report.Workloads)
+				workloadIndex[w.Name] = idx
+				report.Workloads = append(report.Workloads, WorkloadConcurrencyTrend{
+					Name:         w.Name,
+					TargetSchema: w.TargetSchema,
+				})
+			}
+			report.Workloads[idx].Levels = append(report.Workloads[idx].Levels, WorkloadConcurrencyLevel{
+				Concurrency:         level,
+				ExecutionCount:      w.ExecutionCount,
+				Passed:              w.Passed,
+				P50:                 w.P50,
+				P95:                 w.P95,
+				P99:                 w.P99,
+				QPS:                 w.QPS,
+				StabilityAssertions: filterStabilityAssertions(w.AssertionStats),
+			})
+		}
+	}
+
+	return report, nil
+}
+
+func summaryConcurrency(summary SummaryReport) int {
+	if summary.Provenance != nil && summary.Provenance.Concurrency > 1 {
+		return summary.Provenance.Concurrency
+	}
+	return 1
+}
+
+// concurrencyAgnosticIdentity is buildComparabilityIdentity with the
+// concurrency segment removed: sweep runs differ in concurrency by design.
+func concurrencyAgnosticIdentity(summary SummaryReport) string {
+	if summary.Provenance == nil {
+		return summary.Metadata.BenchmarkID
+	}
+	pc := *summary.Provenance
+	pc.Concurrency = 0
+	stripped := summary
+	stripped.Provenance = &pc
+	return buildComparabilityIdentity(stripped)
+}
+
+func filterStabilityAssertions(stats map[string]AssertionStat) map[string]AssertionStat {
+	var filtered map[string]AssertionStat
+	for _, name := range concurrencyStabilityAssertions {
+		if stat, ok := stats[name]; ok {
+			if filtered == nil {
+				filtered = make(map[string]AssertionStat, len(concurrencyStabilityAssertions))
+			}
+			filtered[name] = stat
+		}
+	}
+	return filtered
+}
+
+// FormatConcurrencyMarkdown renders the report as a single publishable
+// markdown document.
+func FormatConcurrencyMarkdown(report ConcurrencyReport) string {
+	var b strings.Builder
+	b.WriteString("# Concurrency Benchmark Report\n\n")
+
+	b.WriteString(fmt.Sprintf("- benchmark_id: %s\n", report.Metadata.BenchmarkID))
+	if p := report.Provenance; p != nil {
+		b.WriteString(fmt.Sprintf("- mode/scale/distribution/tier: %s/%s/%s/%s\n", p.Mode, p.Scale, p.Distribution, p.TierProfile))
+		if p.GitSHA != "" {
+			b.WriteString(fmt.Sprintf("- git: %s (%s)\n", p.GitSHA, p.GitRef))
+		}
+	}
+	env := report.Metadata.Environment
+	b.WriteString(fmt.Sprintf("- environment: %s/%s, %d CPUs", env.GOOS, env.GOARCH, env.NumCPU))
+	if env.Hostname != "" {
+		b.WriteString(fmt.Sprintf(" (%s)", env.Hostname))
+	}
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("- levels: %s\n", joinLevels(report.Levels)))
+
+	if !report.Comparable {
+		b.WriteString("\n**WARNING: runs are not directly comparable**\n")
+		for _, w := range report.Warnings {
+			b.WriteString(fmt.Sprintf("- %s\n", w))
+		}
+	}
+
+	b.WriteString("\n## Overall\n\n")
+	b.WriteString("| Concurrency | P50 | P95 | P99 | QPS | Executions | Passed |\n")
+	b.WriteString("|---|---|---|---|---|---|---|\n")
+	for _, row := range report.Summary {
+		b.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %.2f | %d | %t |\n",
+			row.Concurrency, row.P50, row.P95, row.P99, row.QPS, row.ExecutionCount, row.Passed))
+	}
+
+	for _, workload := range report.Workloads {
+		b.WriteString(fmt.Sprintf("\n## %s\n\n", workload.Name))
+		if workload.TargetSchema != "" {
+			b.WriteString(fmt.Sprintf("target schema: %s\n\n", workload.TargetSchema))
+		}
+		b.WriteString("| Concurrency | P50 | P95 | P99 | QPS | Executions | Passed | Stability |\n")
+		b.WriteString("|---|---|---|---|---|---|---|---|\n")
+		for _, row := range workload.Levels {
+			b.WriteString(fmt.Sprintf("| %d | %s | %s | %s | %.2f | %d | %t | %s |\n",
+				row.Concurrency, row.P50, row.P95, row.P99, row.QPS, row.ExecutionCount, row.Passed,
+				formatStabilityCell(row.StabilityAssertions)))
+		}
+	}
+
+	b.WriteString("\n## Concurrency Stability Assertions\n\n")
+	unstable := false
+	for _, workload := range report.Workloads {
+		for _, row := range workload.Levels {
+			for _, name := range concurrencyStabilityAssertions {
+				if stat, ok := row.StabilityAssertions[name]; ok && stat.Failed > 0 {
+					b.WriteString(fmt.Sprintf("- FAIL %s @ C=%d: %s %d/%d passed\n",
+						workload.Name, row.Concurrency, name, stat.Passed, stat.Passed+stat.Failed))
+					unstable = true
+				}
+			}
+		}
+	}
+	if !unstable {
+		b.WriteString("All concurrency stability assertions passed at every level (C=1 rows are n/a: the assertions only fire at C>=2).\n")
+	}
+
+	return b.String()
+}
+
+func joinLevels(levels []int) string {
+	parts := make([]string, 0, len(levels))
+	for _, l := range levels {
+		parts = append(parts, fmt.Sprintf("C=%d", l))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatStabilityCell renders the four assertion pass counts compactly;
+// "n/a" for C=1 rows where the assertions never fire.
+func formatStabilityCell(stats map[string]AssertionStat) string {
+	if len(stats) == 0 {
+		return "n/a"
+	}
+	parts := make([]string, 0, len(concurrencyStabilityAssertions))
+	for _, name := range concurrencyStabilityAssertions {
+		stat, ok := stats[name]
+		if !ok {
+			continue
+		}
+		short := strings.TrimSuffix(strings.TrimPrefix(name, "concurrent-run-"), "-stable")
+		parts = append(parts, fmt.Sprintf("%s %d/%d", short, stat.Passed, stat.Passed+stat.Failed))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// WriteConcurrencyReport writes the JSON and/or markdown artifacts (empty
+// path skips that artifact).
+func WriteConcurrencyReport(jsonPath, mdPath string, report ConcurrencyReport) error {
+	if jsonPath != "" {
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal concurrency report: %w", err)
+		}
+		if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+			return fmt.Errorf("write concurrency report json: %w", err)
+		}
+	}
+	if mdPath != "" {
+		if err := os.WriteFile(mdPath, []byte(FormatConcurrencyMarkdown(report)), 0o644); err != nil {
+			return fmt.Errorf("write concurrency report markdown: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/e2e_harness/federated/benchmark/concurrency_report_test.go
+++ b/internal/e2e_harness/federated/benchmark/concurrency_report_test.go
@@ -1,6 +1,9 @@
 package benchmark
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -128,6 +131,118 @@ func TestBuildConcurrencyReportFlagsIncomparableRuns(t *testing.T) {
 	}
 }
 
+// TestBuildConcurrencyReportComputesDeltasVsLowestLevel: the original #104
+// acceptance wording asks for p50/p95/p99 *deltas*; each row carries its
+// delta against the lowest level present (zero on the baseline row itself).
+func TestBuildConcurrencyReportComputesDeltasVsLowestLevel(t *testing.T) {
+	report, err := BuildConcurrencyReport([]SummaryReport{
+		concurrencySummaryFixture(1, 20*time.Millisecond),
+		concurrencySummaryFixture(2, 40*time.Millisecond),
+		concurrencySummaryFixture(4, 80*time.Millisecond),
+	})
+	if err != nil {
+		t.Fatalf("build concurrency report: %v", err)
+	}
+
+	if report.Summary[0].P99DeltaVsBase != 0 {
+		t.Fatalf("expected zero delta on the baseline row, got %s", report.Summary[0].P99DeltaVsBase)
+	}
+	if report.Summary[2].P99DeltaVsBase != 60*time.Millisecond {
+		t.Fatalf("expected overall P99 delta of 60ms at C=4, got %s", report.Summary[2].P99DeltaVsBase)
+	}
+	levels := report.Workloads[0].Levels
+	if levels[1].P99DeltaVsBase != 20*time.Millisecond || levels[2].P99DeltaVsBase != 60*time.Millisecond {
+		t.Fatalf("expected workload P99 deltas of 20ms/60ms, got %s/%s", levels[1].P99DeltaVsBase, levels[2].P99DeltaVsBase)
+	}
+}
+
+// TestFormatConcurrencyMarkdownStabilityEvidenceStates: missing stability
+// evidence must be distinct from passed evidence.
+func TestFormatConcurrencyMarkdownStabilityEvidenceStates(t *testing.T) {
+	t.Run("all sequential runs report n/a not passed", func(t *testing.T) {
+		report, err := BuildConcurrencyReport([]SummaryReport{concurrencySummaryFixture(1, 20*time.Millisecond)})
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		md := FormatConcurrencyMarkdown(report)
+		if strings.Contains(md, "All concurrency stability assertions passed") {
+			t.Fatalf("all-sequential report must not claim assertions passed:\n%s", md)
+		}
+		if !strings.Contains(md, "sequential") {
+			t.Fatalf("expected sequential n/a note:\n%s", md)
+		}
+	})
+
+	t.Run("missing stats at C>1 reported as missing evidence", func(t *testing.T) {
+		noStats := concurrencySummaryFixture(4, 80*time.Millisecond)
+		noStats.AssertionStats = nil
+		noStats.Workloads[0].AssertionStats = nil
+
+		report, err := BuildConcurrencyReport([]SummaryReport{
+			concurrencySummaryFixture(1, 20*time.Millisecond),
+			noStats,
+		})
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		md := FormatConcurrencyMarkdown(report)
+		if strings.Contains(md, "All concurrency stability assertions passed") {
+			t.Fatalf("missing evidence must not be reported as passed:\n%s", md)
+		}
+		if !strings.Contains(md, "MISSING") {
+			t.Fatalf("expected missing-evidence marker:\n%s", md)
+		}
+	})
+}
+
+// TestCollectConcurrencySummaries: the evidence collector must fail loudly on
+// malformed inputs (unlike trend, which tolerates them) and must include
+// provenance-less summaries (counted as C=1).
+func TestCollectConcurrencySummaries(t *testing.T) {
+	writeSummary := func(t *testing.T, dir, sub string, summary SummaryReport) {
+		t.Helper()
+		full := filepath.Join(dir, sub)
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		data, err := json.Marshal(summary)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(full, "benchmark-summary.json"), data, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	t.Run("includes provenance-less summaries", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSummary(t, dir, "legacy", SummaryReport{Metadata: ArtifactMetadata{BenchmarkID: "legacy"}})
+		writeSummary(t, dir, "c2", concurrencySummaryFixture(2, 40*time.Millisecond))
+
+		summaries, err := CollectConcurrencySummaries(dir)
+		if err != nil {
+			t.Fatalf("collect: %v", err)
+		}
+		if len(summaries) != 2 {
+			t.Fatalf("expected both summaries collected, got %d", len(summaries))
+		}
+	})
+
+	t.Run("fails loudly on malformed summary", func(t *testing.T) {
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "broken")
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(sub, "benchmark-summary.json"), []byte("{not json"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if _, err := CollectConcurrencySummaries(dir); err == nil {
+			t.Fatalf("expected malformed summary to fail collection")
+		}
+	})
+}
+
 func TestFormatConcurrencyMarkdown(t *testing.T) {
 	report, err := BuildConcurrencyReport([]SummaryReport{
 		concurrencySummaryFixture(1, 20*time.Millisecond),
@@ -141,10 +256,11 @@ func TestFormatConcurrencyMarkdown(t *testing.T) {
 	md := FormatConcurrencyMarkdown(report)
 	for _, want := range []string{
 		"# Concurrency Benchmark Report",
-		"| Concurrency | P50 | P95 | P99 | QPS |",
+		"| Concurrency | P50 | P95 | P99 | P50Δ | P95Δ | P99Δ | QPS |",
 		"## baseline-page-1",
 		"concurrent-run-route-engine-stable",
 		"n/a",
+		"+60ms",
 	} {
 		if !strings.Contains(md, want) {
 			t.Fatalf("expected markdown to contain %q, got:\n%s", want, md)

--- a/internal/e2e_harness/federated/benchmark/concurrency_report_test.go
+++ b/internal/e2e_harness/federated/benchmark/concurrency_report_test.go
@@ -1,0 +1,153 @@
+package benchmark
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func concurrencySummaryFixture(concurrency int, p99 time.Duration) SummaryReport {
+	stats := map[string]AssertionStat{}
+	if concurrency > 1 {
+		stats = map[string]AssertionStat{
+			"concurrent-run-total-records-stable": {Passed: 2},
+			"concurrent-run-page-row-ids-stable":  {Passed: 2},
+			"concurrent-run-failure-kind-stable":  {Passed: 2},
+			"concurrent-run-route-engine-stable":  {Passed: 1, Failed: 1},
+			"result-count-matches":                {Passed: 4},
+		}
+	}
+	return SummaryReport{
+		Metadata: ArtifactMetadata{BenchmarkID: "bench", Environment: EnvironmentMetadata{NumCPU: 8}},
+		Provenance: &RunProvenance{
+			Mode:         string(ExecutionModeLive),
+			Scale:        string(ScaleSmall),
+			Distribution: string(DistributionUniform),
+			TierProfile:  DefaultTierMixProfile().Name,
+			Concurrency:  concurrency,
+		},
+		Passed:         true,
+		ExecutionCount: 2 * concurrency,
+		P50:            10 * time.Millisecond,
+		P95:            p99 / 2,
+		P99:            p99,
+		QPS:            100 / float64(concurrency),
+		AssertionStats: stats,
+		Workloads: []WorkloadSummary{{
+			Name:           "baseline-page-1",
+			TargetSchema:   "trade",
+			Passed:         true,
+			ExecutionCount: 2 * concurrency,
+			P50:            10 * time.Millisecond,
+			P95:            p99 / 2,
+			P99:            p99,
+			QPS:            50 / float64(concurrency),
+			AssertionStats: stats,
+		}},
+	}
+}
+
+func TestBuildConcurrencyReport(t *testing.T) {
+	summaries := []SummaryReport{
+		concurrencySummaryFixture(4, 80*time.Millisecond),
+		concurrencySummaryFixture(1, 20*time.Millisecond),
+		concurrencySummaryFixture(2, 40*time.Millisecond),
+	}
+
+	report, err := BuildConcurrencyReport(summaries)
+	if err != nil {
+		t.Fatalf("build concurrency report: %v", err)
+	}
+
+	if len(report.Levels) != 3 || report.Levels[0] != 1 || report.Levels[1] != 2 || report.Levels[2] != 4 {
+		t.Fatalf("expected ascending levels [1 2 4], got %v", report.Levels)
+	}
+	if !report.Comparable || len(report.Warnings) != 0 {
+		t.Fatalf("expected comparable runs without warnings, got comparable=%t warnings=%v", report.Comparable, report.Warnings)
+	}
+	if len(report.Summary) != 3 || report.Summary[2].Concurrency != 4 || report.Summary[2].P99 != 80*time.Millisecond {
+		t.Fatalf("unexpected summary rows: %+v", report.Summary)
+	}
+	if len(report.Workloads) != 1 || report.Workloads[0].Name != "baseline-page-1" {
+		t.Fatalf("expected one workload trend, got %+v", report.Workloads)
+	}
+	levels := report.Workloads[0].Levels
+	if len(levels) != 3 || levels[2].Concurrency != 4 || levels[2].P99 != 80*time.Millisecond {
+		t.Fatalf("unexpected workload levels: %+v", levels)
+	}
+	// C=1 rows must not carry concurrency stability assertions (they never fire).
+	if len(levels[0].StabilityAssertions) != 0 {
+		t.Fatalf("expected no stability assertions at C=1, got %v", levels[0].StabilityAssertions)
+	}
+	// Only the four concurrent-run-* assertions are stability assertions.
+	stats := levels[2].StabilityAssertions
+	if len(stats) != 4 {
+		t.Fatalf("expected exactly four stability assertions at C=4, got %v", stats)
+	}
+	if stats["concurrent-run-route-engine-stable"].Failed != 1 {
+		t.Fatalf("expected route-engine stability failure to surface, got %v", stats)
+	}
+}
+
+func TestBuildConcurrencyReportRejectsDuplicateLevels(t *testing.T) {
+	summaries := []SummaryReport{
+		concurrencySummaryFixture(2, 40*time.Millisecond),
+		concurrencySummaryFixture(2, 44*time.Millisecond),
+	}
+	if _, err := BuildConcurrencyReport(summaries); err == nil {
+		t.Fatalf("expected duplicate concurrency levels to be rejected")
+	}
+}
+
+func TestBuildConcurrencyReportMissingConcurrencyDefaultsToOne(t *testing.T) {
+	legacy := concurrencySummaryFixture(1, 20*time.Millisecond)
+	legacy.Provenance.Concurrency = 0
+
+	report, err := BuildConcurrencyReport([]SummaryReport{legacy, concurrencySummaryFixture(2, 40*time.Millisecond)})
+	if err != nil {
+		t.Fatalf("build concurrency report: %v", err)
+	}
+	if len(report.Levels) != 2 || report.Levels[0] != 1 {
+		t.Fatalf("expected missing concurrency to default to level 1, got %v", report.Levels)
+	}
+}
+
+func TestBuildConcurrencyReportFlagsIncomparableRuns(t *testing.T) {
+	other := concurrencySummaryFixture(2, 40*time.Millisecond)
+	other.Provenance.Scale = string(ScaleMedium)
+
+	report, err := BuildConcurrencyReport([]SummaryReport{concurrencySummaryFixture(1, 20*time.Millisecond), other})
+	if err != nil {
+		t.Fatalf("build concurrency report: %v", err)
+	}
+	if report.Comparable {
+		t.Fatalf("expected mismatched scale to mark the report incomparable")
+	}
+	if len(report.Warnings) == 0 {
+		t.Fatalf("expected warnings for incomparable runs")
+	}
+}
+
+func TestFormatConcurrencyMarkdown(t *testing.T) {
+	report, err := BuildConcurrencyReport([]SummaryReport{
+		concurrencySummaryFixture(1, 20*time.Millisecond),
+		concurrencySummaryFixture(2, 40*time.Millisecond),
+		concurrencySummaryFixture(4, 80*time.Millisecond),
+	})
+	if err != nil {
+		t.Fatalf("build concurrency report: %v", err)
+	}
+
+	md := FormatConcurrencyMarkdown(report)
+	for _, want := range []string{
+		"# Concurrency Benchmark Report",
+		"| Concurrency | P50 | P95 | P99 | QPS |",
+		"## baseline-page-1",
+		"concurrent-run-route-engine-stable",
+		"n/a",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("expected markdown to contain %q, got:\n%s", want, md)
+		}
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/config.go
+++ b/internal/e2e_harness/federated/benchmark/config.go
@@ -47,6 +47,12 @@ type Config struct {
 	DeleteRatio   float64       `json:"delete_ratio,omitempty"`
 	TierProfile   string        `json:"tier_profile,omitempty"`
 	Workloads     []string      `json:"workloads"`
+	// DuckDBThreads / DuckDBMemoryLimitMB override the harness DuckDB
+	// resources for live runs (0 = harness default). omitempty keeps the
+	// BenchmarkID hash of existing artifacts stable (BuildArtifactMetadata
+	// hashes the whole Config).
+	DuckDBThreads       int `json:"duckdb_threads,omitempty"`
+	DuckDBMemoryLimitMB int `json:"duckdb_memory_limit_mb,omitempty"`
 }
 
 // DefaultConfig returns the benchmark scaffold defaults.
@@ -116,6 +122,12 @@ func (c Config) Validate() error {
 	}
 	if c.PageSize <= 0 {
 		return fmt.Errorf("page size must be greater than zero")
+	}
+	if c.DuckDBThreads < 0 {
+		return fmt.Errorf("duckdb threads must be greater than or equal to zero")
+	}
+	if c.DuckDBMemoryLimitMB < 0 {
+		return fmt.Errorf("duckdb memory limit must be greater than or equal to zero")
 	}
 	if c.TierProfile != "" {
 		if _, err := ResolveTierMixProfile(c.TierProfile); err != nil {

--- a/internal/e2e_harness/federated/benchmark/config_test.go
+++ b/internal/e2e_harness/federated/benchmark/config_test.go
@@ -1,6 +1,10 @@
 package benchmark
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestDefaultConfigValidate(t *testing.T) {
 	cfg := DefaultConfig()
@@ -30,6 +34,33 @@ func TestConfigValidateRejectsUnknownTierProfile(t *testing.T) {
 	cfg.TierProfile = "does-not-exist"
 	if err := cfg.Validate(); err == nil {
 		t.Fatalf("Validate should reject unknown tier profile")
+	}
+}
+
+func TestConfigValidateRejectsNegativeDuckDBResources(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DuckDBThreads = -1
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate should reject negative duckdb threads")
+	}
+
+	cfg = DefaultConfig()
+	cfg.DuckDBMemoryLimitMB = -1
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate should reject negative duckdb memory limit")
+	}
+}
+
+// TestConfigJSONOmitsZeroDuckDBResources protects BenchmarkID continuity:
+// BuildArtifactMetadata hashes the whole Config, so zero-valued resource
+// overrides must not appear in the JSON encoding.
+func TestConfigJSONOmitsZeroDuckDBResources(t *testing.T) {
+	raw, err := json.Marshal(DefaultConfig())
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if strings.Contains(string(raw), "duckdb_threads") || strings.Contains(string(raw), "duckdb_memory_limit_mb") {
+		t.Fatalf("zero-valued DuckDB resource overrides must be omitted from JSON, got: %s", raw)
 	}
 }
 

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -45,6 +45,7 @@ type RunProvenance struct {
 	Scale        string    `json:"scale,omitempty"`
 	Distribution string    `json:"distribution,omitempty"`
 	TierProfile  string    `json:"tier_profile,omitempty"`
+	Concurrency  int       `json:"concurrency,omitempty"`
 }
 
 // DefaultProtectedWorkloads returns the standard set of workloads that trigger
@@ -386,6 +387,9 @@ func SummarizeRunResult(result *RunResult) SummaryReport {
 		if pc.CompletedAt.IsZero() {
 			pc.CompletedAt = result.CompletedAt
 		}
+		if pc.Concurrency == 0 {
+			pc.Concurrency = result.Config.Concurrency
+		}
 		summary.Provenance = &pc
 	} else if !result.StartedAt.IsZero() {
 		summary.Provenance = &RunProvenance{
@@ -395,6 +399,7 @@ func SummarizeRunResult(result *RunResult) SummaryReport {
 			Scale:        string(result.Config.Scale),
 			Distribution: string(result.Config.Distribution),
 			TierProfile:  result.Config.TierProfile,
+			Concurrency:  result.Config.Concurrency,
 		}
 	}
 	if len(result.Executions) == 0 {
@@ -870,12 +875,19 @@ func buildComparabilityIdentity(summary SummaryReport) string {
 		names = append(names, w.Name)
 	}
 	sort.Strings(names)
-	return fmt.Sprintf("%s|%s|%s|%s|%s",
+	identity := fmt.Sprintf("%s|%s|%s|%s|%s",
 		summary.Provenance.Mode,
 		summary.Provenance.Scale,
 		summary.Provenance.Distribution,
 		summary.Provenance.TierProfile,
 		strings.Join(names, ","))
+	// Concurrent runs form their own comparability group so they never mix
+	// into the sequential trend baseline; C<=1 keeps the legacy identity so
+	// historical artifacts stay comparable.
+	if summary.Provenance.Concurrency > 1 {
+		identity = fmt.Sprintf("%s|c%d", identity, summary.Provenance.Concurrency)
+	}
+	return identity
 }
 
 // findCandidateRun returns the specified candidate path or the newest comparable run.

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -843,8 +843,13 @@ func ReadTrendHistory(historyDir string) ([]TrendRun, error) {
 		if readErr != nil {
 			return nil
 		}
+		// Trend needs timestamps: summaries without provenance (manual or
+		// legacy artifacts) are skipped, never dereferenced.
+		if summary.Provenance == nil {
+			return nil
+		}
 		startedAt := summary.Provenance.StartedAt
-		if startedAt.IsZero() && summary.Provenance != nil {
+		if startedAt.IsZero() {
 			startedAt = summary.Provenance.CompletedAt
 		}
 		if startedAt.IsZero() {

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -177,6 +177,7 @@ type WorkloadDiff struct {
 	QPSDelta                 float64       `json:"qps_delta"`
 	AvgLatencyDelta          time.Duration `json:"avg_latency_delta"`
 	P95LatencyDelta          time.Duration `json:"p95_latency_delta"`
+	P99LatencyDelta          time.Duration `json:"p99_latency_delta"`
 	AvgResultCountDelta      float64       `json:"avg_result_count_delta"`
 	AvgTotalRecordsDelta     float64       `json:"avg_total_records_delta"`
 	RouteEngineChanged       bool          `json:"route_engine_changed,omitempty"`
@@ -621,7 +622,7 @@ func FormatDiffSummary(diff DiffReport) string {
 		diff.Summary.P95LatencyDelta,
 	))
 	for _, workload := range diff.Workloads {
-		b.WriteString(fmt.Sprintf("workload %s schema=%s missing_baseline=%t missing_candidate=%t passed_changed=%t correctness_delta=%d qps_delta=%.2f avg_latency_delta=%s p95_latency_delta=%s avg_result_delta=%.2f avg_total_delta=%.2f route_changed=%t\n",
+		b.WriteString(fmt.Sprintf("workload %s schema=%s missing_baseline=%t missing_candidate=%t passed_changed=%t correctness_delta=%d qps_delta=%.2f avg_latency_delta=%s p95_latency_delta=%s p99_latency_delta=%s avg_result_delta=%.2f avg_total_delta=%.2f route_changed=%t\n",
 			workload.Name,
 			workload.TargetSchema,
 			workload.MissingInBaseline,
@@ -631,6 +632,7 @@ func FormatDiffSummary(diff DiffReport) string {
 			workload.QPSDelta,
 			workload.AvgLatencyDelta,
 			workload.P95LatencyDelta,
+			workload.P99LatencyDelta,
 			workload.AvgResultCountDelta,
 			workload.AvgTotalRecordsDelta,
 			workload.RouteEngineChanged,
@@ -1382,6 +1384,7 @@ func compareWorkloadSummaries(baseline, candidate []WorkloadSummary) []WorkloadD
 			QPSDelta:                 cand.QPS - base.QPS,
 			AvgLatencyDelta:          cand.Avg - base.Avg,
 			P95LatencyDelta:          cand.P95 - base.P95,
+			P99LatencyDelta:          cand.P99 - base.P99,
 			AvgResultCountDelta:      cand.AvgResultCount - base.AvgResultCount,
 			AvgTotalRecordsDelta:     cand.AvgTotalRecords - base.AvgTotalRecords,
 			RouteEngineChanged:       routeEngineChanged,

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -455,6 +455,65 @@ func TestReadTrendHistory(t *testing.T) {
 	}
 }
 
+func TestProvenanceCarriesConcurrency(t *testing.T) {
+	baseTime := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	result := &RunResult{
+		Passed:      true,
+		StartedAt:   baseTime,
+		CompletedAt: baseTime.Add(10 * time.Second),
+		Config:      Config{Mode: ExecutionModeLive, Scale: ScaleSmall, Distribution: DistributionUniform, TierProfile: DefaultTierMixProfile().Name, Concurrency: 4},
+		Executions: []WorkloadRunResult{{
+			Name:     "q1",
+			Passed:   true,
+			Duration: 10 * time.Millisecond,
+		}},
+	}
+
+	summary := SummarizeRunResult(result)
+	if summary.Provenance == nil || summary.Provenance.Concurrency != 4 {
+		t.Fatalf("expected fallback provenance to carry concurrency 4, got %+v", summary.Provenance)
+	}
+
+	result.Provenance = &RunProvenance{Channel: "manual"}
+	summary = SummarizeRunResult(result)
+	if summary.Provenance == nil || summary.Provenance.Concurrency != 4 {
+		t.Fatalf("expected explicit provenance to be backfilled with concurrency 4, got %+v", summary.Provenance)
+	}
+}
+
+// TestBuildComparabilityIdentity_ConcurrencySegment: runs at concurrency > 1
+// must not share a trend baseline window with sequential runs, while C<=1
+// keeps the legacy identity so historical artifacts stay comparable.
+func TestBuildComparabilityIdentity_ConcurrencySegment(t *testing.T) {
+	mk := func(concurrency int) SummaryReport {
+		return SummaryReport{
+			Metadata: ArtifactMetadata{BenchmarkID: "bench"},
+			Provenance: &RunProvenance{
+				Mode:         string(ExecutionModeLive),
+				Scale:        string(ScaleSmall),
+				Distribution: string(DistributionUniform),
+				TierProfile:  DefaultTierMixProfile().Name,
+				Concurrency:  concurrency,
+			},
+			Workloads: []WorkloadSummary{{Name: "q1"}},
+		}
+	}
+
+	legacy := mk(0)
+	sequential := mk(1)
+	concurrent := mk(4)
+
+	if buildComparabilityIdentity(legacy) != buildComparabilityIdentity(sequential) {
+		t.Fatalf("expected C<=1 to keep the legacy comparability key")
+	}
+	if buildComparabilityIdentity(concurrent) == buildComparabilityIdentity(legacy) {
+		t.Fatalf("expected concurrent runs to form their own comparability group")
+	}
+	if !strings.HasSuffix(buildComparabilityIdentity(concurrent), "|c4") {
+		t.Fatalf("expected concurrency segment suffix, got %q", buildComparabilityIdentity(concurrent))
+	}
+}
+
 func TestBuildComparabilityIdentity(t *testing.T) {
 	a := SummaryReport{
 		Metadata: ArtifactMetadata{BenchmarkID: "bench-a"},

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -535,6 +535,32 @@ func TestBuildComparabilityIdentity_ConcurrencySegment(t *testing.T) {
 	}
 }
 
+// TestReadTrendHistorySkipsNilProvenance: manual/legacy artifacts without
+// provenance must be skipped (trend needs timestamps), not panic.
+func TestReadTrendHistorySkipsNilProvenance(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "legacy")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacy := SummaryReport{Metadata: ArtifactMetadata{BenchmarkID: "legacy"}}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "benchmark-summary.json"), data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	runs, err := ReadTrendHistory(dir)
+	if err != nil {
+		t.Fatalf("read trend history: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("expected provenance-less summary to be skipped, got %d runs", len(runs))
+	}
+}
+
 func TestBuildComparabilityIdentity(t *testing.T) {
 	a := SummaryReport{
 		Metadata: ArtifactMetadata{BenchmarkID: "bench-a"},

--- a/internal/e2e_harness/federated/benchmark/report_test.go
+++ b/internal/e2e_harness/federated/benchmark/report_test.go
@@ -266,6 +266,27 @@ func TestCompareSummaryReports(t *testing.T) {
 	}
 }
 
+func TestCompareWorkloadSummariesP99Delta(t *testing.T) {
+	baseline := SummaryReport{
+		Workloads: []WorkloadSummary{{Name: "q1", P99: 30 * time.Millisecond}},
+	}
+	candidate := SummaryReport{
+		Workloads: []WorkloadSummary{{Name: "q1", P99: 42 * time.Millisecond}},
+	}
+
+	diff := CompareSummaryReports(baseline, candidate)
+	if len(diff.Workloads) != 1 {
+		t.Fatalf("expected one workload diff, got %d", len(diff.Workloads))
+	}
+	if diff.Workloads[0].P99LatencyDelta != 12*time.Millisecond {
+		t.Fatalf("expected workload p99 delta of 12ms, got %s", diff.Workloads[0].P99LatencyDelta)
+	}
+	formatted := FormatDiffSummary(diff)
+	if !strings.Contains(formatted, "p99_latency_delta=") {
+		t.Fatalf("expected workload p99 delta in formatted diff: %s", formatted)
+	}
+}
+
 func TestWriteAndReadDiffReport(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "diff.json")

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -575,22 +575,7 @@ func (r *Runner) executeKeysetServiceQuery(ctx context.Context, h *federated.Fed
 		return nil, nil, nil, fmt.Errorf("load benchmark metadata: %w", err)
 	}
 
-	duckCfg := forma.DuckDBConfig{}
-	if h.Duck != nil {
-		duckCfg = forma.DuckDBConfig{
-			Enabled:        true,
-			DBPath:         ":memory:",
-			EnableS3:       true,
-			EnableParquet:  true,
-			S3Endpoint:     h.S3Endpoint,
-			S3AccessKey:    h.S3AccessKey,
-			S3SecretKey:    h.S3SecretKey,
-			S3Region:       h.S3Region,
-			MaxConnections: 4,
-			QueryTimeout:   60 * time.Second,
-			MaxParallelism: 4,
-		}
-	}
+	duckCfg := engineDuckDBConfig(h)
 	repo := internal.NewDBPersistentRecordRepository(pool, metadata, internal.WithPlanCache(r.planCache))
 	engine := fedengine.NewDBFederatedQueryEngine(
 		repo,
@@ -731,6 +716,16 @@ func (r *Runner) executeKeysetServiceQuery(ctx context.Context, h *federated.Fed
 	return result, recs, plan, nil
 }
 
+// engineDuckDBConfig returns the engine-level DuckDB config for a harness:
+// the exact configuration the harness started DuckDB with (single source of
+// truth for resource settings), or a zero config when DuckDB is not running.
+func engineDuckDBConfig(h *federated.FederatedTestHarness) forma.DuckDBConfig {
+	if h.Duck == nil {
+		return forma.DuckDBConfig{}
+	}
+	return h.DuckCfg
+}
+
 func executeServiceQuery(ctx context.Context, h *federated.FederatedTestHarness, req *forma.QueryRequest, defaultPageSize int, planCache *queryplan.Cache) (*forma.QueryResult, []*model.PersistentRecord, error) {
 	if h == nil || h.PGDSN == "" {
 		return nil, nil, fmt.Errorf("benchmark harness postgres DSN is required")
@@ -758,22 +753,7 @@ func executeServiceQuery(ctx context.Context, h *federated.FederatedTestHarness,
 		return nil, nil, fmt.Errorf("load benchmark metadata: %w", err)
 	}
 
-	duckCfg := forma.DuckDBConfig{}
-	if h.Duck != nil {
-		duckCfg = forma.DuckDBConfig{
-			Enabled:        true,
-			DBPath:         ":memory:",
-			EnableS3:       true,
-			EnableParquet:  true,
-			S3Endpoint:     h.S3Endpoint,
-			S3AccessKey:    h.S3AccessKey,
-			S3SecretKey:    h.S3SecretKey,
-			S3Region:       h.S3Region,
-			MaxConnections: 4,
-			QueryTimeout:   60 * time.Second,
-			MaxParallelism: 4,
-		}
-	}
+	duckCfg := engineDuckDBConfig(h)
 
 	repo := internal.NewDBPersistentRecordRepository(pool, metadata, internal.WithPlanCache(planCache))
 	engine := fedengine.NewDBFederatedQueryEngine(
@@ -861,22 +841,7 @@ func executeServiceQueryWithPlan(ctx context.Context, h *federated.FederatedTest
 		return nil, nil, nil, fmt.Errorf("resolve schema %s: %w", schemaName, err)
 	}
 
-	duckCfg := forma.DuckDBConfig{}
-	if h.Duck != nil {
-		duckCfg = forma.DuckDBConfig{
-			Enabled:        true,
-			DBPath:         ":memory:",
-			EnableS3:       true,
-			EnableParquet:  true,
-			S3Endpoint:     h.S3Endpoint,
-			S3AccessKey:    h.S3AccessKey,
-			S3SecretKey:    h.S3SecretKey,
-			S3Region:       h.S3Region,
-			MaxConnections: 4,
-			QueryTimeout:   60 * time.Second,
-			MaxParallelism: 4,
-		}
-	}
+	duckCfg := engineDuckDBConfig(h)
 	repo := internal.NewDBPersistentRecordRepository(pool, metadata, internal.WithPlanCache(planCache))
 	engine := fedengine.NewDBFederatedQueryEngine(
 		repo,

--- a/internal/e2e_harness/federated/harness.go
+++ b/internal/e2e_harness/federated/harness.go
@@ -289,10 +289,13 @@ func startContainers(ctx context.Context, base *e2e_harness.TestHarness) error {
 
 func startDuckDB(base *e2e_harness.TestHarness, s3Endpoint, s3AccessKey, s3SecretKey, s3Region string) error {
 	duckCfg := forma.DuckDBConfig{
-		Enabled:        true,
-		DBPath:         ":memory:",
-		MemoryLimitMB:  512,
-		EnableS3:       true,
+		Enabled: true,
+		DBPath:  ":memory:",
+		// 4096 matches the production default; the old 512 never actually
+		// governed federated queries because the query template re-set the
+		// instance to 4GB on every execution before #104 removed that PRAGMA.
+		MemoryLimitMB: 4096,
+		EnableS3:      true,
 		EnableParquet:  true,
 		S3Endpoint:     s3Endpoint,
 		S3AccessKey:    s3AccessKey,

--- a/internal/e2e_harness/federated/harness.go
+++ b/internal/e2e_harness/federated/harness.go
@@ -32,6 +32,9 @@ type FederatedTestHarness struct {
 	S3Prefix  string
 	CDCConfig cdc.CDCConfig
 	Registry  forma.SchemaRegistry
+	// DuckCfg is the DuckDB configuration the harness started DuckDB with,
+	// kept so engine construction reuses the truthful resource settings.
+	DuckCfg forma.DuckDBConfig
 
 	// Postgres connection info for DuckDB postgres_scan
 	PGHost     string
@@ -144,8 +147,32 @@ type ParquetMetadata struct {
 	SizeBytes  int64
 }
 
+// HarnessOption customizes federated test harness construction.
+type HarnessOption func(*harnessOptions)
+
+type harnessOptions struct {
+	duckThreads        int
+	duckMemoryLimitMB  int
+	duckMaxConnections int
+}
+
+// WithDuckDBResources overrides the DuckDB resource settings the harness
+// starts DuckDB with. Zero values keep the harness defaults (4 threads,
+// 4096MB memory limit, 4 connections).
+func WithDuckDBResources(threads, memoryLimitMB, maxConnections int) HarnessOption {
+	return func(o *harnessOptions) {
+		o.duckThreads = threads
+		o.duckMemoryLimitMB = memoryLimitMB
+		o.duckMaxConnections = maxConnections
+	}
+}
+
 // NewFederatedTestHarness creates a new federated test harness with all dependencies.
-func NewFederatedTestHarness(ctx context.Context) (*FederatedTestHarness, error) {
+func NewFederatedTestHarness(ctx context.Context, opts ...HarnessOption) (*FederatedTestHarness, error) {
+	options := harnessOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
 	logger, _ := zap.NewDevelopment()
 	base := &e2e_harness.TestHarness{}
 	externalCfg, err := loadExternalFederatedConfigFromEnv()
@@ -163,6 +190,7 @@ func NewFederatedTestHarness(ctx context.Context) (*FederatedTestHarness, error)
 	s3AccessKey := "minioadmin"
 	s3SecretKey := "minioadmin"
 
+	var duckCfg forma.DuckDBConfig
 	if externalCfg.Enabled {
 		if externalCfg.UseExternalPG {
 			if err := base.ConnectPostgres(ctx, externalCfg.PGDSN); err != nil {
@@ -175,7 +203,9 @@ func NewFederatedTestHarness(ctx context.Context) (*FederatedTestHarness, error)
 		}
 
 		base.S3Endpoint = externalCfg.S3Endpoint
-		if err := startDuckDB(base, externalCfg.S3Endpoint, externalCfg.S3AccessKey, externalCfg.S3SecretKey, externalCfg.S3Region); err != nil {
+		var err error
+		duckCfg, err = startDuckDB(base, externalCfg.S3Endpoint, externalCfg.S3AccessKey, externalCfg.S3SecretKey, externalCfg.S3Region, options)
+		if err != nil {
 			cleanupContainers(ctx, base)
 			return nil, fmt.Errorf("start duckdb: %w", err)
 		}
@@ -192,7 +222,9 @@ func NewFederatedTestHarness(ctx context.Context) (*FederatedTestHarness, error)
 			pgSSLMode = externalCfg.PGSSLMode
 		}
 	} else {
-		if err := startContainers(ctx, base); err != nil {
+		var err error
+		duckCfg, err = startContainers(ctx, base, options)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -220,6 +252,7 @@ func NewFederatedTestHarness(ctx context.Context) (*FederatedTestHarness, error)
 
 	h := &FederatedTestHarness{
 		TestHarness:   base,
+		DuckCfg:       duckCfg,
 		SchemaID:      1,
 		S3Bucket:      bucket,
 		S3Prefix:      prefix,
@@ -267,35 +300,39 @@ func NewFederatedTestHarness(ctx context.Context) (*FederatedTestHarness, error)
 	return h, nil
 }
 
-// startContainers starts Postgres, S3, and DuckDB containers.
-func startContainers(ctx context.Context, base *e2e_harness.TestHarness) error {
+// startContainers starts Postgres, S3, and DuckDB containers. It returns the
+// DuckDB configuration DuckDB was started with.
+func startContainers(ctx context.Context, base *e2e_harness.TestHarness, opts harnessOptions) (forma.DuckDBConfig, error) {
 	if _, err := base.StartPostgres(ctx); err != nil {
-		return fmt.Errorf("start postgres: %w", err)
+		return forma.DuckDBConfig{}, fmt.Errorf("start postgres: %w", err)
 	}
 
 	if _, err := base.StartS3(ctx); err != nil {
 		_ = base.StopPostgres(ctx)
-		return fmt.Errorf("start s3: %w", err)
+		return forma.DuckDBConfig{}, fmt.Errorf("start s3: %w", err)
 	}
 
-	if err := startDuckDB(base, base.S3Endpoint, "minioadmin", "minioadmin", "us-east-1"); err != nil {
+	duckCfg, err := startDuckDB(base, base.S3Endpoint, "minioadmin", "minioadmin", "us-east-1", opts)
+	if err != nil {
 		_ = base.StopS3(ctx)
 		_ = base.StopPostgres(ctx)
-		return fmt.Errorf("start duckdb: %w", err)
+		return forma.DuckDBConfig{}, fmt.Errorf("start duckdb: %w", err)
 	}
 
-	return nil
+	return duckCfg, nil
 }
 
-func startDuckDB(base *e2e_harness.TestHarness, s3Endpoint, s3AccessKey, s3SecretKey, s3Region string) error {
+// startDuckDB starts DuckDB with the harness defaults, applying any resource
+// overrides from opts, and returns the configuration it was started with.
+func startDuckDB(base *e2e_harness.TestHarness, s3Endpoint, s3AccessKey, s3SecretKey, s3Region string, opts harnessOptions) (forma.DuckDBConfig, error) {
 	duckCfg := forma.DuckDBConfig{
 		Enabled: true,
 		DBPath:  ":memory:",
 		// 4096 matches the production default; the old 512 never actually
 		// governed federated queries because the query template re-set the
 		// instance to 4GB on every execution before #104 removed that PRAGMA.
-		MemoryLimitMB: 4096,
-		EnableS3:      true,
+		MemoryLimitMB:  4096,
+		EnableS3:       true,
 		EnableParquet:  true,
 		S3Endpoint:     s3Endpoint,
 		S3AccessKey:    s3AccessKey,
@@ -305,7 +342,16 @@ func startDuckDB(base *e2e_harness.TestHarness, s3Endpoint, s3AccessKey, s3Secre
 		QueryTimeout:   60 * time.Second,
 		MaxParallelism: 4,
 	}
-	return base.StartDuckDB(duckCfg)
+	if opts.duckThreads > 0 {
+		duckCfg.MaxParallelism = opts.duckThreads
+	}
+	if opts.duckMemoryLimitMB > 0 {
+		duckCfg.MemoryLimitMB = opts.duckMemoryLimitMB
+	}
+	if opts.duckMaxConnections > 0 {
+		duckCfg.MaxConnections = opts.duckMaxConnections
+	}
+	return duckCfg, base.StartDuckDB(duckCfg)
 }
 
 // createS3Client creates an AWS S3 client configured for MinIO.

--- a/internal/sqlgen/advanced_query_template_duckdb.go
+++ b/internal/sqlgen/advanced_query_template_duckdb.go
@@ -7,13 +7,12 @@ import "text/template"
 // projection, EAV pivot, and final outer SELECT, supporting any schema layout.
 // Metadata columns (total_records, total_pages, current_page) are rendered in the
 // template directly so that PAGE_SIZE and OFFSET template vars are properly expanded.
+// Resource pragmas (threads / memory_limit) are deliberately absent: they are
+// connection-level configuration (DuckDBConfig via applyResourcePragmas), and a
+// per-query PRAGMA would override the configured values on every execution.
 var AdvancedQueryTemplateDuckDB = template.Must(template.New("optimizedQueryDuckDB").Funcs(template.FuncMap{
 	"add": func(a, b int) int { return a + b },
 }).Parse(`
--- PRAGMA & tuning
-PRAGMA memory_limit='4GB';
-PRAGMA threads=4;
-
 WITH
 dirty_ids AS (
   SELECT row_id

--- a/internal/sqlgen/duckdb_render_and_dirtyids_test.go
+++ b/internal/sqlgen/duckdb_render_and_dirtyids_test.go
@@ -11,6 +11,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestAdvancedTemplate_NoResourcePragmas locks the #104 contract: resource
+// pragmas (threads / memory_limit) are connection-level configuration
+// (DuckDBConfig via applyResourcePragmas), never per-query SQL — a template
+// pragma executes on every query and silently overrides the configured
+// connection-level values.
+func TestAdvancedTemplate_NoResourcePragmas(t *testing.T) {
+	q := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0},
+	}
+	dual := &DualClauses{DuckClause: "1=1"}
+
+	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, nil, dual)
+	require.NoError(t, err)
+	require.NotContains(t, sql, "PRAGMA")
+}
+
 // Test RenderS3ParquetPath templating.
 func TestRenderS3ParquetPath_Render(t *testing.T) {
 	got, err := RenderS3ParquetPath("s3://bucket/schema_{{.SchemaID}}/data.parquet", 42)


### PR DESCRIPTION
## Summary

按 #104 收窄后的范围(资源配置 + 并发 evidence,收窄记录见 issue 评论)实现:DuckDB 资源配置收敛为单一来源,并交付并发基准证据的全套基建。原 scope 的 projection 剖析(条目 1-3)与 per-worker DuckDB 隔离(条目 5)拆出后续 issue。

## 资源配置:单一来源

**问题**:模板级 `PRAGMA memory_limit='4GB'; PRAGMA threads=4`(`advanced_query_template_duckdb.go`)随每次联邦查询执行,覆盖连接级 `applyResourcePragmas` 按 `DuckDBConfig` 设置的值——config 的 `MaxParallelism`/`MemoryLimitMB` 对联邦查询实际无效(bottleneck catalog §4.3)。

**修法**(提交顺序有意为之,先改默认再删模板,避免 1 线程/内存不限的窗口):
1. `defaultDuckDBConfig()` 对齐 `MaxParallelism=4`、`MemoryLimitMB=4096`(与被删模板 pragma 字节级等效,生效行为不变);补 `duckdb.maxParallelism` 校验(0 合法 = 交 DuckDB 自身默认)。
2. 删除模板 pragma 块;回归测试锁定「渲染 SQL 不含 PRAGMA」契约。harness 内存 512→4096(512 从未实际生效:原模板每查询把实例改回 4GB)。
3. `FederatedTestHarness` 增变参 `HarnessOption` + `WithDuckDBResources(threads, memoryMB, maxConns)`(~80 个既有 `NewFederatedTestHarness(ctx)` 调用点零改动);生效配置存 `h.DuckCfg`;runner 三处硬编码 `MaxParallelism:4` 的引擎级 duckCfg 收敛为 `engineDuckDBConfig(h)`。

**Plan cache 零改动**:资源 pragma 从不在 scope hash 里;选连接级方向后骨架文本统一变化,仅进程内缓存。

**默认值波及声明**:`defaultDuckDBConfig` 仅被 `DefaultConfig` 消费;省略 `memoryLimitMB` 的**非联邦** DuckDB 部署语义从「不限」变为 4GB 上限(联邦路径本来每次查询就被改到 4GB,等效)。

## 并发 evidence 基建

- `baseline` 子命令新增 `-concurrency`(0=preset 值)与 `-duckdb-threads`/`-duckdb-memory-mb`(`run` 同步加资源 flag);C>1 产物目录追加 `-c{N}` 后缀,**C=1 路径不变**——`make benchmark-regression` 工件契约字节级不动。
- `RunProvenance.Concurrency`(omitempty)+ trend 可比性 identity 在 C>1 追加 `|c{N}` 段:并发 run 自成对照组,不污染顺序基线窗口,历史工件 key 不变。
- `WorkloadDiff` 补 `P99LatencyDelta`(此前 workload 级只有 avg/p95)。
- **`benchmark concurrency-report`**:聚合 N 份 per-level `benchmark-summary.json` 为单一可发布 markdown/JSON——整体与逐 workload 的 p50/p95/p99/QPS × 并发档位矩阵,加 PR #94 四个 `concurrent-run-*` 稳定性断言通过率(C=1 显示 n/a);缺 provenance 并发按 1(兼容历史工件),重复档位报错,跨 run 可比性(mode/scale/distribution/tier/workload 集)不一致降级为 Warning。纯读 JSON 聚合,runner 零改动。
- `make benchmark-concurrency`:C=1/2/4/8 全量 small-live sweep + 聚合报告;成本已注明(单档 ~35 分钟起,仅空闲机器人工触发,不进 CI);运维文档补操作说明。
- 新增 Config 字段一律 `omitempty`,`BuildArtifactMetadata` 的 BenchmarkID 哈希连续性不受影响(测试锁定)。

## 缩量冒烟(本 PR 附带验证;完整 4 档由 repo owner 空闲时跑)

- `baseline -preset ci-smoke`:现有产物路径 `ci-smoke-uniform` 不变 ✅
- `run -mode live -trade-count 2000 -concurrency 2/4`(真实容器,16 个默认 workloads)+ `concurrency-report` 聚合,链路端到端工作 ✅:
  - **C=2 完全干净**:四个 `concurrent-run-*` 稳定性断言 23/23 全绿;small-live 的 7 个 workload 全 passed(失败仅出现在缩量规模下无意义的 workload,如 `keyset-page-100000` 在 2000 行数据上翻十万偏移)。
  - **C=4 出现真实并发不稳定**:稳定性断言 failure-kind 12/23、page-row-ids 8/23、total-records 10/23 失败,infra+correctness 混合、遍布多数 workload;整体 P99 从 C=2 的 380ms 陡增到 2.05s,而 `baseline-page-1` 等轻 workload 两档皆稳——**这正是 #104 §3.1 描述的并发尾延迟现象**。归因注意:冒烟跑在有其他负载的共享开发机(还挂着长期容器),4 并发 × 16 workloads 的 testcontainers 饱和是首要嫌疑;环境 vs 代码的权威归因交给空闲机器上的正式 `make benchmark-concurrency` sweep(catalog §3.1 也预测了该现象与共享资源竞争相关)。
  - 报告样例(冒烟产物,勿作为正式证据):整体/逐 workload 矩阵、stability 单元格、失败清单均正确呈现。
- 正式证据:`make benchmark-concurrency`(C=1/2/4/8 全量 small-live)产物 `.artifacts/benchmark/concurrency/concurrency-report.md` 后补发布

## 拆出后续(原 #104 条目 1-3、5)

follow-up issue 正文已备好(`.artifacts/issue-104-followup.md`,repo owner 创建后回链):baseline-page-1 projection 剖析/缓存 + per-worker DuckDB 隔离实验;「baseline-page-1 不回归」验收随之移入。

## 验证

- [x] `make test` 25 包全绿;`make lint` exit 0
- [x] 每步测试先行(config 默认值/校验、无 PRAGMA 契约、omitempty 哈希稳定、provenance/可比性、P99Delta、聚合库五用例、CLI 端到端)
- [x] ci-smoke 现有路径回归通过
- [x] 缩量 live 并发冒烟(C=2/4 @ 2000 trades)+ concurrency-report 聚合

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
