### PR TITLE
fix(cdc): propagate manifest update failures from delta flush (#197)

### DIFF
--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -390,9 +390,13 @@ func (e *flushBatchExecutor) executeBatch(ctx context.Context, batchIDs []uuid.U
 	}
 
 	if e.manifestStore != nil {
+		// Rows are already marked flushed, so a re-run will not re-export
+		// them: a delta file missing from the manifest stays invisible to
+		// manifest consumers (e.g. compaction) forever. Propagate so the run
+		// reports failure; the final key in the error is the operator's
+		// pointer to the orphaned file for manual reconciliation (#197).
 		if err := updateManifest(ctx, e.manifestStore, e.manifestResolver, e.schemaID, finalKey, "delta", updatedIDs, flushedAt, e.logger); err != nil {
-			e.logger.Sugar().Errorw("manifest update failed", "err", err)
-			// Don't return - the flush succeeded, manifest is non-critical.
+			return fmt.Errorf("manifest update (%s) for %s: %w", batchKind, finalKey, err)
 		}
 	}
 

--- a/internal/cdc/flusher_test.go
+++ b/internal/cdc/flusher_test.go
@@ -592,7 +592,12 @@ func TestExecuteFlush_SplitsBatchWhenByteTargetIsExceeded(t *testing.T) {
 	require.True(t, chunkCalled)
 }
 
-func TestExecuteBatch_SucceedsWhenManifestUpdateFails(t *testing.T) {
+// executeBatch must not swallow manifest failures: a delta file absent from
+// the manifest is invisible to manifest consumers (e.g. compaction) while
+// the run would otherwise report success. Rows are already marked flushed
+// by this point, so the flush state persists even though the pass fails —
+// the returned error carries the final key for manual reconciliation.
+func TestExecuteBatch_ReturnsErrorWhenManifestLoadFails(t *testing.T) {
 	db, err := sql.Open("duckdb", ":memory:")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -606,8 +611,6 @@ func TestExecuteBatch_SucceedsWhenManifestUpdateFails(t *testing.T) {
 	snapshot := time.Now().UnixMilli()
 	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
 	require.NoError(t, err)
-
-	exportCalled := false
 
 	store := newInMemoryManifestStore()
 	store.loadErr = errors.New("boom")
@@ -625,26 +628,68 @@ func TestExecuteBatch_SucceedsWhenManifestUpdateFails(t *testing.T) {
 		logger:           zap.NewNop(),
 		manifestStore:    store,
 		manifestResolver: resolver,
-		exportSnapshot: func(_ *DuckExporter, _ context.Context, _ CDCConfig, _ string, s3TmpPath string, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
-			exportCalled = true
-			require.Equal(t, int16(7), schemaID)
-			require.Equal(t, snapshot, snapshotTS)
-			require.Equal(t, []uuid.UUID{rowID}, rowIDs)
-			require.Contains(t, s3TmpPath, "s3://test-bucket/cdc/7/_tmp/")
-			require.Nil(t, attrCache)
+		exportSnapshot: func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error {
 			return nil
 		},
 	}
 
 	err = executor.executeBatch(ctx, []uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
-	require.NoError(t, err)
-	require.True(t, exportCalled)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "manifest update")
+	require.Contains(t, err.Error(), "cdc/7/delta-file.parquet")
 
+	// The flush itself is durable: rows stay marked flushed even though the
+	// pass reports failure. A re-run will not re-export them.
 	var flushedAt int64
 	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
 	require.NoError(t, err)
 	require.NotZero(t, flushedAt)
 	require.Zero(t, store.saved)
+}
+
+// Save-failure variant, mirroring init_test.go's failingSaveStore coverage:
+// Load reports NoSuchKey (create path), Save fails inside AppendFile.
+func TestExecuteBatch_ReturnsErrorWhenManifestSaveFails(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
+	snapshot := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
+	require.NoError(t, err)
+
+	saveErr := errors.New("s3 write denied")
+	store := newInMemoryManifestStore()
+	store.saveErr = saveErr
+	resolver := manifest.PathResolver{Prefix: "cdc", PathTemplate: "manifest/{{.SchemaID}}.json"}
+
+	executor := &flushBatchExecutor{
+		db:               db,
+		duck:             &DuckExporter{Logger: zap.NewNop()},
+		s3Client:         &objectOnlyS3Client{},
+		cfg:              CDCConfig{S3Bucket: "test-bucket", S3Prefix: "cdc"},
+		tableName:        "change_log",
+		schemaID:         7,
+		snapshot:         snapshot,
+		pgConnForDuck:    "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
+		logger:           zap.NewNop(),
+		manifestStore:    store,
+		manifestResolver: resolver,
+		exportSnapshot: func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error {
+			return nil
+		},
+	}
+
+	err = executor.executeBatch(ctx, []uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
+	require.Error(t, err)
+	require.ErrorIs(t, err, saveErr)
+	require.Contains(t, err.Error(), "cdc/7/delta-file.parquet")
 }
 
 func TestExecuteBatch_ReturnsErrorWhenExportFailsAndDoesNotAdvanceState(t *testing.T) {


### PR DESCRIPTION
Closes #197.

## Problem

`executeBatch` logged and swallowed `updateManifest` failures (internal/cdc/flusher.go:394), so a delta parquet could land on S3 while staying invisible to manifest consumers (compaction) — and the run reported success. Same pattern the init path fixed in 2591bd2 (PR #191 review).

## Design (option a: propagate)

- **Propagate** the error so the pass fails and `processSchemas`' `errors.Join` surfaces it, without blocking other schemas. Verified end-to-end: the error reaches `runCDCFlush` → `exitOnError: true` → exit code 1.
- Rows are already marked flushed when the manifest append runs, so a re-run cannot re-append — the error message embeds the delta file's final key as the operator's pointer for manual manifest reconciliation.
- Chunked flush stops at the failed chunk: remaining chunks' rows are not yet marked flushed, so a re-run picks them up cleanly; only the failed chunk's parquet is orphaned.
- **Rejected (b) retry with backoff:** `manifest.AppendFile` is load-modify-save with etag optimistic locking; retrying after an ambiguous save failure appends a duplicate entry (the idempotency caveat flagged in the issue).
- **Rejected (c) metric/alarm only:** no metrics infrastructure exists in this codebase; failing the run is the observable signal, and `processSchemas` still logs the full wrapped error.

## Tests

- `TestExecuteBatch_ReturnsErrorWhenManifestLoadFails` — inverts the old swallow characterization (`TestExecuteBatch_SucceedsWhenManifestUpdateFails`); asserts the error carries the final key and that rows remain marked flushed (flush durability is unchanged).
- `TestExecuteBatch_ReturnsErrorWhenManifestSaveFails` — save-failure mode mirroring `init_test.go`'s `failingSaveStore` coverage; asserts `errors.Is` reaches the store error through the wrap chain.

Full `./internal/cdc/` suite green, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)