### PR TITLE
fix(cdc): export main-column-bound unix_ms dates as epoch-ms BIGINT (#194)

### DIFF
--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -383,6 +383,13 @@ func duckTypeForValue(v forma.ValueType) string {
 	}
 }
 
+// castMainValue projects a main-column-bound attribute into its parquet
+// column. The output type must match what the federated reader consumes:
+// its projection casts date/datetime attrs with CAST(attr AS BIGINT)
+// (sqlgen.duckDBAttrCast) and scans them as epoch-ms int64, mirroring the
+// write side (transform.storeInMainColumn), which stores unix_ms-encoded
+// dates as raw epoch millis in a bigint column. So unix_ms dates must stay
+// epoch-ms BIGINT here, matching castEAVValue's date handling (#194).
 func castMainValue(col string, meta forma.AttributeMetadata) string {
 	switch meta.ValueType {
 	case forma.ValueTypeBool:
@@ -396,12 +403,12 @@ func castMainValue(col string, meta forma.AttributeMetadata) string {
 		}
 	case forma.ValueTypeDate:
 		if meta.ColumnBinding != nil && meta.ColumnBinding.Encoding == forma.MainColumnEncodingUnixMs {
-			return fmt.Sprintf("CAST(to_timestamp(CAST(%s AS DOUBLE)/1000) AS DATE)", col)
+			return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", col)
 		}
 		return fmt.Sprintf("TRY_CAST(%s AS DATE)", col)
 	case forma.ValueTypeDateTime:
 		if meta.ColumnBinding != nil && meta.ColumnBinding.Encoding == forma.MainColumnEncodingUnixMs {
-			return fmt.Sprintf("to_timestamp(CAST(%s AS DOUBLE)/1000)", col)
+			return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", col)
 		}
 		return fmt.Sprintf("TRY_CAST(%s AS TIMESTAMP)", col)
 	case forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeNumeric:

--- a/internal/cdc/export_sql_shared_test.go
+++ b/internal/cdc/export_sql_shared_test.go
@@ -30,6 +30,18 @@ func TestBuildExportSQL_CommonSemanticsAcrossModes(t *testing.T) {
 			AttributeID:   11,
 			ValueType:     forma.ValueTypeBool,
 		},
+		"joined": {
+			AttributeName: "joined",
+			AttributeID:   12,
+			ValueType:     forma.ValueTypeDate,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02, Encoding: forma.MainColumnEncodingUnixMs},
+		},
+		"touched": {
+			AttributeName: "touched",
+			AttributeID:   13,
+			ValueType:     forma.ValueTypeDateTime,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint03, Encoding: forma.MainColumnEncodingUnixMs},
+		},
 	}
 
 	tests := []struct {
@@ -132,6 +144,11 @@ func TestBuildExportSQL_CommonSemanticsAcrossModes(t *testing.T) {
 			if !strings.Contains(res.eQuery, "attr_id IN (11)") {
 				t.Fatalf("eav query missing attr_id filter: %s", res.eQuery)
 			}
+			// Bound unix_ms date/datetime must stay epoch-ms BIGINT in parquet:
+			// the federated reader casts date attrs with CAST(attr AS BIGINT) (#194).
+			require.Contains(t, res.sql, "TRY_CAST(m.bigint_02 AS BIGINT) AS joined")
+			require.Contains(t, res.sql, "TRY_CAST(m.bigint_03 AS BIGINT) AS touched")
+			require.NotContains(t, res.sql, "to_timestamp")
 		})
 	}
 }
@@ -283,6 +300,66 @@ func TestBuildSchemaDrivenProjection_PreservesProjectionSplitAcrossBoundAndUnbou
 	require.Equal(t, []string{"MAX(CASE WHEN attr_id = 31 THEN TRY_CAST(value_numeric AS DOUBLE) END) AS annual_revenue"}, projection.eavAgg)
 	require.Equal(t, []string{"e.annual_revenue"}, projection.eavSelect)
 	require.Equal(t, []int16{31}, projection.eavAttrIDs)
+}
+
+func TestBuildSchemaDrivenProjection_BoundUnixMsDateAndDatetimeExportEpochMsBigint(t *testing.T) {
+	projection := buildSchemaDrivenProjection(forma.SchemaAttributeCache{
+		"joined": {
+			AttributeName: "joined",
+			AttributeID:   13,
+			ValueType:     forma.ValueTypeDate,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02, Encoding: forma.MainColumnEncodingUnixMs},
+		},
+		"touched": {
+			AttributeName: "touched",
+			AttributeID:   14,
+			ValueType:     forma.ValueTypeDateTime,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint03, Encoding: forma.MainColumnEncodingUnixMs},
+		},
+	})
+
+	require.Equal(t, []string{
+		"TRY_CAST(m.bigint_02 AS BIGINT) AS joined",
+		"TRY_CAST(m.bigint_03 AS BIGINT) AS touched",
+	}, projection.mainProjections)
+}
+
+func TestCastMainValue_DateAndDatetimeEncodings(t *testing.T) {
+	unixMs := &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02, Encoding: forma.MainColumnEncodingUnixMs}
+	unbound := &forma.MainColumnBinding{ColumnName: forma.MainColumnText01}
+
+	tests := []struct {
+		name     string
+		meta     forma.AttributeMetadata
+		expected string
+	}{
+		{
+			name:     "date unix_ms stays epoch-ms bigint",
+			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDate, ColumnBinding: unixMs},
+			expected: "TRY_CAST(m.bigint_02 AS BIGINT)",
+		},
+		{
+			name:     "datetime unix_ms stays epoch-ms bigint",
+			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime, ColumnBinding: unixMs},
+			expected: "TRY_CAST(m.bigint_02 AS BIGINT)",
+		},
+		{
+			name:     "date default encoding keeps native cast",
+			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDate, ColumnBinding: unbound},
+			expected: "TRY_CAST(m.bigint_02 AS DATE)",
+		},
+		{
+			name:     "datetime default encoding keeps native cast",
+			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime, ColumnBinding: unbound},
+			expected: "TRY_CAST(m.bigint_02 AS TIMESTAMP)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, castMainValue("m.bigint_02", tt.meta))
+		})
+	}
 }
 
 func TestBuildEAVAggregationSQL_GroupsByRowIDWhenNoAggregatesExist(t *testing.T) {

--- a/internal/e2e_harness/production/date_parity_e2e_test.go
+++ b/internal/e2e_harness/production/date_parity_e2e_test.go
@@ -1,0 +1,206 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestBoundDateParityAcrossTiers proves the #194 contract end to end: a
+// main-column-bound date/datetime attribute (unix_ms encoding) must read
+// back the identical epoch-ms int64 from the hot tier (Postgres), the cold
+// tier (base parquet from RunInit), and the warm tier (delta parquet from a
+// flush). Three layers of parity, from physical to logical:
+//  1. the parquet columns are physically BIGINT (typeof check);
+//  2. the raw parquet values equal the hot-read values row by row;
+//  3. the federated query returns the same int64s as the hot query.
+//
+// The hot baseline itself is anchored to the generated event attributes, so
+// a bug that corrupts both sides identically cannot pass.
+func TestBoundDateParityAcrossTiers(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 12})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	truth := boundDateTruth(t, creates)
+
+	// Hot baseline: everything is unflushed, PreferHot serves from Postgres.
+	hot, err := env.Query(ctx, Query{Schema: wide, PreferHot: true, Limit: 100})
+	if err != nil {
+		t.Fatalf("hot query: %v", err)
+	}
+	baseline := collectBoundDates(t, "hot", hot, len(creates))
+	for rowID, want := range truth {
+		if baseline[rowID] != want {
+			t.Fatalf("hot read of %s = %+v, want %+v (event attrs)", rowID, baseline[rowID], want)
+		}
+	}
+
+	// Cold tier: base parquet becomes the only source for creates[0:6].
+	if _, err := env.RunInit(ctx, wide); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	env.ExecSQL(ctx,
+		"DELETE FROM change_log WHERE schema_id = $1 AND row_id = ANY($2)",
+		wide.ID, rowIDs(creates[0:6]))
+
+	// Warm tier: flush creates[6:12] into a delta file.
+	if _, err := env.RunFlush(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// Hot tier: two more creates that stay unflushed.
+	hotCreates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 2})
+	if err := env.ApplyEvents(ctx, hotCreates...); err != nil {
+		t.Fatalf("apply hot creates: %v", err)
+	}
+	for rowID, want := range boundDateTruth(t, hotCreates) {
+		baseline[rowID] = want
+	}
+
+	// Layer 1+2: physical parquet parity for base and delta files.
+	manifests, err := env.loadManifests(ctx)
+	if err != nil {
+		t.Fatalf("load manifests: %v", err)
+	}
+	m := manifests[wide.ID]
+	if m == nil {
+		t.Fatal("no manifest for e2e_wide")
+	}
+	checked := map[string]bool{}
+	for _, f := range m.Files {
+		assertParquetBoundDates(ctx, t, env, f.Path, f.Tier, baseline)
+		checked[f.Tier] = true
+	}
+	if !checked["base"] || !checked["delta"] {
+		t.Fatalf("expected both base and delta parquet files, got tiers %v", checked)
+	}
+
+	// Layer 3: the federated read returns the hot-identical int64s.
+	fed, err := env.Query(ctx, Query{Schema: wide, Limit: 100})
+	if err != nil {
+		t.Fatalf("federated query: %v", err)
+	}
+	if !fed.Plan.Routing.UseDuckDB {
+		t.Errorf("federated query did not route to duckdb: %+v", fed.Plan.Routing)
+	}
+	fedDates := collectBoundDates(t, "federated", fed, len(creates)+len(hotCreates))
+	for rowID, want := range baseline {
+		got, ok := fedDates[rowID]
+		if !ok {
+			t.Errorf("federated result missing row %s", rowID)
+			continue
+		}
+		if got != want {
+			t.Errorf("federated read of %s = %+v, want hot-identical %+v", rowID, got, want)
+		}
+	}
+}
+
+type boundDates struct {
+	joined  int64 // epoch-ms, bigint_02
+	touched int64 // epoch-ms, bigint_03
+}
+
+// boundDateTruth derives the expected epoch-ms values straight from the
+// generated event attributes, independent of any storage path.
+func boundDateTruth(t *testing.T, events []*Event) map[uuid.UUID]boundDates {
+	t.Helper()
+	truth := make(map[uuid.UUID]boundDates, len(events))
+	for _, ev := range events {
+		joined, err := time.ParseInLocation("2006-01-02", ev.Attrs["joined"].(string), time.UTC)
+		if err != nil {
+			t.Fatalf("parse joined attr of %s: %v", ev.RowID, err)
+		}
+		touched, err := time.Parse(time.RFC3339, ev.Attrs["touched"].(string))
+		if err != nil {
+			t.Fatalf("parse touched attr of %s: %v", ev.RowID, err)
+		}
+		truth[ev.RowID] = boundDates{joined: joined.UnixMilli(), touched: touched.UnixMilli()}
+	}
+	return truth
+}
+
+func collectBoundDates(t *testing.T, label string, result *QueryResult, wantRows int) map[uuid.UUID]boundDates {
+	t.Helper()
+	if len(result.Records) != wantRows {
+		t.Fatalf("%s: got %d records, want %d", label, len(result.Records), wantRows)
+	}
+	got := make(map[uuid.UUID]boundDates, len(result.Records))
+	for _, rec := range result.Records {
+		joined, ok := rec.Int64Items["bigint_02"]
+		if !ok {
+			t.Fatalf("%s: row %s has no bigint_02 (joined) value", label, rec.RowID)
+		}
+		touched, ok := rec.Int64Items["bigint_03"]
+		if !ok {
+			t.Fatalf("%s: row %s has no bigint_03 (touched) value", label, rec.RowID)
+		}
+		got[rec.RowID] = boundDates{joined: joined, touched: touched}
+	}
+	return got
+}
+
+// assertParquetBoundDates reads one parquet file directly and checks that
+// the bound date columns are physically BIGINT and hold the hot-identical
+// epoch-ms values.
+func assertParquetBoundDates(ctx context.Context, t *testing.T, env *Env, key, tier string, baseline map[uuid.UUID]boundDates) {
+	t.Helper()
+	path := fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, strings.TrimPrefix(key, "/"))
+
+	var joinedType, touchedType string
+	if err := env.Duck.DB.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT typeof(joined), typeof(touched) FROM read_parquet('%s') LIMIT 1", path),
+	).Scan(&joinedType, &touchedType); err != nil {
+		t.Fatalf("%s parquet typeof: %v", tier, err)
+	}
+	if joinedType != "BIGINT" || touchedType != "BIGINT" {
+		t.Fatalf("%s parquet types joined=%s touched=%s, want BIGINT/BIGINT", tier, joinedType, touchedType)
+	}
+
+	rows, err := env.Duck.DB.QueryContext(ctx,
+		fmt.Sprintf("SELECT CAST(row_id AS VARCHAR), joined, touched FROM read_parquet('%s')", path))
+	if err != nil {
+		t.Fatalf("%s parquet scan: %v", tier, err)
+	}
+	defer rows.Close()
+	n := 0
+	for rows.Next() {
+		var rowIDStr string
+		var joined, touched int64
+		if err := rows.Scan(&rowIDStr, &joined, &touched); err != nil {
+			t.Fatalf("%s parquet row scan: %v", tier, err)
+		}
+		rowID, err := uuid.Parse(rowIDStr)
+		if err != nil {
+			t.Fatalf("%s parquet row_id %q: %v", tier, rowIDStr, err)
+		}
+		want, ok := baseline[rowID]
+		if !ok {
+			t.Fatalf("%s parquet holds unknown row %s", tier, rowID)
+		}
+		if joined != want.joined || touched != want.touched {
+			t.Errorf("%s parquet row %s joined=%d touched=%d, want hot-identical %d/%d",
+				tier, rowID, joined, touched, want.joined, want.touched)
+		}
+		n++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("%s parquet rows: %v", tier, err)
+	}
+	if n == 0 {
+		t.Fatalf("%s parquet file %s is empty", tier, key)
+	}
+	t.Logf("%s parquet %s: %d rows byte-identical to hot baseline", tier, key, n)
+}

--- a/internal/e2e_harness/production/date_parity_e2e_test.go
+++ b/internal/e2e_harness/production/date_parity_e2e_test.go
@@ -119,11 +119,19 @@ func boundDateTruth(t *testing.T, events []*Event) map[uuid.UUID]boundDates {
 	t.Helper()
 	truth := make(map[uuid.UUID]boundDates, len(events))
 	for _, ev := range events {
-		joined, err := time.ParseInLocation("2006-01-02", ev.Attrs["joined"].(string), time.UTC)
+		joinedStr, ok := ev.Attrs["joined"].(string)
+		if !ok {
+			t.Fatalf("event %s has no string joined attr: %v", ev.RowID, ev.Attrs["joined"])
+		}
+		touchedStr, ok := ev.Attrs["touched"].(string)
+		if !ok {
+			t.Fatalf("event %s has no string touched attr: %v", ev.RowID, ev.Attrs["touched"])
+		}
+		joined, err := time.ParseInLocation("2006-01-02", joinedStr, time.UTC)
 		if err != nil {
 			t.Fatalf("parse joined attr of %s: %v", ev.RowID, err)
 		}
-		touched, err := time.Parse(time.RFC3339, ev.Attrs["touched"].(string))
+		touched, err := time.Parse(time.RFC3339, touchedStr)
 		if err != nil {
 			t.Fatalf("parse touched attr of %s: %v", ev.RowID, err)
 		}

--- a/internal/e2e_harness/production/generator.go
+++ b/internal/e2e_harness/production/generator.go
@@ -125,6 +125,8 @@ func FullTypeProfile() AttrProfile {
 		attrs["active"] = r.Intn(2) == 0
 		attrs["born"] = base.AddDate(0, 0, -r.Intn(20000)).Format("2006-01-02")
 		attrs["seen"] = base.Add(time.Duration(r.Intn(1_000_000)) * time.Second).Format(time.RFC3339)
+		attrs["joined"] = base.AddDate(0, 0, -r.Intn(20000)).Format("2006-01-02")
+		attrs["touched"] = base.Add(time.Duration(r.Intn(1_000_000)) * time.Second).Format(time.RFC3339)
 		return attrs
 	}
 }

--- a/internal/e2e_harness/production/oracle_test.go
+++ b/internal/e2e_harness/production/oracle_test.go
@@ -11,13 +11,15 @@ import (
 
 func wideCache() forma.SchemaAttributeCache {
 	return forma.SchemaAttributeCache{
-		"title":  {AttributeID: 1, ValueType: forma.ValueTypeText, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnText01}},
-		"count":  {AttributeID: 3, ValueType: forma.ValueTypeInteger, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnInteger01}},
-		"score":  {AttributeID: 5, ValueType: forma.ValueTypeNumeric, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnDouble01}},
-		"note":   {AttributeID: 7, ValueType: forma.ValueTypeText},
-		"active": {AttributeID: 8, ValueType: forma.ValueTypeBool},
-		"born":   {AttributeID: 9, ValueType: forma.ValueTypeDate},
-		"seen":   {AttributeID: 10, ValueType: forma.ValueTypeDateTime},
+		"title":   {AttributeID: 1, ValueType: forma.ValueTypeText, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnText01}},
+		"count":   {AttributeID: 3, ValueType: forma.ValueTypeInteger, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnInteger01}},
+		"score":   {AttributeID: 5, ValueType: forma.ValueTypeNumeric, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnDouble01}},
+		"note":    {AttributeID: 7, ValueType: forma.ValueTypeText},
+		"active":  {AttributeID: 8, ValueType: forma.ValueTypeBool},
+		"born":    {AttributeID: 9, ValueType: forma.ValueTypeDate},
+		"seen":    {AttributeID: 10, ValueType: forma.ValueTypeDateTime},
+		"joined":  {AttributeID: 11, ValueType: forma.ValueTypeDate, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02, Encoding: forma.MainColumnEncodingUnixMs}},
+		"touched": {AttributeID: 12, ValueType: forma.ValueTypeDateTime, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint03, Encoding: forma.MainColumnEncodingUnixMs}},
 	}
 }
 

--- a/internal/e2e_harness/production/schemas/e2e_wide.json
+++ b/internal/e2e_harness/production/schemas/e2e_wide.json
@@ -38,6 +38,14 @@
     "seen": {
       "type": "string",
       "format": "date-time"
+    },
+    "joined": {
+      "type": "string",
+      "format": "date"
+    },
+    "touched": {
+      "type": "string",
+      "format": "date-time"
     }
   }
 }

--- a/internal/e2e_harness/production/schemas/e2e_wide_attributes.json
+++ b/internal/e2e_harness/production/schemas/e2e_wide_attributes.json
@@ -56,5 +56,21 @@
   "seen": {
     "attributeID": 10,
     "valueType": "datetime"
+  },
+  "joined": {
+    "attributeID": 11,
+    "valueType": "date",
+    "column_binding": {
+      "col_name": "bigint_02",
+      "encoding": "unix_ms"
+    }
+  },
+  "touched": {
+    "attributeID": 12,
+    "valueType": "datetime",
+    "column_binding": {
+      "col_name": "bigint_03",
+      "encoding": "unix_ms"
+    }
   }
 }

--- a/internal/e2e_harness/production/smoke_test.go
+++ b/internal/e2e_harness/production/smoke_test.go
@@ -196,6 +196,14 @@ func runSmokeQueries(ctx context.Context, t *testing.T, env *Env, wide SchemaRef
 		Limit:  8,
 		Offset: 8, // page 2
 	})
+	// Sort on the main-column-bound datetime attribute (#194). Sorting only
+	// references the projected column; date filter parameters are not yet
+	// supported on the federated DuckClause side.
+	env.AssertQueryMatches(ctx, Query{
+		Schema: wide,
+		Sorts:  []Sort{{Attr: "touched"}},
+		Limit:  10,
+	})
 	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 100})
 }
 


### PR DESCRIPTION
Closes #194. Follow-up from PR #191 (#173, epic #172).

## Problem

For main-column-bound date/datetime attributes with `unix_ms` encoding, `castMainValue` converted the stored epoch-ms into DuckDB `DATE`/`TIMESTAMP` in the parquet export (`to_timestamp(col/1000)`), while every reader expects raw epoch-ms `BIGINT`:

- write side stores epoch millis in a bigint column (`transform.storeInMainColumn`);
- the federated projection casts date attrs with `CAST(attr AS BIGINT)` (`sqlgen.duckDBAttrCast`) — an **illegal cast from DATE** in DuckDB, so warm/cold reads of a bound date failed outright;
- both the federated and hot-path scanners decode epoch-ms int64 into `Int64Items`.

The EAV path was already aligned in cb0b1bf (#173); this was the residual main-column drift. The path was previously unexercised — `e2e_wide` deliberately kept dates EAV-only.

## Fix

`castMainValue` now emits `TRY_CAST(col AS BIGINT)` for the unix_ms date/datetime branches, mirroring `castEAVValue`. One site covers both export paths (base via `buildBaseExportSQL`, delta via `buildExportSQL`); pinned SQL tests assert both modes and a `to_timestamp` negative sentinel.

## Acceptance coverage

- `e2e_wide` gains main-column-bound `joined` (date → bigint_02) and `touched` (datetime → bigint_03), both `unix_ms`; the smoke battery sorts on the bound datetime and every oracle comparison now covers the new attributes across all three tiers.
- `TestBoundDateParityAcrossTiers` asserts hot vs warm/cold parity at three layers: parquet columns physically `BIGINT` (`typeof` on both base and delta files), raw parquet values equal to the hot baseline row by row, and the federated read returning hot-identical int64s. The hot baseline is itself anchored to the generated event attributes to rule out both-sides-wrong false greens.

## Verification

- `make test` — full unit suite green (includes new pinned SQL red→green tests in `internal/cdc`).
- `make test-e2e-production` — all green, including `TestProductionSmoke` (3-tier hits) and the new parity test (base: 12 rows, delta: 6 rows byte-identical).
- Rendered real export SQL checked in `sql_preview` logs: base and delta both emit `TRY_CAST(m.bigint_02 AS BIGINT) AS joined`; zero `to_timestamp` occurrences in the whole run.

## Out of scope

Date/datetime **filter** parameters on the federated DuckClause still bind `time.Time` as `CAST(? AS TIMESTAMP)`, which mismatches the epoch-ms BIGINT convention for all date attributes (EAV and bound alike) — tracked in #200. The smoke battery therefore adds a date sort (no parameter binding) but no date filter.

Pre-production note: no data migration; any environment that ever ran flush/init against a bound-date schema must re-run cdc-init to rebuild base parquet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)