### PR TITLE
fix(sqlgen): DuckClause references attribute names, retire benchmark translation shim (#167)

### DIFF
--- a/internal/federated/duckdb_namespace_regression_test.go
+++ b/internal/federated/duckdb_namespace_regression_test.go
@@ -1,0 +1,76 @@
+package federated
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDuckClause_NonBenchmark_ReferencesAttributeAliasedColumns is the #167
+// regression guard (row correctness, real DuckDB driver).
+//
+// The DuckDB federated CTEs (s3_source / pg_source / unified / visible) alias
+// every column by ATTRIBUTE name — e.g. `COALESCE(hot_vals.age, m.integer_01)
+// AS age`. The DuckClause (LOGICAL_WHERE_CLAUSE) is applied against those CTEs,
+// so it must reference the attribute name (`age`), not the physical entity_main
+// column (`integer_01`). Non-benchmark schemas have no translation shim, so a
+// DuckClause that emitted the physical column name would reference a column that
+// does not exist in the unified CTE — a binder error / empty result in
+// production. (Benchmark schemas masked this via translateDuckClauseToBenchmark.)
+//
+// This drives a `unified`-shaped CTE with attribute-aliased columns through the
+// real DuckDB engine using the DuckClause that ToDualClauses produces for a
+// column-bound (main) + pure-EAV composite, and asserts the correct intersection
+// comes back. Against the pre-fix code (physical column names) DuckDB raises a
+// binder error for the missing `integer_01` column.
+func TestDuckClause_NonBenchmark_ReferencesAttributeAliasedColumns(t *testing.T) {
+	// Non-benchmark schema cache: `age` is main-column-bound (integer_01),
+	// `tag` is a pure-EAV attribute.
+	cache := forma.SchemaAttributeCache{
+		"age": {AttributeID: 6, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("integer_01")}},
+		"tag": {AttributeID: 7, ValueType: forma.ValueTypeText},
+	}
+	cond := &forma.CompositeCondition{Logic: forma.LogicAnd, Conditions: []forma.Condition{
+		&forma.KvCondition{Attr: "age", Value: "gt:10"},
+		&forma.KvCondition{Attr: "tag", Value: "equals:x"},
+	}}
+
+	idx := 0
+	dc, err := sqlgen.ToDualClauses(cond, "eav_data", 7 /* non-benchmark */, cache, &idx)
+	require.NoError(t, err)
+	require.NotEmpty(t, dc.DuckClause)
+
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	// A `unified`-shaped relation whose columns are aliased by attribute name,
+	// exactly as SchemaProjection builds them (COALESCE(...) AS age, ... AS tag).
+	const rel = `(VALUES
+		('r1', 20, 'x'),
+		('r2', 5,  'x'),
+		('r3', 30, 'y'),
+		('r4', 15, 'x')
+	) AS unified(row_id, age, tag)`
+
+	query := "SELECT row_id FROM " + rel + " WHERE " + dc.DuckClause + " ORDER BY row_id"
+	rows, err := db.Query(query, dc.DuckArgs...)
+	require.NoError(t, err, "DuckClause must reference attribute-aliased columns present in the CTE (query=%s)", query)
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		got = append(got, id)
+	}
+	require.NoError(t, rows.Err())
+
+	// age>10 AND tag='x' -> r1 (20,x) and r4 (15,x); r2 fails age, r3 fails tag.
+	require.Equal(t, []string{"r1", "r4"}, got)
+}

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -256,12 +256,10 @@ func (e *DBFederatedQueryEngine) buildDuckDBQueryWithPlan(
 	// Record Postgres pushdown fragment
 	planCtx.recordPushdownFragment(dc.PgMainClause)
 
-	// For benchmark schemas, the DuckDB logical WHERE clause must reference
-	// attribute names (the S3 parquet has flat attribute columns), not entity_main
-	// column names which ToDualClauses resolves from the schema cache.
-	if isBenchmarkSchemaID(q.SchemaID) {
-		dc.DuckClause = translateDuckClauseToBenchmark(dc.DuckClause, cache)
-	}
+	// The DuckDB logical WHERE clause already references attribute names, which
+	// match the attribute-aliased columns projected by both the benchmark and
+	// production DuckDB CTEs (see resolveDuckDBColumn). No per-schema column-name
+	// translation is needed (#167).
 
 	// Compiled-plan cache (#142): skeleton + template args are reused per
 	// (fingerprint, shape, scope); condition/keyset/dirty operands bind per
@@ -562,20 +560,6 @@ func (e *DBFederatedQueryEngine) finalizeDuckDBExecutionPlan(
 
 	planCtx.opts.ExecutionPlan.Notes = append(planCtx.opts.ExecutionPlan.Notes,
 		fmt.Sprintf("pushdown_efficiency=%.3f (pg_rows=%d final_rows=%d)", ratio, pgRows, finalRows))
-}
-
-// translateDuckClauseToBenchmark rewrites a DuckDB WHERE clause from entity_main
-// column references to benchmark attribute names used in S3 parquet flat columns.
-func translateDuckClauseToBenchmark(clause string, cache forma.SchemaAttributeCache) string {
-	result := clause
-	for attr, meta := range cache {
-		if meta.ColumnBinding == nil {
-			continue
-		}
-		colName := string(meta.ColumnBinding.ColumnName)
-		result = strings.ReplaceAll(result, colName, attr)
-	}
-	return result
 }
 
 // needsEAVJoin checks whether the federated query requires an EAV data JOIN.

--- a/internal/sqlgen/dualpath_sql_generator_test.go
+++ b/internal/sqlgen/dualpath_sql_generator_test.go
@@ -64,8 +64,9 @@ func TestToDualClauses_SimpleKv_WithColumnBinding(t *testing.T) {
 	dc, err := ToDualClauses(cond, "eav_table", 1, cache, &paramIndex)
 	require.NoError(t, err)
 
-	// DuckDB side should use column binding name
-	require.Equal(t, "text_01 = ?", dc.DuckClause)
+	// DuckDB side references the attribute name (the DuckDB CTEs are aliased by
+	// attribute name), not the physical entity_main column (#167).
+	require.Equal(t, "username = ?", dc.DuckClause)
 	require.Equal(t, []any{"Alice"}, dc.DuckArgs)
 
 	// Postgres side still present
@@ -300,7 +301,7 @@ func TestBuildDuckClause_LikeOperators_WildcardRewrite_NoCast(t *testing.T) {
 	starts := &forma.KvCondition{Attr: "bio", Value: "starts_with:pre"}
 	clause, args, err := buildDuckClause(starts, cache)
 	require.NoError(t, err)
-	require.Contains(t, clause, "text_10")
+	require.Contains(t, clause, "bio")
 	require.Contains(t, clause, "LIKE")
 	require.NotContains(t, clause, "CAST(")
 	require.Len(t, args, 1)
@@ -310,7 +311,7 @@ func TestBuildDuckClause_LikeOperators_WildcardRewrite_NoCast(t *testing.T) {
 	contains := &forma.KvCondition{Attr: "bio", Value: "contains:mid"}
 	clause2, args2, err := buildDuckClause(contains, cache)
 	require.NoError(t, err)
-	require.Contains(t, clause2, "text_10")
+	require.Contains(t, clause2, "bio")
 	require.Contains(t, clause2, "LIKE")
 	require.NotContains(t, clause2, "CAST(")
 	require.Len(t, args2, 1)

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -146,10 +146,19 @@ func resolveMainTableColumn(attr string, meta forma.AttributeMetadata) string {
 	return "m." + attr
 }
 
-// resolveDuckDBColumn returns the column name for DuckDB queries.
-func resolveDuckDBColumn(attr string, cache forma.SchemaAttributeCache) string {
-	if m, ok := cache[attr]; ok && m.ColumnBinding != nil {
-		return string(m.ColumnBinding.ColumnName)
-	}
+// resolveDuckDBColumn returns the column name the DuckClause must reference.
+//
+// The DuckClause (LOGICAL_WHERE_CLAUSE) is only ever applied against the DuckDB
+// federated CTEs (s3_source / unified / visible), and those project every
+// attribute by its ATTRIBUTE name — `COALESCE(hot_vals.age, m.integer_01) AS age`
+// for column-bound attrs, `hot_vals.tag AS tag` for pure-EAV attrs. So the clause
+// must use the attribute name, never the physical entity_main column
+// (`integer_01`), which is not a column of those CTEs. Emitting the physical name
+// referenced a nonexistent column on non-benchmark schemas — a binder error /
+// empty result in production, previously masked in the benchmark by
+// translateDuckClauseToBenchmark (#167). Contrast resolveMainTableColumn, which
+// correctly uses the physical `m.<col>` because PgMainClause references the real
+// entity_main table `m` joined in the pg_source CTE.
+func resolveDuckDBColumn(attr string) string {
 	return attr
 }

--- a/internal/sqlgen/duckdb_namespace_render_test.go
+++ b/internal/sqlgen/duckdb_namespace_render_test.go
@@ -1,0 +1,97 @@
+package sqlgen
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// nonBenchmarkNamespaceParams builds render params for a non-benchmark schema
+// (id 7) with the real schema projection injected, so the rendered SQL contains
+// the actual attribute-aliased CTE columns (`... AS age`, `... AS tag`).
+func nonBenchmarkNamespaceParams(t *testing.T, cache forma.SchemaAttributeCache) map[string]any {
+	t.Helper()
+	sp, err := BuildSchemaProjection(7, cache)
+	require.NoError(t, err)
+
+	p := compiledParityParams()
+	p["S3SourceSelect"] = sp.S3SourceSelect
+	p["PGSourceSelect"] = sp.PGSourceSelect
+	p["PGGroupBy"] = sp.PGGroupBy
+	p["EAVPivotSelect"] = sp.EAVPivotSelect
+	p["EAVPivotAttrs"] = sp.EAVPivotAttrs
+	p["HasEAVPivot"] = sp.EAVPivotAttrs != ""
+	p["OuterSelect"] = sp.OuterSelect
+	return p
+}
+
+// TestDuckDBNamespace_RenderPaths_AttributeAliasedClause is the #167 render-path
+// coverage: it drives the changed column resolution through BOTH the direct
+// BuildDuckDBQuery renderer and the compiled-plan CompileDuckDBQuery/Bind
+// renderer for a NON-benchmark schema with a main-column + pure-EAV composite,
+// with the real schema projection injected and a main-column ORDER BY present.
+//
+// It asserts (a) the DuckClause emitted into the s3_source/visible WHERE uses the
+// attribute names that the projection aliases the CTE columns by (`age`, `tag`),
+// never the physical entity_main column (`integer_01`); (b) ORDER BY on a
+// main-column sort key is unaffected — it stays the physical descriptor name
+// (`integer_01`), which the outer SELECT aliases; and (c) both render paths agree.
+func TestDuckDBNamespace_RenderPaths_AttributeAliasedClause(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"age": {AttributeID: 6, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("integer_01")}},
+		"tag": {AttributeID: 7, ValueType: forma.ValueTypeText},
+	}
+	cond := &forma.CompositeCondition{Logic: forma.LogicAnd, Conditions: []forma.Condition{
+		&forma.KvCondition{Attr: "age", Value: "gt:10"},
+		&forma.KvCondition{Attr: "tag", Value: "equals:x"},
+	}}
+	q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{
+		SchemaID:  7,
+		Condition: cond,
+		AttributeOrders: []model.AttributeOrder{{
+			StorageLocation: forma.AttributeStorageLocationMain,
+			ColumnName:      "integer_01",
+			AttrName:        "age",
+			SortOrder:       forma.SortOrderDesc,
+		}},
+	}}
+
+	idx := 0
+	dc, err := ToDualClauses(cond, "eav_t", 7, cache, &idx)
+	require.NoError(t, err)
+
+	// The clause references attribute names (matching the CTE aliases), not the
+	// physical column the attribute is bound to.
+	require.Equal(t, "(age > CAST(? AS INTEGER)) AND (tag = ?)", dc.DuckClause)
+	require.NotContains(t, dc.DuckClause, "integer_01")
+
+	dirty := []uuid.UUID{uuid.New()}
+
+	// Direct renderer.
+	builtSQL, builtArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, nonBenchmarkNamespaceParams(t, cache), q, dirty, &dc)
+	require.NoError(t, err)
+
+	// Compiled-plan renderer.
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, nonBenchmarkNamespaceParams(t, cache), q, &dc, true)
+	require.NoError(t, err)
+	require.NotNil(t, compiled, "non-benchmark column-bound composite must be cacheable")
+	boundSQL, boundArgs := compiled.Bind(q, dc, dirty)
+
+	for name, sql := range map[string]string{"direct": builtSQL, "compiled": boundSQL} {
+		// The attribute-aliased clause flows into the DuckDB CTE WHERE clauses.
+		require.Contains(t, sql, dc.DuckClause, "%s render must embed the attribute-named DuckClause", name)
+		// The projection aliases the column-bound attribute by its attribute name.
+		require.Contains(t, sql, "AS age", "%s render must project the CTE column as the attribute name", name)
+		// ORDER BY on the main-column sort key is unaffected by the DuckClause fix:
+		// it references the physical descriptor name the outer SELECT aliases.
+		require.Contains(t, sql, "ORDER BY integer_01 DESC", "%s render ORDER BY must stay the outer physical alias", name)
+	}
+
+	// Both render paths must agree for this non-benchmark column-bound shape.
+	require.Equal(t, builtSQL, boundSQL, "compiled Bind must equal the direct build")
+	require.Equal(t, builtArgs, boundArgs)
+}

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -71,7 +71,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.text_01 = ?", PgMainArgs: []any{"Alice"},
 				PgClause: charEavClause("$2", "value_text", "=", "$3"), PgArgs: []any{int16(1), "Alice"},
-				DuckClause: "text_01 = ?", DuckArgs: []any{"Alice"},
+				DuckClause: "username = ?", DuckArgs: []any{"Alice"},
 			},
 			span: 3,
 		},
@@ -81,7 +81,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.text_01 = ?", PgMainArgs: []any{"Alice"},
 				PgClause: charEavClause("$2", "value_text", "=", "$3"), PgArgs: []any{int16(1), "Alice"},
-				DuckClause: "text_01 = ?", DuckArgs: []any{"Alice"},
+				DuckClause: "username = ?", DuckArgs: []any{"Alice"},
 			},
 			span: 3,
 		},
@@ -101,7 +101,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.text_01 LIKE ?", PgMainArgs: []any{"Al%"},
 				PgClause: charEavClause("$2", "value_text", "LIKE", "$3"), PgArgs: []any{int16(1), "Al%"},
-				DuckClause: "text_01 LIKE ?", DuckArgs: []any{"Al%"},
+				DuckClause: "username LIKE ?", DuckArgs: []any{"Al%"},
 			},
 			span: 3,
 		},
@@ -121,7 +121,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(30)},
 				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), float64(30)},
-				DuckClause: "integer_01 > CAST(? AS INTEGER)", DuckArgs: []any{float64(30)},
+				DuckClause: "age > CAST(? AS INTEGER)", DuckArgs: []any{float64(30)},
 			},
 			span: 3,
 		},
@@ -141,7 +141,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.integer_01 = ?", PgMainArgs: []any{int64(9007199254740993)},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), float64(9007199254740992)},
-				DuckClause: "integer_01 = CAST(? AS INTEGER)", DuckArgs: []any{float64(9007199254740992)},
+				DuckClause: "age = CAST(? AS INTEGER)", DuckArgs: []any{float64(9007199254740992)},
 			},
 			span: 3,
 		},
@@ -151,7 +151,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.bool_01 = ?", PgMainArgs: []any{int64(1)},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(5), float64(1)},
-				DuckClause: "bool_01 = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
+				DuckClause: "active = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
 			},
 			span: 3,
 		},
@@ -161,7 +161,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.text_02 = ?", PgMainArgs: []any{"0"},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(6), float64(0)},
-				DuckClause: "text_02 = CAST(? AS BOOLEAN)", DuckArgs: []any{false},
+				DuckClause: "verified = CAST(? AS BOOLEAN)", DuckArgs: []any{false},
 			},
 			span: 3,
 		},
@@ -181,7 +181,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.bigint_01 >= ?", PgMainArgs: []any{int64(1700000000000)},
 				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(8), int64(1700000000000)},
-				DuckClause: "bigint_01 >= CAST(? AS TIMESTAMP)", DuckArgs: []any{time.UnixMilli(1700000000000).UTC()},
+				DuckClause: "born >= CAST(? AS TIMESTAMP)", DuckArgs: []any{time.UnixMilli(1700000000000).UTC()},
 			},
 			span: 3,
 		},
@@ -191,7 +191,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 			want: DualClauses{
 				PgMainClause: "m.text_03 >= ?", PgMainArgs: []any{iso},
 				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(9), iso},
-				DuckClause: "text_03 >= CAST(? AS TIMESTAMP)", DuckArgs: []any{isoTime},
+				DuckClause: "joined >= CAST(? AS TIMESTAMP)", DuckArgs: []any{isoTime},
 			},
 			span: 3,
 		},
@@ -224,7 +224,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 					charEavClause("$4", "value_numeric", ">", "$5") + ") OR (" +
 					charEavClause("$6", "value_text", "=", "$7") + "))))",
 				PgArgs:     []any{int16(1), "Alice", int16(2), float64(18), int16(4), "x"},
-				DuckClause: "(text_01 = ?) AND ((integer_01 > CAST(? AS INTEGER)) OR (tag = ?))",
+				DuckClause: "(username = ?) AND ((age > CAST(? AS INTEGER)) OR (tag = ?))",
 				DuckArgs:   []any{"Alice", float64(18), "x"},
 			},
 			span: 7,
@@ -237,7 +237,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 				PgClause: "((" + charEavClause("$3", "value_text", "=", "$4") + ") OR (" +
 					charEavClause("$5", "value_numeric", ">", "$6") + "))",
 				PgArgs:     []any{int16(1), "A", int16(2), float64(5)},
-				DuckClause: "(text_01 = ?) OR (integer_01 > CAST(? AS INTEGER))",
+				DuckClause: "(username = ?) OR (age > CAST(? AS INTEGER))",
 				DuckArgs:   []any{"A", float64(5)},
 			},
 			span: 6,
@@ -250,7 +250,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 				PgClause: "((" + charEavClause("$3", "value_numeric", ">", "$4") + ") AND (" +
 					charEavClause("$5", "value_numeric", "<", "$6") + "))",
 				PgArgs:     []any{int16(2), float64(10), int16(2), float64(90)},
-				DuckClause: "(integer_01 > CAST(? AS INTEGER)) AND (integer_01 < CAST(? AS INTEGER))",
+				DuckClause: "(age > CAST(? AS INTEGER)) AND (age < CAST(? AS INTEGER))",
 				DuckArgs:   []any{float64(10), float64(90)},
 			},
 			span: 6,
@@ -369,7 +369,7 @@ func TestStandaloneBuilders_Characterization(t *testing.T) {
 	t.Run("duck nil child renders 1=1", func(t *testing.T) {
 		clause, args, err := BuildDuckClause(charAnd(charKv("username", "equals:Alice"), nil), cache)
 		require.NoError(t, err)
-		require.Equal(t, "(text_01 = ?) AND (1=1)", clause)
+		require.Equal(t, "(username = ?) AND (1=1)", clause)
 		require.Equal(t, []any{"Alice"}, args)
 	})
 

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -101,7 +101,7 @@ func normalizeLeaf(kv *forma.KvCondition, cache forma.SchemaAttributeCache, targ
 		leaf.PgMain = normalizePgMainPayload(kv, meta, hasMeta, classifyOK, lenient, lenientSQL, lenientSQLErr)
 	}
 	if targets&targetDuck != 0 {
-		leaf.Duck = normalizeDuckPayload(kv, cache, meta, hasMeta, lenientSQL, lenientSQLErr)
+		leaf.Duck = normalizeDuckPayload(kv, meta, hasMeta, lenientSQL, lenientSQLErr)
 	}
 	if targets&targetHybrid != 0 {
 		leaf.Hybrid = normalizeHybridPayload(kv, meta, hasMeta, lenientSQL, lenientSQLErr)
@@ -347,7 +347,6 @@ func normalizePgMainPayload(
 // no-cast emission.
 func normalizeDuckPayload(
 	kv *forma.KvCondition,
-	cache forma.SchemaAttributeCache,
 	meta forma.AttributeMetadata,
 	hasMeta bool,
 	lenientSQL conditionexpr.SQLOperatorResult,
@@ -357,7 +356,7 @@ func normalizeDuckPayload(
 		return DuckLeafPayload{Err: lenientSQLErr}
 	}
 
-	column := resolveDuckDBColumn(kv.Attr, cache)
+	column := resolveDuckDBColumn(kv.Attr)
 
 	if lenientSQL.SQLOperator == "LIKE" {
 		return DuckLeafPayload{Column: column, SQLOp: lenientSQL.SQLOperator, TextLike: true, Param: lenientSQL.Value}


### PR DESCRIPTION
## Summary

For **non-benchmark (production) schemas**, a federated DuckDB query with a column-bound-attribute filter referenced a **physical `entity_main` column** in the WHERE clause (e.g. `integer_01`) while the DuckDB CTEs it filters expose columns **aliased by attribute name** (e.g. `age`). DuckDB then raises `Binder Error: Referenced column "integer_01" not found`. Benchmark schemas were unaffected only because of the `translateDuckClauseToBenchmark` shim.

Discovered while fixing #161 (PR #166); confirmed independent and filed as #167.

## Root cause

`resolveDuckDBColumn` returned `meta.ColumnBinding.ColumnName` (physical column) for the DuckDB path, but the `DuckClause` (`LOGICAL_WHERE_CLAUSE`) is only ever applied against the attribute-aliased CTEs (`s3_source`, `unified`, `visible`), which project `COALESCE(hot_vals.age, m.integer_01) AS age`, `hot_vals.tag AS tag`, etc.

## Fix

- `resolveDuckDBColumn` returns the **attribute name** — matching the CTE aliasing for both production and benchmark — so the `DuckClause` is correct natively.
- **Deleted `translateDuckClauseToBenchmark`** (and its callsite): the naive nondeterministic `strings.ReplaceAll(colName -> attr)` shim is no longer needed.
- `resolveMainTableColumn` is unchanged and still correctly uses physical `m.<col>`, because `PgMainClause` references the real `entity_main` table `m` joined in `pg_source` (not the aliased CTE).

## Tests

- **New regression** `TestDuckClause_NonBenchmark_ReferencesAttributeAliasedColumns` (`internal/federated`): drives a `unified`-shaped attribute-aliased relation through the **real DuckDB driver** with the `DuckClause` from a main+EAV composite and asserts the correct intersection (`r1`, `r4`). Verified it **fails pre-fix** with the `integer_01` binder error.
- Updated characterization / dualpath goldens: `DuckClause` now uses attribute names (`username`, `age`, `active`, …). `PgMainClause` (`m.<col>`) and the EAV `PgClause` (`$n`) are unchanged.
- **Full benchmark e2e harness** (`TestBenchmarkWorkloadExecution_RunWithHarness`) passes with the shim removed — real row-correctness coverage for benchmark schemas.
- Full non-e2e suite, gofmt, goimports, golangci-lint (v1.64.8) all clean.

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)