### PR TITLE
fix(sqlgen): emit ? not $n for main-column pushdown in DuckDB federated query (#161)

### DIFF
--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -29,21 +29,10 @@ import (
 //     batching proved (via TestTruthPassBatchEqualsPerCandidate) that this is a
 //     harness truth-query bug independent of the per-candidate/batch split, so
 //     it is tracked on its own (#163).
-//   - mixed-hot-eav-page / tier-pushdown-mixed: the service path returns zero
-//     rows for the composite main+EAV filter (symbol AND exchange) though each
-//     condition works alone (#161).
 var knownFailingAssertions = map[string]map[string]string{
 	"eav-low-selectivity-page": {
 		"total-records-match-expected": "#163",
 		"page-row-ids-match-expected":  "#163",
-	},
-	"mixed-hot-eav-page": {
-		"total-records-match-expected": "#161",
-		"page-row-ids-match-expected":  "#161",
-	},
-	"tier-pushdown-mixed": {
-		"total-records-match-expected": "#161",
-		"page-row-ids-match-expected":  "#161",
 	},
 }
 
@@ -137,7 +126,7 @@ type workloadCoverage struct {
 	customer, security, filtered, lowSelective, eav, mixedFilter bool
 	mixedTier, hotOnly, coldOnly                                 bool
 	expectedOracleAssertions, tradeTimeWindow, repeatedStability bool
-	pushdownHot, pushdownEAV, pushdownMixed, pushdownColdOnly     bool
+	pushdownHot, pushdownEAV, pushdownMixed, pushdownColdOnly    bool
 	pushdownAssertions                                           bool
 }
 

--- a/internal/sqlgen/dualpath_sql_generator.go
+++ b/internal/sqlgen/dualpath_sql_generator.go
@@ -94,9 +94,20 @@ func (e *pgMainTypedEmitter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, 
 		return "", nil, nil
 	}
 
+	// PgMainClause is only ever embedded in the DuckDB federated query template
+	// (as PG_WHERE_CLAUSE for the pg_source CTE) — it is never sent to Postgres.
+	// It therefore must use DuckDB's positional "?" placeholder, not "$n":
+	// DuckDB cannot mix "?" (auto-numbered) with "$1" (numbered) in one statement,
+	// and the DuckClause (also embedded here) uses "?". Mixing the two mis-binds
+	// arguments — the "$1" aliases DuckDB positional param 1 and shifts every "?"
+	// after it — so a main-column AND EAV composite silently returned zero rows
+	// (#161). The advanced-template arg interleave (DuckArgs, PgMainArgs, DuckArgs)
+	// already matches the left-to-right "?" order once every placeholder is "?".
+	//
+	// paramIndex is still advanced so the sibling EAV EXISTS clause (PgClause),
+	// which shares this counter and does use "$n", keeps its numbering stable.
 	*e.paramIndex++
-	ph := fmt.Sprintf("$%d", *e.paramIndex)
-	sql := fmt.Sprintf("%s %s %s", p.Column, p.SQLOp, ph)
+	sql := fmt.Sprintf("%s %s ?", p.Column, p.SQLOp)
 	return sql, []any{p.Value}, nil
 }
 

--- a/internal/sqlgen/dualpath_sql_generator.go
+++ b/internal/sqlgen/dualpath_sql_generator.go
@@ -21,7 +21,10 @@ type DualClauses struct {
 // - PgClause reuses existing SQLGenerator (EAV-based EXISTS expressions).
 // - PgMainClause contains predicates suitable for entity_main pushdown.
 // - DuckClause maps attributes to column names when available and emits a simple DuckDB-style clause.
-// Note: DuckDB placeholders are "?" and args are returned in order. Postgres uses $n placeholders.
+// Placeholder styles: PgClause (the EAV EXISTS clause, genuinely Postgres-bound)
+// uses "$n"; DuckClause and PgMainClause both use DuckDB positional "?", because
+// PgMainClause is only ever embedded in the DuckDB federated template (see
+// pgMainTypedEmitter and #161). Args are returned in order for all three.
 //
 // The condition tree is normalized into the typed predicate IR exactly once
 // (#143); the three emitters below consume that shared tree.
@@ -34,7 +37,9 @@ func ToDualClauses(
 ) (DualClauses, error) {
 	tree := normalizePredicates(condition, cache, targetsAll)
 
-	// Build pushdown-capable main table predicates first so placeholders ($n) align.
+	// Build pushdown-capable main table predicates first so paramIndex advances
+	// before the EAV clause, keeping the EAV EXISTS "$n" numbering stable. The
+	// main clause itself emits DuckDB positional "?" (see pgMainTypedEmitter).
 	pgMainClause, pgMainArgs, err := pgMainClauseFromTree(tree, paramIndex)
 	if err != nil {
 		return DualClauses{}, fmt.Errorf("pg main generation: %w", err)
@@ -119,7 +124,9 @@ func pgMainClauseFromTree(tree PredicateNode, paramIndex *int) (string, []any, e
 }
 
 // buildPgMainClause traverses the condition tree and emits a WHERE fragment targeting entity_main (m.*)
-// It returns the clause string (with $n placeholders) and args slice, advancing paramIndex as needed.
+// It returns the clause string (with DuckDB positional "?" placeholders, since the
+// main clause is DuckDB-embedded — see pgMainTypedEmitter) and args slice,
+// advancing paramIndex as needed to keep the sibling EAV "$n" numbering stable.
 func buildPgMainClause(cond forma.Condition, cache forma.SchemaAttributeCache, paramIndex *int) (string, []any, error) {
 	if cond == nil {
 		return "", nil, nil

--- a/internal/sqlgen/dualpath_sql_generator_test.go
+++ b/internal/sqlgen/dualpath_sql_generator_test.go
@@ -106,13 +106,14 @@ func TestToDualClauses_NestedAndOr_GroupingAndOrdering(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, pgClause)
 
-	// Then: grouping operators are present and placeholder ordering is $1 then $2 then $3
+	// Then: grouping operators are present. PgMainClause is embedded in the DuckDB
+	// federated template, so it emits positional "?" placeholders, not "$n" (#161).
+	// Placeholder ordering is therefore carried by the args slice: the three leaves
+	// bind in left-to-right order A, B, C.
 	require.Contains(t, pgClause, "AND")
 	require.Contains(t, pgClause, "OR")
-	i1 := strings.Index(pgClause, "$1")
-	i2 := strings.Index(pgClause, "$2")
-	i3 := strings.Index(pgClause, "$3")
-	require.True(t, i1 >= 0 && i2 > i1 && i3 > i2, "placeholders should appear in order $1,$2,$3")
+	require.Equal(t, 3, strings.Count(pgClause, "?"), "expected three positional ? placeholders")
+	require.NotContains(t, pgClause, "$", "PgMainClause must not use $n placeholders in the DuckDB path")
 	require.Equal(t, []any{"A", "B", "C"}, pgArgs)
 
 	// And: DuckDB clause preserves grouping and argument ordering

--- a/internal/sqlgen/duckdb_mixed_placeholder_regression_test.go
+++ b/internal/sqlgen/duckdb_mixed_placeholder_regression_test.go
@@ -1,0 +1,50 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDuckDBMixedComposite_NoPlaceholderStyleMixing is the #161 regression guard.
+//
+// A composite `main-column AND pure-EAV` filter is rendered into the DuckDB
+// federated template. The DuckClause (s3_source / visible WHERE) uses positional
+// "?" placeholders; the PgMainClause (pg_source WHERE) historically used "$n".
+// DuckDB cannot mix "?" and "$n" in one statement — the "$1" aliases positional
+// param 1, shifting every "?" after it — so the composite silently returned zero
+// rows in production and the benchmark. The whole rendered statement must use a
+// single placeholder style ("?") so the DuckArgs+PgMainArgs+DuckArgs interleave
+// binds positionally.
+func TestDuckDBMixedComposite_NoPlaceholderStyleMixing(t *testing.T) {
+	cache := dualPlanTestCache() // age -> integer_01 (main), tag -> pure EAV
+	mixed := &forma.CompositeCondition{Logic: forma.LogicAnd, Conditions: []forma.Condition{
+		&forma.KvCondition{Attr: "age", Value: "gt:10"},
+		&forma.KvCondition{Attr: "tag", Value: "equals:x"},
+	}}
+	q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7, Condition: mixed}}
+
+	dual := parityDual(t, mixed, cache)
+	// Sanity: the composite really does exercise both a main-column pushdown and
+	// an EAV leaf, otherwise the mixing hazard would not be present.
+	require.NotEmpty(t, dual.PgMainClause, "expected a main-column pushdown clause")
+	require.NotEmpty(t, dual.DuckClause, "expected a DuckDB logical clause")
+
+	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), q, nil, &dual)
+	require.NoError(t, err)
+
+	// Core guard: no "$n" numbered placeholders anywhere in the DuckDB statement.
+	require.NotContains(t, sql, "$", "DuckDB federated SQL must not contain $n placeholders (#161): %s", dual.PgMainClause)
+
+	// The positional "?" count must equal the number of bound args, so every
+	// placeholder maps to exactly one argument in appearance order.
+	require.Equal(t, strings.Count(sql, "?"), len(args),
+		"placeholder count must equal arg count for positional binding")
+
+	// The interleave is DuckArgs + PgMainArgs + DuckArgs (s3 WHERE, pg WHERE,
+	// visible WHERE); pin it so a future reordering can't silently mis-bind.
+	require.Equal(t, 2*len(dual.DuckArgs)+len(dual.PgMainArgs), len(args))
+}

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -69,7 +69,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "text equals bound",
 			cond: charKv("username", "equals:Alice"),
 			want: DualClauses{
-				PgMainClause: "m.text_01 = $1", PgMainArgs: []any{"Alice"},
+				PgMainClause: "m.text_01 = ?", PgMainArgs: []any{"Alice"},
 				PgClause: charEavClause("$2", "value_text", "=", "$3"), PgArgs: []any{int16(1), "Alice"},
 				DuckClause: "text_01 = ?", DuckArgs: []any{"Alice"},
 			},
@@ -79,7 +79,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "text bare value defaults to equals",
 			cond: charKv("username", "Alice"),
 			want: DualClauses{
-				PgMainClause: "m.text_01 = $1", PgMainArgs: []any{"Alice"},
+				PgMainClause: "m.text_01 = ?", PgMainArgs: []any{"Alice"},
 				PgClause: charEavClause("$2", "value_text", "=", "$3"), PgArgs: []any{int16(1), "Alice"},
 				DuckClause: "text_01 = ?", DuckArgs: []any{"Alice"},
 			},
@@ -99,7 +99,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "starts_with wildcards suffix",
 			cond: charKv("username", "starts_with:Al"),
 			want: DualClauses{
-				PgMainClause: "m.text_01 LIKE $1", PgMainArgs: []any{"Al%"},
+				PgMainClause: "m.text_01 LIKE ?", PgMainArgs: []any{"Al%"},
 				PgClause: charEavClause("$2", "value_text", "LIKE", "$3"), PgArgs: []any{int16(1), "Al%"},
 				DuckClause: "text_01 LIKE ?", DuckArgs: []any{"Al%"},
 			},
@@ -119,7 +119,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "integer gt: main int64, eav float64, duck float64",
 			cond: charKv("age", "gt:30"),
 			want: DualClauses{
-				PgMainClause: "m.integer_01 > $1", PgMainArgs: []any{int64(30)},
+				PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(30)},
 				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), float64(30)},
 				DuckClause: "integer_01 > CAST(? AS INTEGER)", DuckArgs: []any{float64(30)},
 			},
@@ -139,7 +139,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "big integral: main keeps int64 beyond 2^53, eav/duck lose to float64",
 			cond: charKv("age", "equals:9007199254740993"),
 			want: DualClauses{
-				PgMainClause: "m.integer_01 = $1", PgMainArgs: []any{int64(9007199254740993)},
+				PgMainClause: "m.integer_01 = ?", PgMainArgs: []any{int64(9007199254740993)},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), float64(9007199254740992)},
 				DuckClause: "integer_01 = CAST(? AS INTEGER)", DuckArgs: []any{float64(9007199254740992)},
 			},
@@ -149,7 +149,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "bool bool-int encoding: main int64(1), eav float64(1), duck true",
 			cond: charKv("active", "equals:1"),
 			want: DualClauses{
-				PgMainClause: "m.bool_01 = $1", PgMainArgs: []any{int64(1)},
+				PgMainClause: "m.bool_01 = ?", PgMainArgs: []any{int64(1)},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(5), float64(1)},
 				DuckClause: "bool_01 = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
 			},
@@ -159,7 +159,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "bool bool-text encoding zero: main \"0\", eav float64(0), duck false",
 			cond: charKv("verified", "equals:0"),
 			want: DualClauses{
-				PgMainClause: "m.text_02 = $1", PgMainArgs: []any{"0"},
+				PgMainClause: "m.text_02 = ?", PgMainArgs: []any{"0"},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(6), float64(0)},
 				DuckClause: "text_02 = CAST(? AS BOOLEAN)", DuckArgs: []any{false},
 			},
@@ -179,7 +179,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "date unix-ms encoding: main/eav int64 ms, duck time.Time",
 			cond: charKv("born", "gte:1700000000000"),
 			want: DualClauses{
-				PgMainClause: "m.bigint_01 >= $1", PgMainArgs: []any{int64(1700000000000)},
+				PgMainClause: "m.bigint_01 >= ?", PgMainArgs: []any{int64(1700000000000)},
 				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(8), int64(1700000000000)},
 				DuckClause: "bigint_01 >= CAST(? AS TIMESTAMP)", DuckArgs: []any{time.UnixMilli(1700000000000).UTC()},
 			},
@@ -187,9 +187,9 @@ func TestToDualClauses_Characterization(t *testing.T) {
 		},
 		{
 			name: "datetime ISO8601 encoding: main/eav bind ISO string, duck time.Time",
-			cond: charKv("joined", "gte:" + iso),
+			cond: charKv("joined", "gte:"+iso),
 			want: DualClauses{
-				PgMainClause: "m.text_03 >= $1", PgMainArgs: []any{iso},
+				PgMainClause: "m.text_03 >= ?", PgMainArgs: []any{iso},
 				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(9), iso},
 				DuckClause: "text_03 >= CAST(? AS TIMESTAMP)", DuckArgs: []any{isoTime},
 			},
@@ -197,7 +197,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 		},
 		{
 			name: "datetime unbound: eav unix-ms int64, duck time.Time",
-			cond: charKv("seen", "gte:" + iso),
+			cond: charKv("seen", "gte:"+iso),
 			want: DualClauses{
 				PgMainClause: "", PgMainArgs: nil,
 				PgClause: charEavClause("$1", "value_numeric", ">=", "$2"), PgArgs: []any{int16(10), int64(1704164645000)},
@@ -219,7 +219,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "AND(main leaf, vetoed OR): pg-main keeps only pushable branch",
 			cond: charAnd(charKv("username", "equals:Alice"), charOr(charKv("age", "gt:18"), charKv("tag", "equals:x"))),
 			want: DualClauses{
-				PgMainClause: "(m.text_01 = $1)", PgMainArgs: []any{"Alice"},
+				PgMainClause: "(m.text_01 = ?)", PgMainArgs: []any{"Alice"},
 				PgClause: "((" + charEavClause("$2", "value_text", "=", "$3") + ") AND (((" +
 					charEavClause("$4", "value_numeric", ">", "$5") + ") OR (" +
 					charEavClause("$6", "value_text", "=", "$7") + "))))",
@@ -233,7 +233,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "OR all pushable emits pg-main prefilter",
 			cond: charOr(charKv("username", "equals:A"), charKv("age", "gt:5")),
 			want: DualClauses{
-				PgMainClause: "((m.text_01 = $1) OR (m.integer_01 > $2))", PgMainArgs: []any{"A", int64(5)},
+				PgMainClause: "((m.text_01 = ?) OR (m.integer_01 > ?))", PgMainArgs: []any{"A", int64(5)},
 				PgClause: "((" + charEavClause("$3", "value_text", "=", "$4") + ") OR (" +
 					charEavClause("$5", "value_numeric", ">", "$6") + "))",
 				PgArgs:     []any{int16(1), "A", int16(2), float64(5)},
@@ -246,7 +246,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			name: "AND of two main predicates on same column",
 			cond: charAnd(charKv("age", "gt:10"), charKv("age", "lt:90")),
 			want: DualClauses{
-				PgMainClause: "((m.integer_01 > $1) AND (m.integer_01 < $2))", PgMainArgs: []any{int64(10), int64(90)},
+				PgMainClause: "((m.integer_01 > ?) AND (m.integer_01 < ?))", PgMainArgs: []any{int64(10), int64(90)},
 				PgClause: "((" + charEavClause("$3", "value_numeric", ">", "$4") + ") AND (" +
 					charEavClause("$5", "value_numeric", "<", "$6") + "))",
 				PgArgs:     []any{int16(2), float64(10), int16(2), float64(90)},
@@ -401,7 +401,7 @@ func TestStandaloneBuilders_Characterization(t *testing.T) {
 		idx := 0
 		clause, args, err := BuildPgMainClause(charAnd(charKv("username", "equals:Alice"), nil), cache, &idx)
 		require.NoError(t, err)
-		require.Equal(t, "(m.text_01 = $1)", clause)
+		require.Equal(t, "(m.text_01 = ?)", clause)
 		require.Equal(t, []any{"Alice"}, args)
 		require.Equal(t, 1, idx)
 	})


### PR DESCRIPTION
## Summary

A federated **service-path** query with a composite `AND` mixing a **main-column-bound** attribute and a **pure-EAV** attribute returned **zero rows** instead of the intersection, though each condition returned correctly alone (`mixed-hot-eav-page`, `tier-pushdown-mixed`, both trade schema 102 with `{symbol, exchange}`).

## Root cause (confirmed empirically)

`PgMainClause` (the `entity_main` pushdown predicate from `ToDualClauses`) is embedded **only** in the DuckDB federated template (`pg_source` WHERE) — it is never sent to Postgres — yet it emitted Postgres-style `$n` placeholders while the co-located `DuckClause` (s3_source / visible WHERE) uses DuckDB's positional `?`.

**DuckDB cannot mix `?` and `$n` in one statement.** The `$1` aliases positional param 1, colliding with the first `?` and shifting every `?` after it. For `symbol(main) AND exchange(EAV)`, the generated SQL was:

```
s3_source  WHERE (exchange = ?) AND (symbol = ?)      -- ?, ?
pg_source  WHERE (m.text_01 = $1)                     -- $1  <-- collides
visible    WHERE (exchange = ?) AND (symbol = ?)      -- ?, ?
ARGS = [NYSE, SYM00001, SYM00001, NYSE, SYM00001]
```

`$1` bound `m.text_01` (symbol column) to `NYSE`, and the visible re-filter bound the wrong operands → empty set. Each condition alone masked it: EAV-only has no `$n`; a single main-column filter binds identical values so the collision is invisible. Confirmed directly against the DuckDB CLI: the `?,?,$1,?,?` pattern errors/mis-binds; uniform `?` binds every value to the correct position.

> Note: this differs from the originating issue's suspected area. The benchmark shim (`translateDuckClauseToBenchmark`) actually produces a **correct** attribute-named clause; the operative defect is the placeholder-style mixing.

## Fix

Emit `?` from `pgMainTypedEmitter` so the whole DuckDB statement uses a single placeholder style. The advanced-template arg interleave (`DuckArgs, PgMainArgs, DuckArgs`) already matches left-to-right `?` order. `paramIndex` is still advanced so the sibling EAV EXISTS clause (`PgClause`, genuinely Postgres-bound) keeps its `$n` numbering.

## Tests

- **New regression** `TestDuckDBMixedComposite_NoPlaceholderStyleMixing`: renders the full DuckDB federated SQL for a main+EAV composite (non-benchmark schema) and asserts no `$` appears and placeholder count equals arg count. Verified it **fails** against the old `$n` emission.
- Updated characterization goldens to the corrected `?` (PgMainClause only; EAV `PgClause` `$n` numbering unchanged).
- Removed `mixed-hot-eav-page` / `tier-pushdown-mixed` from `knownFailingAssertions`; the full e2e harness (`TestBenchmarkWorkloadExecution_RunWithHarness`) passes with them re-enabled (both now return 20 rows).

## Follow-up (separate issue)

While rendering the SQL I confirmed a **separate** production bug: for non-benchmark schemas the DuckClause references the physical column (`integer_01`) while the CTE column is attribute-aliased (`age`) — masked in the benchmark only by `translateDuckClauseToBenchmark`. Filed as #167 (production namespace mismatch + shim retirement); orthogonal to this placeholder fix.

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
