### PR TITLE
test(e2e): entity lifecycle across CDC boundaries — create/update/delete/flush/query (#175)

### DIFF
--- a/internal/e2e_harness/harness.go
+++ b/internal/e2e_harness/harness.go
@@ -83,6 +83,41 @@ func (h *TestHarness) ConnectPostgres(ctx context.Context, dsn string) error {
 	}
 }
 
+// RestartPostgres stops and restarts the Postgres container in place
+// (docker stop/start — the writable layer and therefore all data survive,
+// unlike StopPostgres, which terminates and destroys the container). The
+// host-mapped port is not guaranteed stable across restarts, so the DSN is
+// re-derived before reconnecting.
+func (h *TestHarness) RestartPostgres(ctx context.Context) error {
+	if h.PGContainer == nil {
+		return fmt.Errorf("restart postgres: no container (external infrastructure or already terminated)")
+	}
+	if h.PGDB != nil {
+		h.PGDB.Close()
+		h.PGDB = nil
+	}
+	stopTimeout := 30 * time.Second
+	if err := h.PGContainer.Stop(ctx, &stopTimeout); err != nil {
+		return fmt.Errorf("stop postgres container: %w", err)
+	}
+	if err := h.PGContainer.Start(ctx); err != nil {
+		return fmt.Errorf("start postgres container: %w", err)
+	}
+	host, err := h.PGContainer.Host(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve postgres host after restart: %w", err)
+	}
+	mapped, err := h.PGContainer.MappedPort(ctx, "5432")
+	if err != nil {
+		return fmt.Errorf("resolve postgres port after restart: %w", err)
+	}
+	dsn := fmt.Sprintf("postgres://postgres:password@%s:%s/postgres?sslmode=disable", host, mapped.Port())
+	if err := h.ConnectPostgres(ctx, dsn); err != nil {
+		return fmt.Errorf("reconnect postgres after restart: %w", err)
+	}
+	return nil
+}
+
 // StopPostgres stops the Postgres container and closes DB handle.
 func (h *TestHarness) StopPostgres(ctx context.Context) error {
 	if h.PGDB != nil {

--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -142,6 +142,11 @@ where cdc-init bootstraps base files before federated reads. Use
   (Update on a deleted row returns `ErrNotFound`, pinned live) — with the
   restore timestamp forced past the tombstone's `changed_at` so the revival
   wins LWW. Scoped to text/numeric attributes (e2e_simple shapes).
+- `RunCompaction` wraps the real compactor (`compaction.Compactor.RunOnce`)
+  over the Env's manifest. Today's compactor is manifest-level only: the
+  dirty-ratio rewrite is unimplemented (reports `RewritePending`, manifest
+  untouched) and promotion needs ≥1 MB of delta — the lifecycle suite pins
+  that contract as a tripwire for #188.
 - `Env.RestartPostgres` (#175) restarts the Postgres container in place
   (docker stop/start, data preserved) and rebinds the pool, CDC config,
   DuckDB client, and lazy engine/manager. Restart tests must own a

--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -137,6 +137,16 @@ where cdc-init bootstraps base files before federated reads. Use
   are `"1"`/`"0"`; dates accept ISO strings or epoch millis).
 - `ExecSQL` is the escape hatch for failure-state injection (#179/#181),
   e.g. truncating `change_log` to model post-init onboarding.
+- `InjectRestore` (#175) re-materializes a hard-deleted row under its
+  original row_id at the storage layer — production has no restore API
+  (Update on a deleted row returns `ErrNotFound`, pinned live) — with the
+  restore timestamp forced past the tombstone's `changed_at` so the revival
+  wins LWW. Scoped to text/numeric attributes (e2e_simple shapes).
+- `Env.RestartPostgres` (#175) restarts the Postgres container in place
+  (docker stop/start, data preserved) and rebinds the pool, CDC config,
+  DuckDB client, and lazy engine/manager. Restart tests must own a
+  `DedicatedCluster` — restarting the shared cluster would break every
+  parallel Env — and are skipped on external infrastructure.
 
 ## Diagnostic artifacts
 
@@ -170,7 +180,7 @@ On failure (or `KEEP_E2E_ENV=1`) the Env writes
 | Issue | Building block |
 |---|---|
 | #174 full-type coverage | `e2e_wide` + `FullTypeProfile` |
-| #175 lifecycle sequences | `Event` model + `ApplyEvents` |
+| #175 lifecycle sequences | `Event` model + `ApplyEvents` + `InjectRestore` + `RestartPostgres` (`lifecycle_e2e_test.go`, `restart_e2e_test.go`) |
 | #179 flush thresholds | `WithFlushThresholds` + `FlushReport` |
 | #180 dry-run semantics | `RunFlushDry` |
 | #181 failure injection | `ExecSQL` |

--- a/internal/e2e_harness/production/cdc.go
+++ b/internal/e2e_harness/production/cdc.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/lychee-technology/forma/internal/cdc"
+	"github.com/lychee-technology/forma/internal/compaction"
 	"github.com/lychee-technology/forma/internal/manifest"
 )
 
@@ -106,6 +107,36 @@ func (e *Env) RunInit(ctx context.Context, schema SchemaRef) (*InitReport, error
 	}
 	report.Manifest = manifests[schema.ID]
 	return report, nil
+}
+
+// RunCompaction executes the real compactor (compaction.Compactor.RunOnce)
+// against the Env's manifest for one schema and returns its typed result.
+// Note the current compactor is manifest-level only: promotion retags delta
+// entries as base once the delta tier reaches TargetBaseSizeMB (≥1 MB, out of
+// reach at lifecycle-test scale), and the dirty-ratio rewrite is not
+// implemented — it reports RewritePending and leaves the manifest untouched
+// (internal/compaction/compactor.go). The federated read path never consults
+// the manifest, so parquet contents and query results are unaffected either
+// way today.
+func (e *Env) RunCompaction(ctx context.Context, schema SchemaRef) (compaction.CompactionResult, error) {
+	if e.CDC.ManifestTemplate == "" {
+		return compaction.CompactionResult{}, fmt.Errorf("compaction requires a manifest (Env built WithoutManifest)")
+	}
+	provider := compaction.NewS3ManifestProvider(cdc.ManifestConfig{
+		Bucket:       e.Cluster.Bucket,
+		Prefix:       e.CDC.ManifestPrefix,
+		PathTemplate: e.CDC.ManifestTemplate,
+	}, e.Cluster.S3)
+	compactor := &compaction.Compactor{
+		Logger:   e.logger,
+		Config:   cdc.CompactionConfig{SchemaID: schema.ID},
+		Provider: provider,
+	}
+	result, err := compactor.RunOnce(ctx)
+	if err != nil {
+		return result, fmt.Errorf("compaction run once (schema %d): %w", schema.ID, err)
+	}
+	return result, nil
 }
 
 // countUnflushed counts change_log rows with flushed_at = 0 across all

--- a/internal/e2e_harness/production/cluster.go
+++ b/internal/e2e_harness/production/cluster.go
@@ -191,6 +191,22 @@ func (c *Cluster) connectExternal(ctx context.Context, pgDSN, s3Endpoint string)
 	return nil
 }
 
+// RestartPostgres restarts the cluster's Postgres container in place (state
+// preserving stop/start) and re-derives the connection coordinates — the
+// host-mapped port can change across restarts. External infrastructure
+// cannot be restarted. Only tests owning a dedicated cluster may call this:
+// restarting the SharedCluster would break every parallel Env.
+func (c *Cluster) RestartPostgres(ctx context.Context) error {
+	if c.external {
+		return fmt.Errorf("restart postgres: external infrastructure (%s) cannot be restarted", externalPGDSNVar)
+	}
+	if err := c.Base.RestartPostgres(ctx); err != nil {
+		return err
+	}
+	c.PGHost, c.PGPort = pgHostPortFromDSN(c.Base.PGDSN)
+	return nil
+}
+
 // Shutdown stops the shared containers. Under KEEP_E2E_ENV=1 it prints
 // connection info instead and leaves everything running.
 func (c *Cluster) Shutdown(ctx context.Context) error {
@@ -240,6 +256,28 @@ func SharedCluster(t *testing.T) *Cluster {
 		t.Skipf("production e2e cluster unavailable (docker required): %v", sharedErr)
 	}
 	return sharedCluster
+}
+
+// DedicatedCluster starts a private, non-shared cluster for tests that
+// mutate cluster-wide state (e.g. RestartPostgres) and registers its
+// shutdown. Skips the test when docker is unavailable (matching
+// SharedCluster) or when the PRODUCTION_E2E_EXTERNAL_* escape hatch is set —
+// external infrastructure cannot be restarted.
+func DedicatedCluster(t *testing.T) *Cluster {
+	t.Helper()
+	if os.Getenv(externalPGDSNVar) != "" {
+		t.Skipf("dedicated cluster unavailable: external infrastructure (%s) cannot be restarted", externalPGDSNVar)
+	}
+	cluster, err := StartCluster(context.Background())
+	if err != nil {
+		t.Skipf("production e2e cluster unavailable (docker required): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cluster.Shutdown(context.Background()); err != nil {
+			t.Logf("shutdown dedicated cluster: %v", err)
+		}
+	})
+	return cluster
 }
 
 // ShutdownSharedCluster releases the SharedCluster infrastructure; call it

--- a/internal/e2e_harness/production/cluster.go
+++ b/internal/e2e_harness/production/cluster.go
@@ -201,7 +201,7 @@ func (c *Cluster) RestartPostgres(ctx context.Context) error {
 		return fmt.Errorf("restart postgres: external infrastructure (%s) cannot be restarted", externalPGDSNVar)
 	}
 	if err := c.Base.RestartPostgres(ctx); err != nil {
-		return err
+		return fmt.Errorf("restart postgres container: %w", err)
 	}
 	c.PGHost, c.PGPort = pgHostPortFromDSN(c.Base.PGDSN)
 	return nil

--- a/internal/e2e_harness/production/env.go
+++ b/internal/e2e_harness/production/env.go
@@ -300,7 +300,7 @@ func (e *Env) reconnectAfterRestart(ctx context.Context) error {
 		_ = e.Duck.Close()
 	}
 	if err := e.startDuckDB(); err != nil {
-		return err
+		return fmt.Errorf("rebuild duckdb client after restart: %w", err)
 	}
 	e.CDC = e.buildCDCConfig()
 	e.manager = nil

--- a/internal/e2e_harness/production/env.go
+++ b/internal/e2e_harness/production/env.go
@@ -271,6 +271,43 @@ func (e *Env) buildCDCConfig() cdc.CDCConfig {
 	return cfg
 }
 
+// RestartPostgres restarts the cluster's Postgres container and rebinds
+// every per-test handle that referenced the old server: the pgx pool, the
+// CDC config (the host-mapped port can change), the DuckDB client (so no
+// cached postgres attachment survives), and the lazily built EntityManager
+// and federated engine. Registry and Metadata are load-once snapshots and
+// need no rebuild. Only for tests owning a DedicatedCluster.
+func (e *Env) RestartPostgres(ctx context.Context) error {
+	if err := e.Cluster.RestartPostgres(ctx); err != nil {
+		return fmt.Errorf("restart cluster postgres: %w", err)
+	}
+	return e.reconnectAfterRestart(ctx)
+}
+
+// reconnectAfterRestart rebuilds the Env's server-bound handles against the
+// restarted Postgres.
+func (e *Env) reconnectAfterRestart(ctx context.Context) error {
+	if e.Pool != nil {
+		e.Pool.Close()
+	}
+	pool, err := pgxpool.New(ctx, e.PGDSN())
+	if err != nil {
+		return fmt.Errorf("reconnect test database after restart: %w", err)
+	}
+	e.Pool = pool
+
+	if e.Duck != nil {
+		_ = e.Duck.Close()
+	}
+	if err := e.startDuckDB(); err != nil {
+		return err
+	}
+	e.CDC = e.buildCDCConfig()
+	e.manager = nil
+	e.engine = nil
+	return nil
+}
+
 // PGDSN returns the DSN of this Env's dedicated database.
 func (e *Env) PGDSN() string {
 	c := e.Cluster

--- a/internal/e2e_harness/production/lifecycle_e2e_test.go
+++ b/internal/e2e_harness/production/lifecycle_e2e_test.go
@@ -23,242 +23,246 @@ import (
 // the flush (parquet LWW over the exported tombstone), and across retries.
 func TestEntityLifecycle(t *testing.T) {
 	cluster := SharedCluster(t)
-	wide := DefaultSchemaFixtures()[1] // e2e_wide
+	wide := DefaultSchemaFixtures()[1]   // e2e_wide
+	simple := DefaultSchemaFixtures()[0] // e2e_simple
 
-	// Scenario 1: create → flush → query. Exactly one visible row with
-	// correct values, one live delta version exported.
-	t.Run("create_flush_query", func(t *testing.T) {
-		t.Parallel()
-		env := NewEnv(t, cluster)
-		ctx := context.Background()
-
-		creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
-		if err := env.ApplyEvents(ctx, creates...); err != nil {
-			t.Fatalf("apply create: %v", err)
-		}
-
-		env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
-
-		flush := mustFlush(ctx, t, env)
-		if got := countTier(flush.Manifests[wide.ID], "delta"); got != 1 {
-			t.Fatalf("manifest holds %d delta files, want 1", got)
-		}
-
-		result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-		if result != nil && !result.Plan.Routing.UseDuckDB {
-			t.Errorf("post-flush query did not route to duckdb: %+v", result.Plan.Routing)
-		}
-
-		assertLiveParquetRow(ctx, t, env, soleParquetKey(t, flush), creates[0])
-	})
-
-	// Scenario 2: create → update → flush → query. The latest version wins
-	// with no duplicate: the pre-flush change_log upsert coalesces both
-	// mutations into the single slot-0 row, so exactly one (updated) version
-	// reaches the delta parquet.
-	t.Run("update_lww", func(t *testing.T) {
-		t.Parallel()
-		env := NewEnv(t, cluster)
-		ctx := context.Background()
-
-		script := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1, Updates: 1})
-		if err := env.ApplyEvents(ctx, script...); err != nil {
-			t.Fatalf("apply create+update: %v", err)
-		}
-		update := script[1]
-		if update.Kind != EventUpdate {
-			t.Fatalf("script[1] is %s, want update", update.Kind)
-		}
-
-		var slot0 int64
-		if err := env.Pool.QueryRow(ctx,
-			"SELECT COUNT(*) FROM change_log WHERE schema_id = $1 AND row_id = $2",
-			wide.ID, update.RowID).Scan(&slot0); err != nil {
-			t.Fatalf("count change_log rows: %v", err)
-		}
-		if slot0 != 1 {
-			t.Fatalf("change_log holds %d rows for the mutated row, want 1 coalesced slot-0 row", slot0)
-		}
-
-		flush := mustFlush(ctx, t, env)
-
-		// The oracle folds create+update by LWW into one row carrying the
-		// update's values — a duplicate or stale engine row fails the diff.
-		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-
-		assertLiveParquetRow(ctx, t, env, soleParquetKey(t, flush), update)
-	})
-
-	// Scenario 3: create → delete → query, before any flush. The deleted
-	// row's only surviving source is the cold base parquet (its change_log
-	// entry is truncated after init, modeling the production onboarding
-	// contract), so hiding it rests entirely on the dirty-set anti-join: the
-	// hard delete leaves no entity_main row for pg_source and the unflushed
-	// tombstone must evict the base version from s3_source.
-	t.Run("delete_before_flush", func(t *testing.T) {
-		t.Parallel()
-		env := NewEnv(t, cluster)
-		ctx := context.Background()
-
-		creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
-		if err := env.ApplyEvents(ctx, creates...); err != nil {
-			t.Fatalf("apply create: %v", err)
-		}
-		row := creates[0]
-
-		initReport, err := env.RunInit(ctx, wide)
-		if err != nil {
-			t.Fatalf("run init: %v", err)
-		}
-		if initReport.RowsExported != 1 {
-			t.Fatalf("init exported %d rows, want 1", initReport.RowsExported)
-		}
-		env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1 AND row_id = $2",
-			wide.ID, row.RowID)
-
-		// The base file must actually serve the row before the delete —
-		// otherwise the post-delete zero-row check could be a glob-mismatch
-		// false green.
-		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-
-		if err := env.ApplyEvents(ctx, DeleteEvent(wide, row.RowID)); err != nil {
-			t.Fatalf("apply delete: %v", err)
-		}
-
-		assertTombstoneChangeLog(ctx, t, env, wide, row)
-		// Hidden across every tier, pre-flush, and idempotently so.
-		env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
-		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-	})
-
-	// Scenario 4 — the delete-resurrection core: create → flush (live
-	// versions now in base AND delta parquet) → delete → flush. The tombstone
-	// must be exported to the delta (deleted_at set, every attribute and
-	// entity_main column NULL — the hard-deleted row no longer joins), and
-	// once the dirty set is drained the row must stay invisible on parquet
-	// LWW alone: the tombstone's later changed_at beats both live versions.
-	t.Run("delete_resurrection", func(t *testing.T) {
-		t.Parallel()
-		env := NewEnv(t, cluster)
-		ctx := context.Background()
-
-		creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
-		if err := env.ApplyEvents(ctx, creates...); err != nil {
-			t.Fatalf("apply create: %v", err)
-		}
-		row := creates[0]
-
-		// Live versions in the cold base (RunInit) and, because the create's
-		// change_log entry is still unflushed, in a warm delta too — two
-		// independent resurrection sources for the tombstone to beat.
-		if _, err := env.RunInit(ctx, wide); err != nil {
-			t.Fatalf("run init: %v", err)
-		}
-		mustFlush(ctx, t, env)
-		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-
-		del := DeleteEvent(wide, row.RowID)
-		if err := env.ApplyEvents(ctx, del); err != nil {
-			t.Fatalf("apply delete: %v", err)
-		}
-		// Pre-flush window: hidden by the dirty-set anti-join.
-		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-
-		flush2 := mustFlush(ctx, t, env)
-		assertTombstoneParquet(ctx, t, env, soleParquetKey(t, flush2), del)
-
-		// Post-flush: the dirty set is empty (mustFlush), so invisibility now
-		// rests purely on parquet LWW — and no tier-preference hint may
-		// resurrect the cold or warm live version.
-		env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
-		for _, tiers := range [][]model.DataTier{
-			nil,
-			{model.DataTierCold},
-			{model.DataTierWarm, model.DataTierCold},
-		} {
-			result := env.AssertQueryMatches(ctx, Query{Schema: wide, PreferredTiers: tiers, Limit: 10})
-			if result != nil && !result.Plan.Routing.UseDuckDB {
-				t.Errorf("tiers %v did not route to duckdb: %+v", tiers, result.Plan.Routing)
-			}
-		}
-
-		// Idempotency: a retried flush moves nothing and exports nothing, and
-		// the row stays deleted.
-		flush3, err := env.RunFlush(ctx)
-		if err != nil {
-			t.Fatalf("retry flush: %v", err)
-		}
-		if flush3.UnflushedBefore != 0 || flush3.UnflushedAfter != 0 {
-			t.Errorf("retry flush saw unflushed %d -> %d, want 0 -> 0", flush3.UnflushedBefore, flush3.UnflushedAfter)
-		}
-		if len(flush3.NewObjects) != 0 {
-			t.Errorf("retry flush created objects %v, want none", flush3.NewObjects)
-		}
-		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-	})
-
-	// Scenario 5: create → flush → delete → flush → restore → flush → query.
-	// Production has no restore API — Update on the hard-deleted row must
-	// return ErrNotFound — so the revival is injected at the storage layer
-	// (InjectRestore). The restored version must then beat the already
-	// flushed parquet tombstone in LWW: one visible row with the original
-	// attributes and no zombie tombstone hiding it.
-	t.Run("restore_after_delete", func(t *testing.T) {
-		t.Parallel()
-		env := NewEnv(t, cluster)
-		ctx := context.Background()
-		simple := DefaultSchemaFixtures()[0] // e2e_simple
-
-		creates := env.GenerateScript(ScriptSpec{Schema: simple, Creates: 1})
-		if err := env.ApplyEvents(ctx, creates...); err != nil {
-			t.Fatalf("apply create: %v", err)
-		}
-		row := creates[0]
-		mustFlush(ctx, t, env)
-
-		del := DeleteEvent(simple, row.RowID)
-		if err := env.ApplyEvents(ctx, del); err != nil {
-			t.Fatalf("apply delete: %v", err)
-		}
-		mustFlush(ctx, t, env) // tombstone now lives in a delta parquet
-		env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
-
-		// Contract pin: the production API cannot revive a hard-deleted row.
-		_, err := env.EntityManager().Update(ctx, &forma.EntityOperation{
-			EntityIdentifier: forma.EntityIdentifier{SchemaName: simple.Name, RowID: row.RowID},
-			Type:             forma.OperationUpdate,
-			Updates:          map[string]any{"name": "resurrect-attempt"},
+	scenarios := []struct {
+		name   string
+		schema SchemaRef
+		run    func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"create_flush_query", wide, testCreateFlushQuery},
+		{"update_lww", wide, testUpdateLWW},
+		{"delete_before_flush", wide, testDeleteBeforeFlush},
+		{"delete_resurrection", wide, testDeleteResurrection},
+		{"restore_after_delete", simple, testRestoreAfterDelete},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), sc.schema)
 		})
-		if !errors.Is(err, forma.ErrNotFound) {
-			t.Fatalf("update of deleted row returned %v, want ErrNotFound", err)
-		}
+	}
+}
 
-		restored := env.InjectRestore(ctx, row, del)
-		flush3 := mustFlush(ctx, t, env)
+// testCreateFlushQuery is scenario 1: create → flush → query. Exactly one
+// visible row with correct values, one live delta version exported.
+func testCreateFlushQuery(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply create: %v", err)
+	}
 
-		// Visible again everywhere — the restored delta version must win LWW
-		// over the flushed tombstone — and idempotently so.
-		env.AssertQueryMatches(ctx, Query{Schema: simple, PreferHot: true, Limit: 10})
-		env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
-		env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
 
-		// Physical check: the restore flush exported exactly one live version.
-		key := soleParquetKey(t, flush3)
-		path := fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, strings.TrimPrefix(key, "/"))
-		var n int
-		var deletedAt, changedAt sql.NullInt64
-		if err := env.Duck.DB.QueryRowContext(ctx, fmt.Sprintf(
-			`SELECT COUNT(*), MAX(deleted_at), MAX(changed_at)
-			 FROM read_parquet('%s') WHERE CAST(row_id AS VARCHAR) = ?`, path),
-			row.RowID.String()).Scan(&n, &deletedAt, &changedAt); err != nil {
-			t.Fatalf("scan restore delta %s: %v", key, err)
+	flush := mustFlush(ctx, t, env)
+	if got := countTier(flush.Manifests[wide.ID], "delta"); got != 1 {
+		t.Fatalf("manifest holds %d delta files, want 1", got)
+	}
+
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	if result != nil && !result.Plan.Routing.UseDuckDB {
+		t.Errorf("post-flush query did not route to duckdb: %+v", result.Plan.Routing)
+	}
+
+	assertLiveParquetRow(ctx, t, env, soleParquetKey(t, flush), creates[0])
+}
+
+// testUpdateLWW is scenario 2: create → update → flush → query. The latest
+// version wins with no duplicate: the pre-flush change_log upsert coalesces
+// both mutations into the single slot-0 row, so exactly one (updated)
+// version reaches the delta parquet.
+func testUpdateLWW(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	script := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1, Updates: 1})
+	if err := env.ApplyEvents(ctx, script...); err != nil {
+		t.Fatalf("apply create+update: %v", err)
+	}
+	update := script[1]
+	if update.Kind != EventUpdate {
+		t.Fatalf("script[1] is %s, want update", update.Kind)
+	}
+
+	var slot0 int64
+	if err := env.Pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM change_log WHERE schema_id = $1 AND row_id = $2",
+		wide.ID, update.RowID).Scan(&slot0); err != nil {
+		t.Fatalf("count change_log rows: %v", err)
+	}
+	if slot0 != 1 {
+		t.Fatalf("change_log holds %d rows for the mutated row, want 1 coalesced slot-0 row", slot0)
+	}
+
+	flush := mustFlush(ctx, t, env)
+
+	// The oracle folds create+update by LWW into one row carrying the
+	// update's values — a duplicate or stale engine row fails the diff.
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+	assertLiveParquetRow(ctx, t, env, soleParquetKey(t, flush), update)
+}
+
+// testDeleteBeforeFlush is scenario 3: create → delete → query, before any
+// flush. The deleted row's only surviving source is the cold base parquet
+// (its change_log entry is truncated after init, modeling the production
+// onboarding contract), so hiding it rests entirely on the dirty-set
+// anti-join: the hard delete leaves no entity_main row for pg_source and the
+// unflushed tombstone must evict the base version from s3_source.
+func testDeleteBeforeFlush(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply create: %v", err)
+	}
+	row := creates[0]
+
+	initReport, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	if initReport.RowsExported != 1 {
+		t.Fatalf("init exported %d rows, want 1", initReport.RowsExported)
+	}
+	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1 AND row_id = $2",
+		wide.ID, row.RowID)
+
+	// The base file must actually serve the row before the delete —
+	// otherwise the post-delete zero-row check could be a glob-mismatch
+	// false green.
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+	if err := env.ApplyEvents(ctx, DeleteEvent(wide, row.RowID)); err != nil {
+		t.Fatalf("apply delete: %v", err)
+	}
+
+	assertTombstoneChangeLog(ctx, t, env, wide, row)
+	// Hidden across every tier, pre-flush, and idempotently so.
+	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+}
+
+// testDeleteResurrection is scenario 4 — the delete-resurrection core:
+// create → flush (live versions now in base AND delta parquet) → delete →
+// flush. The tombstone must be exported to the delta (deleted_at set, every
+// attribute and entity_main column NULL — the hard-deleted row no longer
+// joins), and once the dirty set is drained the row must stay invisible on
+// parquet LWW alone: the tombstone's later changed_at beats both live
+// versions.
+func testDeleteResurrection(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply create: %v", err)
+	}
+	row := creates[0]
+
+	// Live versions in the cold base (RunInit) and, because the create's
+	// change_log entry is still unflushed, in a warm delta too — two
+	// independent resurrection sources for the tombstone to beat.
+	if _, err := env.RunInit(ctx, wide); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	mustFlush(ctx, t, env)
+	// Load-bearing positive check: the row must be served from parquet
+	// before the delete, or every zero-row assertion below would also pass
+	// with a globally broken read path.
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+	del := DeleteEvent(wide, row.RowID)
+	if err := env.ApplyEvents(ctx, del); err != nil {
+		t.Fatalf("apply delete: %v", err)
+	}
+	// Pre-flush window: hidden by the dirty-set anti-join.
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+	flush2 := mustFlush(ctx, t, env)
+	assertTombstoneParquet(ctx, t, env, soleParquetKey(t, flush2), del)
+
+	// Post-flush: the dirty set is empty (mustFlush), so invisibility now
+	// rests purely on parquet LWW — and no tier-preference hint may
+	// resurrect the cold or warm live version.
+	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
+	for _, tiers := range [][]model.DataTier{
+		nil,
+		{model.DataTierCold},
+		{model.DataTierWarm, model.DataTierCold},
+	} {
+		result := env.AssertQueryMatches(ctx, Query{Schema: wide, PreferredTiers: tiers, Limit: 10})
+		if result != nil && !result.Plan.Routing.UseDuckDB {
+			t.Errorf("tiers %v did not route to duckdb: %+v", tiers, result.Plan.Routing)
 		}
-		if n != 1 || deletedAt.Valid || !changedAt.Valid || changedAt.Int64 != restored.ChangedAt {
-			t.Errorf("restore delta: versions=%d deleted_at=(%d,%t) changed_at=(%d,%t), want 1 live version at %d",
-				n, deletedAt.Int64, deletedAt.Valid, changedAt.Int64, changedAt.Valid, restored.ChangedAt)
-		}
+	}
+
+	// Idempotency: a retried flush moves nothing and exports nothing, and
+	// the row stays deleted.
+	flush3, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("retry flush: %v", err)
+	}
+	if flush3.UnflushedBefore != 0 || flush3.UnflushedAfter != 0 {
+		t.Errorf("retry flush saw unflushed %d -> %d, want 0 -> 0", flush3.UnflushedBefore, flush3.UnflushedAfter)
+	}
+	if len(flush3.NewObjects) != 0 {
+		t.Errorf("retry flush created objects %v, want none", flush3.NewObjects)
+	}
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+	// Row reuse after delete, real-API side: a fresh create through the
+	// EntityManager must become the only visible row — the flushed tombstone
+	// must not bleed onto new rows. (Same-row_id revival is storage-injected
+	// in scenario 5; the public API cannot reuse a row_id.)
+	postCreates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+	if err := env.ApplyEvents(ctx, postCreates...); err != nil {
+		t.Fatalf("apply post-delete create: %v", err)
+	}
+	mustFlush(ctx, t, env)
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+}
+
+// testRestoreAfterDelete is scenario 5: create → flush → delete → flush →
+// restore → flush → query. Production has no restore API — Update on the
+// hard-deleted row must return ErrNotFound — so the revival is injected at
+// the storage layer (InjectRestore). The restored version must then beat the
+// already flushed parquet tombstone in LWW: one visible row with the
+// original attributes and no zombie tombstone hiding it.
+func testRestoreAfterDelete(ctx context.Context, t *testing.T, env *Env, simple SchemaRef) {
+	creates := env.GenerateScript(ScriptSpec{Schema: simple, Creates: 1})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply create: %v", err)
+	}
+	row := creates[0]
+	mustFlush(ctx, t, env)
+	// Load-bearing positive check before the delete (see testDeleteResurrection).
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+
+	del := DeleteEvent(simple, row.RowID)
+	if err := env.ApplyEvents(ctx, del); err != nil {
+		t.Fatalf("apply delete: %v", err)
+	}
+	mustFlush(ctx, t, env) // tombstone now lives in a delta parquet
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+
+	// Contract pin: the production API cannot revive a hard-deleted row.
+	_, err := env.EntityManager().Update(ctx, &forma.EntityOperation{
+		EntityIdentifier: forma.EntityIdentifier{SchemaName: simple.Name, RowID: row.RowID},
+		Type:             forma.OperationUpdate,
+		Updates:          map[string]any{"name": "resurrect-attempt"},
 	})
+	if !errors.Is(err, forma.ErrNotFound) {
+		t.Fatalf("update of deleted row returned %v, want ErrNotFound", err)
+	}
+
+	restored := env.InjectRestore(ctx, row, del)
+	flush3 := mustFlush(ctx, t, env)
+
+	// Visible again everywhere, idempotently so. LWW supersession of the
+	// flushed tombstone is proven by these engine-vs-oracle diffs — the
+	// tombstone parquet itself is immutable and stays in place; only the
+	// merge-on-read outcome changes.
+	env.AssertQueryMatches(ctx, Query{Schema: simple, PreferHot: true, Limit: 10})
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+
+	// Physical check: the restore flush exported exactly one live version.
+	assertSoleLiveVersion(ctx, t, env, soleParquetKey(t, flush3), restored)
 }
 
 // allWideAttrsNullSQL is the tombstone NULL-ness predicate over every
@@ -302,6 +306,27 @@ func assertTombstoneParquet(ctx context.Context, t *testing.T, env *Env, key str
 	}
 	if !deletedAt.Valid || deletedAt.Int64 != del.DeletedAt || del.DeletedAt <= 0 {
 		t.Errorf("tombstone %s.deleted_at = %d (valid=%t), want %d > 0", del.RowID, deletedAt.Int64, deletedAt.Valid, del.DeletedAt)
+	}
+}
+
+// assertSoleLiveVersion asserts one delta parquet file holds exactly one
+// version of the event's row and that it is live: deleted_at NULL and
+// changed_at equal to the event's read-back change_log timestamp. Attribute
+// columns are not inspected — use assertLiveParquetRow for e2e_wide rows.
+func assertSoleLiveVersion(ctx context.Context, t *testing.T, env *Env, key string, ev *Event) {
+	t.Helper()
+	path := fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, strings.TrimPrefix(key, "/"))
+	var n int
+	var deletedAt, changedAt sql.NullInt64
+	if err := env.Duck.DB.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT COUNT(*), MAX(deleted_at), MAX(changed_at)
+		 FROM read_parquet('%s') WHERE CAST(row_id AS VARCHAR) = ?`, path),
+		ev.RowID.String()).Scan(&n, &deletedAt, &changedAt); err != nil {
+		t.Fatalf("scan delta parquet %s: %v", key, err)
+	}
+	if n != 1 || deletedAt.Valid || !changedAt.Valid || changedAt.Int64 != ev.ChangedAt {
+		t.Errorf("delta %s: versions=%d deleted_at=(%d,%t) changed_at=(%d,%t), want 1 live version at %d",
+			ev.RowID, n, deletedAt.Int64, deletedAt.Valid, changedAt.Int64, changedAt.Valid, ev.ChangedAt)
 	}
 }
 
@@ -372,6 +397,16 @@ func soleParquetKey(t *testing.T, flush *FlushReport) string {
 // equal to the event payload.
 func assertLiveParquetRow(ctx context.Context, t *testing.T, env *Env, key string, ev *Event) {
 	t.Helper()
+	wantTitle, isStr := ev.Attrs["title"].(string)
+	if !isStr {
+		t.Fatalf("event %s has no string title attribute (%T)", ev.RowID, ev.Attrs["title"])
+	}
+	countF, isF64 := ev.Attrs["count"].(float64)
+	if !isF64 {
+		t.Fatalf("event %s has no float64 count attribute (%T)", ev.RowID, ev.Attrs["count"])
+	}
+	wantCount := int32(countF)
+
 	path := fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, strings.TrimPrefix(key, "/"))
 	rows, err := env.Duck.DB.QueryContext(ctx, fmt.Sprintf(
 		`SELECT "title", "count", "changed_at", "deleted_at"
@@ -394,11 +429,9 @@ func assertLiveParquetRow(ctx context.Context, t *testing.T, env *Env, key strin
 		if !changedAt.Valid || changedAt.Int64 != ev.ChangedAt {
 			t.Errorf("delta %s.changed_at = %d (valid=%t), want %d", ev.RowID, changedAt.Int64, changedAt.Valid, ev.ChangedAt)
 		}
-		wantTitle := ev.Attrs["title"].(string)
 		if !title.Valid || title.String != wantTitle {
 			t.Errorf("delta %s.title = %q (valid=%t), want %q", ev.RowID, title.String, title.Valid, wantTitle)
 		}
-		wantCount := int32(ev.Attrs["count"].(float64))
 		if !count.Valid || count.Int32 != wantCount {
 			t.Errorf("delta %s.count = %d (valid=%t), want %d", ev.RowID, count.Int32, count.Valid, wantCount)
 		}

--- a/internal/e2e_harness/production/lifecycle_e2e_test.go
+++ b/internal/e2e_harness/production/lifecycle_e2e_test.go
@@ -5,10 +5,12 @@ package production
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
+	forma "github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/model"
 )
 
@@ -194,6 +196,68 @@ func TestEntityLifecycle(t *testing.T) {
 			t.Errorf("retry flush created objects %v, want none", flush3.NewObjects)
 		}
 		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	})
+
+	// Scenario 5: create → flush → delete → flush → restore → flush → query.
+	// Production has no restore API — Update on the hard-deleted row must
+	// return ErrNotFound — so the revival is injected at the storage layer
+	// (InjectRestore). The restored version must then beat the already
+	// flushed parquet tombstone in LWW: one visible row with the original
+	// attributes and no zombie tombstone hiding it.
+	t.Run("restore_after_delete", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, cluster)
+		ctx := context.Background()
+		simple := DefaultSchemaFixtures()[0] // e2e_simple
+
+		creates := env.GenerateScript(ScriptSpec{Schema: simple, Creates: 1})
+		if err := env.ApplyEvents(ctx, creates...); err != nil {
+			t.Fatalf("apply create: %v", err)
+		}
+		row := creates[0]
+		mustFlush(ctx, t, env)
+
+		del := DeleteEvent(simple, row.RowID)
+		if err := env.ApplyEvents(ctx, del); err != nil {
+			t.Fatalf("apply delete: %v", err)
+		}
+		mustFlush(ctx, t, env) // tombstone now lives in a delta parquet
+		env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+
+		// Contract pin: the production API cannot revive a hard-deleted row.
+		_, err := env.EntityManager().Update(ctx, &forma.EntityOperation{
+			EntityIdentifier: forma.EntityIdentifier{SchemaName: simple.Name, RowID: row.RowID},
+			Type:             forma.OperationUpdate,
+			Updates:          map[string]any{"name": "resurrect-attempt"},
+		})
+		if !errors.Is(err, forma.ErrNotFound) {
+			t.Fatalf("update of deleted row returned %v, want ErrNotFound", err)
+		}
+
+		restored := env.InjectRestore(ctx, row, del)
+		flush3 := mustFlush(ctx, t, env)
+
+		// Visible again everywhere — the restored delta version must win LWW
+		// over the flushed tombstone — and idempotently so.
+		env.AssertQueryMatches(ctx, Query{Schema: simple, PreferHot: true, Limit: 10})
+		env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+		env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+
+		// Physical check: the restore flush exported exactly one live version.
+		key := soleParquetKey(t, flush3)
+		path := fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, strings.TrimPrefix(key, "/"))
+		var n int
+		var deletedAt, changedAt sql.NullInt64
+		if err := env.Duck.DB.QueryRowContext(ctx, fmt.Sprintf(
+			`SELECT COUNT(*), MAX(deleted_at), MAX(changed_at)
+			 FROM read_parquet('%s') WHERE CAST(row_id AS VARCHAR) = ?`, path),
+			row.RowID.String()).Scan(&n, &deletedAt, &changedAt); err != nil {
+			t.Fatalf("scan restore delta %s: %v", key, err)
+		}
+		if n != 1 || deletedAt.Valid || !changedAt.Valid || changedAt.Int64 != restored.ChangedAt {
+			t.Errorf("restore delta: versions=%d deleted_at=(%d,%t) changed_at=(%d,%t), want 1 live version at %d",
+				n, deletedAt.Int64, deletedAt.Valid, changedAt.Int64, changedAt.Valid, restored.ChangedAt)
+		}
 	})
 }
 

--- a/internal/e2e_harness/production/lifecycle_e2e_test.go
+++ b/internal/e2e_harness/production/lifecycle_e2e_test.go
@@ -1,0 +1,164 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestEntityLifecycle proves the entity lifecycle is correct across CDC
+// boundaries (#175). Each subtest drives one lifecycle chain through the
+// real EntityManager, CDC flusher, and federated engine, checking every
+// query against the independent oracle plus targeted physical (parquet) and
+// change_log assertions. The headline risk is delete resurrection: a
+// deletion must stay invisible before the flush (dirty-set anti-join), after
+// the flush (parquet LWW over the exported tombstone), and across retries.
+func TestEntityLifecycle(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	// Scenario 1: create → flush → query. Exactly one visible row with
+	// correct values, one live delta version exported.
+	t.Run("create_flush_query", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, cluster)
+		ctx := context.Background()
+
+		creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+		if err := env.ApplyEvents(ctx, creates...); err != nil {
+			t.Fatalf("apply create: %v", err)
+		}
+
+		env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
+
+		flush := mustFlush(ctx, t, env)
+		if got := countTier(flush.Manifests[wide.ID], "delta"); got != 1 {
+			t.Fatalf("manifest holds %d delta files, want 1", got)
+		}
+
+		result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+		if result != nil && !result.Plan.Routing.UseDuckDB {
+			t.Errorf("post-flush query did not route to duckdb: %+v", result.Plan.Routing)
+		}
+
+		assertLiveParquetRow(ctx, t, env, soleParquetKey(t, flush), creates[0])
+	})
+
+	// Scenario 2: create → update → flush → query. The latest version wins
+	// with no duplicate: the pre-flush change_log upsert coalesces both
+	// mutations into the single slot-0 row, so exactly one (updated) version
+	// reaches the delta parquet.
+	t.Run("update_lww", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, cluster)
+		ctx := context.Background()
+
+		script := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1, Updates: 1})
+		if err := env.ApplyEvents(ctx, script...); err != nil {
+			t.Fatalf("apply create+update: %v", err)
+		}
+		update := script[1]
+		if update.Kind != EventUpdate {
+			t.Fatalf("script[1] is %s, want update", update.Kind)
+		}
+
+		var slot0 int64
+		if err := env.Pool.QueryRow(ctx,
+			"SELECT COUNT(*) FROM change_log WHERE schema_id = $1 AND row_id = $2",
+			wide.ID, update.RowID).Scan(&slot0); err != nil {
+			t.Fatalf("count change_log rows: %v", err)
+		}
+		if slot0 != 1 {
+			t.Fatalf("change_log holds %d rows for the mutated row, want 1 coalesced slot-0 row", slot0)
+		}
+
+		flush := mustFlush(ctx, t, env)
+
+		// The oracle folds create+update by LWW into one row carrying the
+		// update's values — a duplicate or stale engine row fails the diff.
+		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+		assertLiveParquetRow(ctx, t, env, soleParquetKey(t, flush), update)
+	})
+}
+
+// mustFlush runs a real CDC flush and fails the test unless it drained the
+// dirty set completely.
+func mustFlush(ctx context.Context, t *testing.T, env *Env) *FlushReport {
+	t.Helper()
+	flush, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if flush.UnflushedAfter != 0 {
+		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
+	}
+	return flush
+}
+
+// soleParquetKey returns the single parquet object a flush created, failing
+// on any other count (manifest JSON objects are ignored).
+func soleParquetKey(t *testing.T, flush *FlushReport) string {
+	t.Helper()
+	var keys []string
+	for _, k := range flush.NewObjects {
+		if strings.HasSuffix(k, ".parquet") {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) != 1 {
+		t.Fatalf("flush created %d parquet objects %v, want exactly 1", len(keys), keys)
+	}
+	return keys[0]
+}
+
+// assertLiveParquetRow asserts one delta parquet file holds exactly one
+// version of the event's row and that it is live: deleted_at NULL (the delta
+// exporter emits raw cl.deleted_at), changed_at equal to the event's
+// read-back change_log timestamp, and the pinned title/count attributes
+// equal to the event payload.
+func assertLiveParquetRow(ctx context.Context, t *testing.T, env *Env, key string, ev *Event) {
+	t.Helper()
+	path := fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, strings.TrimPrefix(key, "/"))
+	rows, err := env.Duck.DB.QueryContext(ctx, fmt.Sprintf(
+		`SELECT "title", "count", "changed_at", "deleted_at"
+		 FROM read_parquet('%s') WHERE CAST(row_id AS VARCHAR) = ?`, path), ev.RowID.String())
+	if err != nil {
+		t.Fatalf("scan delta parquet %s: %v", key, err)
+	}
+	defer rows.Close()
+	n := 0
+	for rows.Next() {
+		var title sql.NullString
+		var count sql.NullInt32
+		var changedAt, deletedAt sql.NullInt64
+		if err := rows.Scan(&title, &count, &changedAt, &deletedAt); err != nil {
+			t.Fatalf("scan delta parquet row: %v", err)
+		}
+		if deletedAt.Valid {
+			t.Errorf("delta %s.deleted_at = %d, want NULL (live row)", ev.RowID, deletedAt.Int64)
+		}
+		if !changedAt.Valid || changedAt.Int64 != ev.ChangedAt {
+			t.Errorf("delta %s.changed_at = %d (valid=%t), want %d", ev.RowID, changedAt.Int64, changedAt.Valid, ev.ChangedAt)
+		}
+		wantTitle := ev.Attrs["title"].(string)
+		if !title.Valid || title.String != wantTitle {
+			t.Errorf("delta %s.title = %q (valid=%t), want %q", ev.RowID, title.String, title.Valid, wantTitle)
+		}
+		wantCount := int32(ev.Attrs["count"].(float64))
+		if !count.Valid || count.Int32 != wantCount {
+			t.Errorf("delta %s.count = %d (valid=%t), want %d", ev.RowID, count.Int32, count.Valid, wantCount)
+		}
+		n++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("delta parquet rows: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("delta parquet holds %d versions of row %s, want exactly 1", n, ev.RowID)
+	}
+}

--- a/internal/e2e_harness/production/lifecycle_e2e_test.go
+++ b/internal/e2e_harness/production/lifecycle_e2e_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	forma "github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/compaction"
+	"github.com/lychee-technology/forma/internal/manifest"
 	"github.com/lychee-technology/forma/internal/model"
 )
 
@@ -205,6 +207,8 @@ func testDeleteResurrection(ctx context.Context, t *testing.T, env *Env, wide Sc
 	}
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
 
+	assertCompactionPreservesDeletion(ctx, t, env, wide, flush2.Manifests[wide.ID])
+
 	// Row reuse after delete, real-API side: a fresh create through the
 	// EntityManager must become the only visible row — the flushed tombstone
 	// must not bleed onto new rows. (Same-row_id revival is storage-injected
@@ -263,6 +267,41 @@ func testRestoreAfterDelete(ctx context.Context, t *testing.T, env *Env, simple 
 
 	// Physical check: the restore flush exported exactly one live version.
 	assertSoleLiveVersion(ctx, t, env, soleParquetKey(t, flush3), restored)
+}
+
+// assertCompactionPreservesDeletion runs the real compactor on the schema's
+// manifest and pins today's compaction contract on a tombstone-bearing
+// dataset (#175 "invisible after compaction"): the dirty ratio — delta rows
+// over base rows, here 2/1 — exceeds the rewrite threshold, but the rewrite
+// is not implemented, so the compactor must report RewritePending and leave
+// the manifest untouched, and the deletion must stay invisible. Promotion
+// needs a TargetBaseSizeMB-sized delta tier (≥1 MB, out of reach here), and
+// the federated read path never consults the manifest — so a genuine
+// before/after equivalence test only becomes possible when #188 implements
+// the rewrite. This assertion is #188's tripwire: implementing the rewrite
+// flips the outcome and forces that issue to replace it with real coverage.
+func assertCompactionPreservesDeletion(ctx context.Context, t *testing.T, env *Env, wide SchemaRef, before *manifest.Manifest) {
+	t.Helper()
+	if before == nil {
+		t.Fatal("no manifest recorded before compaction")
+	}
+	result, err := env.RunCompaction(ctx, wide)
+	if err != nil {
+		t.Fatalf("run compaction: %v", err)
+	}
+	if result.Outcome != compaction.RewritePending {
+		t.Errorf("compaction outcome = %s (dirty ratio %.2f), want %s — the rewrite landed (#188); replace this tripwire with before/after equivalence coverage",
+			result.Outcome, result.DirtyRatio, compaction.RewritePending)
+	}
+	after, err := env.loadManifests(ctx)
+	if err != nil {
+		t.Fatalf("reload manifests: %v", err)
+	}
+	m := after[wide.ID]
+	if m == nil || m.Version != before.Version || countTier(m, "delta") != countTier(before, "delta") {
+		t.Errorf("compaction mutated the manifest (version %d -> %v), want untouched on RewritePending", before.Version, m)
+	}
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
 }
 
 // allWideAttrsNullSQL is the tombstone NULL-ness predicate over every

--- a/internal/e2e_harness/production/lifecycle_e2e_test.go
+++ b/internal/e2e_harness/production/lifecycle_e2e_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
 )
 
 // TestEntityLifecycle proves the entity lifecycle is correct across CDC
@@ -127,6 +129,116 @@ func TestEntityLifecycle(t *testing.T) {
 		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
 		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
 	})
+
+	// Scenario 4 — the delete-resurrection core: create → flush (live
+	// versions now in base AND delta parquet) → delete → flush. The tombstone
+	// must be exported to the delta (deleted_at set, every attribute and
+	// entity_main column NULL — the hard-deleted row no longer joins), and
+	// once the dirty set is drained the row must stay invisible on parquet
+	// LWW alone: the tombstone's later changed_at beats both live versions.
+	t.Run("delete_resurrection", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, cluster)
+		ctx := context.Background()
+
+		creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+		if err := env.ApplyEvents(ctx, creates...); err != nil {
+			t.Fatalf("apply create: %v", err)
+		}
+		row := creates[0]
+
+		// Live versions in the cold base (RunInit) and, because the create's
+		// change_log entry is still unflushed, in a warm delta too — two
+		// independent resurrection sources for the tombstone to beat.
+		if _, err := env.RunInit(ctx, wide); err != nil {
+			t.Fatalf("run init: %v", err)
+		}
+		mustFlush(ctx, t, env)
+		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+		del := DeleteEvent(wide, row.RowID)
+		if err := env.ApplyEvents(ctx, del); err != nil {
+			t.Fatalf("apply delete: %v", err)
+		}
+		// Pre-flush window: hidden by the dirty-set anti-join.
+		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+		flush2 := mustFlush(ctx, t, env)
+		assertTombstoneParquet(ctx, t, env, soleParquetKey(t, flush2), del)
+
+		// Post-flush: the dirty set is empty (mustFlush), so invisibility now
+		// rests purely on parquet LWW — and no tier-preference hint may
+		// resurrect the cold or warm live version.
+		env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
+		for _, tiers := range [][]model.DataTier{
+			nil,
+			{model.DataTierCold},
+			{model.DataTierWarm, model.DataTierCold},
+		} {
+			result := env.AssertQueryMatches(ctx, Query{Schema: wide, PreferredTiers: tiers, Limit: 10})
+			if result != nil && !result.Plan.Routing.UseDuckDB {
+				t.Errorf("tiers %v did not route to duckdb: %+v", tiers, result.Plan.Routing)
+			}
+		}
+
+		// Idempotency: a retried flush moves nothing and exports nothing, and
+		// the row stays deleted.
+		flush3, err := env.RunFlush(ctx)
+		if err != nil {
+			t.Fatalf("retry flush: %v", err)
+		}
+		if flush3.UnflushedBefore != 0 || flush3.UnflushedAfter != 0 {
+			t.Errorf("retry flush saw unflushed %d -> %d, want 0 -> 0", flush3.UnflushedBefore, flush3.UnflushedAfter)
+		}
+		if len(flush3.NewObjects) != 0 {
+			t.Errorf("retry flush created objects %v, want none", flush3.NewObjects)
+		}
+		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	})
+}
+
+// allWideAttrsNullSQL is the tombstone NULL-ness predicate over every
+// e2e_wide attribute column (17 scalar attributes, both bound and EAV).
+const allWideAttrsNullSQL = `"title" IS NULL AND "rank" IS NULL AND "count" IS NULL AND "amount" IS NULL ` +
+	`AND "score" IS NULL AND "ref" IS NULL AND "joined" IS NULL AND "touched" IS NULL AND "note" IS NULL ` +
+	`AND "active" IS NULL AND "born" IS NULL AND "seen" IS NULL AND "level" IS NULL AND "qty" IS NULL ` +
+	`AND "total" IS NULL AND "ratio" IS NULL AND "token" IS NULL`
+
+// assertTombstoneParquet asserts one delta parquet file holds exactly one
+// version of the deleted row, shaped as a tombstone: changed_at/deleted_at
+// carry the delete's change_log entry, and every attribute column plus the
+// entity_main system columns are NULL — the delta export LEFT JOINs
+// entity_main precisely so a hard delete still reaches parquet
+// (internal/cdc/duckdb_exporter.go).
+func assertTombstoneParquet(ctx context.Context, t *testing.T, env *Env, key string, del *Event) {
+	t.Helper()
+	path := fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, strings.TrimPrefix(key, "/"))
+	var n int
+	var attrsNull, ltbaseNull sql.NullBool
+	var changedAt, deletedAt sql.NullInt64
+	if err := env.Duck.DB.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT COUNT(*), BOOL_AND(%s),
+		        BOOL_AND(ltbase_created_at IS NULL AND ltbase_updated_at IS NULL AND ltbase_deleted_at IS NULL),
+		        MAX(changed_at), MAX(deleted_at)
+		 FROM read_parquet('%s') WHERE CAST(row_id AS VARCHAR) = ?`,
+		allWideAttrsNullSQL, path), del.RowID.String()).Scan(&n, &attrsNull, &ltbaseNull, &changedAt, &deletedAt); err != nil {
+		t.Fatalf("scan tombstone parquet %s: %v", key, err)
+	}
+	if n != 1 {
+		t.Fatalf("delta parquet holds %d versions of deleted row %s, want exactly 1 tombstone", n, del.RowID)
+	}
+	if !attrsNull.Valid || !attrsNull.Bool {
+		t.Errorf("tombstone %s carries non-NULL attribute columns", del.RowID)
+	}
+	if !ltbaseNull.Valid || !ltbaseNull.Bool {
+		t.Errorf("tombstone %s carries non-NULL entity_main system columns", del.RowID)
+	}
+	if !changedAt.Valid || changedAt.Int64 != del.ChangedAt {
+		t.Errorf("tombstone %s.changed_at = %d (valid=%t), want %d", del.RowID, changedAt.Int64, changedAt.Valid, del.ChangedAt)
+	}
+	if !deletedAt.Valid || deletedAt.Int64 != del.DeletedAt || del.DeletedAt <= 0 {
+		t.Errorf("tombstone %s.deleted_at = %d (valid=%t), want %d > 0", del.RowID, deletedAt.Int64, deletedAt.Valid, del.DeletedAt)
+	}
 }
 
 // assertTombstoneChangeLog asserts the hard delete's storage contract: the

--- a/internal/e2e_harness/production/lifecycle_e2e_test.go
+++ b/internal/e2e_harness/production/lifecycle_e2e_test.go
@@ -84,6 +84,79 @@ func TestEntityLifecycle(t *testing.T) {
 
 		assertLiveParquetRow(ctx, t, env, soleParquetKey(t, flush), update)
 	})
+
+	// Scenario 3: create → delete → query, before any flush. The deleted
+	// row's only surviving source is the cold base parquet (its change_log
+	// entry is truncated after init, modeling the production onboarding
+	// contract), so hiding it rests entirely on the dirty-set anti-join: the
+	// hard delete leaves no entity_main row for pg_source and the unflushed
+	// tombstone must evict the base version from s3_source.
+	t.Run("delete_before_flush", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, cluster)
+		ctx := context.Background()
+
+		creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+		if err := env.ApplyEvents(ctx, creates...); err != nil {
+			t.Fatalf("apply create: %v", err)
+		}
+		row := creates[0]
+
+		initReport, err := env.RunInit(ctx, wide)
+		if err != nil {
+			t.Fatalf("run init: %v", err)
+		}
+		if initReport.RowsExported != 1 {
+			t.Fatalf("init exported %d rows, want 1", initReport.RowsExported)
+		}
+		env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1 AND row_id = $2",
+			wide.ID, row.RowID)
+
+		// The base file must actually serve the row before the delete —
+		// otherwise the post-delete zero-row check could be a glob-mismatch
+		// false green.
+		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+		if err := env.ApplyEvents(ctx, DeleteEvent(wide, row.RowID)); err != nil {
+			t.Fatalf("apply delete: %v", err)
+		}
+
+		assertTombstoneChangeLog(ctx, t, env, wide, row)
+		// Hidden across every tier, pre-flush, and idempotently so.
+		env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
+		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+		env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	})
+}
+
+// assertTombstoneChangeLog asserts the hard delete's storage contract: the
+// entity_main and eav_data rows are gone and the single unflushed change_log
+// slot-0 entry carries the tombstone.
+func assertTombstoneChangeLog(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, ev *Event) {
+	t.Helper()
+	var mainRows, eavRows int64
+	if err := env.Pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM entity_main WHERE ltbase_schema_id = $1 AND ltbase_row_id = $2",
+		schema.ID, ev.RowID).Scan(&mainRows); err != nil {
+		t.Fatalf("count entity_main rows: %v", err)
+	}
+	if err := env.Pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM eav_data WHERE schema_id = $1 AND row_id = $2",
+		schema.ID, ev.RowID).Scan(&eavRows); err != nil {
+		t.Fatalf("count eav_data rows: %v", err)
+	}
+	if mainRows != 0 || eavRows != 0 {
+		t.Errorf("hard delete left entity_main=%d eav_data=%d rows, want 0/0", mainRows, eavRows)
+	}
+	var deletedAt int64
+	if err := env.Pool.QueryRow(ctx,
+		"SELECT COALESCE(deleted_at, 0) FROM change_log WHERE schema_id = $1 AND row_id = $2 AND flushed_at = 0",
+		schema.ID, ev.RowID).Scan(&deletedAt); err != nil {
+		t.Fatalf("load slot-0 tombstone: %v", err)
+	}
+	if deletedAt <= 0 {
+		t.Errorf("slot-0 change_log entry deleted_at = %d, want > 0 (tombstone)", deletedAt)
+	}
 }
 
 // mustFlush runs a real CDC flush and fails the test unless it drained the

--- a/internal/e2e_harness/production/restart_e2e_test.go
+++ b/internal/e2e_harness/production/restart_e2e_test.go
@@ -1,0 +1,41 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+)
+
+// TestPostgresRestartRoundtrip proves the state-preserving Postgres restart
+// (#175 scenario 6 plumbing): rows written before the restart must survive
+// it, and every rebound handle — pool, CDC config, DuckDB, entity manager,
+// federated engine — must work against the restarted server. It owns a
+// dedicated cluster because restarting the shared one would break every
+// parallel Env.
+func TestPostgresRestartRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	cluster := DedicatedCluster(t)
+	env := NewEnv(t, cluster)
+	wide := DefaultSchemaFixtures()[1]
+
+	events := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 3})
+	if err := env.ApplyEvents(ctx, events...); err != nil {
+		t.Fatalf("apply events: %v", err)
+	}
+
+	if err := env.RestartPostgres(ctx); err != nil {
+		t.Fatalf("restart postgres: %v", err)
+	}
+
+	// Hot query through the rebuilt pool/engine: all three rows survived.
+	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
+
+	// Writes still work after the restart (fresh EntityManager over the new
+	// pool), proving the rebind is complete, not just read-capable.
+	more := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+	if err := env.ApplyEvents(ctx, more...); err != nil {
+		t.Fatalf("apply events after restart: %v", err)
+	}
+	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
+}

--- a/internal/e2e_harness/production/restart_e2e_test.go
+++ b/internal/e2e_harness/production/restart_e2e_test.go
@@ -45,9 +45,9 @@ func TestPostgresRestartRoundtrip(t *testing.T) {
 // matters — entity rows, change_log tombstones, flushed_at markers — lives
 // in the persistence layer, never in process memory. Restart points cover
 // each lifecycle stage: after the live flush, after an unflushed update,
-// after the unflushed delete, after the tombstone flush (plus flush-retry
-// no-op), and after an injected restore. Serial on a dedicated cluster
-// (restarting the shared one would break parallel Envs).
+// after the update flush, after the unflushed delete, after the tombstone
+// flush (plus flush-retry no-op), and after an injected restore. Serial on a
+// dedicated cluster (restarting the shared one would break parallel Envs).
 func TestEntityLifecycleCrossRestart(t *testing.T) {
 	ctx := context.Background()
 	cluster := DedicatedCluster(t)
@@ -61,9 +61,7 @@ func TestEntityLifecycleCrossRestart(t *testing.T) {
 	mustFlush(ctx, t, env)
 
 	// Restart point 1: a flushed live row survives.
-	if err := env.RestartPostgres(ctx); err != nil {
-		t.Fatalf("restart after live flush: %v", err)
-	}
+	restartPG(ctx, t, env, "after live flush")
 	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
 	if result != nil && !result.Plan.Routing.UseDuckDB {
 		t.Errorf("post-restart query did not route to duckdb: %+v", result.Plan.Routing)
@@ -78,22 +76,23 @@ func TestEntityLifecycleCrossRestart(t *testing.T) {
 	if err := env.ApplyEvents(ctx, update); err != nil {
 		t.Fatalf("apply update: %v", err)
 	}
-	if err := env.RestartPostgres(ctx); err != nil {
-		t.Fatalf("restart after unflushed update: %v", err)
-	}
+	restartPG(ctx, t, env, "after unflushed update")
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+	// Restart point 3: with the update flushed there are two live parquet
+	// versions of the row; LWW must still resolve to the updated value.
 	mustFlush(ctx, t, env)
+	restartPG(ctx, t, env, "after update flush")
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
 
 	del := DeleteEvent(wide, creates[0].RowID)
 	if err := env.ApplyEvents(ctx, del); err != nil {
 		t.Fatalf("apply delete: %v", err)
 	}
 
-	// Restart point 3: the unflushed tombstone survives in change_log and
+	// Restart point 4: the unflushed tombstone survives in change_log and
 	// keeps masking the flushed live versions.
-	if err := env.RestartPostgres(ctx); err != nil {
-		t.Fatalf("restart after unflushed delete: %v", err)
-	}
+	restartPG(ctx, t, env, "after unflushed delete")
 	assertTombstoneChangeLog(ctx, t, env, wide, del)
 	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
@@ -101,11 +100,9 @@ func TestEntityLifecycleCrossRestart(t *testing.T) {
 	flush2 := mustFlush(ctx, t, env)
 	assertTombstoneParquet(ctx, t, env, soleParquetKey(t, flush2), del)
 
-	// Restart point 4: with the tombstone flushed, the deletion stays
+	// Restart point 5: with the tombstone flushed, the deletion stays
 	// invisible and a retried flush is still a no-op.
-	if err := env.RestartPostgres(ctx); err != nil {
-		t.Fatalf("restart after tombstone flush: %v", err)
-	}
+	restartPG(ctx, t, env, "after tombstone flush")
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
 	retry, err := env.RunFlush(ctx)
 	if err != nil {
@@ -117,9 +114,16 @@ func TestEntityLifecycleCrossRestart(t *testing.T) {
 	}
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
 
-	// Restart point 5: a restored row (scenario 5's injected revival, on the
-	// simple fixture) stays visible across a restart, with its single live
-	// delta version readable through the rebuilt DuckDB client.
+	// Restart point 6: an injected restore stays visible across a restart.
+	testRestoreAcrossRestart(ctx, t, env)
+}
+
+// testRestoreAcrossRestart drives scenario 5's injected revival on the
+// simple fixture and restarts after the restore flush: the restored row must
+// stay visible, with its single live delta version readable through the
+// rebuilt DuckDB client.
+func testRestoreAcrossRestart(ctx context.Context, t *testing.T, env *Env) {
+	t.Helper()
 	simple := DefaultSchemaFixtures()[0]
 	screates := env.GenerateScript(ScriptSpec{Schema: simple, Creates: 1})
 	if err := env.ApplyEvents(ctx, screates...); err != nil {
@@ -133,10 +137,17 @@ func TestEntityLifecycleCrossRestart(t *testing.T) {
 	mustFlush(ctx, t, env)
 	restored := env.InjectRestore(ctx, screates[0], sdel)
 	restoreFlush := mustFlush(ctx, t, env)
-	if err := env.RestartPostgres(ctx); err != nil {
-		t.Fatalf("restart after restore flush: %v", err)
-	}
+	restartPG(ctx, t, env, "after restore flush")
 	env.AssertQueryMatches(ctx, Query{Schema: simple, PreferHot: true, Limit: 10})
 	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
 	assertSoleLiveVersion(ctx, t, env, soleParquetKey(t, restoreFlush), restored)
+}
+
+// restartPG restarts the Env's Postgres and fails the test on error; stage
+// names the lifecycle point for the failure message.
+func restartPG(ctx context.Context, t *testing.T, env *Env, stage string) {
+	t.Helper()
+	if err := env.RestartPostgres(ctx); err != nil {
+		t.Fatalf("restart postgres %s: %v", stage, err)
+	}
 }

--- a/internal/e2e_harness/production/restart_e2e_test.go
+++ b/internal/e2e_harness/production/restart_e2e_test.go
@@ -39,3 +39,65 @@ func TestPostgresRestartRoundtrip(t *testing.T) {
 	}
 	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
 }
+
+// TestEntityLifecycleCrossRestart is scenario 6 of #175: every lifecycle
+// stage must be idempotent across a Postgres restart, because all state that
+// matters — entity rows, change_log tombstones, flushed_at markers — lives
+// in the persistence layer, never in process memory. The restart points
+// bracket the delete-resurrection chain: after the live flush, after the
+// unflushed delete, and after the tombstone flush. Serial on a dedicated
+// cluster (restarting the shared one would break parallel Envs).
+func TestEntityLifecycleCrossRestart(t *testing.T) {
+	ctx := context.Background()
+	cluster := DedicatedCluster(t)
+	env := NewEnv(t, cluster)
+	wide := DefaultSchemaFixtures()[1]
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply create: %v", err)
+	}
+	mustFlush(ctx, t, env)
+
+	// Restart point 1: a flushed live row survives.
+	if err := env.RestartPostgres(ctx); err != nil {
+		t.Fatalf("restart after live flush: %v", err)
+	}
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	if result != nil && !result.Plan.Routing.UseDuckDB {
+		t.Errorf("post-restart query did not route to duckdb: %+v", result.Plan.Routing)
+	}
+
+	del := DeleteEvent(wide, creates[0].RowID)
+	if err := env.ApplyEvents(ctx, del); err != nil {
+		t.Fatalf("apply delete: %v", err)
+	}
+
+	// Restart point 2: the unflushed tombstone survives in change_log and
+	// keeps masking the flushed live version.
+	if err := env.RestartPostgres(ctx); err != nil {
+		t.Fatalf("restart after unflushed delete: %v", err)
+	}
+	assertTombstoneChangeLog(ctx, t, env, wide, del)
+	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+	flush2 := mustFlush(ctx, t, env)
+	assertTombstoneParquet(ctx, t, env, soleParquetKey(t, flush2), del)
+
+	// Restart point 3: with the tombstone flushed, the deletion stays
+	// invisible and a retried flush is still a no-op.
+	if err := env.RestartPostgres(ctx); err != nil {
+		t.Fatalf("restart after tombstone flush: %v", err)
+	}
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	retry, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("retry flush after restart: %v", err)
+	}
+	if retry.UnflushedBefore != 0 || retry.UnflushedAfter != 0 || len(retry.NewObjects) != 0 {
+		t.Errorf("post-restart flush retry moved state: unflushed %d -> %d, new objects %v",
+			retry.UnflushedBefore, retry.UnflushedAfter, retry.NewObjects)
+	}
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+}

--- a/internal/e2e_harness/production/restart_e2e_test.go
+++ b/internal/e2e_harness/production/restart_e2e_test.go
@@ -43,10 +43,11 @@ func TestPostgresRestartRoundtrip(t *testing.T) {
 // TestEntityLifecycleCrossRestart is scenario 6 of #175: every lifecycle
 // stage must be idempotent across a Postgres restart, because all state that
 // matters — entity rows, change_log tombstones, flushed_at markers — lives
-// in the persistence layer, never in process memory. The restart points
-// bracket the delete-resurrection chain: after the live flush, after the
-// unflushed delete, and after the tombstone flush. Serial on a dedicated
-// cluster (restarting the shared one would break parallel Envs).
+// in the persistence layer, never in process memory. Restart points cover
+// each lifecycle stage: after the live flush, after an unflushed update,
+// after the unflushed delete, after the tombstone flush (plus flush-retry
+// no-op), and after an injected restore. Serial on a dedicated cluster
+// (restarting the shared one would break parallel Envs).
 func TestEntityLifecycleCrossRestart(t *testing.T) {
 	ctx := context.Background()
 	cluster := DedicatedCluster(t)
@@ -68,13 +69,28 @@ func TestEntityLifecycleCrossRestart(t *testing.T) {
 		t.Errorf("post-restart query did not route to duckdb: %+v", result.Plan.Routing)
 	}
 
+	// Restart point 2: an unflushed update survives in change_log/entity_main
+	// and still wins LWW over the flushed original (oracle checks the value).
+	update := UpdateEvent(wide, creates[0].RowID, map[string]any{
+		"title": "restart-updated",
+		"count": float64(424242),
+	})
+	if err := env.ApplyEvents(ctx, update); err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+	if err := env.RestartPostgres(ctx); err != nil {
+		t.Fatalf("restart after unflushed update: %v", err)
+	}
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	mustFlush(ctx, t, env)
+
 	del := DeleteEvent(wide, creates[0].RowID)
 	if err := env.ApplyEvents(ctx, del); err != nil {
 		t.Fatalf("apply delete: %v", err)
 	}
 
-	// Restart point 2: the unflushed tombstone survives in change_log and
-	// keeps masking the flushed live version.
+	// Restart point 3: the unflushed tombstone survives in change_log and
+	// keeps masking the flushed live versions.
 	if err := env.RestartPostgres(ctx); err != nil {
 		t.Fatalf("restart after unflushed delete: %v", err)
 	}
@@ -85,7 +101,7 @@ func TestEntityLifecycleCrossRestart(t *testing.T) {
 	flush2 := mustFlush(ctx, t, env)
 	assertTombstoneParquet(ctx, t, env, soleParquetKey(t, flush2), del)
 
-	// Restart point 3: with the tombstone flushed, the deletion stays
+	// Restart point 4: with the tombstone flushed, the deletion stays
 	// invisible and a retried flush is still a no-op.
 	if err := env.RestartPostgres(ctx); err != nil {
 		t.Fatalf("restart after tombstone flush: %v", err)
@@ -100,4 +116,27 @@ func TestEntityLifecycleCrossRestart(t *testing.T) {
 			retry.UnflushedBefore, retry.UnflushedAfter, retry.NewObjects)
 	}
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+
+	// Restart point 5: a restored row (scenario 5's injected revival, on the
+	// simple fixture) stays visible across a restart, with its single live
+	// delta version readable through the rebuilt DuckDB client.
+	simple := DefaultSchemaFixtures()[0]
+	screates := env.GenerateScript(ScriptSpec{Schema: simple, Creates: 1})
+	if err := env.ApplyEvents(ctx, screates...); err != nil {
+		t.Fatalf("apply simple create: %v", err)
+	}
+	mustFlush(ctx, t, env)
+	sdel := DeleteEvent(simple, screates[0].RowID)
+	if err := env.ApplyEvents(ctx, sdel); err != nil {
+		t.Fatalf("apply simple delete: %v", err)
+	}
+	mustFlush(ctx, t, env)
+	restored := env.InjectRestore(ctx, screates[0], sdel)
+	restoreFlush := mustFlush(ctx, t, env)
+	if err := env.RestartPostgres(ctx); err != nil {
+		t.Fatalf("restart after restore flush: %v", err)
+	}
+	env.AssertQueryMatches(ctx, Query{Schema: simple, PreferHot: true, Limit: 10})
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 10})
+	assertSoleLiveVersion(ctx, t, env, soleParquetKey(t, restoreFlush), restored)
 }

--- a/internal/e2e_harness/production/restore.go
+++ b/internal/e2e_harness/production/restore.go
@@ -1,0 +1,132 @@
+package production
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	forma "github.com/lychee-technology/forma"
+)
+
+// InjectRestore re-materializes a hard-deleted row under its original row_id
+// by writing storage directly — the production API has no restore operation
+// (Create mints a fresh UUIDv7, Update on a deleted row returns ErrNotFound),
+// so this escape hatch models the storage effect a future restore API would
+// have: rebuild the entity_main and eav_data rows from the create event's
+// attributes and clear the slot-0 change_log tombstone. It appends a
+// synthetic update event to the Env's log so the oracle folds the revival,
+// and returns that event.
+//
+// The restore timestamp is forced strictly past the tombstone's changed_at:
+// the federated LWW tiebreak (ver_ts DESC, tier, deleted_ts DESC) lets a
+// tombstone win an equal timestamp, which would keep the row hidden.
+//
+// Scope guard: only text and numeric attributes are reconstructed (the
+// e2e_simple fixture shapes) — value transformation for richer types belongs
+// to the production write path, which the create/update scenarios cover.
+func (e *Env) InjectRestore(ctx context.Context, create, del *Event) *Event {
+	e.T.Helper()
+	if create.RowID == (uuid.UUID{}) || create.RowID != del.RowID {
+		e.T.Fatalf("InjectRestore needs applied create/delete events for one row, got create=%s delete=%s", create.RowID, del.RowID)
+	}
+
+	ts := time.Now().UnixMilli()
+	if ts <= del.ChangedAt {
+		ts = del.ChangedAt + 1
+	}
+
+	_, cache, err := e.Registry.GetSchemaAttributeCacheByID(create.Schema.ID)
+	if err != nil {
+		e.T.Fatalf("attribute cache for schema %d: %v", create.Schema.ID, err)
+	}
+
+	e.insertRestoredRows(ctx, create, cache, ts)
+
+	// Clear the slot-0 tombstone the way the production upsert would
+	// (postgres_persistent_repository.go upsertChangeLog).
+	e.ExecSQL(ctx,
+		`INSERT INTO change_log (schema_id, row_id, changed_at, deleted_at, flushed_at)
+		 VALUES ($1, $2, $3, NULL, 0)
+		 ON CONFLICT (schema_id, row_id, flushed_at)
+		 DO UPDATE SET changed_at = EXCLUDED.changed_at, deleted_at = NULL`,
+		create.Schema.ID, create.RowID, ts)
+
+	// Oracle sync: an update event revives the row with the create's
+	// attributes; readBackTimestamps loads the slot-0 entry just written.
+	restored := UpdateEvent(create.Schema, create.RowID, create.Attrs)
+	e.eventSeq++
+	restored.Seq = e.eventSeq
+	if err := e.readBackTimestamps(ctx, restored); err != nil {
+		e.T.Fatalf("read back restore timestamps: %v", err)
+	}
+	e.events = append(e.events, restored)
+	return restored
+}
+
+// insertRestoredRows rebuilds the entity_main row (bound columns inline,
+// ltbase_deleted_at NULL) and one eav_data row per unbound attribute.
+func (e *Env) insertRestoredRows(ctx context.Context, create *Event, cache forma.SchemaAttributeCache, ts int64) {
+	e.T.Helper()
+	mainCols := []string{"ltbase_schema_id", "ltbase_row_id", "ltbase_created_at", "ltbase_updated_at", "ltbase_deleted_at"}
+	mainVals := []any{create.Schema.ID, create.RowID, ts, ts, nil}
+
+	type eavRow struct {
+		attrID  int16
+		text    any
+		numeric any
+	}
+	var eavRows []eavRow
+
+	for name, raw := range create.Attrs {
+		meta, ok := cache[name]
+		if !ok {
+			e.T.Fatalf("InjectRestore: attribute %q not in schema %d cache", name, create.Schema.ID)
+		}
+		var textVal, numericVal any
+		switch meta.ValueType {
+		case forma.ValueTypeText:
+			s, isStr := raw.(string)
+			if !isStr {
+				e.T.Fatalf("InjectRestore: text attribute %q holds %T", name, raw)
+			}
+			textVal = s
+		case forma.ValueTypeNumeric:
+			f, isF64 := raw.(float64)
+			if !isF64 {
+				e.T.Fatalf("InjectRestore: numeric attribute %q holds %T", name, raw)
+			}
+			numericVal = f
+		default:
+			e.T.Fatalf("InjectRestore only reconstructs text/numeric attributes, %q is %s", name, meta.ValueType)
+		}
+		if meta.ColumnBinding != nil {
+			if meta.ColumnBinding.Encoding != "" && meta.ColumnBinding.Encoding != forma.MainColumnEncodingDefault {
+				e.T.Fatalf("InjectRestore does not support encoding %q on %q", meta.ColumnBinding.Encoding, name)
+			}
+			mainCols = append(mainCols, string(meta.ColumnBinding.ColumnName))
+			if textVal != nil {
+				mainVals = append(mainVals, textVal)
+			} else {
+				mainVals = append(mainVals, numericVal)
+			}
+			continue
+		}
+		eavRows = append(eavRows, eavRow{attrID: meta.AttributeID, text: textVal, numeric: numericVal})
+	}
+
+	placeholders := make([]string, len(mainCols))
+	for i := range mainCols {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+	}
+	e.ExecSQL(ctx, fmt.Sprintf("INSERT INTO entity_main (%s) VALUES (%s)",
+		strings.Join(mainCols, ", "), strings.Join(placeholders, ", ")), mainVals...)
+
+	for _, row := range eavRows {
+		e.ExecSQL(ctx,
+			`INSERT INTO eav_data (schema_id, row_id, attr_id, array_indices, value_text, value_numeric)
+			 VALUES ($1, $2, $3, '', $4, $5)`,
+			create.Schema.ID, create.RowID, row.attrID, row.text, row.numeric)
+	}
+}


### PR DESCRIPTION
Closes #175. Part of epic #172 (Phase 2). **Required follow-up: #188** carries the compaction-rewrite half of the "invisible after compaction" criterion — see the compaction paragraph below.

## What this proves

The full entity lifecycle is correct across CDC boundaries, with **delete resurrection** as the headline risk. The inner-join export bug the issue describes was already fixed in PR #191 (delta export drives from `change_log` LEFT JOIN `entity_main`); like #178, this PR pins those semantics with dedicated tests — and adds the first end-to-end coverage of the real production delete path (`Delete` → hard-delete main/EAV → change_log tombstone → CDC export → federated read; the old `federated/soft_delete_test.go` seeds parquet directly and never exercises it).

## Scenario matrix (`lifecycle_e2e_test.go`, `restart_e2e_test.go`)

| # | Chain | Key assertions |
|---|---|---|
| 1 | create → flush → query | exactly one visible row, one live delta version (`deleted_at` NULL, pinned attrs) |
| 2 | create → update → flush → query | slot-0 upsert coalesces to one row; latest wins, no duplicate (oracle diff) |
| 3 | create → delete → query (pre-flush) | cold-only row (onboarding truncation) hidden purely by the dirty-set anti-join; hard-delete storage contract (main/EAV gone, slot-0 tombstone) |
| 4 | create → flush → delete → flush → query | **core**: tombstone exported to delta (`deleted_at`/`changed_at` from change_log, all 17 attribute + `ltbase_*` columns NULL); with dirty set drained, invisibility rests on parquet LWW alone; no tier hint (`[cold]`, `[warm,cold]`, hot) resurrects; retried flush is a no-op; real compactor pass preserves invisibility (see below); a fresh post-delete create becomes the only visible row (row reuse, real-API side) |
| 5 | create → flush → delete → flush → restore → flush → query | Update on deleted row pins `ErrNotFound` (no restore API); `InjectRestore` revives at the storage layer with timestamp forced past the tombstone (equal ts loses the LWW tiebreak); restored row wins over the **flushed** parquet tombstone |
| 6 | cross-restart | state-preserving Postgres restart (docker stop/start) at six points: flushed live row, unflushed update, flushed update (two live parquet versions under LWW), unflushed tombstone, flushed tombstone (+ flush retry no-op), injected restore |

## Compaction (review finding 1)

Scenario 4 now drives the **real compactor** (`compaction.Compactor.RunOnce`) on the tombstone-bearing manifest and pins today's contract: the dirty ratio (2 delta rows / 1 base row) crosses the rewrite threshold, but the rewrite is unimplemented (`compactor.go` → `RewritePending`), so the manifest must be left untouched and the deletion must stay invisible. Two structural facts bound what more this PR could prove: promotion needs a `TargetBaseSizeMB` (floor 1 MB) delta tier — unreachable at lifecycle-test scale — and the federated read path never consults the manifest, so manifest-level promotion cannot affect visibility by construction. The assertion is **#188's tripwire**: when the rewrite lands, the outcome flips and #188 must replace it with genuine before/after equivalence coverage. #188 is therefore the required follow-up for the remaining half of the "invisible after compaction" criterion; tier-preference contracts stay with #184.

## Harness additions

- `TestHarness.RestartPostgres` / `Cluster.RestartPostgres` / `Env.RestartPostgres`: data-preserving restart with port re-query and full handle rebind (pool, CDC config, DuckDB, lazy engine/manager). `DedicatedCluster` isolates restart tests from the shared cluster; skipped on external infra.
- `Env.InjectRestore`: storage-level restore escape hatch, scoped to text/numeric attributes (e2e_simple).
- `Env.RunCompaction`: real compactor over the Env's manifest.

## Verification

- `make lint`, `make test` green
- `make test-e2e-production` green (full suite incl. the six new scenarios; restart test adds ~7s on a dedicated cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
