### PR TITLE
feat: heavy-live benchmark preset — full live workload matrix at large scale with sampled truth-pass oracle (#100)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,9 @@ benchmark-smoke: create-build-dir
 benchmark-regression: create-build-dir
 	@echo "Running benchmark regression live subset..."
 	@mkdir -p .artifacts/benchmark/regression
-	@$(GOENV) go run ./cmd/benchmark baseline -preset small-live -output-dir .artifacts/benchmark/regression \
+	@$(GOENV) go run ./cmd/benchmark baseline -preset small-live \
+		-distribution uniform \
+		-output-dir .artifacts/benchmark/regression \
 		-channel manual \
 		-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
 		-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
@@ -86,6 +88,7 @@ benchmark-concurrency: create-build-dir
 	@mkdir -p .artifacts/benchmark/concurrency
 	@for c in 1 2 4 8; do \
 		$(GOENV) go run ./cmd/benchmark baseline -preset small-live \
+			-distribution uniform \
 			-concurrency $$c \
 			-output-dir .artifacts/benchmark/concurrency \
 			-channel manual -label concurrency-sweep-c$$c \
@@ -101,7 +104,9 @@ benchmark-concurrency: create-build-dir
 benchmark-heavy: create-build-dir
 	@echo "Running benchmark heavy planning set..."
 	@mkdir -p .artifacts/benchmark/heavy
-	@$(GOENV) go run ./cmd/benchmark baseline -preset heavy-plan -output-dir .artifacts/benchmark/heavy \
+	@$(GOENV) go run ./cmd/benchmark baseline -preset heavy-plan \
+		-distribution uniform \
+		-output-dir .artifacts/benchmark/heavy \
 		-channel manual \
 		-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
 		-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit lint coverage build build-tools build-benchmark benchmark-smoke benchmark-regression benchmark-heavy build-all build-lambda clean all create-build-dir link validate-schema-consistency
+.PHONY: test test-unit lint coverage build build-tools build-benchmark benchmark-smoke benchmark-regression benchmark-heavy benchmark-heavy-live build-all build-lambda clean all create-build-dir link validate-schema-consistency
 
 # Binary names
 BINARY_SERVER=server
@@ -102,6 +102,19 @@ benchmark-heavy: create-build-dir
 	@echo "Running benchmark heavy planning set..."
 	@mkdir -p .artifacts/benchmark/heavy
 	@$(GOENV) go run ./cmd/benchmark baseline -preset heavy-plan -output-dir .artifacts/benchmark/heavy \
+		-channel manual \
+		-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
+		-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# Full live workload matrix at large scale (10M trades). Hours of wall clock
+# and heavy RAM/disk — operator-initiated on an idle machine only, never CI.
+# Truth-pass oracles are spot-check sampled (see the baseline runbook).
+benchmark-heavy-live: create-build-dir
+	@echo "Running benchmark heavy live set (hours; idle machine only)..."
+	@mkdir -p .artifacts/benchmark/heavy-live
+	@$(GOENV) go run ./cmd/benchmark baseline -preset heavy-live \
+		-distribution hotspot-overlap \
+		-output-dir .artifacts/benchmark/heavy-live \
 		-channel manual \
 		-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
 		-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
 	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
@@ -127,13 +128,18 @@ func runBenchmark(ctx context.Context, args []string, out, errOut io.Writer) int
 	if exitCode != 0 {
 		return exitCode
 	}
+	if outputs.runTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, outputs.runTimeout)
+		defer cancel()
+	}
 	return executeBenchmarkRun(ctx, config, outputs, out, errOut)
 }
 
 func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int {
 	flags := flag.NewFlagSet("run", flag.ContinueOnError)
 	flags.SetOutput(errOut)
-	preset := flags.String("preset", "small", "Baseline preset: ci-smoke, small, small-live, medium, medium-live, or heavy-plan")
+	preset := flags.String("preset", "small", "Baseline preset: ci-smoke, small, small-live, medium, medium-live, heavy, heavy-live, or heavy-plan")
 	outputDir := flags.String("output-dir", ".artifacts/benchmark", "Directory to store baseline captures")
 	distribution := flags.String("distribution", string(bench.DistributionUniform), "Data distribution preset")
 	compareTo := flags.String("compare-to", "", "Optional path to an existing benchmark-summary.json for diff output")
@@ -144,6 +150,9 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 	concurrency := flags.Int("concurrency", 0, "Override preset concurrency (0 = preset value)")
 	duckDBThreads := flags.Int("duckdb-threads", 0, "Override DuckDB threads for live runs (0 = harness default)")
 	duckDBMemoryMB := flags.Int("duckdb-memory-mb", 0, "Override DuckDB memory limit in MB for live runs (0 = harness default)")
+	truthPassCap := flags.Int("truth-pass-sample-cap", -1, "Override truth-pass oracle sample cap (-1 = preset value, 0 = uncapped full truth pass)")
+	runTimeout := flags.Duration("run-timeout", 0, "Abort the entire run after this duration (0 = no timeout)")
+	tierProfile := flags.String("tier-profile", "", "Override preset tier mix profile (empty = preset value)")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -155,8 +164,18 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 	if *concurrency > 0 {
 		config.Concurrency = *concurrency
 	}
-	config.DuckDBThreads = *duckDBThreads
-	config.DuckDBMemoryLimitMB = *duckDBMemoryMB
+	config = applyDuckDBOverrides(config, *duckDBThreads, *duckDBMemoryMB)
+	if *truthPassCap >= 0 {
+		config.TruthPassSampleCap = *truthPassCap
+	}
+	if *tierProfile != "" {
+		config.TierProfile = *tierProfile
+	}
+	if *runTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *runTimeout)
+		defer cancel()
+	}
 	// Concurrent baselines get their own artifact directory (-c{N}); C<=1
 	// keeps the preset directory so existing capture paths (and the
 	// make benchmark-regression contract) are untouched.
@@ -340,6 +359,7 @@ type runOutputs struct {
 	gitSHA      string
 	gitRef      string
 	label       string
+	runTimeout  time.Duration
 }
 
 func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, int) {
@@ -356,6 +376,8 @@ func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, 
 	tradeCount := flags.Int("trade-count", 0, "Override generated trade row count")
 	duckDBThreads := flags.Int("duckdb-threads", 0, "Override DuckDB threads for live runs (0 = harness default)")
 	duckDBMemoryMB := flags.Int("duckdb-memory-mb", 0, "Override DuckDB memory limit in MB for live runs (0 = harness default)")
+	truthPassCap := flags.Int("truth-pass-sample-cap", 0, "Truth-pass oracle sample cap (0 = uncapped full truth pass)")
+	runTimeout := flags.Duration("run-timeout", 0, "Abort the entire run after this duration (0 = no timeout)")
 	customerCount := flags.Int("customer-count", 0, "Override generated customer row count")
 	securityCount := flags.Int("security-count", 0, "Override generated security row count")
 	overlapRatio := flags.Float64("overlap-ratio", 0, "Override overlap ratio")
@@ -389,12 +411,14 @@ func parseRunConfig(args []string, errOut io.Writer) (bench.Config, runOutputs, 
 
 		DuckDBThreads:       *duckDBThreads,
 		DuckDBMemoryLimitMB: *duckDBMemoryMB,
+		TruthPassSampleCap:  *truthPassCap,
 	}.WithDefaults()
 	outputs := runOutputs{jsonOut: *jsonOut, mdOut: *mdOut, baselineDir: *baselineDir}
 	outputs.channel = *channel
 	outputs.gitSHA = *gitSHA
 	outputs.gitRef = *gitRef
 	outputs.label = *label
+	outputs.runTimeout = *runTimeout
 	return cfg, outputs, 0
 }
 
@@ -459,6 +483,20 @@ func executeBenchmarkRun(ctx context.Context, cfg bench.Config, outputs runOutpu
 	return 0
 }
 
+// applyDuckDBOverrides keeps preset-provided DuckDB resources unless the
+// operator explicitly overrides them (flag default 0 = keep preset/harness
+// value). Without this guard the zero-valued flags would erase preset
+// resource bounds such as heavy-live's 8192MB memory limit.
+func applyDuckDBOverrides(cfg bench.Config, threads, memoryMB int) bench.Config {
+	if threads > 0 {
+		cfg.DuckDBThreads = threads
+	}
+	if memoryMB > 0 {
+		cfg.DuckDBMemoryLimitMB = memoryMB
+	}
+	return cfg
+}
+
 func baselinePresetConfig(rawPreset string, distribution bench.Distribution) (bench.Config, string, error) {
 	preset, err := resolveBenchmarkPreset(rawPreset, distribution)
 	if err != nil {
@@ -505,6 +543,15 @@ func defaultBenchmarkPresets() []benchmarkPreset {
 			ExpectedUsage: "manual or nightly planning review only",
 			Config:        bench.Config{Mode: bench.ExecutionModePlan, Scale: bench.ScaleLarge, Distribution: bench.DistributionHotspot, Iterations: 3, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: bench.DefaultWorkloadNames()}.WithDefaults(),
 		},
+		{
+			Name:          "heavy-live",
+			Description:   "Full live workload matrix at large scale for capacity-aware baseline capture.",
+			RuntimeClass:  "heavy",
+			BaselineDir:   "heavy-live-hotspot-overlap",
+			CISafe:        false,
+			ExpectedUsage: "manual capacity-aware baseline capture only (idle machine, hours)",
+			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleLarge, Distribution: bench.DistributionHotspot, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: bench.DefaultWorkloadNames(), TruthPassSampleCap: 10000, DuckDBMemoryLimitMB: 8192}.WithDefaults(),
+		},
 	}
 }
 
@@ -515,6 +562,9 @@ func resolveBenchmarkPreset(rawPreset string, distribution bench.Distribution) (
 	}
 	if presetName == "medium" {
 		presetName = "medium-live"
+	}
+	if presetName == "heavy" {
+		presetName = "heavy-live"
 	}
 	for _, preset := range defaultBenchmarkPresets() {
 		if preset.Name != presetName {

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -17,16 +17,6 @@ import (
 	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
 )
 
-type benchmarkPreset struct {
-	Name          string       `json:"name"`
-	Description   string       `json:"description"`
-	RuntimeClass  string       `json:"runtime_class"`
-	BaselineDir   string       `json:"baseline_dir"`
-	CISafe        bool         `json:"ci_safe"`
-	ExpectedUsage string       `json:"expected_usage"`
-	Config        bench.Config `json:"config"`
-}
-
 var (
 	newBenchmarkRunner = bench.NewRunner
 	runValidationMode  = func(ctx context.Context, runner *bench.Runner) (*bench.RunResult, error) {
@@ -495,104 +485,6 @@ func applyDuckDBOverrides(cfg bench.Config, threads, memoryMB int) bench.Config 
 		cfg.DuckDBMemoryLimitMB = memoryMB
 	}
 	return cfg
-}
-
-func baselinePresetConfig(rawPreset string, distribution bench.Distribution) (bench.Config, string, error) {
-	preset, err := resolveBenchmarkPreset(rawPreset, distribution)
-	if err != nil {
-		return bench.Config{}, "", err
-	}
-	return preset.Config, preset.BaselineDir, nil
-}
-
-func defaultBenchmarkPresets() []benchmarkPreset {
-	return []benchmarkPreset{
-		{
-			Name:          "ci-smoke",
-			Description:   "Cheap CI-safe smoke validation with artifact capture.",
-			RuntimeClass:  "fast",
-			BaselineDir:   "ci-smoke-uniform",
-			CISafe:        true,
-			ExpectedUsage: "pull requests and quick local validation",
-			Config:        bench.Config{Mode: bench.ExecutionModeSmoke, Scale: bench.ScaleSmall, Distribution: bench.DistributionUniform, Iterations: 1, PageSize: 20, Seed: 42, Workloads: []string{"baseline-page-1", "hot-selective-page"}}.WithDefaults(),
-		},
-		{
-			Name:          "small-live",
-			Description:   "Live small-scale baseline subset for routine benchmark evidence.",
-			RuntimeClass:  "medium",
-			BaselineDir:   "small-live-hotspot-overlap",
-			CISafe:        false,
-			ExpectedUsage: "local or controlled review baseline capture",
-			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleSmall, Distribution: bench.DistributionHotspot, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: []string{"baseline-page-1", "customer-region-page", "security-symbol-page", "hot-selective-page", "eav-selective-page", "mixed-tier-window", "hot-only-window"}}.WithDefaults(),
-		},
-		{
-			Name:          "medium-live",
-			Description:   "Controlled medium-scale live baseline subset for regression review.",
-			RuntimeClass:  "medium",
-			BaselineDir:   "medium-live-zipf",
-			CISafe:        false,
-			ExpectedUsage: "manual or scheduled baseline capture",
-			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleMedium, Distribution: bench.DistributionZipf, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: []string{"baseline-page-1", "hot-selective-page", "eav-selective-page", "mixed-tier-window", "hot-only-window", "cold-only-window", "deep-page-1000"}}.WithDefaults(),
-		},
-		{
-			Name:          "heavy-plan",
-			Description:   "Heavy planning-only workload set for manual or nightly review.",
-			RuntimeClass:  "heavy",
-			BaselineDir:   "heavy-plan-hotspot-overlap",
-			CISafe:        false,
-			ExpectedUsage: "manual or nightly planning review only",
-			Config:        bench.Config{Mode: bench.ExecutionModePlan, Scale: bench.ScaleLarge, Distribution: bench.DistributionHotspot, Iterations: 3, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: bench.DefaultWorkloadNames()}.WithDefaults(),
-		},
-		{
-			Name:          "heavy-live",
-			Description:   "Full live workload matrix at large scale for capacity-aware baseline capture.",
-			RuntimeClass:  "heavy",
-			BaselineDir:   "heavy-live-hotspot-overlap",
-			CISafe:        false,
-			ExpectedUsage: "manual capacity-aware baseline capture only (idle machine, hours)",
-			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleLarge, Distribution: bench.DistributionHotspot, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: bench.DefaultWorkloadNames(), TruthPassSampleCap: 10000, DuckDBMemoryLimitMB: 8192}.WithDefaults(),
-		},
-	}
-}
-
-func resolveBenchmarkPreset(rawPreset string, distribution bench.Distribution) (benchmarkPreset, error) {
-	presetName := strings.ToLower(strings.TrimSpace(rawPreset))
-	if presetName == "small" {
-		presetName = "small-live"
-	}
-	if presetName == "medium" {
-		presetName = "medium-live"
-	}
-	if presetName == "heavy" {
-		presetName = "heavy-live"
-	}
-	for _, preset := range defaultBenchmarkPresets() {
-		if preset.Name != presetName {
-			continue
-		}
-		resolved := preset
-		if distribution != "" {
-			resolved.Config.Distribution = distribution
-			resolved.BaselineDir = fmt.Sprintf("%s-%s", resolved.Name, distribution)
-		}
-		return resolved, nil
-	}
-	return benchmarkPreset{}, fmt.Errorf("unknown baseline preset %q", rawPreset)
-}
-
-func parseWorkloads(raw string) []string {
-	if strings.TrimSpace(raw) == "" {
-		return nil
-	}
-	parts := strings.Split(raw, ",")
-	result := make([]string, 0, len(parts))
-	for _, part := range parts {
-		name := strings.TrimSpace(part)
-		if name != "" {
-			result = append(result, name)
-		}
-	}
-	return result
 }
 
 func writeJSON(out io.Writer, payload any) int {

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -131,7 +131,7 @@ func runBaseline(ctx context.Context, args []string, out, errOut io.Writer) int 
 	flags.SetOutput(errOut)
 	preset := flags.String("preset", "small", "Baseline preset: ci-smoke, small, small-live, medium, medium-live, heavy, heavy-live, or heavy-plan")
 	outputDir := flags.String("output-dir", ".artifacts/benchmark", "Directory to store baseline captures")
-	distribution := flags.String("distribution", string(bench.DistributionUniform), "Data distribution preset")
+	distribution := flags.String("distribution", "", "Data distribution preset (empty = use the preset's own distribution)")
 	compareTo := flags.String("compare-to", "", "Optional path to an existing benchmark-summary.json for diff output")
 	channel := flags.String("channel", "", "Provenance channel: ci, nightly, manual")
 	gitSHA := flags.String("git-sha", "", "Provenance git commit SHA")

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -483,3 +483,52 @@ func TestRunBenchmarkMainTrendFileOutput(t *testing.T) {
 		t.Fatalf("expected trend report file to exist: %v", err)
 	}
 }
+
+func TestResolveBenchmarkPresetHeavyLive(t *testing.T) {
+	preset, err := resolveBenchmarkPreset("heavy", bench.DistributionHotspot)
+	if err != nil {
+		t.Fatalf("resolveBenchmarkPreset heavy failed: %v", err)
+	}
+	if preset.Name != "heavy-live" {
+		t.Fatalf("expected heavy alias to resolve to heavy-live, got %q", preset.Name)
+	}
+	if preset.Config.Mode != bench.ExecutionModeLive || preset.Config.Scale != bench.ScaleLarge {
+		t.Fatalf("expected live/large heavy-live config, got %+v", preset.Config)
+	}
+	if preset.Config.TruthPassSampleCap != 10000 {
+		t.Fatalf("expected heavy-live truth-pass sample cap 10000, got %d", preset.Config.TruthPassSampleCap)
+	}
+	if preset.Config.DuckDBMemoryLimitMB != 8192 {
+		t.Fatalf("expected heavy-live DuckDB memory 8192MB, got %d", preset.Config.DuckDBMemoryLimitMB)
+	}
+	if len(preset.Config.Workloads) != len(bench.DefaultWorkloadNames()) {
+		t.Fatalf("expected the full workload matrix, got %d workloads", len(preset.Config.Workloads))
+	}
+	if preset.CISafe {
+		t.Fatal("heavy-live must not be CI-safe")
+	}
+	if preset.BaselineDir != "heavy-live-hotspot-overlap" {
+		t.Fatalf("unexpected baseline dir %q", preset.BaselineDir)
+	}
+}
+
+func TestApplyDuckDBOverridesKeepsPresetValues(t *testing.T) {
+	cfg := bench.Config{DuckDBThreads: 4, DuckDBMemoryLimitMB: 8192}
+	got := applyDuckDBOverrides(cfg, 0, 0)
+	if got.DuckDBThreads != 4 || got.DuckDBMemoryLimitMB != 8192 {
+		t.Fatalf("zero flags must keep preset resources, got %+v", got)
+	}
+	got = applyDuckDBOverrides(cfg, 8, 16384)
+	if got.DuckDBThreads != 8 || got.DuckDBMemoryLimitMB != 16384 {
+		t.Fatalf("positive flags must override preset resources, got %+v", got)
+	}
+}
+
+func TestRunBaselineRunTimeoutExpires(t *testing.T) {
+	dir := t.TempDir()
+	var out, errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"baseline", "-preset", "ci-smoke", "-run-timeout", "1ns", "-output-dir", dir}, &out, &errOut)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit when run timeout expires, stderr=%s", errOut.String())
+	}
+}

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -58,61 +58,6 @@ func TestRunBenchmarkMainBaseline(t *testing.T) {
 	}
 }
 
-// TestRunBenchmarkMainBaselineTierProfileOverride verifies -tier-profile on
-// the baseline subcommand overrides the preset's tier mix profile (#100
-// final-review Fix 4). ci-smoke is smoke mode (bench.Runner.Run, not
-// RunWithHarness) so this runs fast with no Docker/live harness required.
-func TestRunBenchmarkMainBaselineTierProfileOverride(t *testing.T) {
-	dir := t.TempDir()
-	var out bytes.Buffer
-	var errOut bytes.Buffer
-	exitCode := runBenchmarkMain(context.Background(), []string{
-		"baseline",
-		"-preset", "ci-smoke",
-		"-tier-profile", "high-hot-40-20-40",
-		"-output-dir", dir,
-	}, &out, &errOut)
-	if exitCode != 0 {
-		t.Fatalf("baseline returned exit code %d: %s", exitCode, errOut.String())
-	}
-	matches, err := filepath.Glob(filepath.Join(dir, "ci-smoke*", "benchmark-result.json"))
-	if err != nil || len(matches) == 0 {
-		t.Fatalf("expected baseline artifact benchmark-result.json to exist, err=%v matches=%v", err, matches)
-	}
-	data, err := os.ReadFile(matches[0])
-	if err != nil {
-		t.Fatalf("failed to read benchmark-result.json: %v", err)
-	}
-	var captured struct {
-		Config struct {
-			TierProfile string `json:"tier_profile"`
-		} `json:"config"`
-	}
-	if err := json.Unmarshal(data, &captured); err != nil {
-		t.Fatalf("failed to unmarshal benchmark-result.json: %v", err)
-	}
-	if captured.Config.TierProfile != "high-hot-40-20-40" {
-		t.Fatalf("expected tier_profile override high-hot-40-20-40, got %q", captured.Config.TierProfile)
-	}
-}
-
-func TestResolveBenchmarkPresetSupportsAliasesAndPresets(t *testing.T) {
-	small, err := resolveBenchmarkPreset("small", bench.DistributionUniform)
-	if err != nil {
-		t.Fatalf("resolveBenchmarkPreset small failed: %v", err)
-	}
-	if small.Name != "small-live" || small.Config.Mode != bench.ExecutionModeLive {
-		t.Fatalf("expected small alias to resolve to small-live live preset, got %+v", small)
-	}
-	ci, err := resolveBenchmarkPreset("ci-smoke", bench.DistributionUniform)
-	if err != nil {
-		t.Fatalf("resolveBenchmarkPreset ci-smoke failed: %v", err)
-	}
-	if !ci.CISafe || ci.Config.Mode != bench.ExecutionModeSmoke {
-		t.Fatalf("expected ci-smoke preset to be CI-safe smoke, got %+v", ci)
-	}
-}
-
 func TestRunBenchmarkMainDescribeIncludesPresets(t *testing.T) {
 	var out bytes.Buffer
 	var errOut bytes.Buffer
@@ -519,46 +464,6 @@ func TestRunBenchmarkMainTrendFileOutput(t *testing.T) {
 	}
 	if _, err := os.Stat(jsonOut); err != nil {
 		t.Fatalf("expected trend report file to exist: %v", err)
-	}
-}
-
-func TestResolveBenchmarkPresetHeavyLive(t *testing.T) {
-	preset, err := resolveBenchmarkPreset("heavy", bench.DistributionHotspot)
-	if err != nil {
-		t.Fatalf("resolveBenchmarkPreset heavy failed: %v", err)
-	}
-	if preset.Name != "heavy-live" {
-		t.Fatalf("expected heavy alias to resolve to heavy-live, got %q", preset.Name)
-	}
-	if preset.Config.Mode != bench.ExecutionModeLive || preset.Config.Scale != bench.ScaleLarge {
-		t.Fatalf("expected live/large heavy-live config, got %+v", preset.Config)
-	}
-	if preset.Config.TruthPassSampleCap != 10000 {
-		t.Fatalf("expected heavy-live truth-pass sample cap 10000, got %d", preset.Config.TruthPassSampleCap)
-	}
-	if preset.Config.DuckDBMemoryLimitMB != 8192 {
-		t.Fatalf("expected heavy-live DuckDB memory 8192MB, got %d", preset.Config.DuckDBMemoryLimitMB)
-	}
-	if len(preset.Config.Workloads) != len(bench.DefaultWorkloadNames()) {
-		t.Fatalf("expected the full workload matrix, got %d workloads", len(preset.Config.Workloads))
-	}
-	if preset.CISafe {
-		t.Fatal("heavy-live must not be CI-safe")
-	}
-	if preset.BaselineDir != "heavy-live-hotspot-overlap" {
-		t.Fatalf("unexpected baseline dir %q", preset.BaselineDir)
-	}
-}
-
-func TestApplyDuckDBOverridesKeepsPresetValues(t *testing.T) {
-	cfg := bench.Config{DuckDBThreads: 4, DuckDBMemoryLimitMB: 8192}
-	got := applyDuckDBOverrides(cfg, 0, 0)
-	if got.DuckDBThreads != 4 || got.DuckDBMemoryLimitMB != 8192 {
-		t.Fatalf("zero flags must keep preset resources, got %+v", got)
-	}
-	got = applyDuckDBOverrides(cfg, 8, 16384)
-	if got.DuckDBThreads != 8 || got.DuckDBMemoryLimitMB != 16384 {
-		t.Fatalf("positive flags must override preset resources, got %+v", got)
 	}
 }
 

--- a/cmd/benchmark/main_test.go
+++ b/cmd/benchmark/main_test.go
@@ -58,6 +58,44 @@ func TestRunBenchmarkMainBaseline(t *testing.T) {
 	}
 }
 
+// TestRunBenchmarkMainBaselineTierProfileOverride verifies -tier-profile on
+// the baseline subcommand overrides the preset's tier mix profile (#100
+// final-review Fix 4). ci-smoke is smoke mode (bench.Runner.Run, not
+// RunWithHarness) so this runs fast with no Docker/live harness required.
+func TestRunBenchmarkMainBaselineTierProfileOverride(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{
+		"baseline",
+		"-preset", "ci-smoke",
+		"-tier-profile", "high-hot-40-20-40",
+		"-output-dir", dir,
+	}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("baseline returned exit code %d: %s", exitCode, errOut.String())
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "ci-smoke*", "benchmark-result.json"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("expected baseline artifact benchmark-result.json to exist, err=%v matches=%v", err, matches)
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("failed to read benchmark-result.json: %v", err)
+	}
+	var captured struct {
+		Config struct {
+			TierProfile string `json:"tier_profile"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(data, &captured); err != nil {
+		t.Fatalf("failed to unmarshal benchmark-result.json: %v", err)
+	}
+	if captured.Config.TierProfile != "high-hot-40-20-40" {
+		t.Fatalf("expected tier_profile override high-hot-40-20-40, got %q", captured.Config.TierProfile)
+	}
+}
+
 func TestResolveBenchmarkPresetSupportsAliasesAndPresets(t *testing.T) {
 	small, err := resolveBenchmarkPreset("small", bench.DistributionUniform)
 	if err != nil {

--- a/cmd/benchmark/presets.go
+++ b/cmd/benchmark/presets.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
+)
+
+type benchmarkPreset struct {
+	Name          string       `json:"name"`
+	Description   string       `json:"description"`
+	RuntimeClass  string       `json:"runtime_class"`
+	BaselineDir   string       `json:"baseline_dir"`
+	CISafe        bool         `json:"ci_safe"`
+	ExpectedUsage string       `json:"expected_usage"`
+	Config        bench.Config `json:"config"`
+}
+
+func baselinePresetConfig(rawPreset string, distribution bench.Distribution) (bench.Config, string, error) {
+	preset, err := resolveBenchmarkPreset(rawPreset, distribution)
+	if err != nil {
+		return bench.Config{}, "", err
+	}
+	return preset.Config, preset.BaselineDir, nil
+}
+
+func defaultBenchmarkPresets() []benchmarkPreset {
+	return []benchmarkPreset{
+		{
+			Name:          "ci-smoke",
+			Description:   "Cheap CI-safe smoke validation with artifact capture.",
+			RuntimeClass:  "fast",
+			BaselineDir:   "ci-smoke-uniform",
+			CISafe:        true,
+			ExpectedUsage: "pull requests and quick local validation",
+			Config:        bench.Config{Mode: bench.ExecutionModeSmoke, Scale: bench.ScaleSmall, Distribution: bench.DistributionUniform, Iterations: 1, PageSize: 20, Seed: 42, Workloads: []string{"baseline-page-1", "hot-selective-page"}}.WithDefaults(),
+		},
+		{
+			Name:          "small-live",
+			Description:   "Live small-scale baseline subset for routine benchmark evidence.",
+			RuntimeClass:  "medium",
+			BaselineDir:   "small-live-hotspot-overlap",
+			CISafe:        false,
+			ExpectedUsage: "local or controlled review baseline capture",
+			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleSmall, Distribution: bench.DistributionHotspot, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: []string{"baseline-page-1", "customer-region-page", "security-symbol-page", "hot-selective-page", "eav-selective-page", "mixed-tier-window", "hot-only-window"}}.WithDefaults(),
+		},
+		{
+			Name:          "medium-live",
+			Description:   "Controlled medium-scale live baseline subset for regression review.",
+			RuntimeClass:  "medium",
+			BaselineDir:   "medium-live-zipf",
+			CISafe:        false,
+			ExpectedUsage: "manual or scheduled baseline capture",
+			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleMedium, Distribution: bench.DistributionZipf, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: []string{"baseline-page-1", "hot-selective-page", "eav-selective-page", "mixed-tier-window", "hot-only-window", "cold-only-window", "deep-page-1000"}}.WithDefaults(),
+		},
+		{
+			Name:          "heavy-plan",
+			Description:   "Heavy planning-only workload set for manual or nightly review.",
+			RuntimeClass:  "heavy",
+			BaselineDir:   "heavy-plan-hotspot-overlap",
+			CISafe:        false,
+			ExpectedUsage: "manual or nightly planning review only",
+			Config:        bench.Config{Mode: bench.ExecutionModePlan, Scale: bench.ScaleLarge, Distribution: bench.DistributionHotspot, Iterations: 3, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: bench.DefaultWorkloadNames()}.WithDefaults(),
+		},
+		{
+			Name:          "heavy-live",
+			Description:   "Full live workload matrix at large scale for capacity-aware baseline capture.",
+			RuntimeClass:  "heavy",
+			BaselineDir:   "heavy-live-hotspot-overlap",
+			CISafe:        false,
+			ExpectedUsage: "manual capacity-aware baseline capture only (idle machine, hours)",
+			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleLarge, Distribution: bench.DistributionHotspot, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: bench.DefaultWorkloadNames(), TruthPassSampleCap: 10000, DuckDBMemoryLimitMB: 8192}.WithDefaults(),
+		},
+	}
+}
+
+func resolveBenchmarkPreset(rawPreset string, distribution bench.Distribution) (benchmarkPreset, error) {
+	presetName := strings.ToLower(strings.TrimSpace(rawPreset))
+	if presetName == "small" {
+		presetName = "small-live"
+	}
+	if presetName == "medium" {
+		presetName = "medium-live"
+	}
+	if presetName == "heavy" {
+		presetName = "heavy-live"
+	}
+	for _, preset := range defaultBenchmarkPresets() {
+		if preset.Name != presetName {
+			continue
+		}
+		resolved := preset
+		if distribution != "" {
+			resolved.Config.Distribution = distribution
+			resolved.BaselineDir = fmt.Sprintf("%s-%s", resolved.Name, distribution)
+		}
+		return resolved, nil
+	}
+	return benchmarkPreset{}, fmt.Errorf("unknown baseline preset %q", rawPreset)
+}
+
+func parseWorkloads(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name != "" {
+			result = append(result, name)
+		}
+	}
+	return result
+}

--- a/cmd/benchmark/presets_test.go
+++ b/cmd/benchmark/presets_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	bench "github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark"
+)
+
+// TestRunBenchmarkMainBaselineTierProfileOverride verifies -tier-profile on
+// the baseline subcommand overrides the preset's tier mix profile (#100
+// final-review Fix 4). ci-smoke is smoke mode (bench.Runner.Run, not
+// RunWithHarness) so this runs fast with no Docker/live harness required.
+func TestRunBenchmarkMainBaselineTierProfileOverride(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{
+		"baseline",
+		"-preset", "ci-smoke",
+		"-tier-profile", "high-hot-40-20-40",
+		"-output-dir", dir,
+	}, &out, &errOut)
+	if exitCode != 0 {
+		t.Fatalf("baseline returned exit code %d: %s", exitCode, errOut.String())
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "ci-smoke*", "benchmark-result.json"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("expected baseline artifact benchmark-result.json to exist, err=%v matches=%v", err, matches)
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("failed to read benchmark-result.json: %v", err)
+	}
+	var captured struct {
+		Config struct {
+			TierProfile string `json:"tier_profile"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(data, &captured); err != nil {
+		t.Fatalf("failed to unmarshal benchmark-result.json: %v", err)
+	}
+	if captured.Config.TierProfile != "high-hot-40-20-40" {
+		t.Fatalf("expected tier_profile override high-hot-40-20-40, got %q", captured.Config.TierProfile)
+	}
+}
+
+func TestResolveBenchmarkPresetSupportsAliasesAndPresets(t *testing.T) {
+	small, err := resolveBenchmarkPreset("small", bench.DistributionUniform)
+	if err != nil {
+		t.Fatalf("resolveBenchmarkPreset small failed: %v", err)
+	}
+	if small.Name != "small-live" || small.Config.Mode != bench.ExecutionModeLive {
+		t.Fatalf("expected small alias to resolve to small-live live preset, got %+v", small)
+	}
+	ci, err := resolveBenchmarkPreset("ci-smoke", bench.DistributionUniform)
+	if err != nil {
+		t.Fatalf("resolveBenchmarkPreset ci-smoke failed: %v", err)
+	}
+	if !ci.CISafe || ci.Config.Mode != bench.ExecutionModeSmoke {
+		t.Fatalf("expected ci-smoke preset to be CI-safe smoke, got %+v", ci)
+	}
+}
+
+func TestResolveBenchmarkPresetHeavyLive(t *testing.T) {
+	preset, err := resolveBenchmarkPreset("heavy", bench.DistributionHotspot)
+	if err != nil {
+		t.Fatalf("resolveBenchmarkPreset heavy failed: %v", err)
+	}
+	if preset.Name != "heavy-live" {
+		t.Fatalf("expected heavy alias to resolve to heavy-live, got %q", preset.Name)
+	}
+	if preset.Config.Mode != bench.ExecutionModeLive || preset.Config.Scale != bench.ScaleLarge {
+		t.Fatalf("expected live/large heavy-live config, got %+v", preset.Config)
+	}
+	if preset.Config.TruthPassSampleCap != 10000 {
+		t.Fatalf("expected heavy-live truth-pass sample cap 10000, got %d", preset.Config.TruthPassSampleCap)
+	}
+	if preset.Config.DuckDBMemoryLimitMB != 8192 {
+		t.Fatalf("expected heavy-live DuckDB memory 8192MB, got %d", preset.Config.DuckDBMemoryLimitMB)
+	}
+	if len(preset.Config.Workloads) != len(bench.DefaultWorkloadNames()) {
+		t.Fatalf("expected the full workload matrix, got %d workloads", len(preset.Config.Workloads))
+	}
+	if preset.CISafe {
+		t.Fatal("heavy-live must not be CI-safe")
+	}
+	if preset.BaselineDir != "heavy-live-hotspot-overlap" {
+		t.Fatalf("unexpected baseline dir %q", preset.BaselineDir)
+	}
+}
+
+func TestApplyDuckDBOverridesKeepsPresetValues(t *testing.T) {
+	cfg := bench.Config{DuckDBThreads: 4, DuckDBMemoryLimitMB: 8192}
+	got := applyDuckDBOverrides(cfg, 0, 0)
+	if got.DuckDBThreads != 4 || got.DuckDBMemoryLimitMB != 8192 {
+		t.Fatalf("zero flags must keep preset resources, got %+v", got)
+	}
+	got = applyDuckDBOverrides(cfg, 8, 16384)
+	if got.DuckDBThreads != 8 || got.DuckDBMemoryLimitMB != 16384 {
+		t.Fatalf("positive flags must override preset resources, got %+v", got)
+	}
+}

--- a/cmd/benchmark/presets_test.go
+++ b/cmd/benchmark/presets_test.go
@@ -94,6 +94,25 @@ func TestResolveBenchmarkPresetHeavyLive(t *testing.T) {
 	}
 }
 
+// TestResolveBenchmarkPresetHeavyLiveDefaultsToPresetDistribution verifies
+// that omitting -distribution on the baseline subcommand no longer silently
+// overrides a preset's own distribution with DistributionUniform (#100 PR
+// #157 Fix A). Before the fix, runBaseline's -distribution flag defaulted to
+// "uniform", so resolveBenchmarkPreset("heavy-live", "uniform") always
+// replaced heavy-live's hotspot-overlap distribution.
+func TestResolveBenchmarkPresetHeavyLiveDefaultsToPresetDistribution(t *testing.T) {
+	preset, err := resolveBenchmarkPreset("heavy-live", "")
+	if err != nil {
+		t.Fatalf("resolveBenchmarkPreset heavy-live failed: %v", err)
+	}
+	if preset.Config.Distribution != bench.DistributionHotspot {
+		t.Fatalf("omitted -distribution must keep preset hotspot-overlap, got %q", preset.Config.Distribution)
+	}
+	if preset.BaselineDir != "heavy-live-hotspot-overlap" {
+		t.Fatalf("omitted -distribution must keep preset baseline dir, got %q", preset.BaselineDir)
+	}
+}
+
 func TestApplyDuckDBOverridesKeepsPresetValues(t *testing.T) {
 	cfg := bench.Config{DuckDBThreads: 4, DuckDBMemoryLimitMB: 8192}
 	got := applyDuckDBOverrides(cfg, 0, 0)

--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -13,6 +13,7 @@ This runbook defines a repeatable baseline capture flow for the federated query 
 - `small-live`: default live baseline subset for local or controlled review runs
 - `medium-live`: medium-scale live subset for manual regression review
 - `heavy-plan`: planning-only heavyweight set for manual or nightly use
+- `heavy-live`: full live workload matrix at large scale; manual capacity-aware capture only
 
 Use `go run ./cmd/benchmark describe` to inspect the current preset definitions and workload matrix. The CLI also accepts the legacy aliases `small` -> `small-live` and `medium` -> `medium-live` when running `benchmark baseline`.
 
@@ -56,6 +57,82 @@ The default baseline directory naming now follows the benchmark preset name, for
 - `.artifacts/benchmark/small-live-hotspot-overlap`
 - `.artifacts/benchmark/medium-live-zipf`
 - `.artifacts/benchmark/heavy-plan-hotspot-overlap`
+- `.artifacts/benchmark/heavy-live/heavy-live-hotspot-overlap`
+
+## Heavy-Live Baseline Capture
+
+`heavy-live` executes the full workload matrix live at `large` scale. It is
+the only preset that exercises deep pagination and tier hotness behavior at
+production-representative volume.
+
+### Calibration ladder (run before the first official capture)
+
+The large-scale pipeline holds the dataset in memory several times over
+(generation, tiering, loaded-state snapshot). Measure before committing to
+the full 10M run, recording wall clock, peak RSS, and Docker disk usage:
+
+```bash
+/usr/bin/time -l go run ./cmd/benchmark run -mode live -scale large \
+  -distribution hotspot-overlap -iterations 2 -seed 42 \
+  -trade-count 2000000 -customer-count 200000 -security-count 20000 \
+  -truth-pass-sample-cap 10000 -duckdb-memory-mb 8192 \
+  -json-out .artifacts/benchmark/heavy-live-probe/2m.json \
+  -md-out .artifacts/benchmark/heavy-live-probe/2m.md
+```
+
+Repeat with `-trade-count 5000000 -customer-count 500000 -security-count 50000`
+(outputs `5m.json` / `5m.md`). Extrapolate: if the projected 10M peak RSS
+exceeds machine RAM or the projected runtime is unacceptable, stop and file
+the streaming/batched-load follow-up instead of forcing the run.
+
+### Official capture
+
+```bash
+/usr/bin/time -l make benchmark-heavy-live
+```
+
+- idle machine only; check load first (truth-pass throughput drops 5-10x
+  under load)
+- use `-run-timeout` when running unattended
+- expected runtime / peak RSS / disk: fill in from the first successful
+  capture and keep current
+
+### Reading sampled truth-pass results
+
+`heavy-live` reports `truth-pass-sampled` oracle mode for selective
+workloads: the expected result is the full reconstructed candidate set, and
+the engine was consulted for a seeded sample of `truth_pass_sample_cap`
+candidates. A sampled pass is strictly weaker evidence than an uncapped
+truth pass; `compare` flags capped-vs-uncapped runs as a methodology change.
+A spot-check failure means reconstruction and engine truth diverge — rerun
+the failing workload uncapped at `small` scale to investigate.
+
+### Tier-profile variants
+
+The official baseline uses `balanced-60-30-10`. To exercise the profiles
+called out in #100 manually:
+
+```bash
+go run ./cmd/benchmark baseline -preset heavy-live \
+  -distribution hotspot-overlap -tier-profile high-hot-40-20-40 \
+  -output-dir .artifacts/benchmark/heavy-live-high-hot \
+  -channel manual \
+  -git-sha $(git rev-parse HEAD) \
+  -git-ref $(git rev-parse --abbrev-ref HEAD)
+
+go run ./cmd/benchmark baseline -preset heavy-live \
+  -distribution hotspot-overlap -tier-profile long-history-85-10-5 \
+  -output-dir .artifacts/benchmark/heavy-live-long-history \
+  -channel manual \
+  -git-sha $(git rev-parse HEAD) \
+  -git-ref $(git rev-parse --abbrev-ref HEAD)
+```
+
+The `-tier-profile` flag on `baseline` depends on the tier-profile override
+plumbing added alongside the `heavy-live` preset. Note the tier profile
+changes `bench.Config`, so variant runs get their own `BenchmarkID` and never
+pollute the balanced baseline trend (same principle as #104's concurrency
+identity).
 
 ## How To Compare Runs
 
@@ -139,6 +216,7 @@ Treat any future change that turns `prefer_hot` into a real execution flag as a 
 - use `small-live` to collect executable baseline evidence without the full heavy workload set
 - use `medium-live` to compare behavior across distributions and page-depth workloads
 - use `heavy-plan` only when you need planning coverage for the full workload matrix
+- use `heavy-live` for large-scale executable evidence (manual, hours)
 - treat assertion failures as correctness regressions even if latency improves
 - treat large `max` growth separately from percentile movement; it is often a sign of tier skew or unstable deep pagination
 - read `correctness_failures` and `infra_failures` separately in benchmark summaries; only the latter indicates an execution-environment problem
@@ -153,6 +231,7 @@ Treat any future change that turns `prefer_hot` into a real execution flag as a 
 - `small-live`: roughly 1 to 5 minutes depending on machine size and Docker startup overhead
 - `medium-live`: noticeably slower; use in controlled review environments rather than PR-time CI
 - `heavy-plan`: planning-only and suitable for manual or nightly review, not routine pre-merge execution
+- `heavy-live`: pending first calibrated capture (see the calibration ladder above); plan for multiple hours on an idle machine, manual capacity-aware runs only
 
 ## Current Limitations
 

--- a/docs/federated-query/federated-query-benchmark-baseline-runbook.md
+++ b/docs/federated-query/federated-query-benchmark-baseline-runbook.md
@@ -5,7 +5,7 @@ Repository: `forma`
 
 ## Purpose
 
-This runbook defines a repeatable baseline capture flow for the federated query benchmark at `small` and `medium` scale.
+This runbook defines a repeatable baseline capture flow for the federated query benchmark at `small`, `medium`, and `large` (`heavy-live`) scale.
 
 ## Recommended Baseline Presets
 
@@ -105,7 +105,11 @@ the engine was consulted for a seeded sample of `truth_pass_sample_cap`
 candidates. A sampled pass is strictly weaker evidence than an uncapped
 truth pass; `compare` flags capped-vs-uncapped runs as a methodology change.
 A spot-check failure means reconstruction and engine truth diverge — rerun
-the failing workload uncapped at `small` scale to investigate.
+the failing workload uncapped at `small` scale to investigate. Sampling is
+applied per workload: a truth-pass workload whose candidate count is at or
+below the cap stays plain `truth-pass` rather than `truth-pass-sampled`, so a
+mixed-mode result (some workloads sampled, some not) within the same run is
+expected and not a defect.
 
 ### Tier-profile variants
 
@@ -235,7 +239,7 @@ Treat any future change that turns `prefer_hot` into a real execution flag as a 
 
 ## Current Limitations
 
-- live baseline capture now exists through `small-live` and `medium-live`, but CI should still default to the cheaper `ci-smoke` preset
+- live baseline capture now exists through `small-live`, `medium-live`, and `heavy-live`, but CI should still default to the cheaper `ci-smoke` preset
 - use `go run ./cmd/benchmark run -mode live ...` when you need a custom executable workload mix instead of the documented presets
 - live benchmark correctness checks compare query results against the benchmark's loaded tier state rather than only the pre-split generated dataset
 - selective hot/EAV workloads may use a truth-pass-backed oracle mode to align expected results with the executable federated filter semantics

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -110,7 +110,8 @@ go test -v ./internal/e2e_harness/federated/... -run TestBenchmarkWorkloadExecut
 - mode: live, full workload matrix
 - scale: `large` (10M trades / 1M customers / 100k securities)
 - distribution: `hotspot-overlap`; tier profile: `balanced-60-30-10`
-- truth-pass oracles are spot-check sampled (`truth_pass_sample_cap=10000`);
+- truth-pass oracles are spot-check sampled (`truth_pass_sample_cap=10000`),
+  per workload (a workload at or under the cap stays plain `truth-pass`);
   a sampled pass asserts reconstruction ≡ engine truth on the sample only —
   see the baseline runbook before comparing against uncapped baselines
 - resource bounds: DuckDB memory 8192MB (preset), `-duckdb-memory-mb` to

--- a/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
+++ b/docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md
@@ -96,22 +96,31 @@ make benchmark-regression
 go test -v ./internal/e2e_harness/federated/... -run TestBenchmarkWorkloadExecution_RunWithHarness -timeout=10m
 ```
 
-### Heavy Run
-
-Use for manual performance review or nightly jobs only.
+### Heavy Plan Run
 
 - preset: `heavy-plan`
-- workloads: full workload set including `deep-page-1000` and `deep-page-100000`
+- mode: plan (validation only — it does not generate data or execute queries)
 - scale: `large`
-- mode: `plan`
-- goal: compare deep-pagination planning shape and prepare for later real benchmark gating
-- expected runtime: several minutes for planning, significantly longer once large executable runs are wired into the CLI
+- expected runtime: minutes
+- command: `make benchmark-heavy`
 
-Command:
+### Heavy Live Run
 
-```bash
-make benchmark-heavy
-```
+- preset: `heavy-live`
+- mode: live, full workload matrix
+- scale: `large` (10M trades / 1M customers / 100k securities)
+- distribution: `hotspot-overlap`; tier profile: `balanced-60-30-10`
+- truth-pass oracles are spot-check sampled (`truth_pass_sample_cap=10000`);
+  a sampled pass asserts reconstruction ≡ engine truth on the sample only —
+  see the baseline runbook before comparing against uncapped baselines
+- resource bounds: DuckDB memory 8192MB (preset), `-duckdb-memory-mb` to
+  override; `-run-timeout` aborts a stuck run
+- expected runtime and peak RSS/disk: pending first calibrated capture (see
+  the calibration ladder in the baseline runbook); plan for multiple hours
+  on an idle machine
+- policy: manual, on-demand only. Never in CI, no scheduled job. Run on an
+  idle machine — loaded machines inflate truth-pass oracle cost by 5-10x
+- command: `make benchmark-heavy-live`
 
 ## Recommended Commands
 
@@ -183,7 +192,7 @@ Use these rules in CI and automation for the current benchmark model.
 - keep PR-time benchmark automation on the `ci-smoke` preset only
 - do not run `deep-page-100000` in PR-time CI
 - use scheduled jobs or manual review environments for `make benchmark-regression`
-- reserve `benchmark-heavy` for manual or nightly jobs
+- reserve `benchmark-heavy` and `benchmark-heavy-live` for manual capacity-aware runs
 - treat harness-backed execution tests as smoke coverage, not as stable performance thresholds
 
 The repository CI workflow now includes a dedicated `benchmark-smoke` job for the scaffolded benchmark command and the existing federated e2e smoke tests remain the executable coverage path.

--- a/docs/superpowers/plans/2026-07-06-heavy-live-baseline.md
+++ b/docs/superpowers/plans/2026-07-06-heavy-live-baseline.md
@@ -1,0 +1,966 @@
+# Heavy-Live Baseline Implementation Plan (issue #100)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a repeatable `heavy-live` benchmark preset that executes the full 16-workload matrix live at `large` scale (10M trades) with a sampled truth-pass oracle, a run timeout, and documented runtime/environment expectations.
+
+**Architecture:** Minimal wiring over the existing `RunWithHarness` live path. The only semantic change is a spot-check sampling cap on truth-pass oracle construction: expected results stay derived from the full reconstructed candidate set; federated truth queries run only on a seeded deterministic sample, and any sampled-candidate divergence is a hard failure. Everything else is preset/flag/Makefile/docs plumbing.
+
+**Tech Stack:** Go, testcontainers federated harness (`internal/e2e_harness/federated`), `cmd/benchmark` CLI, Makefile targets.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md` (approved). Issue: Lychee-Technology/forma#100.
+
+## Global Constraints
+
+- **Never `git add -A` or `git add .`** — always explicit paths (workspace hard rule; the repo carries unrelated untracked files like `.opencode/`, `docs/superpowers/`, `.artifacts/`).
+- Work on a feature branch in `.worktrees/<branch>` (repo convention). Before branching: clean up merged local branches, `git pull` on main, and verify `git log origin/main..main` is empty.
+- `TruthPassSampleCap` (and any new Config field) MUST be `json:"...,omitempty"` — `BuildArtifactMetadata` hashes the whole `bench.Config` and existing baselines' BenchmarkIDs must not change (locked by tests).
+- With `TruthPassSampleCap == 0` every existing behavior must be byte-identical, including the exact note string `oracle_modes loaded_state=%d truth_pass=%d` (asserted by `TestBenchmarkWorkloadExecution_RunWithHarness`).
+- Existing oracle-mode strings use hyphens (`truth-pass`, `loaded-state`); the new mode is `truth-pass-sampled`.
+- Lint arbiter is CI's pinned golangci-lint v1.64.8 (`make lint`). If local lint disagrees with CI, suspect version drift, not the code.
+- Unit tests: `go test ./cmd/benchmark/... ./internal/e2e_harness/federated/benchmark/...`. E2E tests need the `e2e` build tag and Docker.
+- Include `Closes #100` in the eventual PR body.
+
+## File Structure
+
+| File | Role in this change |
+|---|---|
+| `internal/e2e_harness/federated/benchmark/config.go` | Add `TruthPassSampleCap` field + validation |
+| `internal/e2e_harness/federated/benchmark/config_test.go` | omitempty lock + validation tests |
+| `internal/e2e_harness/federated/benchmark/truth_pass_sample.go` (new) | Pure deterministic sampler |
+| `internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go` (new) | Sampler determinism tests + spot-check core tests |
+| `internal/e2e_harness/federated/benchmark/workload.go` | `OracleModeTruthPassSampled` constant |
+| `internal/e2e_harness/federated/benchmark/runner.go` | Spot-check refactor of truth-pass oracle; notes/mode plumbing |
+| `internal/e2e_harness/federated/benchmark/report.go` | Per-workload summary prefers run-time oracle mode |
+| `cmd/benchmark/main.go` | `heavy-live` preset, `heavy` alias, `-truth-pass-sample-cap`, `-run-timeout`, DuckDB override guard |
+| `cmd/benchmark/main_test.go` | Preset/alias/flag/timeout tests |
+| `Makefile` | `benchmark-heavy-live` target |
+| `internal/e2e_harness/federated/benchmark_workload_execution_test.go` | e2e sampled-oracle feasibility test |
+| `docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md` | heavy-plan vs heavy-live split |
+| `docs/federated-query/federated-query-benchmark-baseline-runbook.md` | heavy-live capture section + calibration ladder |
+
+---
+
+### Task 1: `TruthPassSampleCap` config field
+
+**Files:**
+- Modify: `internal/e2e_harness/federated/benchmark/config.go`
+- Test: `internal/e2e_harness/federated/benchmark/config_test.go`
+
+**Interfaces:**
+- Produces: `Config.TruthPassSampleCap int` (`json:"truth_pass_sample_cap,omitempty"`), validated `>= 0`. Tasks 3 and 4 read this field.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/e2e_harness/federated/benchmark/config_test.go` (the file already imports `encoding/json`, `strings`, `testing` — follow the style of `TestConfigJSONOmitsZeroDuckDBResources` at line 54):
+
+```go
+// TestConfigJSONOmitsZeroTruthPassSampleCap protects BenchmarkID continuity:
+// BuildArtifactMetadata hashes the whole Config, so an unset cap must not
+// change the serialized form of existing configs.
+func TestConfigJSONOmitsZeroTruthPassSampleCap(t *testing.T) {
+	raw, err := json.Marshal(DefaultConfig())
+	if err != nil {
+		t.Fatalf("marshal default config: %v", err)
+	}
+	if strings.Contains(string(raw), "truth_pass_sample_cap") {
+		t.Fatalf("zero TruthPassSampleCap must be omitted from JSON, got: %s", raw)
+	}
+}
+
+func TestConfigValidateRejectsNegativeTruthPassSampleCap(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.TruthPassSampleCap = -1
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected negative truth-pass sample cap to be rejected")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/e2e_harness/federated/benchmark/ -run 'TruthPassSampleCap' -v`
+Expected: FAIL — `cfg.TruthPassSampleCap undefined`.
+
+- [ ] **Step 3: Implement the field**
+
+In `internal/e2e_harness/federated/benchmark/config.go`, extend the `Config` struct (after the DuckDB fields, line 55):
+
+```go
+	// TruthPassSampleCap bounds truth-pass oracle construction: when > 0 and
+	// a workload's candidate set exceeds the cap, only a seeded deterministic
+	// sample of candidates is verified through the engine (spot check) and
+	// the expected result is taken from the full reconstructed candidate set.
+	// 0 = full truth pass (existing behavior). omitempty keeps the
+	// BenchmarkID hash of existing artifacts stable.
+	TruthPassSampleCap int `json:"truth_pass_sample_cap,omitempty"`
+```
+
+Extend `Validate()` (after the DuckDB checks, line 131):
+
+```go
+	if c.TruthPassSampleCap < 0 {
+		return fmt.Errorf("truth-pass sample cap must be greater than or equal to zero")
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/e2e_harness/federated/benchmark/ -run 'Config' -v`
+Expected: PASS (including the pre-existing Config tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/e2e_harness/federated/benchmark/config.go internal/e2e_harness/federated/benchmark/config_test.go
+git commit -m "feat(benchmark): add TruthPassSampleCap config field (#100)"
+```
+
+---
+
+### Task 2: Deterministic truth-pass sampler
+
+**Files:**
+- Create: `internal/e2e_harness/federated/benchmark/truth_pass_sample.go`
+- Test: `internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go`
+
+**Interfaces:**
+- Produces: `truthPassSampleIndices(seed int64, workloadName string, total, cap int) map[int]struct{}` — returns `nil` when sampling does not apply (`cap <= 0` or `total <= cap`); otherwise exactly `cap` distinct indices in `[0, total)`, deterministic for identical inputs. Task 3 consumes this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go`:
+
+```go
+package benchmark
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTruthPassSampleIndicesNotAppliedWhenCapCoversTotal(t *testing.T) {
+	if got := truthPassSampleIndices(42, "eav-selective-page", 100, 0); got != nil {
+		t.Fatalf("cap=0 must disable sampling, got %v", got)
+	}
+	if got := truthPassSampleIndices(42, "eav-selective-page", 100, 100); got != nil {
+		t.Fatalf("total<=cap must disable sampling, got %v", got)
+	}
+}
+
+func TestTruthPassSampleIndicesDeterministicAndBounded(t *testing.T) {
+	first := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	second := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("same seed/workload/total/cap must sample identically")
+	}
+	if len(first) != 25 {
+		t.Fatalf("expected exactly 25 sampled indices, got %d", len(first))
+	}
+	for idx := range first {
+		if idx < 0 || idx >= 1000 {
+			t.Fatalf("sampled index %d out of range [0,1000)", idx)
+		}
+	}
+}
+
+func TestTruthPassSampleIndicesVaryBySeedAndWorkload(t *testing.T) {
+	base := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	otherSeed := truthPassSampleIndices(43, "eav-selective-page", 1000, 25)
+	otherWorkload := truthPassSampleIndices(42, "hot-selective-page", 1000, 25)
+	if reflect.DeepEqual(base, otherSeed) && reflect.DeepEqual(base, otherWorkload) {
+		t.Fatal("expected seed and workload name to influence the sample")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/e2e_harness/federated/benchmark/ -run 'TruthPassSampleIndices' -v`
+Expected: FAIL — `undefined: truthPassSampleIndices`.
+
+- [ ] **Step 3: Implement the sampler**
+
+Create `internal/e2e_harness/federated/benchmark/truth_pass_sample.go`:
+
+```go
+package benchmark
+
+import (
+	"hash/fnv"
+	"math/rand"
+)
+
+// truthPassSampleIndices picks the candidate indices to spot-check when the
+// truth-pass sample cap applies. It returns nil when sampling is disabled
+// (cap <= 0) or unnecessary (total <= cap). The selection is deterministic
+// for a given (seed, workloadName, total, cap) so identical benchmark
+// configs verify identical candidates — a repeatability requirement for
+// heavy-live baselines (#100).
+func truthPassSampleIndices(seed int64, workloadName string, total, cap int) map[int]struct{} {
+	if cap <= 0 || total <= cap {
+		return nil
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(workloadName))
+	rng := rand.New(rand.NewSource(seed ^ int64(h.Sum64()))) //nolint:gosec // deterministic sampling, not crypto
+	picked := make(map[int]struct{}, cap)
+	for _, idx := range rng.Perm(total)[:cap] {
+		picked[idx] = struct{}{}
+	}
+	return picked
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/e2e_harness/federated/benchmark/ -run 'TruthPassSampleIndices' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/e2e_harness/federated/benchmark/truth_pass_sample.go internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go
+git commit -m "feat(benchmark): deterministic truth-pass sample index selection (#100)"
+```
+
+---
+
+### Task 3: Spot-check truth-pass oracle
+
+**Files:**
+- Modify: `internal/e2e_harness/federated/benchmark/workload.go` (constant, line ~22)
+- Modify: `internal/e2e_harness/federated/benchmark/runner.go` (`buildExpectedResults` line 346, `buildExpectedWorkloadResultFromFederatedTruth` line 1312, `RunWithHarness` notes block lines 333-341)
+- Modify: `internal/e2e_harness/federated/benchmark/report.go` (`summarizeWorkloads`, line ~669)
+- Test: `internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go` (extend)
+
+**Interfaces:**
+- Consumes: `truthPassSampleIndices` (Task 2), `Config.TruthPassSampleCap` (Task 1).
+- Produces:
+  - `OracleModeTruthPassSampled OracleMode = "truth-pass-sampled"` in `workload.go` (Task 6 asserts it).
+  - `type truthPassSampleStats struct { Applied bool; Cap, Candidates, Sampled int }` in `runner.go`.
+  - `buildTruthPassExpected(ctx context.Context, isVisible func(context.Context, GeneratedRecord) (bool, error), workload WorkloadDefinition, defaultPageSize int, candidates []GeneratedRecord, sampleCap int, seed int64) (expectedWorkloadResult, truthPassSampleStats, error)` — pure core, unit-tested.
+  - `buildExpectedWorkloadResultFromFederatedTruth` gains `sampleCap int, seed int64` params and returns the stats as second value.
+  - `(*Runner).buildExpectedResults` now returns notes as `[]string` (first element is the existing `oracle_modes ...` summary line).
+
+- [ ] **Step 1: Write the failing tests for the core**
+
+Append to `internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go` (add imports `context`, `fmt`, `strings`, `github.com/google/uuid` to the file's import block):
+
+```go
+func spotCheckCandidates(n int) []GeneratedRecord {
+	records := make([]GeneratedRecord, 0, n)
+	for i := 0; i < n; i++ {
+		records = append(records, GeneratedRecord{
+			RowID: uuid.MustParse(fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1)),
+		})
+	}
+	return records
+}
+
+func TestBuildTruthPassExpectedUncappedKeepsFilteringSemantics(t *testing.T) {
+	candidates := spotCheckCandidates(5)
+	invisible := map[string]struct{}{
+		candidates[1].RowID.String(): {},
+		candidates[3].RowID.String(): {},
+	}
+	calls := 0
+	isVisible := func(_ context.Context, candidate GeneratedRecord) (bool, error) {
+		calls++
+		_, hidden := invisible[candidate.RowID.String()]
+		return !hidden, nil
+	}
+	workload := WorkloadDefinition{Name: "spot-check-test", PageSize: 20, PageNumber: 1}
+	expected, stats, err := buildTruthPassExpected(context.Background(), isVisible, workload, 20, candidates, 0, 42)
+	if err != nil {
+		t.Fatalf("uncapped truth pass failed: %v", err)
+	}
+	if calls != 5 {
+		t.Fatalf("uncapped pass must query every candidate, queried %d of 5", calls)
+	}
+	if expected.TotalRecords != 3 {
+		t.Fatalf("expected invisible candidates removed (total=3), got %d", expected.TotalRecords)
+	}
+	if stats.Applied {
+		t.Fatal("cap=0 must not report sampling as applied")
+	}
+}
+
+func TestBuildTruthPassExpectedCappedSpotCheckPasses(t *testing.T) {
+	candidates := spotCheckCandidates(50)
+	calls := 0
+	isVisible := func(_ context.Context, _ GeneratedRecord) (bool, error) {
+		calls++
+		return true, nil
+	}
+	workload := WorkloadDefinition{Name: "spot-check-test", PageSize: 20, PageNumber: 1}
+	expected, stats, err := buildTruthPassExpected(context.Background(), isVisible, workload, 20, candidates, 10, 42)
+	if err != nil {
+		t.Fatalf("capped spot check failed: %v", err)
+	}
+	if calls != 10 {
+		t.Fatalf("capped pass must query exactly cap candidates, queried %d", calls)
+	}
+	if expected.TotalRecords != 50 {
+		t.Fatalf("capped pass must keep the full candidate set as expected (total=50), got %d", expected.TotalRecords)
+	}
+	if !stats.Applied || stats.Cap != 10 || stats.Candidates != 50 || stats.Sampled != 10 {
+		t.Fatalf("unexpected sample stats: %+v", stats)
+	}
+}
+
+func TestBuildTruthPassExpectedCappedSpotCheckFailsHardOnInvisibleCandidate(t *testing.T) {
+	candidates := spotCheckCandidates(50)
+	isVisible := func(_ context.Context, _ GeneratedRecord) (bool, error) {
+		return false, nil
+	}
+	workload := WorkloadDefinition{Name: "spot-check-test", PageSize: 20, PageNumber: 1}
+	_, _, err := buildTruthPassExpected(context.Background(), isVisible, workload, 20, candidates, 10, 42)
+	if err == nil {
+		t.Fatal("expected hard failure when a sampled candidate is not visible")
+	}
+	if !strings.Contains(err.Error(), "spot check failed") {
+		t.Fatalf("error must identify the spot-check divergence, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/e2e_harness/federated/benchmark/ -run 'BuildTruthPassExpected' -v`
+Expected: FAIL — `undefined: buildTruthPassExpected`.
+
+- [ ] **Step 3: Add the oracle-mode constant**
+
+In `internal/e2e_harness/federated/benchmark/workload.go`, extend the const block (line 21-22):
+
+```go
+	OracleModeLoadedState OracleMode = "loaded-state"
+	OracleModeTruthPass   OracleMode = "truth-pass"
+	// OracleModeTruthPassSampled marks a truth-pass oracle whose engine
+	// verification was spot-checked on a seeded sample because the candidate
+	// set exceeded Config.TruthPassSampleCap (#100). The expected result is
+	// still the full reconstructed candidate set.
+	OracleModeTruthPassSampled OracleMode = "truth-pass-sampled"
+```
+
+- [ ] **Step 4: Implement the spot-check core and rewire the wrapper**
+
+In `internal/e2e_harness/federated/benchmark/runner.go`, replace `buildExpectedWorkloadResultFromFederatedTruth` (lines 1312-1353) with:
+
+```go
+// truthPassSampleStats reports how truth-pass verification was bounded.
+type truthPassSampleStats struct {
+	Applied    bool
+	Cap        int
+	Candidates int
+	Sampled    int
+}
+
+func buildExpectedWorkloadResultFromFederatedTruth(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition, defaultPageSize int, loadedRecords []GeneratedRecord, genCfg GeneratorConfig, sampleCap int, seed int64) (expectedWorkloadResult, truthPassSampleStats, error) {
+	if h == nil {
+		return expectedWorkloadResult{}, truthPassSampleStats{}, fmt.Errorf("harness cannot be nil")
+	}
+	semantics := semanticsForWorkload(workload, genCfg)
+	candidates := filterExpectedRecordsForWorkload(expectedVisibleRecords(loadedRecords), workload, semantics)
+	sortExpectedRecordsForWorkload(candidates, workload)
+	previousSchemaID := h.SchemaID
+	schemaID, err := workloadSchemaID(workload.TargetSchema)
+	if err != nil {
+		return expectedWorkloadResult{}, truthPassSampleStats{}, err
+	}
+	h.SchemaID = schemaID
+	defer func() {
+		h.SchemaID = previousSchemaID
+	}()
+	isVisible := func(ctx context.Context, candidate GeneratedRecord) (bool, error) {
+		result, err := h.ExecuteFederatedQuery(ctx, &federated.QueryOptions{
+			Limit: 1,
+			Filter: &federated.Filter{
+				RowID:      candidate.RowID,
+				Conditions: workload.ResolvedFilterConditions(),
+			},
+			SortBy:   "tradeTime",
+			SortDesc: true,
+		})
+		if err != nil {
+			return false, err
+		}
+		return result.TotalRecords > 0, nil
+	}
+	return buildTruthPassExpected(ctx, isVisible, workload, defaultPageSize, candidates, sampleCap, seed)
+}
+
+// buildTruthPassExpected derives the expected result for a truth-pass
+// workload. Uncapped (sampleCap <= 0 or candidates <= cap) it verifies every
+// candidate and keeps only the visible ones — existing behavior. Capped, it
+// keeps the full reconstructed candidate set as the expected result and
+// verifies a seeded deterministic sample; a sampled candidate the engine
+// cannot see means reconstruction and engine truth diverge, which no
+// sampling rate can absorb, so the run fails hard.
+func buildTruthPassExpected(ctx context.Context, isVisible func(context.Context, GeneratedRecord) (bool, error), workload WorkloadDefinition, defaultPageSize int, candidates []GeneratedRecord, sampleCap int, seed int64) (expectedWorkloadResult, truthPassSampleStats, error) {
+	pageSize := workload.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	sampledIdx := truthPassSampleIndices(seed, workload.Name, len(candidates), sampleCap)
+	if sampledIdx == nil {
+		matching := make([]GeneratedRecord, 0, len(candidates))
+		for _, candidate := range candidates {
+			visible, err := isVisible(ctx, candidate)
+			if err != nil {
+				return expectedWorkloadResult{}, truthPassSampleStats{}, err
+			}
+			if visible {
+				matching = append(matching, candidate)
+			}
+		}
+		rowIDs := expectedPageRowIDs(matching, workload.DerivedOffset(defaultPageSize), pageSize)
+		return expectedWorkloadResult{TotalRecords: int64(len(matching)), RowIDs: rowIDs}, truthPassSampleStats{Candidates: len(candidates), Sampled: len(candidates)}, nil
+	}
+	stats := truthPassSampleStats{Applied: true, Cap: sampleCap, Candidates: len(candidates), Sampled: len(sampledIdx)}
+	for i, candidate := range candidates {
+		if _, ok := sampledIdx[i]; !ok {
+			continue
+		}
+		visible, err := isVisible(ctx, candidate)
+		if err != nil {
+			return expectedWorkloadResult{}, stats, err
+		}
+		if !visible {
+			return expectedWorkloadResult{}, stats, fmt.Errorf("truth-pass spot check failed for workload %s: sampled candidate row_id=%s is not visible through the engine; reconstruction diverges from engine truth — investigate at a smaller scale without the sample cap before trusting sampled oracles", workload.Name, candidate.RowID)
+		}
+	}
+	rowIDs := expectedPageRowIDs(candidates, workload.DerivedOffset(defaultPageSize), pageSize)
+	return expectedWorkloadResult{TotalRecords: int64(len(candidates)), RowIDs: rowIDs}, stats, nil
+}
+```
+
+Note: the old body's per-candidate query loop moves verbatim into the `isVisible` closure; do not change the `QueryOptions` shape.
+
+- [ ] **Step 5: Thread cap/seed and notes through `buildExpectedResults`**
+
+Replace `buildExpectedResults` (runner.go lines 346-367) with:
+
+```go
+func (r *Runner) buildExpectedResults(ctx context.Context, h *federated.FederatedTestHarness, loadedRecords []GeneratedRecord, hotKeys map[string]struct{}) (map[string]expectedWorkloadResult, map[string]string, []string, error) {
+	results := buildExpectedWorkloadResultsFromRecords(loadedRecords, r.workloads, r.config.PageSize, r.genConfig, hotKeys)
+	oracleModes := make(map[string]string, len(r.workloads))
+	loadedStateCount := 0
+	truthPassCount := 0
+	sampledCount := 0
+	var sampleNotes []string
+	for _, workload := range r.workloads {
+		mode := string(workload.ResolvedOracleMode())
+		oracleModes[workload.Name] = mode
+		switch workload.ResolvedOracleMode() {
+		case OracleModeTruthPass:
+			expected, stats, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, workload, r.config.PageSize, loadedRecords, r.genConfig, r.config.TruthPassSampleCap, r.config.Seed)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("build truth-pass expected result for %s: %w", workload.Name, err)
+			}
+			results[workload.Name] = expected
+			truthPassCount++
+			if stats.Applied {
+				oracleModes[workload.Name] = string(OracleModeTruthPassSampled)
+				sampledCount++
+				sampleNotes = append(sampleNotes, fmt.Sprintf("truth_pass_sample workload=%s cap=%d candidates=%d sampled=%d", workload.Name, stats.Cap, stats.Candidates, stats.Sampled))
+			}
+		default:
+			loadedStateCount++
+		}
+	}
+	summary := fmt.Sprintf("oracle_modes loaded_state=%d truth_pass=%d", loadedStateCount, truthPassCount)
+	if sampledCount > 0 {
+		summary = fmt.Sprintf("%s truth_pass_sampled=%d", summary, sampledCount)
+	}
+	return results, oracleModes, append([]string{summary}, sampleNotes...), nil
+}
+```
+
+In `RunWithHarness`, the call site (line 222) keeps its shape (`oracleNotes` is now `[]string`), and the `Notes` block (lines 333-341) becomes:
+
+```go
+	notes := []string{
+		"loaded TPC-E-inspired schema fixtures",
+		fmt.Sprintf("generated dataset with distribution=%s", r.genConfig.Distribution),
+		fmt.Sprintf("loaded tiered dataset profile=%s", profile.Name),
+		fmt.Sprintf("loaded-state snapshot rows=%d", len(loadedRecords)),
+	}
+	notes = append(notes, oracleNotes...)
+	notes = append(notes,
+		"prefer_hot expresses workload intent and report provenance, not hard execution routing",
+		"executed supported federated query workloads",
+	)
+```
+
+and set `Notes: notes,` in the `RunResult` literal. With `cap=0` the notes are element-for-element identical to today.
+
+- [ ] **Step 6: Surface the sampled mode in workload summaries**
+
+In `internal/e2e_harness/federated/benchmark/report.go`, inside `summarizeWorkloads` right after the `if def, ok := workloadDefs[name]; ok { ... }` block (line 673), add:
+
+```go
+		if mode, ok := result.OracleModes[name]; ok && mode != "" {
+			workload.OracleMode = mode
+		}
+```
+
+This makes the per-workload summary agree with `RunResult.OracleModes` when sampling rewrites the mode; `detectMethodologyChanges` (report.go:963) then flags capped-vs-uncapped comparisons automatically — desired.
+
+- [ ] **Step 7: Run the package tests**
+
+Run: `go test ./internal/e2e_harness/federated/benchmark/ -v`
+Expected: PASS — new `BuildTruthPassExpected` tests green, and every pre-existing test green (cap=0 characterization).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/e2e_harness/federated/benchmark/workload.go internal/e2e_harness/federated/benchmark/runner.go internal/e2e_harness/federated/benchmark/report.go internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go
+git commit -m "feat(benchmark): spot-check sampled truth-pass oracle behind TruthPassSampleCap (#100)"
+```
+
+---
+
+### Task 4: CLI — `heavy-live` preset, alias, cap/timeout flags, DuckDB override guard
+
+**Files:**
+- Modify: `cmd/benchmark/main.go`
+- Test: `cmd/benchmark/main_test.go`
+
+**Interfaces:**
+- Consumes: `bench.Config.TruthPassSampleCap` (Task 1), `bench.OracleModeTruthPassSampled` (Task 3, describe output only).
+- Produces: preset name `heavy-live` (alias `heavy`), flags `-truth-pass-sample-cap` and `-run-timeout` on `baseline` and `run`, helper `applyDuckDBOverrides(cfg bench.Config, threads, memoryMB int) bench.Config`. Task 5's Makefile target and Task 8's ladder commands rely on these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cmd/benchmark/main_test.go` (file already imports `bytes`, `context`, `testing`, and `bench`):
+
+```go
+func TestResolveBenchmarkPresetHeavyLive(t *testing.T) {
+	preset, err := resolveBenchmarkPreset("heavy", bench.DistributionHotspot)
+	if err != nil {
+		t.Fatalf("resolveBenchmarkPreset heavy failed: %v", err)
+	}
+	if preset.Name != "heavy-live" {
+		t.Fatalf("expected heavy alias to resolve to heavy-live, got %q", preset.Name)
+	}
+	if preset.Config.Mode != bench.ExecutionModeLive || preset.Config.Scale != bench.ScaleLarge {
+		t.Fatalf("expected live/large heavy-live config, got %+v", preset.Config)
+	}
+	if preset.Config.TruthPassSampleCap != 10000 {
+		t.Fatalf("expected heavy-live truth-pass sample cap 10000, got %d", preset.Config.TruthPassSampleCap)
+	}
+	if preset.Config.DuckDBMemoryLimitMB != 8192 {
+		t.Fatalf("expected heavy-live DuckDB memory 8192MB, got %d", preset.Config.DuckDBMemoryLimitMB)
+	}
+	if len(preset.Config.Workloads) != len(bench.DefaultWorkloadNames()) {
+		t.Fatalf("expected the full workload matrix, got %d workloads", len(preset.Config.Workloads))
+	}
+	if preset.CISafe {
+		t.Fatal("heavy-live must not be CI-safe")
+	}
+	if preset.BaselineDir != "heavy-live-hotspot-overlap" {
+		t.Fatalf("unexpected baseline dir %q", preset.BaselineDir)
+	}
+}
+
+func TestApplyDuckDBOverridesKeepsPresetValues(t *testing.T) {
+	cfg := bench.Config{DuckDBThreads: 4, DuckDBMemoryLimitMB: 8192}
+	got := applyDuckDBOverrides(cfg, 0, 0)
+	if got.DuckDBThreads != 4 || got.DuckDBMemoryLimitMB != 8192 {
+		t.Fatalf("zero flags must keep preset resources, got %+v", got)
+	}
+	got = applyDuckDBOverrides(cfg, 8, 16384)
+	if got.DuckDBThreads != 8 || got.DuckDBMemoryLimitMB != 16384 {
+		t.Fatalf("positive flags must override preset resources, got %+v", got)
+	}
+}
+
+func TestRunBaselineRunTimeoutExpires(t *testing.T) {
+	dir := t.TempDir()
+	var out, errOut bytes.Buffer
+	exitCode := runBenchmarkMain(context.Background(), []string{"baseline", "-preset", "ci-smoke", "-run-timeout", "1ns", "-output-dir", dir}, &out, &errOut)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit when run timeout expires, stderr=%s", errOut.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/benchmark/ -run 'HeavyLive|ApplyDuckDBOverrides|RunTimeout' -v`
+Expected: FAIL — `unknown baseline preset "heavy"`, `undefined: applyDuckDBOverrides`, and flag-parse error for `-run-timeout`.
+
+- [ ] **Step 3: Implement the CLI changes**
+
+All in `cmd/benchmark/main.go`:
+
+a) Append the preset to `defaultBenchmarkPresets()` (after `heavy-plan`, line ~505):
+
+```go
+		{
+			Name:          "heavy-live",
+			Description:   "Full live workload matrix at large scale for capacity-aware baseline capture.",
+			RuntimeClass:  "heavy",
+			BaselineDir:   "heavy-live-hotspot-overlap",
+			CISafe:        false,
+			ExpectedUsage: "manual capacity-aware baseline capture only (idle machine, hours)",
+			Config:        bench.Config{Mode: bench.ExecutionModeLive, Scale: bench.ScaleLarge, Distribution: bench.DistributionHotspot, Iterations: 2, PageSize: 20, Seed: 42, TierProfile: bench.DefaultTierMixProfile().Name, Workloads: bench.DefaultWorkloadNames(), TruthPassSampleCap: 10000, DuckDBMemoryLimitMB: 8192}.WithDefaults(),
+		},
+```
+
+b) In `resolveBenchmarkPreset` (line ~512), after the `medium` alias:
+
+```go
+	if presetName == "heavy" {
+		presetName = "heavy-live"
+	}
+```
+
+c) Update the preset flag usage string (line 136):
+
+```go
+	preset := flags.String("preset", "small", "Baseline preset: ci-smoke, small, small-live, medium, medium-live, heavy, heavy-live, or heavy-plan")
+```
+
+d) Add the override helper near `baselinePresetConfig`:
+
+```go
+// applyDuckDBOverrides keeps preset-provided DuckDB resources unless the
+// operator explicitly overrides them (flag default 0 = keep preset/harness
+// value). Without this guard the zero-valued flags would erase preset
+// resource bounds such as heavy-live's 8192MB memory limit.
+func applyDuckDBOverrides(cfg bench.Config, threads, memoryMB int) bench.Config {
+	if threads > 0 {
+		cfg.DuckDBThreads = threads
+	}
+	if memoryMB > 0 {
+		cfg.DuckDBMemoryLimitMB = memoryMB
+	}
+	return cfg
+}
+```
+
+e) In `runBaseline`: add flags after `duckDBMemoryMB` (line 146):
+
+```go
+	truthPassCap := flags.Int("truth-pass-sample-cap", -1, "Override truth-pass oracle sample cap (-1 = preset value, 0 = uncapped full truth pass)")
+	runTimeout := flags.Duration("run-timeout", 0, "Abort the entire run after this duration (0 = no timeout)")
+	tierProfile := flags.String("tier-profile", "", "Override preset tier mix profile (empty = preset value)")
+```
+
+Replace the unconditional assignments (lines 158-159) with:
+
+```go
+	config = applyDuckDBOverrides(config, *duckDBThreads, *duckDBMemoryMB)
+	if *truthPassCap >= 0 {
+		config.TruthPassSampleCap = *truthPassCap
+	}
+	if *tierProfile != "" {
+		config.TierProfile = *tierProfile
+	}
+	if *runTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *runTimeout)
+		defer cancel()
+	}
+```
+
+f) In `parseRunConfig`: add the same two flags after `duckDBMemoryMB` (line 358) but with `truthPassCap := flags.Int("truth-pass-sample-cap", 0, "Truth-pass oracle sample cap (0 = uncapped full truth pass)")`, set `TruthPassSampleCap: *truthPassCap,` in the `bench.Config` literal, and surface the timeout by adding a `runTimeout time.Duration` field to `runOutputs` set from the flag. Then in `runBenchmark` (line 125), before `executeBenchmarkRun`:
+
+```go
+	if outputs.runTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, outputs.runTimeout)
+		defer cancel()
+	}
+```
+
+(`main.go` already imports `time`? If not, add `"time"` to the import block.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/benchmark/ -v`
+Expected: PASS — new tests green, `TestResolveBenchmarkPresetSupportsAliasesAndPresets` and the ci-smoke baseline test still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/benchmark/main.go cmd/benchmark/main_test.go
+git commit -m "feat(benchmark): heavy-live preset, truth-pass cap and run-timeout flags (#100)"
+```
+
+---
+
+### Task 5: Makefile target
+
+**Files:**
+- Modify: `Makefile` (`.PHONY` line 1; new target after `benchmark-heavy`, line ~108)
+
+**Interfaces:**
+- Consumes: `baseline -preset heavy-live` (Task 4).
+- Produces: `make benchmark-heavy-live` writing to `.artifacts/benchmark/heavy-live/heavy-live-hotspot-overlap`. Task 7 documents it; Task 8 runs it.
+
+- [ ] **Step 1: Add the target**
+
+Add `benchmark-heavy-live` to the `.PHONY` list (line 1), and after the `benchmark-heavy` target:
+
+```make
+# Full live workload matrix at large scale (10M trades). Hours of wall clock
+# and heavy RAM/disk — operator-initiated on an idle machine only, never CI.
+# Truth-pass oracles are spot-check sampled (see the baseline runbook).
+benchmark-heavy-live: create-build-dir
+	@echo "Running benchmark heavy live set (hours; idle machine only)..."
+	@mkdir -p .artifacts/benchmark/heavy-live
+	@$(GOENV) go run ./cmd/benchmark baseline -preset heavy-live \
+		-distribution hotspot-overlap \
+		-output-dir .artifacts/benchmark/heavy-live \
+		-channel manual \
+		-git-sha $$(git rev-parse HEAD 2>/dev/null || echo "") \
+		-git-ref $$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+```
+
+Note `-distribution hotspot-overlap` is explicit: the flag default is `uniform` and `resolveBenchmarkPreset` always applies a non-empty distribution flag over the preset value.
+
+- [ ] **Step 2: Verify the target expands correctly**
+
+Run: `make -n benchmark-heavy-live`
+Expected: dry-run output shows the `baseline -preset heavy-live -distribution hotspot-overlap ...` command; no execution.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "feat(benchmark): make benchmark-heavy-live target (#100)"
+```
+
+---
+
+### Task 6: e2e sampled-oracle feasibility test
+
+**Files:**
+- Modify: `internal/e2e_harness/federated/benchmark_workload_execution_test.go`
+
+**Interfaces:**
+- Consumes: `bench.Config.TruthPassSampleCap`, `bench.OracleModeTruthPassSampled`, existing `RunWithHarness` tiny-dataset technique (#147: ~30s per run under the `e2e` tag).
+
+- [ ] **Step 1: Write the test**
+
+Append to `internal/e2e_harness/federated/benchmark_workload_execution_test.go` (add `"strings"` to imports):
+
+```go
+func TestBenchmarkTruthPassSampledSpotCheck_RunWithHarness(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	h, err := federated.NewFederatedTestHarness(ctx)
+	require.NoError(t, err)
+	defer h.Cleanup(ctx)
+
+	runner, err := bench.NewRunner(bench.Config{
+		Mode:               bench.ExecutionModeLive,
+		Scale:              bench.ScaleSmall,
+		Distribution:       bench.DistributionHotspot,
+		Iterations:         1,
+		PageSize:           20,
+		Seed:               42,
+		TradeCount:         300,
+		CustomerCount:      20,
+		SecurityCount:      10,
+		OverlapRatio:       0.10,
+		DeleteRatio:        0.05,
+		TruthPassSampleCap: 5,
+		Workloads: []string{
+			"baseline-page-1",
+			"hot-selective-page",
+			"eav-selective-page",
+		},
+	}.WithDefaults())
+	require.NoError(t, err)
+
+	result, err := runner.RunWithHarness(ctx, h, bench.TierMixBalanced)
+	require.NoError(t, err)
+	require.True(t, result.Passed, "sampled heavy-live semantics must still pass at tiny scale")
+	require.Equal(t, string(bench.OracleModeTruthPassSampled), result.OracleModes["hot-selective-page"])
+	require.Equal(t, string(bench.OracleModeTruthPassSampled), result.OracleModes["eav-selective-page"])
+
+	sampledNote := false
+	for _, note := range result.Notes {
+		if strings.Contains(note, "truth_pass_sampled=2") {
+			sampledNote = true
+		}
+	}
+	require.True(t, sampledNote, "expected sampled oracle summary note, got %v", result.Notes)
+}
+```
+
+If a selective workload's candidate count at TradeCount=300 turns out to be ≤ 5 (sampling then never engages and the mode stays `truth-pass`), raise `TradeCount` to 600 rather than lowering the cap below 5.
+
+- [ ] **Step 2: Run the e2e tests (Docker required)**
+
+Run: `go test -tags e2e ./internal/e2e_harness/federated/ -run 'TestBenchmarkTruthPassSampledSpotCheck|TestBenchmarkWorkloadExecution_RunWithHarness' -v -timeout 15m`
+Expected: both PASS — the new sampled test, and the pre-existing execution test still emitting the exact note `oracle_modes loaded_state=8 truth_pass=8` (cap=0 characterization).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/e2e_harness/federated/benchmark_workload_execution_test.go
+git commit -m "test(benchmark): e2e sampled truth-pass spot-check at tiny scale (#100)"
+```
+
+---
+
+### Task 7: Documentation — ops guide and runbook
+
+**Files:**
+- Modify: `docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md` (Heavy Run section, line ~99; recommendations, lines ~186, ~241)
+- Modify: `docs/federated-query/federated-query-benchmark-baseline-runbook.md` (preset list line ~15, artifact dirs line ~58, usage guidance lines ~139-155)
+
+**Interfaces:**
+- Consumes: preset/flags (Task 4), Makefile target (Task 5). Runtime numbers come from Task 8 and are marked "pending first capture" until then.
+
+- [ ] **Step 1: Update the ops guide**
+
+In `federated-query-benchmark-ci-and-ops-guide.md`, replace the `### Heavy Run` section with two subsections:
+
+```markdown
+### Heavy Plan Run
+
+- preset: `heavy-plan`
+- mode: plan (validation only — it does not generate data or execute queries)
+- scale: `large`
+- expected runtime: minutes
+- command: `make benchmark-heavy`
+
+### Heavy Live Run
+
+- preset: `heavy-live`
+- mode: live, full 16-workload matrix
+- scale: `large` (10M trades / 1M customers / 100k securities)
+- distribution: `hotspot-overlap`; tier profile: `balanced-60-30-10`
+- truth-pass oracles are spot-check sampled (`truth_pass_sample_cap=10000`);
+  a sampled pass asserts reconstruction ≡ engine truth on the sample only —
+  see the baseline runbook before comparing against uncapped baselines
+- resource bounds: DuckDB memory 8192MB (preset), `-duckdb-memory-mb` to
+  override; `-run-timeout` aborts a stuck run
+- expected runtime and peak RSS/disk: pending first calibrated capture (see
+  the calibration ladder in the baseline runbook); plan for multiple hours
+  on an idle machine
+- policy: manual, on-demand only. Never in CI, no scheduled job. Run on an
+  idle machine — loaded machines inflate truth-pass oracle cost by 5-10x
+- command: `make benchmark-heavy-live`
+```
+
+Update the surrounding references: line ~186 `reserve benchmark-heavy for manual or nightly jobs` becomes `reserve benchmark-heavy and benchmark-heavy-live for manual capacity-aware runs`; keep line ~241 (`large` reserved for capacity-aware environments); remove `heavy preset only runs plan mode` phrasing wherever it appears (it was the gap #100 closes).
+
+- [ ] **Step 2: Update the baseline runbook**
+
+In `federated-query-benchmark-baseline-runbook.md`:
+
+a) Preset list (line ~15): add `- \`heavy-live\`: full live workload matrix at large scale; manual capacity-aware capture only`.
+
+b) Artifact dirs (line ~58): add `- \`.artifacts/benchmark/heavy-live/heavy-live-hotspot-overlap\``.
+
+c) Add a new section after the existing capture instructions:
+
+```markdown
+## Heavy-Live Baseline Capture
+
+`heavy-live` executes the full workload matrix live at `large` scale. It is
+the only preset that exercises deep pagination and tier hotness behavior at
+production-representative volume.
+
+### Calibration ladder (run before the first official capture)
+
+The large-scale pipeline holds the dataset in memory several times over
+(generation, tiering, loaded-state snapshot). Measure before committing to
+the full 10M run, recording wall clock, peak RSS, and Docker disk usage:
+
+    /usr/bin/time -l go run ./cmd/benchmark run -mode live -scale large \
+      -distribution hotspot-overlap -iterations 2 -seed 42 \
+      -trade-count 2000000 -customer-count 200000 -security-count 20000 \
+      -truth-pass-sample-cap 10000 -duckdb-memory-mb 8192 \
+      -json-out .artifacts/benchmark/heavy-live-probe/2m.json \
+      -md-out .artifacts/benchmark/heavy-live-probe/2m.md
+
+Repeat with `-trade-count 5000000 -customer-count 500000 -security-count 50000`
+(outputs `5m.json` / `5m.md`). Extrapolate: if the projected 10M peak RSS
+exceeds machine RAM or the projected runtime is unacceptable, stop and file
+the streaming/batched-load follow-up instead of forcing the run.
+
+### Official capture
+
+    /usr/bin/time -l make benchmark-heavy-live
+
+- idle machine only; check load first (truth-pass throughput drops 5-10x
+  under load)
+- use `-run-timeout` when running unattended
+- expected runtime / peak RSS / disk: fill in from the first successful
+  capture and keep current
+
+### Reading sampled truth-pass results
+
+`heavy-live` reports `truth-pass-sampled` oracle mode for selective
+workloads: the expected result is the full reconstructed candidate set, and
+the engine was consulted for a seeded sample of `truth_pass_sample_cap`
+candidates. A sampled pass is strictly weaker evidence than an uncapped
+truth pass; `compare` flags capped-vs-uncapped runs as a methodology change.
+A spot-check failure means reconstruction and engine truth diverge — rerun
+the failing workload uncapped at `small` scale to investigate.
+
+### Tier-profile variants
+
+The official baseline uses `balanced-60-30-10`. To exercise the profiles
+called out in #100 manually:
+
+    go run ./cmd/benchmark baseline -preset heavy-live \
+      -distribution hotspot-overlap -tier-profile high-hot-40-20-40 \
+      -output-dir .artifacts/benchmark/heavy-live-high-hot ...
+
+    go run ./cmd/benchmark baseline -preset heavy-live \
+      -distribution hotspot-overlap -tier-profile long-history-85-10-5 \
+      -output-dir .artifacts/benchmark/heavy-live-long-history ...
+```
+
+The `-tier-profile` flag on `baseline` is added in Task 4 step 3e — the variant commands above depend on it. Note the tier profile changes `bench.Config`, so variant runs get their own BenchmarkID and never pollute the balanced baseline trend (same principle as #104's concurrency identity).
+
+d) Update the usage guidance list (lines ~139-155): change `use heavy-plan only when you need planning coverage for the full workload matrix` to also mention `use heavy-live for large-scale executable evidence (manual, hours)`.
+
+- [ ] **Step 3: Verify docs**
+
+Run: `grep -n "heavy-live" docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md docs/federated-query/federated-query-benchmark-baseline-runbook.md | head -20`
+Expected: both files reference the preset; no stale "heavy preset only runs plan mode" text remains (`grep -rn "only runs plan" docs/federated-query/` returns nothing).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md docs/federated-query/federated-query-benchmark-baseline-runbook.md
+git commit -m "docs(benchmark): heavy-live run policy, calibration ladder, sampled-oracle guidance (#100)"
+```
+
+---
+
+### Task 8: Operator checkpoint — calibration ladder and official baseline (manual)
+
+**This task is not for an AFK implementer.** It needs hours on an idle machine and judgment calls; stop here and report. The operator (user) runs:
+
+- [ ] **Step 1: 2M probe** — the `run` command from the runbook's calibration ladder (Task 7 §2c), recording wall clock / peak RSS / Docker disk.
+- [ ] **Step 2: 5M probe** — same with the 5M counts. Extrapolate to 10M; abort criteria per runbook. If aborting: draft the streaming/batched-load follow-up issue body under `.artifacts/` for the user to create (do not `gh issue create` from an AFK session — #143 lesson).
+- [ ] **Step 3: Official 10M capture** — `/usr/bin/time -l make benchmark-heavy-live` on an idle machine. Artifacts land in `.artifacts/benchmark/heavy-live/heavy-live-hotspot-overlap` (local convention; not committed).
+- [ ] **Step 4: Backfill measured numbers** into the two docs from Task 7 (runtime, peak RSS, disk) and commit:
+
+```bash
+git add docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md docs/federated-query/federated-query-benchmark-baseline-runbook.md
+git commit -m "docs(benchmark): backfill measured heavy-live runtime envelope (#100)"
+```
+
+---
+
+## Final Verification (before PR)
+
+- [ ] `go test ./cmd/benchmark/... ./internal/e2e_harness/federated/benchmark/...` — all green.
+- [ ] `make lint` — clean (pinned golangci-lint v1.64.8).
+- [ ] `go test -tags e2e ./internal/e2e_harness/federated/ -run 'TestBenchmark' -v -timeout 20m` — sampled spot-check test and existing execution test green (Docker required).
+- [ ] `go run ./cmd/benchmark describe | grep -A3 heavy-live` — preset visible with cap and memory bounds.
+- [ ] PR body: `Closes #100`, notes that Task 8 (calibration ladder + official capture) is an operator step, links `docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md`. Include the spec and this plan in the PR with explicit `git add` paths.

--- a/docs/superpowers/plans/2026-07-06-heavy-live-baseline.md
+++ b/docs/superpowers/plans/2026-07-06-heavy-live-baseline.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a repeatable `heavy-live` benchmark preset that executes the full 16-workload matrix live at `large` scale (10M trades) with a sampled truth-pass oracle, a run timeout, and documented runtime/environment expectations.
+**Goal:** Add a repeatable `heavy-live` benchmark preset that executes the full workload matrix live at `large` scale (10M trades) with a sampled truth-pass oracle, a run timeout, and documented runtime/environment expectations.
 
 **Architecture:** Minimal wiring over the existing `RunWithHarness` live path. The only semantic change is a spot-check sampling cap on truth-pass oracle construction: expected results stay derived from the full reconstructed candidate set; federated truth queries run only on a seeded deterministic sample, and any sampled-candidate divergence is a hard failure. Everything else is preset/flag/Makefile/docs plumbing.
 
@@ -836,7 +836,7 @@ In `federated-query-benchmark-ci-and-ops-guide.md`, replace the `### Heavy Run` 
 ### Heavy Live Run
 
 - preset: `heavy-live`
-- mode: live, full 16-workload matrix
+- mode: live, full workload matrix
 - scale: `large` (10M trades / 1M customers / 100k securities)
 - distribution: `hotspot-overlap`; tier profile: `balanced-60-30-10`
 - truth-pass oracles are spot-check sampled (`truth_pass_sample_cap=10000`);

--- a/docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md
+++ b/docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md
@@ -17,7 +17,7 @@ expectations, and a captured baseline artifact set.
 |---|---|
 | Run environment / time envelope | Manual, on-demand only. No scheduled job. Document expected runtime instead of enforcing an envelope. |
 | Truth-pass oracle at 10M rows | Keep selective workloads; add a sampling cap with spot-check semantics (see §2). |
-| Workload set | Full 16 workloads, aligned with `heavy-plan` so plan-vs-live artifacts compare directly. |
+| Workload set | Full workload matrix, aligned with `heavy-plan` so plan-vs-live artifacts compare directly. |
 | Tier profile | Single run on default `balanced-60-30-10`. `high-hot-40-20-40` and `long-history-85-10-5` documented as manual `-tier-profile` variants. |
 | Implementation route | Minimal wiring over the existing `RunWithHarness` path + calibration ladder. Memory/streaming hardening only if the ladder proves it necessary (follow-up issue). |
 
@@ -41,7 +41,7 @@ queries ≈ 35 min idle (#147). At 10M rows an uncapped pass is days — hence �
 - New preset `heavy-live` in `defaultBenchmarkPresets()` (`cmd/benchmark/main.go`):
   - `Mode=Live, Scale=Large, Distribution=Hotspot, Iterations=2, PageSize=20, Seed=42`
   - `TierProfile=balanced-60-30-10` (default profile)
-  - `Workloads=bench.DefaultWorkloadNames()` (all 16)
+  - `Workloads=bench.DefaultWorkloadNames()` (full workload matrix)
   - `BaselineDir="heavy-live-hotspot-overlap"`, `RuntimeClass="heavy"`, `CISafe=false`
   - `ExpectedUsage`: manual capacity-aware baseline capture only
   - `TruthPassSampleCap=10000` (see §2)

--- a/docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md
+++ b/docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md
@@ -79,9 +79,14 @@ Naively truncating the candidate set would corrupt the expected result
     "reconstruction ≡ engine truth" on the sample. A legitimate divergence
     cannot be absorbed by any sampling rate; it requires human
     investigation, never silent acceptance.
-- Artifacts: oracle mode reported as `truth_pass_sampled`; oracle notes
-  record cap, total candidate count, and sampled count. The cap participates
-  in the config hash, so capped and uncapped runs never share a BenchmarkID.
+- Artifacts: the oracle **mode** is reported as `truth-pass-sampled`
+  (hyphenated, consistent with the sibling modes `truth-pass` and
+  `loaded-state`); the oracle **note token** is `truth_pass_sampled=N`
+  (underscored, consistent with the existing note style
+  `oracle_modes loaded_state=… truth_pass=…`). These are two distinct
+  identifiers on two different surfaces, not a mismatch. Oracle notes record
+  cap, total candidate count, and sampled count. The cap participates in the
+  config hash, so capped and uncapped runs never share a BenchmarkID.
 - CLI: `-truth-pass-sample-cap` flag on `baseline` and `run` overrides the
   preset value.
 

--- a/docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md
+++ b/docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md
@@ -1,0 +1,159 @@
+# Heavy-Live Baseline Design (issue #100)
+
+Date: 2026-07-06
+Status: approved in brainstorming session
+Issue: Lychee-Technology/forma#100 — Wire up large-scale live benchmark execution
+
+## Goal
+
+Add a repeatable `heavy-live` benchmark preset that executes the full workload
+matrix live at `large` scale (10M trades / 1M customers / 100k securities),
+with bounded oracle cost, configurable timeout, documented runtime/environment
+expectations, and a captured baseline artifact set.
+
+## Decisions Made During Brainstorming
+
+| Question | Decision |
+|---|---|
+| Run environment / time envelope | Manual, on-demand only. No scheduled job. Document expected runtime instead of enforcing an envelope. |
+| Truth-pass oracle at 10M rows | Keep selective workloads; add a sampling cap with spot-check semantics (see §2). |
+| Workload set | Full 16 workloads, aligned with `heavy-plan` so plan-vs-live artifacts compare directly. |
+| Tier profile | Single run on default `balanced-60-30-10`. `high-hot-40-20-40` and `long-history-85-10-5` documented as manual `-tier-profile` variants. |
+| Implementation route | Minimal wiring over the existing `RunWithHarness` path + calibration ladder. Memory/streaming hardening only if the ladder proves it necessary (follow-up issue). |
+
+## Key Constraint Discovered
+
+`heavy-plan` never exercises the large-scale pipeline: plan mode
+(`Runner.Run`, `runner.go:146-185`) validates fixtures and writes notes
+without generating data. The full chain — in-memory generation →
+`SplitIntoTiers` → `LoadTieredDataset` → loaded-state snapshot → oracle
+construction — is unproven at 10M rows. Peak RSS holds 2-3 copies of the
+dataset (dataset / tiered / loadedRecords). This is why §4's calibration
+ladder exists.
+
+Truth-pass oracles (`hot-selective-page`, `eav-selective-page`) issue one
+federated query per candidate record (`buildExpectedWorkloadResultFromFederatedTruth`,
+`runner.go:1312`). At small scale (100k trades, uniform) that was ~24k
+queries ≈ 35 min idle (#147). At 10M rows an uncapped pass is days — hence §2.
+
+## §1 Preset and CLI Surface
+
+- New preset `heavy-live` in `defaultBenchmarkPresets()` (`cmd/benchmark/main.go`):
+  - `Mode=Live, Scale=Large, Distribution=Hotspot, Iterations=2, PageSize=20, Seed=42`
+  - `TierProfile=balanced-60-30-10` (default profile)
+  - `Workloads=bench.DefaultWorkloadNames()` (all 16)
+  - `BaselineDir="heavy-live-hotspot-overlap"`, `RuntimeClass="heavy"`, `CISafe=false`
+  - `ExpectedUsage`: manual capacity-aware baseline capture only
+  - `TruthPassSampleCap=10000` (see §2)
+  - `DuckDBMemoryLimitMB=8192`; threads stay at 4. Values flow through the
+    existing `applyResourcePragmas` single source (#104); flags still override.
+- Bare-name alias: `heavy` resolves to `heavy-live`, matching the existing
+  `small`→`small-live`, `medium`→`medium-live` convention. `heavy-plan`
+  keeps its explicit name and behavior.
+- Makefile: new `benchmark-heavy-live` target writing to
+  `.artifacts/benchmark/heavy-live` with the usual provenance flags.
+  Existing `benchmark-heavy` (plan) target unchanged.
+
+## §2 Truth-Pass Sampling Cap — Spot-Check Semantics
+
+Naively truncating the candidate set would corrupt the expected result
+(`TotalRecords` and page rowIDs are derived from it). The cap is therefore a
+**spot check**, not a truncation:
+
+- New field `bench.Config.TruthPassSampleCap int`
+  (`json:"truth_pass_sample_cap,omitempty"`). `omitempty` preserves
+  BenchmarkID continuity for existing baselines (#104 lesson); a test locks
+  this.
+- `cap == 0` (default): behavior is byte-identical to today. All existing
+  presets are unaffected.
+- `cap > 0` and `len(candidates) > cap` in
+  `buildExpectedWorkloadResultFromFederatedTruth`:
+  - The expected result is built from the **full reconstructed candidate
+    set** (full sort, full count, unchanged page rowIDs).
+  - Federated truth queries run only against a **seeded deterministic
+    sample** of `cap` candidates. The sample seed derives from
+    `Config.Seed` + workload name, so identical configs sample identically
+    (repeatability requirement).
+  - Any sampled candidate not visible through the engine → **hard failure**
+    with an explicit error. Semantics: the run asserts
+    "reconstruction ≡ engine truth" on the sample. A legitimate divergence
+    cannot be absorbed by any sampling rate; it requires human
+    investigation, never silent acceptance.
+- Artifacts: oracle mode reported as `truth_pass_sampled`; oracle notes
+  record cap, total candidate count, and sampled count. The cap participates
+  in the config hash, so capped and uncapped runs never share a BenchmarkID.
+- CLI: `-truth-pass-sample-cap` flag on `baseline` and `run` overrides the
+  preset value.
+
+## §3 Timeout and Resource Bounds
+
+- New `-run-timeout` duration flag on `baseline` and `run` (default `0` =
+  unlimited). When set, wraps the run context with `context.WithTimeout`;
+  expiry fails the run with a clear error. Existing signal handling and the
+  infra retry policy (`maxInfraRetries=2`) are unchanged.
+- DuckDB bounds come from the preset (§1). Postgres-container disk and host
+  RAM requirements are not enforced in code; they are measured by the
+  calibration ladder (§4) and documented (§5).
+
+## §4 Calibration Ladder (process, no code)
+
+Before the first official 10M baseline, measure incrementally using the
+existing `run` subcommand overrides. Record wall clock, peak RSS
+(`/usr/bin/time -l` on darwin), and Postgres container disk usage at each
+step:
+
+1. **2M probe**: `run -mode live -scale large -trade-count 2000000` +
+   full workload set + cap.
+2. **5M probe**: same with `-trade-count 5000000`.
+3. **10M official**: `make benchmark-heavy-live` on an idle machine.
+
+Abort criterion at each step: extrapolate growth; if projected 10M RSS
+exceeds machine RAM or projected runtime is unreasonable, stop and file the
+streaming/batched-load follow-up issue (draft body under `.artifacts/`, user
+creates or authorizes creation — #143 lesson) instead of forcing the run.
+Measured numbers backfill the §5 documentation.
+
+## §5 Documentation Updates
+
+- **Ops guide** (`docs/federated-query/federated-query-benchmark-ci-and-ops-guide.md`):
+  split the Heavy Run section into `heavy-plan` and `heavy-live`; for
+  `heavy-live` document measured expected runtime, RAM/disk/idle-machine
+  requirements, manual-on-demand-only policy (no scheduled job), and
+  never-in-CI.
+- **Runbook** (`docs/federated-query/federated-query-benchmark-baseline-runbook.md`):
+  add a heavy-live baseline capture section (commands, artifact dir,
+  provenance conventions); manual `-tier-profile` variant commands for
+  `high-hot-40-20-40` and `long-history-85-10-5`; a "reading sampled
+  oracles" caveat — a sampled pass is weaker than a full truth-pass.
+
+## §6 Testing and Acceptance
+
+Tests:
+
+- Preset resolution: `heavy` alias, `heavy-live` field values.
+- Sampling determinism: same seed → same sample.
+- Spot-check failure path: injected invisible sampled candidate → hard
+  failure with explicit error.
+- BenchmarkID continuity: `TruthPassSampleCap` absent ⇒ metadata hash
+  unchanged (omitempty lock).
+- `cap=0` characterization: existing tests stay green, behavior unchanged.
+- Small-scale feasibility (e2e tag, ~30s via the #147 technique): tiny
+  TradeCount with cap < candidate count asserts `truth_pass_sampled`
+  annotation and a passing run.
+
+Acceptance (mapped to issue #100 AC):
+
+- `benchmark baseline -preset heavy-live` produces live execution artifacts
+  without hitting resource limits.
+- Runtime envelope documented from calibration-ladder measurements.
+- Ops guide updated with large-scale run recommendations.
+- Baseline artifact set exists at `.artifacts/benchmark/heavy-live`
+  (captured locally per existing convention; not committed to git).
+
+## Non-Goals
+
+- Scheduled (nightly/weekly) execution — explicitly deselected; manual only.
+- Distributed or multi-host execution (deferred separately in #100).
+- Streaming/batched data generation or loading — only if the calibration
+  ladder proves the current in-memory path infeasible, and then as a
+  follow-up issue, not in this change.

--- a/internal/e2e_harness/federated/benchmark/config.go
+++ b/internal/e2e_harness/federated/benchmark/config.go
@@ -53,6 +53,13 @@ type Config struct {
 	// hashes the whole Config).
 	DuckDBThreads       int `json:"duckdb_threads,omitempty"`
 	DuckDBMemoryLimitMB int `json:"duckdb_memory_limit_mb,omitempty"`
+	// TruthPassSampleCap bounds truth-pass oracle construction: when > 0 and
+	// a workload's candidate set exceeds the cap, only a seeded deterministic
+	// sample of candidates is verified through the engine (spot check) and
+	// the expected result is taken from the full reconstructed candidate set.
+	// 0 = full truth pass (existing behavior). omitempty keeps the
+	// BenchmarkID hash of existing artifacts stable.
+	TruthPassSampleCap int `json:"truth_pass_sample_cap,omitempty"`
 }
 
 // DefaultConfig returns the benchmark scaffold defaults.
@@ -128,6 +135,9 @@ func (c Config) Validate() error {
 	}
 	if c.DuckDBMemoryLimitMB < 0 {
 		return fmt.Errorf("duckdb memory limit must be greater than or equal to zero")
+	}
+	if c.TruthPassSampleCap < 0 {
+		return fmt.Errorf("truth-pass sample cap must be greater than or equal to zero")
 	}
 	if c.TierProfile != "" {
 		if _, err := ResolveTierMixProfile(c.TierProfile); err != nil {

--- a/internal/e2e_harness/federated/benchmark/config_test.go
+++ b/internal/e2e_harness/federated/benchmark/config_test.go
@@ -80,3 +80,24 @@ func TestDefaultWorkloadNamesIncludesSchemaScopedCoverage(t *testing.T) {
 		t.Fatalf("expected default workloads to include schema-scoped customer and security coverage: %v", names)
 	}
 }
+
+// TestConfigJSONOmitsZeroTruthPassSampleCap protects BenchmarkID continuity:
+// BuildArtifactMetadata hashes the whole Config, so an unset cap must not
+// change the serialized form of existing configs.
+func TestConfigJSONOmitsZeroTruthPassSampleCap(t *testing.T) {
+	raw, err := json.Marshal(DefaultConfig())
+	if err != nil {
+		t.Fatalf("marshal default config: %v", err)
+	}
+	if strings.Contains(string(raw), "truth_pass_sample_cap") {
+		t.Fatalf("zero TruthPassSampleCap must be omitted from JSON, got: %s", raw)
+	}
+}
+
+func TestConfigValidateRejectsNegativeTruthPassSampleCap(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.TruthPassSampleCap = -1
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected negative truth-pass sample cap to be rejected")
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -752,6 +752,9 @@ func summarizeOracleProvenance(result *RunResult) []OracleProvenance {
 	if len(result.Workloads) > 0 {
 		for _, workload := range result.Workloads {
 			mode := string(workload.ResolvedOracleMode())
+			if sampled, ok := result.OracleModes[workload.Name]; ok && sampled != "" {
+				mode = sampled
+			}
 			byMode[mode] = append(byMode[mode], workload.Name)
 		}
 	} else {

--- a/internal/e2e_harness/federated/benchmark/report.go
+++ b/internal/e2e_harness/federated/benchmark/report.go
@@ -671,6 +671,9 @@ func summarizeWorkloads(result *RunResult) []WorkloadSummary {
 			workload.Distribution = runs[0].Distribution
 			workload.PageSize = def.PageSize
 		}
+		if mode, ok := result.OracleModes[name]; ok && mode != "" {
+			workload.OracleMode = mode
+		}
 		durations := make([]time.Duration, 0, len(runs))
 		var totalDuration time.Duration
 		var totalResultCount int

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -281,7 +281,7 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 				semantics := semanticsForWorkload(workload, r.genConfig)
 				run.Assertions = append(run.Assertions, validateBasicWorkloadAssertions(workload, run)...)
 				run.Assertions = append(run.Assertions, validateResultLevelAssertions(workload, run, result.records, semantics)...)
-				run.OracleMode = resolvedRunOracleMode(oracleModes, workload)
+				run.OracleMode = resolveRunOracleMode(oracleModes, workload)
 				if expected, ok := expectedByWorkload[workload.Name]; ok {
 					run.Assertions = append(run.Assertions, validateExpectedWorkloadOutcome(run, expected)...)
 				}
@@ -380,10 +380,10 @@ func (r *Runner) buildExpectedResults(ctx context.Context, h *federated.Federate
 	return results, oracleModes, append([]string{summary}, sampleNotes...), nil
 }
 
-// resolvedRunOracleMode returns the run-time oracle mode for a workload,
+// resolveRunOracleMode returns the run-time oracle mode for a workload,
 // preferring the (possibly sampled) mode recorded in oracleModes and falling
 // back to the workload's static resolved mode when the map has no entry.
-func resolvedRunOracleMode(oracleModes map[string]string, workload WorkloadDefinition) string {
+func resolveRunOracleMode(oracleModes map[string]string, workload WorkloadDefinition) string {
 	if mode, ok := oracleModes[workload.Name]; ok && mode != "" {
 		return mode
 	}
@@ -1351,7 +1351,7 @@ func buildExpectedWorkloadResultFromFederatedTruth(ctx context.Context, h *feder
 	previousSchemaID := h.SchemaID
 	schemaID, err := workloadSchemaID(workload.TargetSchema)
 	if err != nil {
-		return expectedWorkloadResult{}, truthPassSampleStats{}, err
+		return expectedWorkloadResult{}, truthPassSampleStats{}, fmt.Errorf("resolve schema id for workload %s: %w", workload.Name, err)
 	}
 	h.SchemaID = schemaID
 	defer func() {
@@ -1368,7 +1368,7 @@ func buildExpectedWorkloadResultFromFederatedTruth(ctx context.Context, h *feder
 			SortDesc: true,
 		})
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("execute federated truth query for candidate %s: %w", candidate.RowID, err)
 		}
 		return result.TotalRecords > 0, nil
 	}
@@ -1387,7 +1387,7 @@ func buildTruthPassExpected(ctx context.Context, isVisible func(context.Context,
 	if pageSize <= 0 {
 		pageSize = defaultPageSize
 	}
-	sampledIdx := truthPassSampleIndices(seed, workload.Name, len(candidates), sampleCap)
+	sampledIdx := selectTruthPassSampleIndices(seed, workload.Name, len(candidates), sampleCap)
 	if sampledIdx == nil {
 		matching := make([]GeneratedRecord, 0, len(candidates))
 		for _, candidate := range candidates {

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -330,40 +330,54 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 		Workloads:      append([]WorkloadDefinition(nil), r.workloads...),
 		Executions:     executions,
 		OracleModes:    oracleModes,
-		Notes: []string{
-			"loaded TPC-E-inspired schema fixtures",
-			fmt.Sprintf("generated dataset with distribution=%s", r.genConfig.Distribution),
-			fmt.Sprintf("loaded tiered dataset profile=%s", profile.Name),
-			fmt.Sprintf("loaded-state snapshot rows=%d", len(loadedRecords)),
-			oracleNotes,
-			"prefer_hot expresses workload intent and report provenance, not hard execution routing",
-			"executed supported federated query workloads",
-		},
 	}
+	notes := []string{
+		"loaded TPC-E-inspired schema fixtures",
+		fmt.Sprintf("generated dataset with distribution=%s", r.genConfig.Distribution),
+		fmt.Sprintf("loaded tiered dataset profile=%s", profile.Name),
+		fmt.Sprintf("loaded-state snapshot rows=%d", len(loadedRecords)),
+	}
+	notes = append(notes, oracleNotes...)
+	notes = append(notes,
+		"prefer_hot expresses workload intent and report provenance, not hard execution routing",
+		"executed supported federated query workloads",
+	)
+	result.Notes = notes
 	return result, nil
 }
 
-func (r *Runner) buildExpectedResults(ctx context.Context, h *federated.FederatedTestHarness, loadedRecords []GeneratedRecord, hotKeys map[string]struct{}) (map[string]expectedWorkloadResult, map[string]string, string, error) {
+func (r *Runner) buildExpectedResults(ctx context.Context, h *federated.FederatedTestHarness, loadedRecords []GeneratedRecord, hotKeys map[string]struct{}) (map[string]expectedWorkloadResult, map[string]string, []string, error) {
 	results := buildExpectedWorkloadResultsFromRecords(loadedRecords, r.workloads, r.config.PageSize, r.genConfig, hotKeys)
 	oracleModes := make(map[string]string, len(r.workloads))
 	loadedStateCount := 0
 	truthPassCount := 0
+	sampledCount := 0
+	var sampleNotes []string
 	for _, workload := range r.workloads {
 		mode := string(workload.ResolvedOracleMode())
 		oracleModes[workload.Name] = mode
 		switch workload.ResolvedOracleMode() {
 		case OracleModeTruthPass:
-			expected, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, workload, r.config.PageSize, loadedRecords, r.genConfig)
+			expected, stats, err := buildExpectedWorkloadResultFromFederatedTruth(ctx, h, workload, r.config.PageSize, loadedRecords, r.genConfig, r.config.TruthPassSampleCap, r.config.Seed)
 			if err != nil {
-				return nil, nil, "", fmt.Errorf("build truth-pass expected result for %s: %w", workload.Name, err)
+				return nil, nil, nil, fmt.Errorf("build truth-pass expected result for %s: %w", workload.Name, err)
 			}
 			results[workload.Name] = expected
 			truthPassCount++
+			if stats.Applied {
+				oracleModes[workload.Name] = string(OracleModeTruthPassSampled)
+				sampledCount++
+				sampleNotes = append(sampleNotes, fmt.Sprintf("truth_pass_sample workload=%s cap=%d candidates=%d sampled=%d", workload.Name, stats.Cap, stats.Candidates, stats.Sampled))
+			}
 		default:
 			loadedStateCount++
 		}
 	}
-	return results, oracleModes, fmt.Sprintf("oracle_modes loaded_state=%d truth_pass=%d", loadedStateCount, truthPassCount), nil
+	summary := fmt.Sprintf("oracle_modes loaded_state=%d truth_pass=%d", loadedStateCount, truthPassCount)
+	if sampledCount > 0 {
+		summary = fmt.Sprintf("%s truth_pass_sampled=%d", summary, sampledCount)
+	}
+	return results, oracleModes, append([]string{summary}, sampleNotes...), nil
 }
 
 func (r *Runner) validateFixtures() error {
@@ -1309,47 +1323,90 @@ func schemaNameForID(schemaID int16) (string, error) {
 	return "", fmt.Errorf("unknown benchmark schema id %d", schemaID)
 }
 
-func buildExpectedWorkloadResultFromFederatedTruth(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition, defaultPageSize int, loadedRecords []GeneratedRecord, genCfg GeneratorConfig) (expectedWorkloadResult, error) {
+// truthPassSampleStats reports how truth-pass verification was bounded.
+type truthPassSampleStats struct {
+	Applied    bool
+	Cap        int
+	Candidates int
+	Sampled    int
+}
+
+func buildExpectedWorkloadResultFromFederatedTruth(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition, defaultPageSize int, loadedRecords []GeneratedRecord, genCfg GeneratorConfig, sampleCap int, seed int64) (expectedWorkloadResult, truthPassSampleStats, error) {
 	if h == nil {
-		return expectedWorkloadResult{}, fmt.Errorf("harness cannot be nil")
+		return expectedWorkloadResult{}, truthPassSampleStats{}, fmt.Errorf("harness cannot be nil")
 	}
 	semantics := semanticsForWorkload(workload, genCfg)
 	candidates := filterExpectedRecordsForWorkload(expectedVisibleRecords(loadedRecords), workload, semantics)
 	sortExpectedRecordsForWorkload(candidates, workload)
-	matching := make([]GeneratedRecord, 0, len(candidates))
-	pageSize := workload.PageSize
-	if pageSize <= 0 {
-		pageSize = defaultPageSize
-	}
 	previousSchemaID := h.SchemaID
 	schemaID, err := workloadSchemaID(workload.TargetSchema)
 	if err != nil {
-		return expectedWorkloadResult{}, err
+		return expectedWorkloadResult{}, truthPassSampleStats{}, err
 	}
 	h.SchemaID = schemaID
 	defer func() {
 		h.SchemaID = previousSchemaID
 	}()
-	for _, candidate := range candidates {
-		conditions := workload.ResolvedFilterConditions()
+	isVisible := func(ctx context.Context, candidate GeneratedRecord) (bool, error) {
 		result, err := h.ExecuteFederatedQuery(ctx, &federated.QueryOptions{
 			Limit: 1,
 			Filter: &federated.Filter{
 				RowID:      candidate.RowID,
-				Conditions: conditions,
+				Conditions: workload.ResolvedFilterConditions(),
 			},
 			SortBy:   "tradeTime",
 			SortDesc: true,
 		})
 		if err != nil {
-			return expectedWorkloadResult{}, err
+			return false, err
 		}
-		if result.TotalRecords > 0 {
-			matching = append(matching, candidate)
+		return result.TotalRecords > 0, nil
+	}
+	return buildTruthPassExpected(ctx, isVisible, workload, defaultPageSize, candidates, sampleCap, seed)
+}
+
+// buildTruthPassExpected derives the expected result for a truth-pass
+// workload. Uncapped (sampleCap <= 0 or candidates <= cap) it verifies every
+// candidate and keeps only the visible ones — existing behavior. Capped, it
+// keeps the full reconstructed candidate set as the expected result and
+// verifies a seeded deterministic sample; a sampled candidate the engine
+// cannot see means reconstruction and engine truth diverge, which no
+// sampling rate can absorb, so the run fails hard.
+func buildTruthPassExpected(ctx context.Context, isVisible func(context.Context, GeneratedRecord) (bool, error), workload WorkloadDefinition, defaultPageSize int, candidates []GeneratedRecord, sampleCap int, seed int64) (expectedWorkloadResult, truthPassSampleStats, error) {
+	pageSize := workload.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	sampledIdx := truthPassSampleIndices(seed, workload.Name, len(candidates), sampleCap)
+	if sampledIdx == nil {
+		matching := make([]GeneratedRecord, 0, len(candidates))
+		for _, candidate := range candidates {
+			visible, err := isVisible(ctx, candidate)
+			if err != nil {
+				return expectedWorkloadResult{}, truthPassSampleStats{}, err
+			}
+			if visible {
+				matching = append(matching, candidate)
+			}
+		}
+		rowIDs := expectedPageRowIDs(matching, workload.DerivedOffset(defaultPageSize), pageSize)
+		return expectedWorkloadResult{TotalRecords: int64(len(matching)), RowIDs: rowIDs}, truthPassSampleStats{Candidates: len(candidates), Sampled: len(candidates)}, nil
+	}
+	stats := truthPassSampleStats{Applied: true, Cap: sampleCap, Candidates: len(candidates), Sampled: len(sampledIdx)}
+	for i, candidate := range candidates {
+		if _, ok := sampledIdx[i]; !ok {
+			continue
+		}
+		visible, err := isVisible(ctx, candidate)
+		if err != nil {
+			return expectedWorkloadResult{}, stats, err
+		}
+		if !visible {
+			return expectedWorkloadResult{}, stats, fmt.Errorf("truth-pass spot check failed for workload %s: sampled candidate row_id=%s is not visible through the engine; reconstruction diverges from engine truth — investigate at a smaller scale without the sample cap before trusting sampled oracles", workload.Name, candidate.RowID)
 		}
 	}
-	rowIDs := expectedPageRowIDs(matching, workload.DerivedOffset(defaultPageSize), pageSize)
-	return expectedWorkloadResult{TotalRecords: int64(len(matching)), RowIDs: rowIDs}, nil
+	rowIDs := expectedPageRowIDs(candidates, workload.DerivedOffset(defaultPageSize), pageSize)
+	return expectedWorkloadResult{TotalRecords: int64(len(candidates)), RowIDs: rowIDs}, stats, nil
 }
 
 func expectedVisibleRecords(records []GeneratedRecord) []GeneratedRecord {

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -281,7 +281,7 @@ func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestH
 				semantics := semanticsForWorkload(workload, r.genConfig)
 				run.Assertions = append(run.Assertions, validateBasicWorkloadAssertions(workload, run)...)
 				run.Assertions = append(run.Assertions, validateResultLevelAssertions(workload, run, result.records, semantics)...)
-				run.OracleMode = string(workload.ResolvedOracleMode())
+				run.OracleMode = resolvedRunOracleMode(oracleModes, workload)
 				if expected, ok := expectedByWorkload[workload.Name]; ok {
 					run.Assertions = append(run.Assertions, validateExpectedWorkloadOutcome(run, expected)...)
 				}
@@ -378,6 +378,16 @@ func (r *Runner) buildExpectedResults(ctx context.Context, h *federated.Federate
 		summary = fmt.Sprintf("%s truth_pass_sampled=%d", summary, sampledCount)
 	}
 	return results, oracleModes, append([]string{summary}, sampleNotes...), nil
+}
+
+// resolvedRunOracleMode returns the run-time oracle mode for a workload,
+// preferring the (possibly sampled) mode recorded in oracleModes and falling
+// back to the workload's static resolved mode when the map has no entry.
+func resolvedRunOracleMode(oracleModes map[string]string, workload WorkloadDefinition) string {
+	if mode, ok := oracleModes[workload.Name]; ok && mode != "" {
+		return mode
+	}
+	return string(workload.ResolvedOracleMode())
 }
 
 func (r *Runner) validateFixtures() error {

--- a/internal/e2e_harness/federated/benchmark/truth_pass_sample.go
+++ b/internal/e2e_harness/federated/benchmark/truth_pass_sample.go
@@ -1,0 +1,26 @@
+package benchmark
+
+import (
+	"hash/fnv"
+	"math/rand"
+)
+
+// truthPassSampleIndices picks the candidate indices to spot-check when the
+// truth-pass sample cap applies. It returns nil when sampling is disabled
+// (cap <= 0) or unnecessary (total <= cap). The selection is deterministic
+// for a given (seed, workloadName, total, cap) so identical benchmark
+// configs verify identical candidates — a repeatability requirement for
+// heavy-live baselines (#100).
+func truthPassSampleIndices(seed int64, workloadName string, total, cap int) map[int]struct{} {
+	if cap <= 0 || total <= cap {
+		return nil
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(workloadName))
+	rng := rand.New(rand.NewSource(seed ^ int64(h.Sum64()))) //nolint:gosec // deterministic sampling, not crypto
+	picked := make(map[int]struct{}, cap)
+	for _, idx := range rng.Perm(total)[:cap] {
+		picked[idx] = struct{}{}
+	}
+	return picked
+}

--- a/internal/e2e_harness/federated/benchmark/truth_pass_sample.go
+++ b/internal/e2e_harness/federated/benchmark/truth_pass_sample.go
@@ -5,13 +5,13 @@ import (
 	"math/rand"
 )
 
-// truthPassSampleIndices picks the candidate indices to spot-check when the
+// selectTruthPassSampleIndices picks the candidate indices to spot-check when the
 // truth-pass sample cap applies. It returns nil when sampling is disabled
 // (cap <= 0) or unnecessary (total <= cap). The selection is deterministic
 // for a given (seed, workloadName, total, cap) so identical benchmark
 // configs verify identical candidates — a repeatability requirement for
 // heavy-live baselines (#100).
-func truthPassSampleIndices(seed int64, workloadName string, total, cap int) map[int]struct{} {
+func selectTruthPassSampleIndices(seed int64, workloadName string, total, cap int) map[int]struct{} {
 	if cap <= 0 || total <= cap {
 		return nil
 	}

--- a/internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go
+++ b/internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go
@@ -1,0 +1,40 @@
+package benchmark
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTruthPassSampleIndicesNotAppliedWhenCapCoversTotal(t *testing.T) {
+	if got := truthPassSampleIndices(42, "eav-selective-page", 100, 0); got != nil {
+		t.Fatalf("cap=0 must disable sampling, got %v", got)
+	}
+	if got := truthPassSampleIndices(42, "eav-selective-page", 100, 100); got != nil {
+		t.Fatalf("total<=cap must disable sampling, got %v", got)
+	}
+}
+
+func TestTruthPassSampleIndicesDeterministicAndBounded(t *testing.T) {
+	first := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	second := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("same seed/workload/total/cap must sample identically")
+	}
+	if len(first) != 25 {
+		t.Fatalf("expected exactly 25 sampled indices, got %d", len(first))
+	}
+	for idx := range first {
+		if idx < 0 || idx >= 1000 {
+			t.Fatalf("sampled index %d out of range [0,1000)", idx)
+		}
+	}
+}
+
+func TestTruthPassSampleIndicesVaryBySeedAndWorkload(t *testing.T) {
+	base := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	otherSeed := truthPassSampleIndices(43, "eav-selective-page", 1000, 25)
+	otherWorkload := truthPassSampleIndices(42, "hot-selective-page", 1000, 25)
+	if reflect.DeepEqual(base, otherSeed) && reflect.DeepEqual(base, otherWorkload) {
+		t.Fatal("expected seed and workload name to influence the sample")
+	}
+}

--- a/internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go
+++ b/internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go
@@ -11,17 +11,17 @@ import (
 )
 
 func TestTruthPassSampleIndicesNotAppliedWhenCapCoversTotal(t *testing.T) {
-	if got := truthPassSampleIndices(42, "eav-selective-page", 100, 0); got != nil {
+	if got := selectTruthPassSampleIndices(42, "eav-selective-page", 100, 0); got != nil {
 		t.Fatalf("cap=0 must disable sampling, got %v", got)
 	}
-	if got := truthPassSampleIndices(42, "eav-selective-page", 100, 100); got != nil {
+	if got := selectTruthPassSampleIndices(42, "eav-selective-page", 100, 100); got != nil {
 		t.Fatalf("total<=cap must disable sampling, got %v", got)
 	}
 }
 
 func TestTruthPassSampleIndicesDeterministicAndBounded(t *testing.T) {
-	first := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
-	second := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	first := selectTruthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	second := selectTruthPassSampleIndices(42, "eav-selective-page", 1000, 25)
 	if !reflect.DeepEqual(first, second) {
 		t.Fatal("same seed/workload/total/cap must sample identically")
 	}
@@ -36,9 +36,9 @@ func TestTruthPassSampleIndicesDeterministicAndBounded(t *testing.T) {
 }
 
 func TestTruthPassSampleIndicesVaryBySeedAndWorkload(t *testing.T) {
-	base := truthPassSampleIndices(42, "eav-selective-page", 1000, 25)
-	otherSeed := truthPassSampleIndices(43, "eav-selective-page", 1000, 25)
-	otherWorkload := truthPassSampleIndices(42, "hot-selective-page", 1000, 25)
+	base := selectTruthPassSampleIndices(42, "eav-selective-page", 1000, 25)
+	otherSeed := selectTruthPassSampleIndices(43, "eav-selective-page", 1000, 25)
+	otherWorkload := selectTruthPassSampleIndices(42, "hot-selective-page", 1000, 25)
 	if reflect.DeepEqual(base, otherSeed) && reflect.DeepEqual(base, otherWorkload) {
 		t.Fatal("expected seed and workload name to influence the sample")
 	}

--- a/internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go
+++ b/internal/e2e_harness/federated/benchmark/truth_pass_sample_test.go
@@ -1,8 +1,13 @@
 package benchmark
 
 import (
+	"context"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestTruthPassSampleIndicesNotAppliedWhenCapCoversTotal(t *testing.T) {
@@ -36,5 +41,81 @@ func TestTruthPassSampleIndicesVaryBySeedAndWorkload(t *testing.T) {
 	otherWorkload := truthPassSampleIndices(42, "hot-selective-page", 1000, 25)
 	if reflect.DeepEqual(base, otherSeed) && reflect.DeepEqual(base, otherWorkload) {
 		t.Fatal("expected seed and workload name to influence the sample")
+	}
+}
+
+func spotCheckCandidates(n int) []GeneratedRecord {
+	records := make([]GeneratedRecord, 0, n)
+	for i := 0; i < n; i++ {
+		records = append(records, GeneratedRecord{
+			RowID: uuid.MustParse(fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1)),
+		})
+	}
+	return records
+}
+
+func TestBuildTruthPassExpectedUncappedKeepsFilteringSemantics(t *testing.T) {
+	candidates := spotCheckCandidates(5)
+	invisible := map[string]struct{}{
+		candidates[1].RowID.String(): {},
+		candidates[3].RowID.String(): {},
+	}
+	calls := 0
+	isVisible := func(_ context.Context, candidate GeneratedRecord) (bool, error) {
+		calls++
+		_, hidden := invisible[candidate.RowID.String()]
+		return !hidden, nil
+	}
+	workload := WorkloadDefinition{Name: "spot-check-test", PageSize: 20, PageNumber: 1}
+	expected, stats, err := buildTruthPassExpected(context.Background(), isVisible, workload, 20, candidates, 0, 42)
+	if err != nil {
+		t.Fatalf("uncapped truth pass failed: %v", err)
+	}
+	if calls != 5 {
+		t.Fatalf("uncapped pass must query every candidate, queried %d of 5", calls)
+	}
+	if expected.TotalRecords != 3 {
+		t.Fatalf("expected invisible candidates removed (total=3), got %d", expected.TotalRecords)
+	}
+	if stats.Applied {
+		t.Fatal("cap=0 must not report sampling as applied")
+	}
+}
+
+func TestBuildTruthPassExpectedCappedSpotCheckPasses(t *testing.T) {
+	candidates := spotCheckCandidates(50)
+	calls := 0
+	isVisible := func(_ context.Context, _ GeneratedRecord) (bool, error) {
+		calls++
+		return true, nil
+	}
+	workload := WorkloadDefinition{Name: "spot-check-test", PageSize: 20, PageNumber: 1}
+	expected, stats, err := buildTruthPassExpected(context.Background(), isVisible, workload, 20, candidates, 10, 42)
+	if err != nil {
+		t.Fatalf("capped spot check failed: %v", err)
+	}
+	if calls != 10 {
+		t.Fatalf("capped pass must query exactly cap candidates, queried %d", calls)
+	}
+	if expected.TotalRecords != 50 {
+		t.Fatalf("capped pass must keep the full candidate set as expected (total=50), got %d", expected.TotalRecords)
+	}
+	if !stats.Applied || stats.Cap != 10 || stats.Candidates != 50 || stats.Sampled != 10 {
+		t.Fatalf("unexpected sample stats: %+v", stats)
+	}
+}
+
+func TestBuildTruthPassExpectedCappedSpotCheckFailsHardOnInvisibleCandidate(t *testing.T) {
+	candidates := spotCheckCandidates(50)
+	isVisible := func(_ context.Context, _ GeneratedRecord) (bool, error) {
+		return false, nil
+	}
+	workload := WorkloadDefinition{Name: "spot-check-test", PageSize: 20, PageNumber: 1}
+	_, _, err := buildTruthPassExpected(context.Background(), isVisible, workload, 20, candidates, 10, 42)
+	if err == nil {
+		t.Fatal("expected hard failure when a sampled candidate is not visible")
+	}
+	if !strings.Contains(err.Error(), "spot check failed") {
+		t.Fatalf("error must identify the spot-check divergence, got: %v", err)
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/workload.go
+++ b/internal/e2e_harness/federated/benchmark/workload.go
@@ -20,6 +20,11 @@ const (
 
 	OracleModeLoadedState OracleMode = "loaded-state"
 	OracleModeTruthPass   OracleMode = "truth-pass"
+	// OracleModeTruthPassSampled marks a truth-pass oracle whose engine
+	// verification was spot-checked on a seeded sample because the candidate
+	// set exceeded Config.TruthPassSampleCap (#100). The expected result is
+	// still the full reconstructed candidate set.
+	OracleModeTruthPassSampled OracleMode = "truth-pass-sampled"
 )
 
 // WorkloadDefinition declares a benchmark workload.

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -217,4 +217,28 @@ func TestBenchmarkTruthPassSampledSpotCheck_RunWithHarness(t *testing.T) {
 		}
 	}
 	require.True(t, sampledNote, "expected sampled oracle summary note, got %v", result.Notes)
+
+	sampledWorkloads := map[string]bool{"hot-selective-page": false, "eav-selective-page": false}
+	for _, execution := range result.Executions {
+		if _, ok := sampledWorkloads[execution.Name]; ok {
+			require.Equal(t, string(bench.OracleModeTruthPassSampled), execution.OracleMode,
+				"execution record for %s must carry the run-time (sampled) oracle mode", execution.Name)
+			sampledWorkloads[execution.Name] = true
+		}
+	}
+	for name, seen := range sampledWorkloads {
+		require.True(t, seen, "expected at least one execution record for workload %s", name)
+	}
+
+	summary := bench.SummarizeRunResult(result)
+	found := false
+	for _, provenance := range summary.OracleProvenance {
+		if provenance.Mode != string(bench.OracleModeTruthPassSampled) {
+			continue
+		}
+		found = true
+		require.Contains(t, provenance.Workloads, "hot-selective-page")
+		require.Contains(t, provenance.Workloads, "eav-selective-page")
+	}
+	require.True(t, found, "expected oracle provenance group for truth-pass-sampled, got %+v", summary.OracleProvenance)
 }

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -4,6 +4,7 @@ package federated_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -172,4 +173,48 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 	require.True(t, pushdownMixedSeen, "expected tier-pushdown-mixed workload to be executed")
 	require.True(t, pushdownColdOnlySeen, "expected tier-pushdown-cold-only workload to be executed")
 	require.True(t, pushdownAssertionsSeen, "expected pushdown assertions to be exercised")
+}
+
+func TestBenchmarkTruthPassSampledSpotCheck_RunWithHarness(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	h, err := federated.NewFederatedTestHarness(ctx)
+	require.NoError(t, err)
+	defer h.Cleanup(ctx)
+
+	runner, err := bench.NewRunner(bench.Config{
+		Mode:               bench.ExecutionModeLive,
+		Scale:              bench.ScaleSmall,
+		Distribution:       bench.DistributionHotspot,
+		Iterations:         1,
+		PageSize:           20,
+		Seed:               42,
+		TradeCount:         300,
+		CustomerCount:      20,
+		SecurityCount:      10,
+		OverlapRatio:       0.10,
+		DeleteRatio:        0.05,
+		TruthPassSampleCap: 5,
+		Workloads: []string{
+			"baseline-page-1",
+			"hot-selective-page",
+			"eav-selective-page",
+		},
+	}.WithDefaults())
+	require.NoError(t, err)
+
+	result, err := runner.RunWithHarness(ctx, h, bench.TierMixBalanced)
+	require.NoError(t, err)
+	require.True(t, result.Passed, "sampled heavy-live semantics must still pass at tiny scale")
+	require.Equal(t, string(bench.OracleModeTruthPassSampled), result.OracleModes["hot-selective-page"])
+	require.Equal(t, string(bench.OracleModeTruthPassSampled), result.OracleModes["eav-selective-page"])
+
+	sampledNote := false
+	for _, note := range result.Notes {
+		if strings.Contains(note, "truth_pass_sampled=2") {
+			sampledNote = true
+		}
+	}
+	require.True(t, sampledNote, "expected sampled oracle summary note, got %v", result.Notes)
 }


### PR DESCRIPTION
## Summary

Adds a repeatable **`heavy-live`** benchmark preset that executes the full workload matrix live at `large` scale (10M trades / 1M customers / 100k securities) — closing the gap where the `heavy` preset only ran in plan mode. Deep-pagination and tier-hotness behavior are now exercised at production-representative volume, not just simulated through planning output.

Implements the heavy-live mechanism for #100. Not auto-closing: two acceptance criteria — a documented runtime/RSS/disk envelope and an existing baseline artifact set — depend on the calibration-ladder capture, which is a deliberate manual operator step (see below). #100 stays open until that capture backfills the docs.

## What's in the branch

- **`TruthPassSampleCap` config field** (`omitempty`, `0` = off) — bounds truth-pass oracle cost without corrupting expected results.
- **Deterministic seeded sampler** (`truthPassSampleIndices`) — identical configs verify identical candidates (repeatability).
- **Spot-check truth-pass oracle** — when the cap engages, the expected result stays the **full reconstructed candidate set** (unchanged `TotalRecords`/page rowIDs); only a seeded sample is verified through the engine. Any sampled candidate the engine can't see is a **hard failure** (`truth-pass spot check failed …`) — a reconstruction/engine divergence no sampling rate can absorb. New `truth-pass-sampled` oracle mode is surfaced in `RunResult.OracleModes`, per-execution records, workload summaries, and top-level `oracle_provenance`.
- **CLI**: `heavy-live` preset (live/large/hotspot-overlap, cap 10000, DuckDB 8192MB, full 23-workload matrix, `balanced-60-30-10`), bare `heavy` alias, `-truth-pass-sample-cap` / `-run-timeout` / `-tier-profile` flags, and an `applyDuckDBOverrides` guard so preset resource bounds survive omitted flags.
- **`make benchmark-heavy-live`** operator entry point.
- **Docs**: ops-guide `heavy-plan` vs `heavy-live` split, runbook calibration ladder (2M→5M→10M probes with abort criteria), sampled-oracle reading guidance, tier-profile variant commands.

## Backward compatibility

`cap=0` is byte-identical to prior behavior — locked by the `omitempty` BenchmarkID-continuity test and re-confirmed by the e2e characterization guard (`oracle_modes loaded_state=8 truth_pass=8` exact-string assert). No existing baseline's BenchmarkID changes.

## Testing

- Unit: `go test ./cmd/benchmark/... ./internal/e2e_harness/federated/benchmark/...` — green.
- Lint: `make lint` (pinned golangci-lint v1.64.8) — clean.
- e2e (Docker): `TestBenchmarkWorkloadExecution_RunWithHarness` PASS (cap=0 guard) + `TestBenchmarkTruthPassSampledSpotCheck_RunWithHarness` PASS (sampling engaged at TradeCount=300, cap=5).

## Operator step (not in this PR)

**Task 8 — calibration ladder + first official capture — is a manual operator step**, not automated here: the `large` pipeline holds the dataset in memory several times over and its 10M runtime/RSS/disk envelope is unmeasured. The runbook documents 2M→5M probes with an abort criterion (file the streaming/batched-load follow-up if projected 10M RSS exceeds machine RAM) before the official `make benchmark-heavy-live` capture. Measured numbers backfill the docs, which currently say "pending first calibrated capture." Because the capped oracle is *stricter* than uncapped (it asserts reconstruction ≡ engine truth on the sample), a scale-only divergence will fail the first capture by design — that routes to small-scale uncapped investigation, as documented.

## Follow-up

- #156 — speed up truth-pass oracle construction (per-candidate federated queries dominate live-run wall clock; the sampling cap bounds but doesn't fix it).

## Provenance

Spec: `docs/superpowers/specs/2026-07-06-heavy-live-baseline-design.md`
Plan: `docs/superpowers/plans/2026-07-06-heavy-live-baseline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

