### PR TITLE
fix(benchmark): reconstruct pure-EAV attributes for hot records in truth-pass oracle (#163)

### DIFF
--- a/internal/e2e_harness/federated/benchmark/loaded_state.go
+++ b/internal/e2e_harness/federated/benchmark/loaded_state.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	forma "github.com/lychee-technology/forma"
 	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
 )
 
@@ -112,7 +113,89 @@ func loadHotStateRecords(ctx context.Context, h *federated.FederatedTestHarness)
 	if err := rows.Err(); err != nil {
 		return nil, nil, fmt.Errorf("iterate hot state snapshot: %w", err)
 	}
+	// The fixed pivot above only reconstructs the handful of column-bound /
+	// hardcoded attributes. Pure-EAV attributes (e.g. orderChannel) would be
+	// lost, which silently drops hot candidates from truth-pass filters on those
+	// attributes (#163). Enrich each hot record with every remaining EAV
+	// attribute, driven by the schema attribute cache, so filters on any
+	// attribute reconstruct the correct candidate set.
+	if err := enrichHotRecordsWithEAVAttributes(ctx, h, registry, records); err != nil {
+		return nil, nil, err
+	}
 	return records, keys, nil
+}
+
+// enrichHotRecordsWithEAVAttributes adds every EAV attribute present in the hot
+// tier to each reconstructed record's Attributes, keyed by attribute name via
+// the schema cache. It only fills attributes the fixed pivot in
+// scanLoadedHotRecord did not already set, so the hardcoded column-bound
+// reconstruction (and its precedence) is preserved. Values mirror the
+// eav_data storage convention (value_text for text, value_numeric otherwise),
+// matching what the federated engine reads for the same rows.
+func enrichHotRecordsWithEAVAttributes(ctx context.Context, h *federated.FederatedTestHarness, registry forma.SchemaRegistry, records []GeneratedRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	// Build (schema_id, attr_id) -> attribute name from the schema caches.
+	attrNames := make(map[int16]map[int16]string)
+	for _, fixture := range DefaultSchemaFixtures() {
+		_, cache, err := registry.GetSchemaAttributeCacheByID(fixture.ID)
+		if err != nil {
+			return fmt.Errorf("load schema %d attribute cache: %w", fixture.ID, err)
+		}
+		byID := make(map[int16]string, len(cache))
+		for name, meta := range cache {
+			byID[meta.AttributeID] = name
+		}
+		attrNames[fixture.ID] = byID
+	}
+	byKey := make(map[string]*GeneratedRecord, len(records))
+	for i := range records {
+		byKey[schemaRowKey(records[i].SchemaID, records[i].RowID)] = &records[i]
+	}
+	rows, err := h.PGDB.QueryContext(ctx, `
+		SELECT ed.schema_id, ed.row_id, ed.attr_id,
+			MAX(ed.value_text) AS value_text,
+			MAX(ed.value_numeric) AS value_numeric
+		FROM eav_data ed
+		JOIN change_log cl ON cl.schema_id = ed.schema_id AND cl.row_id = ed.row_id
+		WHERE cl.flushed_at = 0
+		GROUP BY ed.schema_id, ed.row_id, ed.attr_id
+	`)
+	if err != nil {
+		return fmt.Errorf("load hot eav attributes: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var schemaID, attrID int16
+		var rowID uuid.UUID
+		var valueText sql.NullString
+		var valueNumeric sql.NullFloat64
+		if err := rows.Scan(&schemaID, &rowID, &attrID, &valueText, &valueNumeric); err != nil {
+			return fmt.Errorf("scan hot eav attribute: %w", err)
+		}
+		record, ok := byKey[schemaRowKey(schemaID, rowID)]
+		if !ok {
+			continue
+		}
+		name, ok := attrNames[schemaID][attrID]
+		if !ok {
+			continue
+		}
+		if _, exists := record.Attributes[name]; exists {
+			continue
+		}
+		switch {
+		case valueText.Valid:
+			record.Attributes[name] = valueText.String
+		case valueNumeric.Valid:
+			record.Attributes[name] = valueNumeric.Float64
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate hot eav attributes: %w", err)
+	}
+	return nil
 }
 
 func scanLoadedHotRecord(rows *sql.Rows) (GeneratedRecord, error) {

--- a/internal/e2e_harness/federated/benchmark/truthpass_eav_low_selectivity_e2e_test.go
+++ b/internal/e2e_harness/federated/benchmark/truthpass_eav_low_selectivity_e2e_test.go
@@ -1,0 +1,76 @@
+//go:build e2e
+
+package benchmark
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	federated "github.com/lychee-technology/forma/internal/e2e_harness/federated"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTruthPassOracleFiltersPureEAVAttribute pins #163: the truth-pass oracle
+// must not undercount a filter on a pure-EAV attribute that is absent from the
+// harness's hardcoded attribute maps (orderChannel). The undercount only
+// manifests under a distribution that puts updated records in the hot tier
+// (hotspot): hot records are reconstructed from Postgres, and before the fix
+// that reconstruction dropped every EAV attribute outside the hardcoded set, so
+// hot orderChannel="web" candidates were silently excluded from the oracle's
+// expected set while the production/service query returned them — expected <
+// actual. This asserts the oracle's expected result matches the service actual
+// for eav-low-selectivity-page (total-records and page-row-ids).
+func TestTruthPassOracleFiltersPureEAVAttribute(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	h, err := federated.NewFederatedTestHarness(ctx)
+	require.NoError(t, err)
+	defer h.Cleanup(ctx)
+
+	// Hotspot distribution is required: it appends updated records that rewrite
+	// orderChannel and land in the hot tier, which is where the reconstruction
+	// gap bit. Uniform (all-cold) does not reproduce the undercount.
+	runner, err := NewRunner(Config{
+		Mode:          ExecutionModePlan,
+		Scale:         ScaleSmall,
+		Distribution:  DistributionHotspot,
+		Iterations:    2,
+		PageSize:      20,
+		Seed:          42,
+		TradeCount:    120,
+		CustomerCount: 12,
+		SecurityCount: 6,
+		OverlapRatio:  0.10,
+		DeleteRatio:   0.05,
+		Workloads: []string{
+			"eav-selective-page",       // control: hardcoded EAV attr (exchange)
+			"eav-low-selectivity-page", // the pure-EAV attr under test (orderChannel)
+			"mixed-hot-eav-page",       // control: mixed hot + EAV
+		},
+	}.WithDefaults())
+	require.NoError(t, err)
+
+	result, err := runner.RunWithHarness(ctx, h, TierMixBalanced)
+	require.NoError(t, err)
+
+	var checked int
+	for _, execution := range result.Executions {
+		if execution.Name != "eav-low-selectivity-page" {
+			continue
+		}
+		checked++
+		require.True(t, execution.Passed,
+			"eav-low-selectivity-page must pass all correctness assertions (#163)")
+		for _, a := range execution.Assertions {
+			switch a.Name {
+			case "total-records-match-expected", "page-row-ids-match-expected":
+				require.True(t, a.Passed,
+					"assertion %q must pass (oracle must not undercount pure-EAV orderChannel): %s",
+					a.Name, a.Message)
+			}
+		}
+	}
+	require.Positive(t, checked, "expected eav-low-selectivity-page to be executed")
+}

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -22,19 +22,10 @@ import (
 // issue-referenced allowlist, not a whole-workload skip. Remove entries as
 // their issues land.
 //
-//   - eav-low-selectivity-page: the truth-pass oracle's harness query cannot
-//     filter the pure-EAV attribute orderChannel (absent from the hardcoded
-//     benchmarkQueryColumn / targetedHotFilterExpression / hot-pivot /
-//     parquet-projection maps), so it undercounts hot-tier candidates. The #156
-//     batching proved (via TestTruthPassBatchEqualsPerCandidate) that this is a
-//     harness truth-query bug independent of the per-candidate/batch split, so
-//     it is tracked on its own (#163).
-var knownFailingAssertions = map[string]map[string]string{
-	"eav-low-selectivity-page": {
-		"total-records-match-expected": "#163",
-		"page-row-ids-match-expected":  "#163",
-	},
-}
+// Currently empty: #163 (eav-low-selectivity-page pure-EAV orderChannel
+// undercount) is fixed, so no correctness assertion is expected to fail. Its
+// regression coverage lives in TestTruthPassOracleFiltersPureEAVAttribute.
+var knownFailingAssertions = map[string]map[string]string{}
 
 // assertWorkloadOraclesGreen fails the test if any workload has a failed
 // correctness assertion that is not in the documented knownFailingAssertions


### PR DESCRIPTION
## Summary

Fixes #163. The truth-pass oracle undercounted `eav-low-selectivity-page`
(`orderChannel = "web"`): oracle `expected` dropped the ~hot-tier `web` rows the
production/service query returns (issue's numbers: `expected=65` vs `actual=74`).

## Root cause — not the harness truth query the issue hypothesized

Empirical reproduction (small-scale `RunWithHarness`, hotspot distribution) rules
out the query maps the issue blamed:

- The **visibility sweep** (`collectVisibleRowIDs` → `ExecuteFederatedQuery`)
  passes `orderChannel` into a query that doesn't know the attribute, so it
  **silently drops the predicate and returns an unfiltered superset** of all
  rows. A superset *includes* the hot `web` rows — it cannot undercount.
- The real drop is in **candidate reconstruction**: `buildLoadedStateSnapshot`
  keeps cold records as raw generated records (which carry `orderChannel`) but
  rebuilds **hot** records via `scanLoadedHotRecord`, which only repopulated the
  hardcoded column-bound attributes and dropped every pure-EAV attribute. Hot
  `web` candidates were excluded from `expected` while the engine (reading
  `eav_data`) still returned them.

Probe evidence (hotspot, 120 trades): before fix `hotTradesWithOrderChannel=0`,
the missing `web` rows are all `hot=true, snapshotHasOrderChannel=false,
inVisibleSweep=true`.

## Fix

Enrich each reconstructed hot record with every remaining EAV attribute, driven
by the schema attribute cache, reading the same `eav_data` the federated engine
reads (`value_text`/`value_numeric`). Only fills attributes the fixed pivot did
not set, so the existing column-bound reconstruction and its precedence are
untouched. The undercount only manifests under hotspot (updated records land
hot); uniform is all-cold and unaffected.

**Result:** `eav-low-selectivity-page` now `expected == actual == 25` (was
`21 vs 25` at this scale), stable across iterations.

## Scope decision

The harness truth query is left as-is. Its arbitrary-EAV superset behavior is
correct-but-loose and confirmed unnecessary for the fix; generalizing it is the
exact query-gen change class that regressed in #161/#167, so it was deliberately
not touched.

## Testing

- New `TestTruthPassOracleFiltersPureEAVAttribute` (e2e, hotspot) — asserts the
  oracle `expected` matches the service `actual` for the pure-EAV filter.
  Confirmed it **fails** with the enrichment disabled and **passes** with it.
- `TestBenchmarkWorkloadExecution_RunWithHarness` (empty `knownFailingAssertions`)
  and `TestTruthPassBatchEqualsPerCandidate` — green.
- Container-free package tests, `go vet`, `make lint`, `goimports` — clean.

## Acceptance criteria

- [x] `eav-low-selectivity-page` oracle matches truth / production actual (no undercount).
- [x] Regression test pins a pure-EAV, non-hardcoded-attribute filter at small scale.
- [x] Removed `eav-low-selectivity-page` from `knownFailingAssertions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)