### PR TITLE
test(e2e): init -> incremental CDC handoff correctness (#176)

### DIFF
--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -389,9 +389,11 @@ func exportSchemaBatch(ctx context.Context, runCtx *initRunContext, state *schem
 // updateSchemaManifest records the exported base files in the schema
 // manifest. Failures propagate: base files absent from the manifest are
 // invisible to manifest consumers (e.g. compaction), and a silent miss here
-// would let RunInit report success for an unusable export. Entries are
-// upserted by path so an init rerun (same deterministic base keys) replaces
-// its previous entries instead of duplicating them (#176).
+// would let RunInit report success for an unusable export. Init is a full
+// re-export, so the base tier is replaced wholesale with this run's files:
+// reruns neither duplicate entries nor leave stale ranges behind (#176).
+// Obsolete S3 objects are not deleted here — glob-based readers stay exact
+// via LWW/tombstones, and object reconciliation is #203.
 func updateSchemaManifest(ctx context.Context, runCtx *initRunContext, state *schemaInitState) error {
 	if runCtx.manifestStore == nil || len(state.fileEntries) == 0 || runCtx.dryRun {
 		return nil
@@ -401,7 +403,7 @@ func updateSchemaManifest(ctx context.Context, runCtx *initRunContext, state *sc
 	if err != nil {
 		return fmt.Errorf("resolve manifest path: %w", err)
 	}
-	if err := manifest.UpsertFiles(ctx, runCtx.manifestStore, manifestPath, state.schemaID, state.fileEntries); err != nil {
+	if err := manifest.ReplaceTierFiles(ctx, runCtx.manifestStore, manifestPath, state.schemaID, "base", state.fileEntries); err != nil {
 		return fmt.Errorf("update manifest: %w", err)
 	}
 	runCtx.logger.Info("manifest updated",

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -389,7 +389,9 @@ func exportSchemaBatch(ctx context.Context, runCtx *initRunContext, state *schem
 // updateSchemaManifest records the exported base files in the schema
 // manifest. Failures propagate: base files absent from the manifest are
 // invisible to manifest consumers (e.g. compaction), and a silent miss here
-// would let RunInit report success for an unusable export.
+// would let RunInit report success for an unusable export. Entries are
+// upserted by path so an init rerun (same deterministic base keys) replaces
+// its previous entries instead of duplicating them (#176).
 func updateSchemaManifest(ctx context.Context, runCtx *initRunContext, state *schemaInitState) error {
 	if runCtx.manifestStore == nil || len(state.fileEntries) == 0 || runCtx.dryRun {
 		return nil
@@ -399,7 +401,7 @@ func updateSchemaManifest(ctx context.Context, runCtx *initRunContext, state *sc
 	if err != nil {
 		return fmt.Errorf("resolve manifest path: %w", err)
 	}
-	if err := manifest.AppendFiles(ctx, runCtx.manifestStore, manifestPath, state.schemaID, state.fileEntries); err != nil {
+	if err := manifest.UpsertFiles(ctx, runCtx.manifestStore, manifestPath, state.schemaID, state.fileEntries); err != nil {
 		return fmt.Errorf("update manifest: %w", err)
 	}
 	runCtx.logger.Info("manifest updated",

--- a/internal/cdc/init_test.go
+++ b/internal/cdc/init_test.go
@@ -109,3 +109,51 @@ func TestUpdateSchemaManifest_NoStoreOrDryRunIsNoop(t *testing.T) {
 		t.Fatalf("updateSchemaManifest dry-run = %v, want nil", err)
 	}
 }
+
+// memManifestStore is an in-memory manifest.Store: Load reports not-found
+// until the first Save, then returns the saved payload.
+type memManifestStore struct {
+	data map[string][]byte
+}
+
+func (s *memManifestStore) Load(_ context.Context, path string) ([]byte, string, error) {
+	b, ok := s.data[path]
+	if !ok {
+		return nil, "", errors.New("NoSuchKey: not found")
+	}
+	return b, "", nil
+}
+
+func (s *memManifestStore) Save(_ context.Context, path string, data []byte, _ string) (string, error) {
+	if s.data == nil {
+		s.data = map[string][]byte{}
+	}
+	s.data[path] = data
+	return "", nil
+}
+
+// A cdc-init rerun rebuilds the same file entries; recording them twice must
+// not duplicate manifest entries (#176 scenario 4).
+func TestUpdateSchemaManifest_RerunDoesNotDuplicateEntries(t *testing.T) {
+	st := &memManifestStore{}
+	runCtx := &initRunContext{
+		manifestStore:    st,
+		manifestResolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
+		logger:           zap.NewNop(),
+	}
+
+	if err := updateSchemaManifest(context.Background(), runCtx, initStateWithOneEntry(1)); err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+	if err := updateSchemaManifest(context.Background(), runCtx, initStateWithOneEntry(1)); err != nil {
+		t.Fatalf("rerun update: %v", err)
+	}
+
+	m, _, err := manifest.Load(context.Background(), st, "manifest/1.json")
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if len(m.Files) != 1 {
+		t.Fatalf("manifest has %d entries after rerun, want 1", len(m.Files))
+	}
+}

--- a/internal/cdc/init_test.go
+++ b/internal/cdc/init_test.go
@@ -132,19 +132,26 @@ func (s *memManifestStore) Save(_ context.Context, path string, data []byte, _ s
 	return "", nil
 }
 
-// A cdc-init rerun rebuilds the same file entries; recording them twice must
-// not duplicate manifest entries (#176 scenario 4).
-func TestUpdateSchemaManifest_RerunDoesNotDuplicateEntries(t *testing.T) {
+// A cdc-init rerun is a full re-export: recording it must reconcile the
+// base tier to exactly the new run's entries — no duplicates, no stale
+// ranges — while leaving delta entries alone (#176).
+func TestUpdateSchemaManifest_RerunReconcilesBaseTier(t *testing.T) {
 	st := &memManifestStore{}
+	seed := &manifest.Manifest{SchemaID: 1, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: "prefix/1/d.parquet", RowCount: 5},
+		{Tier: "base", Path: "prefix/1/a_b.parquet", RowCount: 1},
+		{Tier: "base", Path: "prefix/1/a_b.parquet", RowCount: 1}, // historical duplicate
+		{Tier: "base", Path: "prefix/1/stale_range.parquet", RowCount: 9},
+	}}
+	if _, err := manifest.Save(context.Background(), st, "manifest/1.json", seed, ""); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
 	runCtx := &initRunContext{
 		manifestStore:    st,
 		manifestResolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
 		logger:           zap.NewNop(),
 	}
 
-	if err := updateSchemaManifest(context.Background(), runCtx, initStateWithOneEntry(1)); err != nil {
-		t.Fatalf("first update: %v", err)
-	}
 	if err := updateSchemaManifest(context.Background(), runCtx, initStateWithOneEntry(1)); err != nil {
 		t.Fatalf("rerun update: %v", err)
 	}
@@ -153,7 +160,10 @@ func TestUpdateSchemaManifest_RerunDoesNotDuplicateEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load manifest: %v", err)
 	}
-	if len(m.Files) != 1 {
-		t.Fatalf("manifest has %d entries after rerun, want 1", len(m.Files))
+	if len(m.Files) != 2 {
+		t.Fatalf("manifest has %d entries after rerun, want 2 (delta + one reconciled base): %+v", len(m.Files), m.Files)
+	}
+	if m.Files[0].Path != "prefix/1/d.parquet" || m.Files[1].Path != "prefix/1/a_b.parquet" {
+		t.Fatalf("entries = %s,%s want delta preserved then reconciled base", m.Files[0].Path, m.Files[1].Path)
 	}
 }

--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -133,8 +133,10 @@ where cdc-init bootstraps base files before federated reads. Use
   marking and manifest updates (#180).
 - `RunInit` wraps `cdc.RunInit` (base file export + manifest base entries).
   Base keys are deterministic (`<prefix>/<id>/<minRowID>_<maxRowID>.parquet`),
-  and init upserts manifest entries by path, so a no-change rerun overwrites
-  objects and leaves the manifest unchanged (#176). Init never touches
+  and init replaces the manifest's base tier with each run's output, so
+  reruns neither duplicate entries nor leave stale ranges — obsolete S3
+  objects remain (glob+LWW keeps queries exact; reconciliation is #203)
+  (#176). Init never touches
   `change_log`: backfilled rows stay hot until the operator clears the log
   (onboarding contract, see `TestInitBaseOnlyParity`) or the next flush
   re-exports them into delta (`TestInitFlushOverlapWithoutLogCleanup`).

--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -132,6 +132,12 @@ where cdc-init bootstraps base files before federated reads. Use
   mainline dry-run still writes parquet objects — it skips `flushed_at`
   marking and manifest updates (#180).
 - `RunInit` wraps `cdc.RunInit` (base file export + manifest base entries).
+  Base keys are deterministic (`<prefix>/<id>/<minRowID>_<maxRowID>.parquet`),
+  and init upserts manifest entries by path, so a no-change rerun overwrites
+  objects and leaves the manifest unchanged (#176). Init never touches
+  `change_log`: backfilled rows stay hot until the operator clears the log
+  (onboarding contract, see `TestInitBaseOnlyParity`) or the next flush
+  re-exports them into delta (`TestInitFlushOverlapWithoutLogCleanup`).
 - `Query`/`AssertQueryMatches` translate one spec for both engine and
   oracle. Filters use the public `"op:value"` condition forms (bool values
   are `"1"`/`"0"`; dates accept ISO strings or epoch millis).
@@ -185,6 +191,7 @@ On failure (or `KEEP_E2E_ENV=1`) the Env writes
 | Issue | Building block |
 |---|---|
 | #174 full-type coverage | `e2e_wide` + `FullTypeProfile` |
+| #176 init handoff | `RunInit` + `RunFlush` (`init_handoff_e2e_test.go`, `init_delete_e2e_test.go`, `init_rerun_e2e_test.go`, `init_concurrent_e2e_test.go`) |
 | #175 lifecycle sequences | `Event` model + `ApplyEvents` + `InjectRestore` + `RestartPostgres` (`lifecycle_e2e_test.go`, `restart_e2e_test.go`) |
 | #179 flush thresholds | `WithFlushThresholds` + `FlushReport` |
 | #180 dry-run semantics | `RunFlushDry` |

--- a/internal/e2e_harness/production/init_concurrent_e2e_test.go
+++ b/internal/e2e_harness/production/init_concurrent_e2e_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// TestInitUnderConcurrentMutation (#176 scenario 5): cdc-init pages with
+// OFFSET over live data (internal/cdc/init.go selectEntityMainBatch — no
+// snapshot), so concurrent writes can skip or duplicate rows in the base
+// tier. The system-level contract asserted here: whatever the base tier
+// captured, unflushed change_log entries shadow it (hot) and the follow-up
+// flush lands the rest in delta, so the final federated state is exact.
+func TestInitUnderConcurrentMutation(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	env.CDC.BatchSize = 5 // 60 seed rows -> >=12 OFFSET pages of race window
+
+	seed := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 60})
+	if err := env.ApplyEvents(ctx, seed...); err != nil {
+		t.Fatalf("apply seed creates: %v", err)
+	}
+
+	stop := make(chan struct{})
+	type mutations struct {
+		created int
+		deleted int
+		err     error
+	}
+	done := make(chan mutations, 1)
+	go func() {
+		var m mutations
+		defer func() { done <- m }()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			var batch []*Event
+			// One new create per round (created rows are hot until the
+			// post-init flush) — capped so the query limit below stays safe.
+			if m.created < 200 {
+				news := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
+				batch = append(batch, news...)
+				m.created++
+			}
+			// Rolling updates over seed[0:40] (disjoint from delete range).
+			batch = append(batch, UpdateEvent(wide, seed[i%40].RowID, map[string]any{
+				"title": fmt.Sprintf("race-%03d", i),
+				"count": float64(400000 + i),
+			}))
+			// Ten deletes from seed[40:50]: shifts OFFSET pages leftward,
+			// the classic skip trigger.
+			if m.deleted < 10 {
+				batch = append(batch, DeleteEvent(wide, seed[40+m.deleted].RowID))
+				m.deleted++
+			}
+			if err := env.ApplyEvents(ctx, batch...); err != nil {
+				m.err = fmt.Errorf("mutator round %d: %w", i, err)
+				return
+			}
+		}
+	}()
+
+	report, initErr := env.RunInit(ctx, wide)
+	close(stop)
+	m := <-done
+	if m.err != nil {
+		t.Fatalf("concurrent mutator failed: %v", m.err)
+	}
+	if initErr != nil {
+		t.Fatalf("run init under concurrent mutation: %v", initErr)
+	}
+	if report.RowsExported == 0 {
+		t.Fatal("init exported no rows")
+	}
+	t.Logf("init exported %d rows in %d files; mutator created %d, deleted %d",
+		report.RowsExported, report.FilesCreated, m.created, m.deleted)
+
+	// The small BatchSize above only served to widen the init OFFSET race
+	// window; it also caps rows-per-flush, so restore the harness default
+	// (env.go) before the handoff flush so a single RunOnce drains the whole
+	// hot tier in one snapshot, exactly as the sibling handoff tests do. The
+	// mutator has already stopped (m received above), so this is race-free.
+	env.CDC.BatchSize = 10000
+
+	// Handoff: flush everything the mutator produced (plus any rows init's
+	// pagination missed — their change_log entries are still unflushed).
+	flush, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("post-init flush: %v", err)
+	}
+	if flush.UnflushedAfter != 0 {
+		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
+	}
+
+	// Exact end state: 60 seed + created - deleted, every value the latest.
+	expected := 60 + m.created - m.deleted
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: expected + 50})
+	if result != nil && len(result.Records) != expected {
+		t.Fatalf("federated result has %d rows, want %d (no skips, no duplicates)", len(result.Records), expected)
+	}
+	env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "count", Op: "gte", Value: "400000"}},
+		Limit:   expected + 50,
+	})
+}

--- a/internal/e2e_harness/production/init_concurrent_e2e_test.go
+++ b/internal/e2e_harness/production/init_concurrent_e2e_test.go
@@ -5,8 +5,18 @@ package production
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 )
+
+// raceCounters tracks mutator progress. Written only by the mutator
+// goroutine; the main goroutine reads them atomically to prove mutations
+// overlapped RunInit (snapshot before the call vs after it returns).
+type raceCounters struct {
+	created atomic.Int64
+	updated atomic.Int64
+	deleted atomic.Int64
+}
 
 // TestInitUnderConcurrentMutation (#176 scenario 5): cdc-init pages with
 // OFFSET over live data (internal/cdc/init.go selectEntityMainBatch — no
@@ -14,6 +24,9 @@ import (
 // tier. The system-level contract asserted here: whatever the base tier
 // captured, unflushed change_log entries shadow it (hot) and the follow-up
 // flush lands the rest in delta, so the final federated state is exact.
+// The started barrier plus counter snapshots around RunInit prove at least
+// one create and one update genuinely overlapped the init pagination
+// (review round 1: without them the scheduler could serialize the test).
 func TestInitUnderConcurrentMutation(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
@@ -28,52 +41,26 @@ func TestInitUnderConcurrentMutation(t *testing.T) {
 	}
 
 	stop := make(chan struct{})
-	type mutations struct {
-		created int
-		deleted int
-		err     error
+	started := make(chan struct{})
+	counters := &raceCounters{}
+	errCh := make(chan error, 1)
+	go runInitRaceMutator(ctx, env, wide, seed, stop, started, counters, errCh)
+
+	// Barrier: the mutator has completed one full round before init starts.
+	select {
+	case <-started:
+	case err := <-errCh:
+		t.Fatalf("mutator failed before init started: %v", err)
 	}
-	done := make(chan mutations, 1)
-	go func() {
-		var m mutations
-		defer func() { done <- m }()
-		for i := 0; ; i++ {
-			select {
-			case <-stop:
-				return
-			default:
-			}
-			var batch []*Event
-			// One new create per round (created rows are hot until the
-			// post-init flush) — capped so the query limit below stays safe.
-			if m.created < 200 {
-				news := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})
-				batch = append(batch, news...)
-				m.created++
-			}
-			// Rolling updates over seed[0:40] (disjoint from delete range).
-			batch = append(batch, UpdateEvent(wide, seed[i%40].RowID, map[string]any{
-				"title": fmt.Sprintf("race-%03d", i),
-				"count": float64(400000 + i),
-			}))
-			// Ten deletes from seed[40:50]: shifts OFFSET pages leftward,
-			// the classic skip trigger.
-			if m.deleted < 10 {
-				batch = append(batch, DeleteEvent(wide, seed[40+m.deleted].RowID))
-				m.deleted++
-			}
-			if err := env.ApplyEvents(ctx, batch...); err != nil {
-				m.err = fmt.Errorf("mutator round %d: %w", i, err)
-				return
-			}
-		}
-	}()
+	createdBefore := counters.created.Load()
+	updatedBefore := counters.updated.Load()
 
 	report, initErr := env.RunInit(ctx, wide)
+	createdDuring := counters.created.Load() - createdBefore
+	updatedDuring := counters.updated.Load() - updatedBefore
 	close(stop)
-	m := <-done
-	if m.err != nil {
-		t.Fatalf("concurrent mutator failed: %v", m.err)
+	if err := <-errCh; err != nil {
+		t.Fatalf("concurrent mutator failed: %v", err)
 	}
 	if initErr != nil {
 		t.Fatalf("run init under concurrent mutation: %v", initErr)
@@ -81,18 +68,19 @@ func TestInitUnderConcurrentMutation(t *testing.T) {
 	if report.RowsExported == 0 {
 		t.Fatal("init exported no rows")
 	}
-	t.Logf("init exported %d rows in %d files; mutator created %d, deleted %d",
-		report.RowsExported, report.FilesCreated, m.created, m.deleted)
-
-	// The small BatchSize above only served to widen the init OFFSET race
-	// window; it also caps rows-per-flush, so restore the harness default
-	// (env.go) before the handoff flush so a single RunOnce drains the whole
-	// hot tier in one snapshot, exactly as the sibling handoff tests do. The
-	// mutator has already stopped (m received above), so this is race-free.
-	env.CDC.BatchSize = 10000
+	if createdDuring == 0 || updatedDuring == 0 {
+		t.Fatalf("no mutation overlapped init (creates=%d updates=%d during); the race window did not open", createdDuring, updatedDuring)
+	}
+	created, deleted := counters.created.Load(), counters.deleted.Load()
+	t.Logf("init exported %d rows in %d files; mutator created %d (%d during init), updated %d during init, deleted %d",
+		report.RowsExported, report.FilesCreated, created, createdDuring, updatedDuring, deleted)
 
 	// Handoff: flush everything the mutator produced (plus any rows init's
 	// pagination missed — their change_log entries are still unflushed).
+	// One flush pass drains at most BatchSize rows (no drain loop in the
+	// flusher), so restore the default first; race-free because the mutator
+	// has been joined via errCh above.
+	env.CDC.BatchSize = 10000
 	flush, err := env.RunFlush(ctx)
 	if err != nil {
 		t.Fatalf("post-init flush: %v", err)
@@ -102,7 +90,7 @@ func TestInitUnderConcurrentMutation(t *testing.T) {
 	}
 
 	// Exact end state: 60 seed + created - deleted, every value the latest.
-	expected := 60 + m.created - m.deleted
+	expected := 60 + int(created) - int(deleted)
 	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: expected + 50})
 	if result != nil && len(result.Records) != expected {
 		t.Fatalf("federated result has %d rows, want %d (no skips, no duplicates)", len(result.Records), expected)
@@ -112,4 +100,53 @@ func TestInitUnderConcurrentMutation(t *testing.T) {
 		Filters: []Filter{{Attr: "count", Op: "gte", Value: "400000"}},
 		Limit:   expected + 50,
 	})
+}
+
+// runInitRaceMutator applies a continuous create/update/delete stream until
+// stop closes. It is the SOLE ApplyEvents/GenerateScript caller while it
+// runs (Env event bookkeeping is unsynchronized). started closes after the
+// first fully applied round; the final error (or nil) is sent on errCh.
+// Update targets (seed[0:40]) and delete targets (seed[40:50]) are disjoint
+// — Update on a deleted row returns ErrNotFound by pinned contract (#175).
+func runInitRaceMutator(ctx context.Context, env *Env, wide SchemaRef, seed []*Event, stop, started chan struct{}, c *raceCounters, errCh chan<- error) {
+	startedClosed := false
+	for i := 0; ; i++ {
+		select {
+		case <-stop:
+			errCh <- nil
+			return
+		default:
+		}
+		var batch []*Event
+		// New creates are capped so the query limit stays safe.
+		addCreate := c.created.Load() < 200
+		if addCreate {
+			batch = append(batch, env.GenerateScript(ScriptSpec{Schema: wide, Creates: 1})...)
+		}
+		batch = append(batch, UpdateEvent(wide, seed[i%40].RowID, map[string]any{
+			"title": fmt.Sprintf("race-%03d", i),
+			"count": float64(400000 + i),
+		}))
+		// Ten deletes from seed[40:50]: shifts OFFSET pages leftward, the
+		// classic skip trigger.
+		addDelete := c.deleted.Load() < 10
+		if addDelete {
+			batch = append(batch, DeleteEvent(wide, seed[40+int(c.deleted.Load())].RowID))
+		}
+		if err := env.ApplyEvents(ctx, batch...); err != nil {
+			errCh <- fmt.Errorf("mutator round %d: %w", i, err)
+			return
+		}
+		if addCreate {
+			c.created.Add(1)
+		}
+		c.updated.Add(1)
+		if addDelete {
+			c.deleted.Add(1)
+		}
+		if !startedClosed {
+			close(started)
+			startedClosed = true
+		}
+	}
 }

--- a/internal/e2e_harness/production/init_delete_e2e_test.go
+++ b/internal/e2e_harness/production/init_delete_e2e_test.go
@@ -5,6 +5,7 @@ package production
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -84,6 +85,70 @@ func TestInitDeleteHandoff(t *testing.T) {
 	for _, ev := range creates[0:13] {
 		if !got[ev.RowID] {
 			t.Errorf("surviving row %s is missing from the federated result", ev.RowID)
+		}
+	}
+}
+
+// TestInitSoftDeletedRowExcluded (#176 scenario 3, review round 1): a row
+// already soft-deleted in entity_main when cdc-init runs must be excluded
+// by init's `ltbase_deleted_at IS NULL` filter. The production API
+// hard-deletes, so the soft-deleted storage state is injected: the row is
+// deleted through the API first (real change_log tombstone, oracle in
+// sync), then its main row re-materialized with ltbase_deleted_at set via
+// the SQL escape hatch — a legal storage state the API cannot produce.
+func TestInitSoftDeletedRowExcluded(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 6})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	soft := creates[5]
+	if err := env.ApplyEvents(ctx, DeleteEvent(wide, soft.RowID)); err != nil {
+		t.Fatalf("delete row: %v", err)
+	}
+	env.ExecSQL(ctx, `INSERT INTO entity_main
+		(ltbase_schema_id, ltbase_row_id, ltbase_created_at, ltbase_updated_at, ltbase_deleted_at)
+		VALUES ($1, $2, $3, $3, $3)`, wide.ID, soft.RowID, time.Now().UnixMilli())
+
+	report, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	if report.RowsExported != 5 {
+		t.Fatalf("init exported %d rows, want 5 (soft-deleted row must be excluded)", report.RowsExported)
+	}
+	assertBaseRows(ctx, t, env, report.Manifest, 5)
+
+	assertSoftDeletedInvisible(ctx, t, env, wide, soft.RowID)
+
+	flush, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if flush.UnflushedAfter != 0 {
+		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
+	}
+	assertSoftDeletedInvisible(ctx, t, env, wide, soft.RowID)
+}
+
+// assertSoftDeletedInvisible checks the 5 surviving rows are all present
+// (positive guard) and the soft-deleted row is not.
+func assertSoftDeletedInvisible(ctx context.Context, t *testing.T, env *Env, wide SchemaRef, softID uuid.UUID) {
+	t.Helper()
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
+	if result == nil {
+		return
+	}
+	if len(result.Records) != 5 {
+		t.Fatalf("federated result has %d rows, want 5", len(result.Records))
+	}
+	for _, rec := range result.Records {
+		if rec.RowID == softID {
+			t.Fatalf("soft-deleted row %s is visible in the federated result", softID)
 		}
 	}
 }

--- a/internal/e2e_harness/production/init_delete_e2e_test.go
+++ b/internal/e2e_harness/production/init_delete_e2e_test.go
@@ -1,0 +1,89 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestInitDeleteHandoff (#176 scenario 3): rows deleted before the backfill
+// never reach the base tier (production deletes hard-delete entity_main and
+// leave a change_log tombstone — there is no soft-deleted row for init to
+// see); rows deleted after the backfill are tombstoned into delta and the
+// base version must lose LWW. Both delete generations are invisible in the
+// federated result while every surviving row stays visible.
+func TestInitDeleteHandoff(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 20})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+
+	// Pre-init deletes: creates[16:20]. Their create+delete change_log
+	// entries merge into a single unflushed tombstone (slot-0 upsert).
+	var preDel []*Event
+	for _, ev := range creates[16:20] {
+		preDel = append(preDel, DeleteEvent(wide, ev.RowID))
+	}
+	if err := env.ApplyEvents(ctx, preDel...); err != nil {
+		t.Fatalf("apply pre-init deletes: %v", err)
+	}
+
+	report, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	if report.RowsExported != 16 {
+		t.Fatalf("init exported %d rows, want 16 (pre-init deletes must be excluded)", report.RowsExported)
+	}
+	assertBaseRows(ctx, t, env, report.Manifest, 16)
+
+	// Post-init deletes: creates[13:16] are in the base tier; their
+	// tombstones flush to delta and must shadow the base copies.
+	var postDel []*Event
+	for _, ev := range creates[13:16] {
+		postDel = append(postDel, DeleteEvent(wide, ev.RowID))
+	}
+	if err := env.ApplyEvents(ctx, postDel...); err != nil {
+		t.Fatalf("apply post-init deletes: %v", err)
+	}
+
+	flush, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if flush.UnflushedAfter != 0 {
+		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
+	}
+
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
+	if result == nil {
+		return
+	}
+	// Positive guard first: absence assertions below are meaningless if the
+	// whole result is empty.
+	if len(result.Records) != 13 {
+		t.Fatalf("federated result has %d rows, want 13 (20 - 4 pre-init - 3 post-init deletes)", len(result.Records))
+	}
+	got := make(map[uuid.UUID]bool, len(result.Records))
+	for _, rec := range result.Records {
+		got[rec.RowID] = true
+	}
+	for _, ev := range creates[13:20] {
+		if got[ev.RowID] {
+			t.Errorf("deleted row %s is visible in the federated result", ev.RowID)
+		}
+	}
+	for _, ev := range creates[0:13] {
+		if !got[ev.RowID] {
+			t.Errorf("surviving row %s is missing from the federated result", ev.RowID)
+		}
+	}
+}

--- a/internal/e2e_harness/production/init_handoff_e2e_test.go
+++ b/internal/e2e_harness/production/init_handoff_e2e_test.go
@@ -37,7 +37,7 @@ func TestInitBaseOnlyParity(t *testing.T) {
 	if report.RowsExported != 20 || report.FilesCreated != 3 {
 		t.Fatalf("init exported %d rows in %d files, want 20 rows in 3 files", report.RowsExported, report.FilesCreated)
 	}
-	if got := parquetKeys(report.NewObjects); len(got) != 3 {
+	if got := filterParquetKeys(report.NewObjects); len(got) != 3 {
 		t.Fatalf("init created parquet objects %v, want exactly 3", got)
 	}
 	if entries := manifest.FilterByTier(report.Manifest, "base"); len(entries) != 3 {
@@ -65,9 +65,9 @@ func TestInitBaseOnlyParity(t *testing.T) {
 	})
 }
 
-// parquetKeys filters an object-key diff down to parquet files: the first
-// manifest write also shows up in NewObjects.
-func parquetKeys(keys []string) []string {
+// filterParquetKeys filters an object-key diff down to parquet files: the
+// first manifest write also shows up in NewObjects.
+func filterParquetKeys(keys []string) []string {
 	out := make([]string, 0, len(keys))
 	for _, k := range keys {
 		if strings.HasSuffix(k, ".parquet") && !strings.Contains(k, "/_tmp/") {

--- a/internal/e2e_harness/production/init_handoff_e2e_test.go
+++ b/internal/e2e_harness/production/init_handoff_e2e_test.go
@@ -4,6 +4,7 @@ package production
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -89,5 +90,121 @@ func assertBaseRows(ctx context.Context, t *testing.T, env *Env, m *manifest.Man
 	}
 	if got != want {
 		t.Fatalf("base tier holds %d physical rows, want %d", got, want)
+	}
+}
+
+// TestInitThenIncrementalFlush (#176 scenario 2): backfill, clear the log
+// (onboarding contract), then updates to backfilled rows plus new creates
+// flush into delta. Federated count is exact (no duplicates, no gaps) and
+// the delta version wins over the base version where the tiers overlap.
+func TestInitThenIncrementalFlush(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 20})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	report, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	if report.RowsExported != 20 {
+		t.Fatalf("init exported %d rows, want 20", report.RowsExported)
+	}
+	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", wide.ID)
+
+	// Incremental phase: update 5 backfilled rows (base holds v1, delta will
+	// hold v2 -> genuine cross-tier overlap) and create 10 new rows.
+	var incr []*Event
+	for i := 0; i < 5; i++ {
+		incr = append(incr, UpdateEvent(wide, creates[i].RowID, map[string]any{
+			"title": fmt.Sprintf("handoff-%02d", i),
+			"count": float64(300000 + i),
+		}))
+	}
+	late := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 10})
+	incr = append(incr, late...)
+	if err := env.ApplyEvents(ctx, incr...); err != nil {
+		t.Fatalf("apply incremental events: %v", err)
+	}
+
+	flush, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if flush.UnflushedAfter != 0 {
+		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
+	}
+	if len(manifest.FilterByTier(flush.Manifests[wide.ID], "delta")) == 0 {
+		t.Fatal("no delta entries in manifest after incremental flush")
+	}
+
+	// Exact count: 20 backfilled + 10 incremental; the 5 updated rows must
+	// not appear twice despite living in both base and delta.
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
+	if result != nil && len(result.Records) != 30 {
+		t.Fatalf("federated result has %d rows, want 30 (20 base + 10 delta, overlap deduped)", len(result.Records))
+	}
+	// Latest version wins: the oracle expects exactly one row per updated
+	// title, and its attribute values are the post-update ones.
+	env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "handoff-03"}},
+		Limit:   10,
+	})
+	env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "count", Op: "gte", Value: "300000"}},
+		Limit:   100,
+	})
+}
+
+// TestInitFlushOverlapWithoutLogCleanup (#176 scenario 2 variant): nothing
+// enforces the onboarding cleanup. If the operator skips it, the first flush
+// re-exports every backfilled row into delta at the same version, and
+// merge-on-read must still dedupe to an exact count.
+func TestInitFlushOverlapWithoutLogCleanup(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 15})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	report, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	if report.RowsExported != 15 {
+		t.Fatalf("init exported %d rows, want 15", report.RowsExported)
+	}
+
+	// No change_log cleanup: the flush re-exports all 15 rows into delta.
+	flush, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if flush.UnflushedAfter != 0 {
+		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
+	}
+	var deltaRows int64
+	for _, f := range manifest.FilterByTier(flush.Manifests[wide.ID], "delta") {
+		deltaRows += parquetRowCount(ctx, t, env, f.Path)
+	}
+	if deltaRows != 15 {
+		t.Fatalf("delta tier holds %d rows, want 15 (full re-export of the backfilled set)", deltaRows)
+	}
+	assertBaseRows(ctx, t, env, flush.Manifests[wide.ID], 15)
+
+	// Same 15 rows in base AND delta at identical versions: the federated
+	// result must contain each exactly once.
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
+	if result != nil && len(result.Records) != 15 {
+		t.Fatalf("federated result has %d rows, want 15 (base/delta overlap must dedupe)", len(result.Records))
 	}
 }

--- a/internal/e2e_harness/production/init_handoff_e2e_test.go
+++ b/internal/e2e_harness/production/init_handoff_e2e_test.go
@@ -1,0 +1,93 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// TestInitBaseOnlyParity (#176 scenario 1): a multi-batch cdc-init backfill
+// produces a complete base tier, and after the onboarding contract clears
+// change_log (base parquet becomes the rows' only source) the federated
+// result matches the independent oracle exactly.
+func TestInitBaseOnlyParity(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	// TargetFileSizeMB is 0 in the harness config, so BatchSize drives init
+	// batching directly: 20 rows / batch 7 -> base files of 7+7+6 rows.
+	env.CDC.BatchSize = 7
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 20})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+
+	report, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	if report.RowsExported != 20 || report.FilesCreated != 3 {
+		t.Fatalf("init exported %d rows in %d files, want 20 rows in 3 files", report.RowsExported, report.FilesCreated)
+	}
+	if got := parquetKeys(report.NewObjects); len(got) != 3 {
+		t.Fatalf("init created parquet objects %v, want exactly 3", got)
+	}
+	if entries := manifest.FilterByTier(report.Manifest, "base"); len(entries) != 3 {
+		t.Fatalf("manifest holds %d base entries, want 3", len(entries))
+	}
+	assertBaseRows(ctx, t, env, report.Manifest, 20)
+
+	// Onboarding contract (mirrors production cdc-init handoff): clearing the
+	// change_log makes the base parquet the ONLY source for these rows.
+	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", wide.ID)
+
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
+	if result != nil && len(result.Records) != 20 {
+		t.Fatalf("base-only federated result has %d rows, want 20", len(result.Records))
+	}
+	env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: creates[5].Attrs["title"].(string)}},
+		Limit:   10,
+	})
+	env.AssertQueryMatches(ctx, Query{
+		Schema: wide,
+		Sorts:  []Sort{{Attr: "count", Desc: true}},
+		Limit:  10,
+	})
+}
+
+// parquetKeys filters an object-key diff down to parquet files: the first
+// manifest write also shows up in NewObjects.
+func parquetKeys(keys []string) []string {
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if strings.HasSuffix(k, ".parquet") && !strings.Contains(k, "/_tmp/") {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// assertBaseRows sums the physical row counts of every base-tier parquet in
+// the manifest and compares against want.
+func assertBaseRows(ctx context.Context, t *testing.T, env *Env, m *manifest.Manifest, want int64) {
+	t.Helper()
+	if m == nil {
+		t.Fatal("nil manifest")
+	}
+	var got int64
+	for _, f := range manifest.FilterByTier(m, "base") {
+		got += parquetRowCount(ctx, t, env, f.Path)
+	}
+	if got != want {
+		t.Fatalf("base tier holds %d physical rows, want %d", got, want)
+	}
+}

--- a/internal/e2e_harness/production/init_rerun_e2e_test.go
+++ b/internal/e2e_harness/production/init_rerun_e2e_test.go
@@ -31,7 +31,7 @@ func TestInitRerunIdempotency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first init: %v", err)
 	}
-	firstPaths := basePaths(first.Manifest)
+	firstPaths := buildBasePaths(first.Manifest)
 	if len(firstPaths) != 3 {
 		t.Fatalf("first init produced %d base entries, want 3", len(firstPaths))
 	}
@@ -70,7 +70,7 @@ func TestInitRerunIdempotency(t *testing.T) {
 	}
 }
 
-func basePaths(m *manifest.Manifest) map[string]bool {
+func buildBasePaths(m *manifest.Manifest) map[string]bool {
 	paths := make(map[string]bool)
 	for _, f := range manifest.FilterByTier(m, "base") {
 		paths[f.Path] = true

--- a/internal/e2e_harness/production/init_rerun_e2e_test.go
+++ b/internal/e2e_harness/production/init_rerun_e2e_test.go
@@ -77,3 +77,82 @@ func buildBasePaths(m *manifest.Manifest) map[string]bool {
 	}
 	return paths
 }
+
+// TestInitRerunAfterChangesReconcilesManifest (#176 scenario 4, review
+// round 1): a rerun after inserts and deletes produces different
+// deterministic batch ranges; the manifest's base tier must become exactly
+// the new run's file set — no stale entries, no duplicates. The stale S3
+// objects intentionally remain (object reconciliation is #203): the final
+// parity check proves glob+LWW keeps queries exact anyway.
+func TestInitRerunAfterChangesReconcilesManifest(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	env.CDC.BatchSize = 7 // 20 rows -> 3 files; 23 rows -> 4 files
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 20})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	first, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	firstPaths := buildBasePaths(first.Manifest)
+	if len(firstPaths) != 3 {
+		t.Fatalf("first init produced %d base entries, want 3", len(firstPaths))
+	}
+
+	// Change the dataset: 5 new creates, delete the two smallest row-ids so
+	// every batch boundary shifts and at least one run-1 path goes stale.
+	more := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 5})
+	changes := append(append([]*Event{}, more...),
+		DeleteEvent(wide, creates[0].RowID),
+		DeleteEvent(wide, creates[1].RowID))
+	if err := env.ApplyEvents(ctx, changes...); err != nil {
+		t.Fatalf("apply changes: %v", err)
+	}
+
+	second, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+	if second.RowsExported != 23 {
+		t.Fatalf("second init exported %d rows, want 23 (20 - 2 deleted + 5 new)", second.RowsExported)
+	}
+	entries := manifest.FilterByTier(second.Manifest, "base")
+	if len(entries) != 4 {
+		t.Fatalf("manifest holds %d base entries after changed rerun, want 4 (ceil(23/7)), got %+v", len(entries), entries)
+	}
+	secondPaths := buildBasePaths(second.Manifest)
+	if len(secondPaths) != 4 {
+		t.Fatalf("manifest base paths not unique after changed rerun: %d unique of 4", len(secondPaths))
+	}
+	stale := 0
+	for p := range firstPaths {
+		if !secondPaths[p] {
+			stale++
+		}
+	}
+	if stale == 0 {
+		t.Fatal("scenario produced no stale run-1 path; deleting the two smallest row-ids must shift batch boundaries")
+	}
+	assertBaseRows(ctx, t, env, second.Manifest, 23)
+
+	// Handoff flush (tombstones shadow the stale objects' copies), then
+	// exact parity across base + stale objects + delta.
+	env.CDC.BatchSize = 10000 // one flush pass drains at most BatchSize rows
+	flush, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if flush.UnflushedAfter != 0 {
+		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
+	}
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
+	if result != nil && len(result.Records) != 23 {
+		t.Fatalf("federated result has %d rows after changed rerun, want 23", len(result.Records))
+	}
+}

--- a/internal/e2e_harness/production/init_rerun_e2e_test.go
+++ b/internal/e2e_harness/production/init_rerun_e2e_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// TestInitRerunIdempotency (#176 scenario 4): rerunning cdc-init with no
+// data changes rewrites the same deterministic base keys (min/max row-id
+// naming -> S3 overwrite, no new objects) and must not duplicate manifest
+// entries. The federated result is unchanged.
+func TestInitRerunIdempotency(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	env.CDC.BatchSize = 7 // 20 rows -> 3 base files, so duplication is x3-visible
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 20})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+
+	first, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	firstPaths := basePaths(first.Manifest)
+	if len(firstPaths) != 3 {
+		t.Fatalf("first init produced %d base entries, want 3", len(firstPaths))
+	}
+
+	second, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+	// No duplicate objects: identical batching -> identical keys -> overwrite.
+	// (_tmp keys are copy-staging garbage, not duplicates, if one survives.)
+	for _, k := range second.NewObjects {
+		if !strings.Contains(k, "/_tmp/") {
+			t.Errorf("rerun created new object %s, want overwrite of existing keys only", k)
+		}
+	}
+	// No duplicate manifest entries: count RAW entries, not unique paths —
+	// this is the assertion that goes red on append semantics (6 vs 3).
+	rawEntries := manifest.FilterByTier(second.Manifest, "base")
+	if len(rawEntries) != 3 {
+		t.Fatalf("manifest holds %d base entries after rerun, want 3 (no duplicates)", len(rawEntries))
+	}
+	// Path identity with the first run: the rerun must reference the same
+	// deterministic keys, not introduce new ones.
+	for _, f := range rawEntries {
+		if !firstPaths[f.Path] {
+			t.Errorf("rerun introduced unexpected base path %s", f.Path)
+		}
+	}
+	assertBaseRows(ctx, t, env, second.Manifest, 20)
+
+	// Same federated results after the rerun (base-only source).
+	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", wide.ID)
+	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
+	if result != nil && len(result.Records) != 20 {
+		t.Fatalf("federated result has %d rows after rerun, want 20", len(result.Records))
+	}
+}
+
+func basePaths(m *manifest.Manifest) map[string]bool {
+	paths := make(map[string]bool)
+	for _, f := range manifest.FilterByTier(m, "base") {
+		paths[f.Path] = true
+	}
+	return paths
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -177,31 +177,28 @@ func AppendFiles(ctx context.Context, st Store, path string, schemaID int16, ent
 	return nil
 }
 
-// UpsertFiles adds entries to the manifest, replacing any existing entry
-// with the same Path in place instead of appending a duplicate. Init reruns
-// re-export the same row ranges to the same deterministic keys, so append
-// semantics would double every base entry on each rerun (#176). Uses
-// optimistic locking via etag to handle concurrent updates.
-func UpsertFiles(ctx context.Context, st Store, path string, schemaID int16, entries []FileEntry) error {
-	if len(entries) == 0 {
-		return nil
-	}
+// ReplaceTierFiles replaces every manifest entry of the given tier with the
+// provided entries, preserving entries of other tiers in their original
+// order. cdc-init is a full re-export of a schema's live rows, so after a
+// run the base tier's canonical inventory IS that run's output: stale
+// entries from earlier runs (different batch ranges) and historical
+// duplicates must not survive (#176). Compaction-promoted base entries are
+// replaced too — after a full re-export their live content is subsumed by
+// the new base files; their S3 objects remain for glob-based readers, and
+// object-level reconciliation is #203. Uses optimistic locking via etag.
+func ReplaceTierFiles(ctx context.Context, st Store, path string, schemaID int16, tier string, entries []FileEntry) error {
 	m, etag, err := LoadOrCreate(ctx, st, path, schemaID)
 	if err != nil {
 		return fmt.Errorf("load manifest: %w", err)
 	}
-	index := make(map[string]int, len(m.Files))
-	for i, f := range m.Files {
-		index[f.Path] = i
-	}
-	for _, entry := range entries {
-		if i, ok := index[entry.Path]; ok {
-			m.Files[i] = entry
-			continue
+	kept := make([]FileEntry, 0, len(m.Files)+len(entries))
+	target := strings.ToLower(tier)
+	for _, f := range m.Files {
+		if strings.ToLower(f.Tier) != target {
+			kept = append(kept, f)
 		}
-		index[entry.Path] = len(m.Files)
-		m.Files = append(m.Files, entry)
 	}
+	m.Files = append(kept, entries...)
 	if _, err := Save(ctx, st, path, m, etag); err != nil {
 		return fmt.Errorf("save manifest: %w", err)
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -176,3 +176,34 @@ func AppendFiles(ctx context.Context, st Store, path string, schemaID int16, ent
 	}
 	return nil
 }
+
+// UpsertFiles adds entries to the manifest, replacing any existing entry
+// with the same Path in place instead of appending a duplicate. Init reruns
+// re-export the same row ranges to the same deterministic keys, so append
+// semantics would double every base entry on each rerun (#176). Uses
+// optimistic locking via etag to handle concurrent updates.
+func UpsertFiles(ctx context.Context, st Store, path string, schemaID int16, entries []FileEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	m, etag, err := LoadOrCreate(ctx, st, path, schemaID)
+	if err != nil {
+		return fmt.Errorf("load manifest: %w", err)
+	}
+	index := make(map[string]int, len(m.Files))
+	for i, f := range m.Files {
+		index[f.Path] = i
+	}
+	for _, entry := range entries {
+		if i, ok := index[entry.Path]; ok {
+			m.Files[i] = entry
+			continue
+		}
+		index[entry.Path] = len(m.Files)
+		m.Files = append(m.Files, entry)
+	}
+	if _, err := Save(ctx, st, path, m, etag); err != nil {
+		return fmt.Errorf("save manifest: %w", err)
+	}
+	return nil
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -211,58 +211,62 @@ func (s *memStore) Save(_ context.Context, path string, data []byte, _ string) (
 	return fmt.Sprintf("e%d", s.gen), nil
 }
 
-func TestUpsertFiles_ReplacesByPathAndAppendsNew(t *testing.T) {
+func TestReplaceTierFiles_ReplacesTierPreservesOthers(t *testing.T) {
 	ctx := context.Background()
 	st := &memStore{}
 	path := "manifest/1.json"
 
-	if err := UpsertFiles(ctx, st, path, 1, []FileEntry{
+	// Seed: two delta entries around a base tier that carries a historical
+	// duplicate and a stale range — exactly what the old append/upsert
+	// semantics could accumulate.
+	seed := &Manifest{SchemaID: 1, Files: []FileEntry{
+		{Tier: "delta", Path: "p/1/d1.parquet", RowCount: 4},
 		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 10},
-		{Tier: "base", Path: "p/1/c_d.parquet", RowCount: 7},
-	}); err != nil {
-		t.Fatalf("initial upsert: %v", err)
+		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 10}, // historical duplicate
+		{Tier: "delta", Path: "p/1/d2.parquet", RowCount: 2},
+		{Tier: "base", Path: "p/1/c_d.parquet", RowCount: 7}, // stale range
+	}}
+	if _, err := Save(ctx, st, path, seed, ""); err != nil {
+		t.Fatalf("seed save: %v", err)
 	}
-	if err := UpsertFiles(ctx, st, path, 1, []FileEntry{
-		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 12}, // rerun: replaced in place
-		{Tier: "base", Path: "p/1/e_f.parquet", RowCount: 3},  // new range: appended
+
+	if err := ReplaceTierFiles(ctx, st, path, 1, "base", []FileEntry{
+		{Tier: "base", Path: "p/1/a_e.parquet", RowCount: 12},
+		{Tier: "base", Path: "p/1/f_g.parquet", RowCount: 3},
 	}); err != nil {
-		t.Fatalf("rerun upsert: %v", err)
+		t.Fatalf("replace: %v", err)
 	}
 
 	m, _, err := Load(ctx, st, path)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if len(m.Files) != 3 {
-		t.Fatalf("manifest has %d files, want 3 (no duplicates)", len(m.Files))
+	wantPaths := []string{"p/1/d1.parquet", "p/1/d2.parquet", "p/1/a_e.parquet", "p/1/f_g.parquet"}
+	if len(m.Files) != len(wantPaths) {
+		t.Fatalf("manifest has %d files, want %d: %+v", len(m.Files), len(wantPaths), m.Files)
 	}
-	if m.Files[0].Path != "p/1/a_b.parquet" || m.Files[0].RowCount != 12 {
-		t.Fatalf("entry 0 = %+v, want a_b.parquet replaced in place with RowCount 12", m.Files[0])
-	}
-	if m.Files[1].Path != "p/1/c_d.parquet" || m.Files[2].Path != "p/1/e_f.parquet" {
-		t.Fatalf("entries 1,2 = %s,%s want c_d.parquet,e_f.parquet", m.Files[1].Path, m.Files[2].Path)
-	}
-	if m.Version != 2 {
-		t.Fatalf("manifest version = %d, want 2 (one bump per save)", m.Version)
+	for i, want := range wantPaths {
+		if m.Files[i].Path != want {
+			t.Fatalf("entry %d = %s, want %s (delta order preserved, base replaced)", i, m.Files[i].Path, want)
+		}
 	}
 }
 
-func TestUpsertFiles_DedupesWithinOneCall(t *testing.T) {
+func TestReplaceTierFiles_CreatesFreshManifest(t *testing.T) {
 	ctx := context.Background()
 	st := &memStore{}
 	path := "manifest/1.json"
 
-	if err := UpsertFiles(ctx, st, path, 1, []FileEntry{
-		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 1},
-		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 2},
+	if err := ReplaceTierFiles(ctx, st, path, 1, "base", []FileEntry{
+		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 10},
 	}); err != nil {
-		t.Fatalf("upsert: %v", err)
+		t.Fatalf("replace on empty store: %v", err)
 	}
 	m, _, err := Load(ctx, st, path)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if len(m.Files) != 1 || m.Files[0].RowCount != 2 {
-		t.Fatalf("manifest = %+v, want single a_b.parquet entry with RowCount 2", m.Files)
+	if len(m.Files) != 1 || m.Files[0].Path != "p/1/a_b.parquet" || m.Version != 1 {
+		t.Fatalf("fresh manifest = %+v (version %d), want single a_b.parquet at version 1", m.Files, m.Version)
 	}
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -3,6 +3,8 @@ package manifest
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -184,4 +186,83 @@ func TestLoad_IntegrationWithStore(t *testing.T) {
 	require.Empty(t, etag)
 	require.Equal(t, int16(42), loaded.SchemaID)
 	require.Len(t, loaded.Files, 1)
+}
+
+// memStore is an in-memory Store for exercising load-modify-save flows.
+type memStore struct {
+	data map[string][]byte
+	gen  int
+}
+
+func (s *memStore) Load(_ context.Context, path string) ([]byte, string, error) {
+	b, ok := s.data[path]
+	if !ok {
+		return nil, "", errors.New("NoSuchKey: not found")
+	}
+	return b, fmt.Sprintf("e%d", s.gen), nil
+}
+
+func (s *memStore) Save(_ context.Context, path string, data []byte, _ string) (string, error) {
+	if s.data == nil {
+		s.data = map[string][]byte{}
+	}
+	s.data[path] = data
+	s.gen++
+	return fmt.Sprintf("e%d", s.gen), nil
+}
+
+func TestUpsertFiles_ReplacesByPathAndAppendsNew(t *testing.T) {
+	ctx := context.Background()
+	st := &memStore{}
+	path := "manifest/1.json"
+
+	if err := UpsertFiles(ctx, st, path, 1, []FileEntry{
+		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 10},
+		{Tier: "base", Path: "p/1/c_d.parquet", RowCount: 7},
+	}); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	if err := UpsertFiles(ctx, st, path, 1, []FileEntry{
+		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 12}, // rerun: replaced in place
+		{Tier: "base", Path: "p/1/e_f.parquet", RowCount: 3},  // new range: appended
+	}); err != nil {
+		t.Fatalf("rerun upsert: %v", err)
+	}
+
+	m, _, err := Load(ctx, st, path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(m.Files) != 3 {
+		t.Fatalf("manifest has %d files, want 3 (no duplicates)", len(m.Files))
+	}
+	if m.Files[0].Path != "p/1/a_b.parquet" || m.Files[0].RowCount != 12 {
+		t.Fatalf("entry 0 = %+v, want a_b.parquet replaced in place with RowCount 12", m.Files[0])
+	}
+	if m.Files[1].Path != "p/1/c_d.parquet" || m.Files[2].Path != "p/1/e_f.parquet" {
+		t.Fatalf("entries 1,2 = %s,%s want c_d.parquet,e_f.parquet", m.Files[1].Path, m.Files[2].Path)
+	}
+	if m.Version != 2 {
+		t.Fatalf("manifest version = %d, want 2 (one bump per save)", m.Version)
+	}
+}
+
+func TestUpsertFiles_DedupesWithinOneCall(t *testing.T) {
+	ctx := context.Background()
+	st := &memStore{}
+	path := "manifest/1.json"
+
+	if err := UpsertFiles(ctx, st, path, 1, []FileEntry{
+		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 1},
+		{Tier: "base", Path: "p/1/a_b.parquet", RowCount: 2},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	m, _, err := Load(ctx, st, path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(m.Files) != 1 || m.Files[0].RowCount != 2 {
+		t.Fatalf("manifest = %+v, want single a_b.parquet entry with RowCount 2", m.Files)
+	}
 }


### PR DESCRIPTION
Closes #176 (epic #172, Phase 2).

## What

Five E2E scenarios pinning the cdc-init backfill -> incremental cdc-flush handoff, plus one production fix the rerun scenario exposed.

- **S1** `TestInitBaseOnlyParity`: multi-batch backfill -> base-only federated parity (onboarding contract: change_log cleared post-init).
- **S2** `TestInitThenIncrementalFlush` / `TestInitFlushOverlapWithoutLogCleanup`: exact counts across base+delta, delta version wins on overlap; the no-cleanup variant pins that a full first-flush re-export dedupes to exact counts.
- **S3** `TestInitDeleteHandoff` + `TestInitSoftDeletedRowExcluded`: deletes on both sides of the init boundary stay invisible (hard-delete + tombstone path), and a row already soft-deleted in `entity_main` at init time is excluded by init's `ltbase_deleted_at IS NULL` filter (soft-deleted state injected via the SQL escape hatch after an API delete keeps the oracle in sync — the API itself hard-deletes).
- **S4** `TestInitRerunIdempotency` + `TestInitRerunAfterChangesReconcilesManifest`: no-change rerun -> zero new objects (deterministic min/max row-id keys overwrite) and an unchanged manifest; rerun after inserts+deletes -> the manifest base tier becomes exactly the new run's file set (stale ranges and historical duplicates removed), and the final parity check proves glob+LWW keeps queries exact while the stale objects remain.
- **S5** `TestInitUnderConcurrentMutation`: OFFSET pagination races (issue hypothesis 1 is real — no snapshot in `selectEntityMainBatch`) are absorbed by the handoff: skipped rows stay hot then flush to delta, duplicates dedupe via LWW; end state is exact. A started-barrier plus atomic counter snapshots around `RunInit` prove at least one create and one update overlapped init on every run (observed 120-139 during-init mutations across three runs). (One harness nuance surfaced here: a single flush pass drains at most `BatchSize` rows, so the test restores the default batch size after the race window before the handoff flush.)

## Production fix

Issue hypothesis 2 confirmed: `manifest.AppendFiles` appended blindly, so every init rerun doubled the base entries. Since cdc-init is a full re-export of a schema's live rows, `updateSchemaManifest` now calls `manifest.ReplaceTierFiles`: the manifest's base tier is replaced wholesale with each run's output (delta entries preserved in order). Reruns neither duplicate entries nor leave stale ranges behind, and manifests already carrying historical duplicates are healed on their next init run.

Obsolete S3 *objects* from superseded runs are intentionally not deleted here: glob-based federated reads stay exact via LWW/tombstones (asserted end-to-end by `TestInitRerunAfterChangesReconcilesManifest`), and safe object GC needs the global manifest-vs-S3 view of the #203 reconciliation tool (orphans can exist outside the manifest too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
