### PR TITLE
refactor: migrate hybrid condition builder leaf emission onto typed predicate IR (#154)

### DIFF
--- a/internal/postgres_persistent_repository_query.go
+++ b/internal/postgres_persistent_repository_query.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
-	"github.com/lychee-technology/forma/internal/conditionexpr"
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/queryplan"
 
@@ -260,97 +258,62 @@ func (b *hybridConditionBuilder) initCache() {
 }
 
 func (b *hybridConditionBuilder) build(c forma.Condition) (string, []any, error) {
-	return sqlgen.WalkCondition(c, sqlgen.HybridStyle, nil, b)
+	return sqlgen.WalkHybridCondition(c, b.cache, b)
 }
 
-func (b *hybridConditionBuilder) EmitLeaf(cond *forma.KvCondition) (string, []any, error) {
-	colName := b.resolveColumnName(cond.Attr)
-	if colName != "" {
-		return b.buildMainTableCondition(cond, colName)
+// EmitTypedLeaf renders a parse-once hybrid leaf. Routing (main vs EAV) and
+// all parsing/value conversion were resolved by the normalizer; this method
+// only assigns placeholders and formats the shell with request/builder state
+// (table names, the anchor alias, the arg counter).
+func (b *hybridConditionBuilder) EmitTypedLeaf(leaf *sqlgen.PredicateLeaf) (string, []any, error) {
+	p := leaf.Hybrid
+	if p.IsMain {
+		return b.emitMainLeaf(p)
 	}
-	return b.buildEAVCondition(cond)
+	return b.emitEAVLeaf(p)
 }
 
-func (b *hybridConditionBuilder) resolveColumnName(attr string) string {
-	if model.IsMainTableColumn(attr) {
-		return attr
-	}
-	if b.cache != nil {
-		if meta, ok := b.cache[attr]; ok && meta.ColumnBinding != nil {
-			return string(meta.ColumnBinding.ColumnName)
-		}
-	}
-	return ""
-}
-
-func (b *hybridConditionBuilder) buildMainTableCondition(cond *forma.KvCondition, colName string) (string, []any, error) {
-	parsed := conditionexpr.ParseOperatorValueLenient(cond.Value)
-	sqlOpResult, err := conditionexpr.ToSQLOperator(parsed.Operator, parsed.Value)
-	if err != nil {
-		return "", nil, err
-	}
-
-	meta, err := b.resolveLeafMeta(cond, colName)
-	if err != nil {
-		return "", nil, err
-	}
-	parsedValue, err := sqlgen.ConvertPgMainValue(sqlOpResult.Value, cond.Attr, meta)
-	if err != nil {
-		return "", nil, err
+func (b *hybridConditionBuilder) emitMainLeaf(p sqlgen.HybridLeafPayload) (string, []any, error) {
+	if p.Err != nil {
+		return "", nil, p.Err
 	}
 
 	b.argCounter++
 	placeholder := fmt.Sprintf("$%d", b.argCounter)
 
 	if b.useMainTableAsAnchor {
-		return fmt.Sprintf("m.%s %s %s", sanitizeIdentifier(colName), sqlOpResult.SQLOperator, placeholder), []any{parsedValue}, nil
+		return fmt.Sprintf("m.%s %s %s", sanitizeIdentifier(p.MainColumn), p.MainSQLOp, placeholder), []any{p.MainValue}, nil
 	}
 	return fmt.Sprintf("EXISTS (SELECT 1 FROM %s m WHERE m.ltbase_row_id = t.row_id AND m.%s %s %s)",
-		sanitizeIdentifier(b.mainTable), sanitizeIdentifier(colName), sqlOpResult.SQLOperator, placeholder), []any{parsedValue}, nil
+		sanitizeIdentifier(b.mainTable), sanitizeIdentifier(p.MainColumn), p.MainSQLOp, placeholder), []any{p.MainValue}, nil
 }
 
-// resolveLeafMeta returns the attribute metadata driving value conversion for
-// a main-table leaf. The physical column is always validated against the
-// entity_main descriptors (preserving the pre-#140 "unknown main table
-// column" contract even for cache-bound attributes); raw column references
-// without schema metadata derive a minimal metadata from the descriptor kind.
-func (b *hybridConditionBuilder) resolveLeafMeta(cond *forma.KvCondition, colName string) (forma.AttributeMetadata, error) {
-	desc := model.GetMainColumnDescriptor(colName)
-	if desc == nil {
-		return forma.AttributeMetadata{}, fmt.Errorf("unknown main table column: %s", colName)
-	}
-	if b.cache != nil {
-		if meta, ok := b.cache[cond.Attr]; ok {
-			// Bound attributes may omit value_type (e.g. audit columns); the
-			// pre-#140 implementation converted by physical column kind, so
-			// derive the missing type from the descriptor to keep that contract.
-			if meta.ValueType == "" {
-				meta.ValueType = model.ColumnKindToValueType(desc.Kind)
-			}
-			return meta, nil
-		}
-	}
-	return forma.AttributeMetadata{ValueType: model.ColumnKindToValueType(desc.Kind)}, nil
-}
-
-func (b *hybridConditionBuilder) buildEAVCondition(cond *forma.KvCondition) (string, []any, error) {
+// emitEAVLeaf formats the EAV EXISTS subquery directly against the anchor
+// alias (t.* or m.ltbase_*), replacing the retired e.*-then-string-replace
+// path. Placeholder numbering (attr_id then value) matches the pre-#154 EAV
+// emitter exactly.
+func (b *hybridConditionBuilder) emitEAVLeaf(p sqlgen.HybridLeafPayload) (string, []any, error) {
 	if b.cache == nil {
 		return "", nil, fmt.Errorf("schema metadata cache not available for schema_id %d", b.schemaID)
 	}
-	gen := sqlgen.NewSQLGenerator()
-	pIdx := b.argCounter
-	clause, args, err := gen.ToSQLClauses(cond, b.eavTable, b.schemaID, b.cache, &pIdx)
-	if err != nil {
-		return "", nil, err
+	eav := p.Eav
+	if eav.Err != nil {
+		return "", nil, eav.Err
 	}
-	b.argCounter = pIdx
 
+	schemaAlias, rowAlias := "t.schema_id", "t.row_id"
 	if b.useMainTableAsAnchor {
-		clause = strings.ReplaceAll(clause, "e.row_id", "m.ltbase_row_id")
-		clause = strings.ReplaceAll(clause, "e.schema_id", "m.ltbase_schema_id")
-	} else {
-		clause = strings.ReplaceAll(clause, "e.row_id", "t.row_id")
-		clause = strings.ReplaceAll(clause, "e.schema_id", "t.schema_id")
+		schemaAlias, rowAlias = "m.ltbase_schema_id", "m.ltbase_row_id"
 	}
-	return clause, args, nil
+
+	b.argCounter++
+	attrPlaceholder := fmt.Sprintf("$%d", b.argCounter)
+	b.argCounter++
+	valuePlaceholder := fmt.Sprintf("$%d", b.argCounter)
+
+	clause := fmt.Sprintf(
+		"EXISTS (SELECT 1 FROM %s x WHERE x.schema_id = %s AND x.row_id = %s AND x.attr_id = %s AND x.%s %s %s)",
+		b.eavTable, schemaAlias, rowAlias, attrPlaceholder, eav.ValueColumn, eav.SQLOp, valuePlaceholder,
+	)
+	return clause, []any{eav.AttrID, eav.Value}, nil
 }

--- a/internal/sqlgen/condition_walker.go
+++ b/internal/sqlgen/condition_walker.go
@@ -14,8 +14,6 @@ type leafEmitter interface {
 	EmitLeaf(kv *forma.KvCondition) (sql string, args []any, err error)
 }
 
-type LeafEmitter = leafEmitter
-
 // compositeGuard optionally intercepts a CompositeCondition before traversing
 // its children. pg-main uses this to veto an entire OR branch when any child
 // cannot be pushed to the main table.
@@ -23,13 +21,15 @@ type compositeGuard interface {
 	SkipComposite(c *forma.CompositeCondition) bool
 }
 
-type CompositeGuard = compositeGuard
-
 // typedLeafEmitter renders a typed predicate leaf into SQL and args. The
 // skip contract matches leafEmitter: ("", nil, nil) drops the leaf.
 type typedLeafEmitter interface {
 	EmitTypedLeaf(leaf *PredicateLeaf) (sql string, args []any, err error)
 }
+
+// TypedLeafEmitter is the exported alias external packages (the hybrid
+// condition builder) implement to consume typed leaves via WalkHybridCondition.
+type TypedLeafEmitter = typedLeafEmitter
 
 // typedGuard optionally intercepts a PredicateGroup before traversing its
 // children, mirroring compositeGuard on the typed tree.
@@ -93,8 +93,6 @@ var (
 	}
 )
 
-var HybridStyle = hybridStyle
-
 // legacyLeafAdapter feeds the original KvCondition of a typed leaf to a
 // legacy leafEmitter, so untyped consumers (hybrid builder) share the typed
 // traversal instead of a second walker.
@@ -112,8 +110,13 @@ func (a legacyGuardAdapter) SkipGroup(g *PredicateGroup) bool {
 	return a.guard.SkipComposite(g.Source)
 }
 
-func WalkCondition(cond forma.Condition, style compositeStyle, guard CompositeGuard, emit LeafEmitter) (string, []any, error) {
-	return walkCondition(cond, style, guard, emit)
+// WalkHybridCondition normalizes cond with the hybrid leaf target (parse-once)
+// and walks it with the hybrid composite style, emitting each leaf through the
+// caller's typed emitter. It is the entrypoint for the hybrid condition
+// builder: composite traversal and leaf parsing both live in the shared typed
+// walker, so the builder only formats already-resolved leaves.
+func WalkHybridCondition(cond forma.Condition, cache forma.SchemaAttributeCache, emit TypedLeafEmitter) (string, []any, error) {
+	return walkPredicate(normalizePredicates(cond, cache, targetHybrid), hybridStyle, nil, emit)
 }
 
 // walkCondition traverses a forma.Condition AST and emits SQL via the legacy

--- a/internal/sqlgen/predicate_ir.go
+++ b/internal/sqlgen/predicate_ir.go
@@ -88,9 +88,34 @@ type PredicateLeaf struct {
 	PgEav  PgEavLeafPayload
 	PgMain PgMainLeafPayload
 	Duck   DuckLeafPayload
+	Hybrid HybridLeafPayload
 }
 
 func (*PredicateLeaf) isPredicateNode() {}
+
+// HybridLeafPayload carries the parse-once results the hybrid condition
+// builder needs to emit either a main-table predicate or an EAV EXISTS
+// subquery. Routing (IsMain) follows the hybrid column-resolution contract:
+// raw entity_main columns and cache-bound columns emit against entity_main;
+// every other attribute falls to the EAV EXISTS form. Placeholder assignment,
+// identifier sanitization, table names, and the anchor alias remain the
+// emitter's responsibility (they are request/builder state), mirroring the
+// pg-main / pg-eav emitters.
+type HybridLeafPayload struct {
+	// Err is the main-branch resolution error (unsupported operator, unknown
+	// main table column, or value conversion), surfaced verbatim at emit time
+	// before any placeholder is consumed.
+	Err    error
+	IsMain bool
+
+	// Main-table branch (lenient parse + descriptor-validated metadata).
+	MainColumn string // physical column name, unsanitized
+	MainSQLOp  string
+	MainValue  any
+
+	// EAV branch — computed identically to PgEavLeafPayload (strict parse).
+	Eav PgEavLeafPayload
+}
 
 // PgEavLeafPayload is the EAV EXISTS emission payload (strict parse policy).
 type PgEavLeafPayload struct {

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -138,7 +138,7 @@ func normalizeHybridPayload(
 	if lenientSQLErr != nil {
 		return HybridLeafPayload{IsMain: true, Err: lenientSQLErr}
 	}
-	leafMeta, err := resolveHybridLeafMeta(kv, colName, meta, hasMeta)
+	leafMeta, err := resolveHybridLeafMeta(colName, meta, hasMeta)
 	if err != nil {
 		return HybridLeafPayload{IsMain: true, Err: err}
 	}
@@ -160,7 +160,7 @@ func normalizeHybridPayload(
 // "unknown main table column" contract even for cache-bound attributes);
 // cache-bound attributes that omit value_type derive it from the descriptor
 // kind, and raw column references without metadata derive a minimal metadata.
-func resolveHybridLeafMeta(kv *forma.KvCondition, colName string, meta forma.AttributeMetadata, hasMeta bool) (forma.AttributeMetadata, error) {
+func resolveHybridLeafMeta(colName string, meta forma.AttributeMetadata, hasMeta bool) (forma.AttributeMetadata, error) {
 	desc := model.GetMainColumnDescriptor(colName)
 	if desc == nil {
 		return forma.AttributeMetadata{}, fmt.Errorf("unknown main table column: %s", colName)

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/conditionexpr"
+	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/numutil"
 )
 
@@ -19,6 +20,7 @@ const (
 	targetPgEav normalizeTargets = 1 << iota
 	targetPgMain
 	targetDuck
+	targetHybrid
 
 	targetsNone normalizeTargets = 0
 	targetsAll                   = targetPgEav | targetPgMain | targetDuck
@@ -101,7 +103,75 @@ func normalizeLeaf(kv *forma.KvCondition, cache forma.SchemaAttributeCache, targ
 	if targets&targetDuck != 0 {
 		leaf.Duck = normalizeDuckPayload(kv, cache, meta, hasMeta, lenientSQL, lenientSQLErr)
 	}
+	if targets&targetHybrid != 0 {
+		leaf.Hybrid = normalizeHybridPayload(kv, meta, hasMeta, lenientSQL, lenientSQLErr)
+	}
 	return leaf
+}
+
+// normalizeHybridPayload converts a leaf for the hybrid condition builder.
+// Routing mirrors the retired hybridConditionBuilder.resolveColumnName: a raw
+// entity_main column (IsMainTableColumn) or a cache-bound attribute emits
+// against the main table; everything else falls to the EAV EXISTS form. For
+// the main branch the operator parse error is surfaced before the
+// descriptor-validation error, matching the retired buildMainTableCondition
+// ordering. The EAV branch reuses the strict-parse PgEav payload verbatim.
+func normalizeHybridPayload(
+	kv *forma.KvCondition,
+	meta forma.AttributeMetadata,
+	hasMeta bool,
+	lenientSQL conditionexpr.SQLOperatorResult,
+	lenientSQLErr error,
+) HybridLeafPayload {
+	colName := ""
+	if model.IsMainTableColumn(kv.Attr) {
+		colName = kv.Attr
+	} else if hasMeta && meta.ColumnBinding != nil {
+		colName = string(meta.ColumnBinding.ColumnName)
+	}
+
+	if colName == "" {
+		return HybridLeafPayload{IsMain: false, Eav: normalizePgEavPayload(kv, meta, hasMeta)}
+	}
+
+	// Main-table branch. Operator parse error first (pre-#154 ordering).
+	if lenientSQLErr != nil {
+		return HybridLeafPayload{IsMain: true, Err: lenientSQLErr}
+	}
+	leafMeta, err := resolveHybridLeafMeta(kv, colName, meta, hasMeta)
+	if err != nil {
+		return HybridLeafPayload{IsMain: true, Err: err}
+	}
+	value, err := ConvertPgMainValue(lenientSQL.Value, kv.Attr, leafMeta)
+	if err != nil {
+		return HybridLeafPayload{IsMain: true, Err: err}
+	}
+	return HybridLeafPayload{
+		IsMain:     true,
+		MainColumn: colName,
+		MainSQLOp:  lenientSQL.SQLOperator,
+		MainValue:  value,
+	}
+}
+
+// resolveHybridLeafMeta returns the attribute metadata driving value
+// conversion for a main-table hybrid leaf. The physical column is always
+// validated against the entity_main descriptors (preserving the pre-#140
+// "unknown main table column" contract even for cache-bound attributes);
+// cache-bound attributes that omit value_type derive it from the descriptor
+// kind, and raw column references without metadata derive a minimal metadata.
+func resolveHybridLeafMeta(kv *forma.KvCondition, colName string, meta forma.AttributeMetadata, hasMeta bool) (forma.AttributeMetadata, error) {
+	desc := model.GetMainColumnDescriptor(colName)
+	if desc == nil {
+		return forma.AttributeMetadata{}, fmt.Errorf("unknown main table column: %s", colName)
+	}
+	if hasMeta {
+		if meta.ValueType == "" {
+			meta.ValueType = model.ColumnKindToValueType(desc.Kind)
+		}
+		return meta, nil
+	}
+	return forma.AttributeMetadata{ValueType: model.ColumnKindToValueType(desc.Kind)}, nil
 }
 
 // classifyPredicate returns whether a KvCondition can be pushed to main table based on metadata.


### PR DESCRIPTION
## Summary

Migrates `hybridConditionBuilder` leaf emission from the legacy per-leaf re-parse onto the typed predicate IR (`sqlgen.PredicateLeaf`), closing the last thread of the #143/#127 condition-walker unification.

Before this change the composite walk was already shared through the typed walker, but each leaf was still parsed a second time at emit time:
- main-table leaves called `conditionexpr.ParseOperatorValueLenient` + `ToSQLOperator` + `sqlgen.ConvertPgMainValue`
- EAV leaves wrapped `SQLGenerator.ToSQLClauses` and then string-replaced `e.row_id`/`e.schema_id` with the anchor alias

## What changed

- **sqlgen**: new `HybridLeafPayload` + a `targetHybrid` normalize target. The parse-once normalizer now computes hybrid routing (main vs EAV), the descriptor-validated main-table metadata (preserving the pre-#140 *"unknown main table column"* contract and value_type inference from the column kind), and the strict-parse EAV payload. New `WalkHybridCondition` entrypoint + exported `TypedLeafEmitter` alias.
- **hybrid builder**: `EmitLeaf(*forma.KvCondition)` → `EmitTypedLeaf(*sqlgen.PredicateLeaf)`. The emitter now only assigns placeholders and formats the shell from builder state; the EAV branch emits **directly** against the anchor alias (`t.*` / `m.ltbase_*`) rather than emitting `e.*` and string-replacing. Placeholder numbering, argument order, and byte-for-byte SQL are unchanged.
- Removed the now-dead exported seams `WalkCondition` / `HybridStyle` / `LeafEmitter` / `CompositeGuard` — they existed solely to serve the legacy hybrid path.

## Hard constraint (inherited from #143)

The hybrid path no longer imports or calls `conditionexpr` to parse leaves; all parse/normalize logic lives once in the sqlgen normalizer (no parallel parser introduced).

## Verification

- `go test ./internal -run "TestHybrid_|TestBuildHybridConditions"` — all 22 hybrid characterization/builder tests pass **byte-for-byte unchanged**
- `go test ./internal/sqlgen` ✅
- `make test` ✅ (all packages)
- `make lint` ✅ (golangci-lint v1.64.8, exit 0)
- `go vet -tags e2e ./internal/e2e_harness/federated/... ./internal/...` ✅

Refs #143, #127, PR #153. Completes **EPIC #125** (all sub-issues #126–#131 already closed; this was the remaining condition-walker thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)