### PR TITLE
fix(sqlgen): remove synthetic name/version attribute injection from BuildSchemaProjection (#192)

### DIFF
--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -87,10 +87,11 @@ Options: `WithSeed`, `WithSchemaDir`, `WithFlushThresholds` (#179),
 | `e2e_wide` | 21 | one attribute per scalar `forma.ValueType`, mixed main-column/EAV storage (#174) |
 | `e2e_second` | 22 | second schema for multi-schema isolation (#189) |
 
-All fixtures explicitly define `name` and `version` text attributes:
-`sqlgen.BuildSchemaProjection` injects synthetic ones into every schema and
-real CDC exports cannot satisfy the injected columns (see the follow-ups in
-PR for #173). `forma.ValueTypeList` is not covered yet.
+Fixtures define only the attributes their tests use: the synthetic
+`name`/`version` injection in `sqlgen.BuildSchemaProjection` was removed in
+#192, so schemas need no workaround attributes. (`e2e_simple` keeps a real,
+column-bound `name` attribute — proving a schema that legitimately defines
+one still works.) `forma.ValueTypeList` is not covered yet.
 
 Note: the DuckDB federated path requires at least one parquet file per
 schema (`read_parquet` errors on an empty glob) — matching production,

--- a/internal/e2e_harness/production/schemas/e2e_second.json
+++ b/internal/e2e_harness/production/schemas/e2e_second.json
@@ -9,12 +9,6 @@
     },
     "code": {
       "type": "integer"
-    },
-    "name": {
-      "type": "string"
-    },
-    "version": {
-      "type": "string"
     }
   }
 }

--- a/internal/e2e_harness/production/schemas/e2e_second_attributes.json
+++ b/internal/e2e_harness/production/schemas/e2e_second_attributes.json
@@ -9,13 +9,5 @@
     "column_binding": {
       "col_name": "integer_01"
     }
-  },
-  "name": {
-    "attributeID": 3,
-    "valueType": "text"
-  },
-  "version": {
-    "attributeID": 4,
-    "valueType": "text"
   }
 }

--- a/internal/e2e_harness/production/schemas/e2e_simple.json
+++ b/internal/e2e_harness/production/schemas/e2e_simple.json
@@ -9,9 +9,6 @@
     },
     "value": {
       "type": "number"
-    },
-    "version": {
-      "type": "string"
     }
   }
 }

--- a/internal/e2e_harness/production/schemas/e2e_simple_attributes.json
+++ b/internal/e2e_harness/production/schemas/e2e_simple_attributes.json
@@ -9,9 +9,5 @@
   "value": {
     "attributeID": 2,
     "valueType": "numeric"
-  },
-  "version": {
-    "attributeID": 3,
-    "valueType": "text"
   }
 }

--- a/internal/e2e_harness/production/schemas/e2e_wide.json
+++ b/internal/e2e_harness/production/schemas/e2e_wide.json
@@ -38,12 +38,6 @@
     "seen": {
       "type": "string",
       "format": "date-time"
-    },
-    "name": {
-      "type": "string"
-    },
-    "version": {
-      "type": "string"
     }
   }
 }

--- a/internal/e2e_harness/production/schemas/e2e_wide_attributes.json
+++ b/internal/e2e_harness/production/schemas/e2e_wide_attributes.json
@@ -56,13 +56,5 @@
   "seen": {
     "attributeID": 10,
     "valueType": "datetime"
-  },
-  "name": {
-    "attributeID": 11,
-    "valueType": "text"
-  },
-  "version": {
-    "attributeID": 12,
-    "valueType": "text"
   }
 }

--- a/internal/sqlgen/duckdb_schema_projection.go
+++ b/internal/sqlgen/duckdb_schema_projection.go
@@ -98,24 +98,6 @@ func BuildSchemaProjection(schemaID int16, cache forma.SchemaAttributeCache) (*S
 		attrIDs:          make(map[string]int),
 	}
 
-	// Work on a local copy: the caller's cache is a shared, read-only
-	// registry snapshot and must never be mutated here (#142 phase 3).
-	local := make(forma.SchemaAttributeCache, len(cache)+2)
-	for name, meta := range cache {
-		local[name] = meta
-	}
-	cache = local
-
-	// Collect column-bound attributes and EAV-only attributes
-	ensureAttr := func(name string, vt forma.ValueType) {
-		if _, exists := cache[name]; exists {
-			return
-		}
-		cache[name] = forma.AttributeMetadata{ValueType: vt}
-	}
-	ensureAttr("name", forma.ValueTypeText)
-	ensureAttr("version", forma.ValueTypeText)
-
 	attrs := make([]attrProjectionInfo, 0, len(cache))
 	for name, meta := range cache {
 		ai := attrProjectionInfo{name: name, meta: meta}

--- a/internal/sqlgen/duckdb_sql_generator_test.go
+++ b/internal/sqlgen/duckdb_sql_generator_test.go
@@ -402,3 +402,33 @@ func TestBuildDuckClause_GivenNestedAndOrConditions_WhenClauseBuilt_ThenGrouping
 	require.Equal(t, "(status = ?) AND ((score > CAST(? AS DECIMAL(38,10))) OR (email LIKE ?))", clause)
 	require.Equal(t, []any{"active", "10", "ops%"}, args)
 }
+
+// TestBuildSchemaProjection_NoSyntheticNameVersion pins issue #192: the
+// projection must reference only attributes the schema actually defines.
+// Real CDC parquet exports contain no columns for undefined attributes, so
+// the legacy synthetic name/version injection made warm/cold federated
+// queries reference parquet columns that don't exist.
+func TestBuildSchemaProjection_NoSyntheticNameVersion(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"age": {AttributeID: 3, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: "integer_01"}},
+	}
+	sp, err := BuildSchemaProjection(7, cache)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		[]string{"row_id", "created_at", "ver_ts", "deleted_ts", "age"},
+		sp.UnifiedColumnNames)
+	require.Equal(t,
+		"row_id, changed_at AS created_at, changed_at AS ver_ts, deleted_at AS deleted_ts, age",
+		sp.S3SourceSelect)
+	require.Empty(t, sp.EAVAttrs)
+	require.False(t, sp.HasEAVAttrs)
+	// Bound-attribute IDs still enter the pivot WHERE (pre-existing behavior,
+	// harmless: eav_data never holds rows for column-bound attributes). Do NOT
+	// change buildEAVPivot to make this empty — that's out of scope (#192).
+	require.Equal(t, "3", sp.EAVPivotAttrs)
+	require.NotContains(t, sp.PGSourceSelect, "name")
+	require.NotContains(t, sp.PGSourceSelect, "version")
+	require.NotContains(t, sp.OuterSelect, "'version'")
+}

--- a/internal/sqlgen/duckdb_type_mapper_test.go
+++ b/internal/sqlgen/duckdb_type_mapper_test.go
@@ -397,7 +397,8 @@ func TestIsListType_False(t *testing.T) {
 }
 
 // TestBuildSchemaProjectionDoesNotMutateInput pins #142 phase 3: the shared
-// registry snapshot passed in must not gain the synthetic name/version attrs.
+// registry snapshot passed in must never be mutated (e.g. by re-introducing
+// something like the retired synthetic name/version injection, #192).
 func TestBuildSchemaProjectionDoesNotMutateInput(t *testing.T) {
 	cache := forma.SchemaAttributeCache{
 		"age": {AttributeID: 3, ValueType: forma.ValueTypeInteger},


### PR DESCRIPTION
Closes #192. Follow-up from PR #191 (#173, epic #172).

## What

- `BuildSchemaProjection` no longer injects synthetic `name`/`version` text attributes; the projection is derived purely from the schema attribute cache. The defensive cache copy is gone too (nothing mutates the cache anymore; the #142 non-mutation test still guards the invariant, comment refreshed).
- New regression test `TestBuildSchemaProjection_NoSyntheticNameVersion` pins the behavior, including that bound-attribute IDs still enter the EAV pivot WHERE (pre-existing behavior, deliberately untouched for minimal scope).
- Production harness fixtures drop the workaround attributes: `e2e_wide` and `e2e_second` now define no `name`/`version` at all; `e2e_simple` keeps its real column-bound `name` (used by query tests — doubles as coverage that a schema legitimately defining `name` still works). Harness README note updated.
- Benchmark path untouched: `BuildBenchmarkProjections`/`BuildBenchmarkS3Projection`/`BuildBenchmarkOuterSelect` never call `BuildSchemaProjection`, and benchmark fixtures do not rely on the injection. CDC export side verified symmetric: `buildSchemaDrivenProjection` derives columns from the same cache with no injection, so parquet columns and query projection agree by construction.

## Verification

- `make test-e2e-production` — PASS. `TestProductionSmoke` drives `e2e_wide` (no `name`/`version`) through real CDC parquet with tier hits cold=10 / warm=16 / hot=3, covering the exact warm/cold failure mode from the issue.
- `go test ./...` — all packages ok (no golden/characterization test expects the synthetic columns).
- `make lint` — clean.
- `make benchmark-smoke` — ok (exit 0).

## Follow-up (from final review, non-blocking)

- `internal/sqlgen/duckdb_schema_projection.go` is 712 lines (> 500-line limit), pre-existing — this PR shrinks it by 18. Suggested split per #165/#171 precedent: move `BuildBenchmark*` into `duckdb_benchmark_projection.go`.
- Toy-schema template-param defaults in `injectDuckDBTemplateParams` (`duckdb_template_renderer.go`) remain; out of scope here, worth a small cleanup issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)