### PR TITLE
fix: fail fast when a federated query has no schema metadata cache (#151)

### DIFF
--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -224,7 +224,10 @@ func (e *DBFederatedQueryEngine) buildDuckDBQueryWithPlan(
 	}
 
 	// Compute schema-driven projections for the template
-	projectionCacheHit := e.injectSchemaProjections(sqlParams, q.SchemaID, cache)
+	projectionCacheHit, err := e.injectSchemaProjections(sqlParams, q.SchemaID, cache)
+	if err != nil {
+		return "", nil, 0, err
+	}
 	planCtx.recordProjectionCache(projectionCacheHit)
 
 	// Determine if the EAV pivot can be skipped entirely (all filter/sort
@@ -391,7 +394,7 @@ func (e *DBFederatedQueryEngine) schemaProjection(schemaID int16, cache forma.Sc
 	})
 }
 
-func (e *DBFederatedQueryEngine) injectSchemaProjections(sqlParams map[string]any, schemaID int16, cache forma.SchemaAttributeCache) (projectionCacheHit bool) {
+func (e *DBFederatedQueryEngine) injectSchemaProjections(sqlParams map[string]any, schemaID int16, cache forma.SchemaAttributeCache) (projectionCacheHit bool, err error) {
 	if isBenchmarkSchemaID(schemaID) {
 		// Benchmark schemas: use hardcoded benchmarks projections that match
 		// the benchmark parquet shape exactly (flat columns for column-bound
@@ -404,22 +407,23 @@ func (e *DBFederatedQueryEngine) injectSchemaProjections(sqlParams map[string]an
 		sqlParams["EAVPivotAttrs"] = proj.EAVPivotAttrs
 		sqlParams["HasEAVPivot"] = len(proj.EAVPivotAttrs) > 0
 		sqlParams["OuterSelect"] = sqlgen.BuildBenchmarkOuterSelect(schemaID)
-		return false
+		return false, nil
 	}
 	if len(cache) == 0 {
-		// No cache: fall back to defaults that match the fixed layout without EAV
-		sqlParams["S3SourceSelect"] = "row_id, ltbase_created_at AS created_at, ltbase_updated_at AS ver_ts, ltbase_deleted_at AS deleted_ts, name, age, tag"
-		sqlParams["PGSourceSelect"] = "m.ltbase_row_id::VARCHAR AS row_id, m.ltbase_created_at AS created_at, cl.changed_at AS ver_ts, cl.deleted_at AS deleted_ts, CAST(m.text_01 AS VARCHAR) AS name, CAST(m.integer_01 AS INTEGER) AS age, ''::VARCHAR AS tag"
-		sqlParams["PGGroupBy"] = "m.ltbase_row_id, m.ltbase_created_at, cl.changed_at, cl.deleted_at, m.text_01, m.integer_01"
-		sqlParams["HasEAVPivot"] = false
-		sqlParams["OuterSelect"] = fallbackOuterSelect(schemaID)
-		return false
+		// No schema metadata cache: fail fast. The final SELECT must align
+		// positionally with model.EntityMainColumnDescriptors (the #147
+		// positional-scan contract), so a correct projection can only be
+		// derived from the schema's attribute cache. The retired fallback here
+		// emitted a fixed toy-schema projection (name/age/tag, columns absent
+		// from the descriptors) whose column set could not be scanned by
+		// duckDBScanBuffers — a hard error at best, misaligned rows at worst.
+		return false, fmt.Errorf("federated query for schema_id %d requires a schema metadata cache, but none is loaded", schemaID)
 	}
 
 	// Production schema: compute projections from the attribute cache
-	sp, hit, err := e.schemaProjection(schemaID, cache)
-	if err != nil || sp == nil {
-		return hit
+	sp, hit, projErr := e.schemaProjection(schemaID, cache)
+	if projErr != nil || sp == nil {
+		return hit, nil
 	}
 	sqlParams["S3SourceSelect"] = sp.S3SourceSelect
 	sqlParams["PGSourceSelect"] = sp.PGSourceSelect
@@ -428,33 +432,7 @@ func (e *DBFederatedQueryEngine) injectSchemaProjections(sqlParams map[string]an
 	sqlParams["EAVPivotAttrs"] = sp.EAVPivotAttrs
 	sqlParams["HasEAVPivot"] = len(sp.EAVPivotAttrs) > 0
 	sqlParams["OuterSelect"] = sp.OuterSelect
-	return hit
-}
-
-// fallbackOuterSelect returns the fixed outer SELECT for the no-cache fallback path.
-func fallbackOuterSelect(schemaID int16) string {
-	return fmt.Sprintf(`%d::SMALLINT AS ltbase_schema_id,
-			CAST(row_id AS UUID) AS ltbase_row_id,
-			created_at AS ltbase_created_at,
-			ver_ts AS ltbase_updated_at,
-			deleted_ts AS ltbase_deleted_at,
-			name AS text_01,
-			age AS integer_01,
-			tag AS text_02,
-			NULL::SMALLINT AS smallint_01,
-			NULL::INTEGER AS integer_02,
-			NULL::BIGINT AS bigint_01,
-			NULL::BIGINT AS bigint_02,
-			NULL::BIGINT AS bigint_03,
-			NULL::BIGINT AS bigint_04,
-			NULL::DOUBLE AS double_01,
-			NULL::DOUBLE AS double_02,
-			NULL::BOOLEAN AS boolean_01,
-			NULL::UUID AS uuid_01,
-			NULL::VARCHAR AS text_03,
-			NULL::VARCHAR AS text_04,
-			NULL::VARCHAR AS text_05,
-			'[]'::TEXT AS attributes_json`, schemaID)
+	return hit, nil
 }
 
 func duckDBPostgresScanLocation(name string) (string, string) {

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -2,6 +2,7 @@ package federated
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,6 +17,14 @@ import (
 	"github.com/lychee-technology/forma/internal/sqlutil"
 	"github.com/lychee-technology/forma/internal/telemetry"
 )
+
+// ErrSchemaMetadataCacheRequired marks a federated query that cannot build a
+// correct entity_main projection because the schema's metadata cache is not
+// loaded. It is a configuration / data-contract error, not a transient
+// infrastructure failure, so the public Query path must not absorb it under
+// AllowPartialDegradedMode — degrading would silently return a Postgres-only
+// partial result and hide the missing-cache problem #151 makes loud.
+var ErrSchemaMetadataCacheRequired = errors.New("schema metadata cache required but not loaded")
 
 func isBenchmarkSchemaID(schemaID int16) bool { return sqlgen.IsBenchmarkSchemaID(schemaID) }
 
@@ -417,7 +426,7 @@ func (e *DBFederatedQueryEngine) injectSchemaProjections(sqlParams map[string]an
 		// emitted a fixed toy-schema projection (name/age/tag, columns absent
 		// from the descriptors) whose column set could not be scanned by
 		// duckDBScanBuffers — a hard error at best, misaligned rows at worst.
-		return false, fmt.Errorf("federated query for schema_id %d requires a schema metadata cache, but none is loaded", schemaID)
+		return false, fmt.Errorf("federated query for schema_id %d requires a schema metadata cache, but none is loaded: %w", schemaID, ErrSchemaMetadataCacheRequired)
 	}
 
 	// Production schema: compute projections from the attribute cache

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -2,6 +2,7 @@ package federated
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"text/template"
 
@@ -126,7 +127,11 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 
 	records, totalRecords, err := e.ExecuteDuckDBFederatedQuery(ctx, tables, fq, fq.Limit, fq.Offset, fq.AttributeOrders, opts)
 	if err != nil {
-		if opts != nil && opts.AllowPartialDegradedMode {
+		// A missing schema metadata cache is a configuration / data-contract
+		// error, not a transient DuckDB failure: degrading to Postgres-only
+		// would silently return a partial result and mask it (#151). Surface it
+		// even under AllowPartialDegradedMode.
+		if opts != nil && opts.AllowPartialDegradedMode && !errors.Is(err, ErrSchemaMetadataCacheRequired) {
 			return e.queryPostgresOnly(ctx, tables, fq)
 		}
 		return nil, fmt.Errorf("duckdb federated query: %w", err)

--- a/internal/federated/engine_test.go
+++ b/internal/federated/engine_test.go
@@ -303,11 +303,40 @@ func TestInjectSchemaProjectionsNoCacheFailsFast(t *testing.T) {
 	require.Contains(t, err.Error(), "requires a schema metadata cache")
 	require.NotContains(t, params, "OuterSelect", "no projection must be injected on the fail-fast path")
 
+	require.ErrorIs(t, err, ErrSchemaMetadataCacheRequired)
+
 	// Benchmark schemas remain unaffected (they never consult the cache).
 	benchParams := map[string]any{}
 	_, benchErr := engine.injectSchemaProjections(benchParams, int16(100), nil)
 	require.NoError(t, benchErr)
 	require.Contains(t, benchParams, "OuterSelect")
+}
+
+// TestDBFederatedQueryEngine_MissingSchemaCacheNotDegradable pins the #151 PR
+// review finding: the missing-schema-cache error is a configuration error, not
+// a transient DuckDB failure, so the public Query path must surface it even
+// under AllowPartialDegradedMode instead of silently falling back to a
+// Postgres-only partial result.
+func TestDBFederatedQueryEngine_MissingSchemaCacheNotDegradable(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 1}}
+	duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: uuid.New()}}
+	// nil metadata cache → the DuckDB render path cannot build a projection.
+	engine := NewDBFederatedQueryEngine(pg, &fakeDirtyIDFetcher{}, duck, nil,
+		forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}}, nil, "host=x")
+
+	_, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		&model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 2000},
+			PreferredTiers: []model.DataTier{model.DataTierHot, model.DataTierCold},
+		},
+		&model.FederatedQueryOptions{AllowPartialDegradedMode: true})
+
+	require.ErrorIs(t, err, ErrSchemaMetadataCacheRequired)
+	require.Equal(t, 0, pg.queryCalls, "missing-cache error must not degrade to a Postgres-only partial result")
 }
 
 // TestEngineCompiledPlanCache pins #142 phase 5 end to end: two same-shape

--- a/internal/federated/engine_test.go
+++ b/internal/federated/engine_test.go
@@ -21,6 +21,23 @@ func initTestDescriptors() func() {
 	return func() { model.EntityMainColumnDescriptors = orig }
 }
 
+// testMetadataCacheSchema7 registers a minimal schema-7 attribute cache so the
+// DuckDB render path can build a real column projection. Post-#151 the
+// no-metadata-cache path fails fast instead of emitting a toy fallback
+// projection, so engine tests that drive the render path must supply a cache.
+func testMetadataCacheSchema7(t *testing.T) *schemameta.MetadataCache {
+	t.Helper()
+	mc := schemameta.NewMetadataCache()
+	require.NoError(t, mc.RegisterSchema("test", 7, forma.SchemaAttributeCache{
+		"age": {
+			AttributeID:   6,
+			ValueType:     forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("integer_01")},
+		},
+	}))
+	return mc
+}
+
 type fakePostgresFederatedSource struct {
 	queryCalls int
 	lastQuery  *model.PersistentRecordQuery
@@ -119,7 +136,7 @@ func TestDBFederatedQueryEngine_QueryHotOnlyDelegatesToPostgres(t *testing.T) {
 func TestDBFederatedQueryEngine_DuckDBFailureWithDegradedModeFallsBackToPostgres(t *testing.T) {
 	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 1}}
 	duck := &fakeDuckDBExecutor{err: fmt.Errorf("forced duck failure")}
-	engine := NewDBFederatedQueryEngine(pg, nil, duck, nil, forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}}, nil, "")
+	engine := NewDBFederatedQueryEngine(pg, nil, duck, nil, forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}}, testMetadataCacheSchema7(t), "")
 
 	page, err := engine.Query(context.Background(), model.StorageTables{EntityMain: "main", EAVData: "eav"}, &model.FederatedAttributeQuery{
 		AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 2000},
@@ -141,7 +158,7 @@ func TestDBFederatedQueryEngine_DuckDBRouteUsesInjectedExecutorAndDirtyFetcher(t
 	pg := &fakePostgresFederatedSource{}
 	dirty := &fakeDirtyIDFetcher{ids: []uuid.UUID{dirtyID}}
 	duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: rowID}}
-	engine := NewDBFederatedQueryEngine(pg, dirty, duck, nil, forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}}, nil, "")
+	engine := NewDBFederatedQueryEngine(pg, dirty, duck, nil, forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}}, testMetadataCacheSchema7(t), "")
 	engine.buildDuckSQL = func(tpl *template.Template, params any, q *model.FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *sqlgen.DualClauses) (string, []any, error) {
 		require.Equal(t, []uuid.UUID{dirtyID}, dirtyIDs)
 		return "SELECT fake", nil, nil
@@ -192,7 +209,7 @@ func TestDBFederatedQueryEngine_ExecutionPlanPopulated(t *testing.T) {
 	pg := &fakePostgresFederatedSource{}
 	dirty := &fakeDirtyIDFetcher{}
 	duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: uuid.New()}}
-	engine := NewDBFederatedQueryEngine(pg, dirty, duck, nil, forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}}, nil, "")
+	engine := NewDBFederatedQueryEngine(pg, dirty, duck, nil, forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}}, testMetadataCacheSchema7(t), "")
 	engine.buildDuckSQL = func(tpl *template.Template, params any, q *model.FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *sqlgen.DualClauses) (string, []any, error) {
 		return "SELECT fake", nil, nil
 	}
@@ -261,9 +278,36 @@ func TestSchemaProjectionCache(t *testing.T) {
 	opts := &model.FederatedQueryOptions{IncludeExecutionPlan: true, ExecutionPlan: &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}}}
 	planCtx := newDuckDBExecutionPlanContext(opts)
 	params := map[string]any{}
-	hitFlag := engine.injectSchemaProjections(params, 7, cache)
+	hitFlag, err := engine.injectSchemaProjections(params, 7, cache)
+	require.NoError(t, err)
 	planCtx.recordProjectionCache(hitFlag)
 	require.Contains(t, opts.ExecutionPlan.Notes, "schema_projection_cache_hit")
+}
+
+// TestInjectSchemaProjectionsNoCacheFailsFast pins #151: a non-benchmark schema
+// with no metadata cache must fail fast rather than emit a stale toy-schema
+// projection that violates the positional-scan contract. The retired fallback
+// wrote name/age/tag columns that duckDBScanBuffers cannot scan.
+func TestInjectSchemaProjectionsNoCacheFailsFast(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	engine := NewDBFederatedQueryEngine(&fakePostgresFederatedSource{}, &fakeDirtyIDFetcher{}, &fakeDuckDBExecutor{}, nil,
+		forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}},
+		schemameta.NewMetadataCache(), "host=x")
+
+	params := map[string]any{}
+	hit, err := engine.injectSchemaProjections(params, 7, nil)
+	require.Error(t, err)
+	require.False(t, hit)
+	require.Contains(t, err.Error(), "requires a schema metadata cache")
+	require.NotContains(t, params, "OuterSelect", "no projection must be injected on the fail-fast path")
+
+	// Benchmark schemas remain unaffected (they never consult the cache).
+	benchParams := map[string]any{}
+	_, benchErr := engine.injectSchemaProjections(benchParams, int16(100), nil)
+	require.NoError(t, benchErr)
+	require.Contains(t, benchParams, "OuterSelect")
 }
 
 // TestEngineCompiledPlanCache pins #142 phase 5 end to end: two same-shape


### PR DESCRIPTION
## Summary

The no-metadata-cache branch of `injectSchemaProjections` (`internal/federated/duckdb_query.go`) emitted a fixed **toy-schema** projection — `fallbackOuterSelect` produced `name`/`age`/`tag` columns plus columns absent from the descriptors (`bigint_04`, `boolean_01`, …), with matching stale `S3SourceSelect`/`PGSourceSelect`/`PGGroupBy`.

That column set does not align with `model.EntityMainColumnDescriptors`, so it violates the **#147 positional-scan contract** (`streamDuckDBRows` / `duckDBScanBuffers` scan by descriptor order). If this path were ever hit with real DuckDB rows, `rows.Scan` would fail on a target-count mismatch, or — if counts happened to coincide — silently misplace values.

## Decision: fail fast (issue option 1)

Call-site evidence shows there is no *correct* fixed projection for a cacheless non-benchmark schema — the entity_main column order is only recoverable from the schema's attribute cache (and `BuildSchemaProjection` over an empty cache likewise degrades to a toy `name`/`version` shape). So rather than maintain a second, drift-prone column-order source, the cacheless path now errors explicitly.

- `injectSchemaProjections` returns `(bool, error)`; the `len(cache)==0` branch returns `federated query for schema_id N requires a schema metadata cache, but none is loaded`, propagated by `buildDuckDBQueryWithPlan`.
- Removed the dead `fallbackOuterSelect` helper.
- **Benchmark schemas (IDs 100–102) are unaffected** — they're handled before the cache check and never consult it.

## Tests

- New `TestInjectSchemaProjectionsNoCacheFailsFast` pins the fail-fast error, that no projection is injected on that path, and the benchmark-schema exemption.
- Three engine tests (`DuckDBFailureWithDegradedModeFallsBackToPostgres`, `DuckDBRouteUsesInjectedExecutorAndDirtyFetcher`, `ExecutionPlanPopulated`) were driving the render path with a `nil` metadata cache and inert fake executors — they silently relied on the toy fallback. They now register a real schema-7 cache via a `testMetadataCacheSchema7` helper, exercising the genuine projection path.

## Verification

- `go test ./internal/federated/` ✅
- `make test` ✅ (all packages)
- `make lint` ✅ (golangci-lint v1.64.8, exit 0)
- `go vet -tags e2e ./internal/e2e_harness/federated/... ./internal/federated/...` ✅

Refs #147, #149. Out of scope: benchmark projections (fixed in #149) and the cache-loading strategy itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)