### PR TITLE
test(e2e): filter-before-LWW semantic correctness (#178)

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -169,10 +169,17 @@ s3_source AS (
         tag  
     FROM read_parquet($S3_PATHS)  
     WHERE   
-        -- 1. S3 Partition Pruning (via Min/Max stats)  
-        (age > 18 AND name LIKE 'John%' AND tag = 'developer')  
-        -- 2. Anti-Join: Exclude if a newer version exists in PG  
-        AND row_id NOT IN (SELECT row_id FROM dirty_ids)  
+        -- 1. Anti-Join: Exclude if a newer version exists in PG  
+        row_id NOT IN (SELECT row_id FROM dirty_ids)  
+        -- 2. Predicate pushdown as a row_id SEMIJOIN: a row qualifies when  
+        --    ANY of its parquet versions matches; ALL of its versions then  
+        --    enter dedup so the latest wins BEFORE the real filter below.  
+        --    Filtering versions directly here drops newer non-matching  
+        --    versions pre-dedup and resurrects stale rows (#173/#178).  
+        AND row_id IN (  
+            SELECT row_id FROM read_parquet($S3_PATHS)  
+            WHERE (age > 18 AND name LIKE 'John%' AND tag = 'developer')  
+        )  
 ),
 
 -- =========================================================================  
@@ -224,18 +231,24 @@ unified AS (
 -- Final Selection  
 -- Deduplication -> Sorting -> Pagination  
 -- =========================================================================  
-SELECT   
-    row_id, name, age, tag, created_at  
-FROM unified  
-WHERE   
-    -- Final Logical Filter check (Ensures PG EAV data matches criteria)  
-    (age > 18 AND name LIKE 'John%' AND tag = 'developer')
+ranked AS (
+    SELECT *,
+        ROW_NUMBER() OVER (
+            PARTITION BY row_id
+            ORDER BY ver_ts DESC, source_tier_priority DESC, deleted_ts DESC, row_id ASC
+        ) AS rn
+    FROM unified
+)
 
--- Deduplication (Last-Write-Wins)  
-QUALIFY ROW_NUMBER() OVER (PARTITION BY row_id ORDER BY ver_ts DESC) = 1
-
--- Exclude Soft Deletes  
-AND (deleted_ts IS NULL OR deleted_ts = 0)
+SELECT
+    row_id, name, age, tag, created_at
+FROM ranked
+WHERE rn = 1
+    -- Exclude Soft Deletes (the tombstone must WIN dedup first, then be dropped)
+    AND (deleted_ts IS NULL OR deleted_ts = 0)
+    -- Final logical filter, applied to the LWW WINNER only (#173/#178):
+    -- a newer non-matching version must never expose an older matching one.
+    AND (age > 18 AND name LIKE 'John%' AND tag = 'developer')
 
 -- Sorting & Pagination  
 ORDER BY created_at DESC  

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -155,7 +155,7 @@ dirty_ids AS (
 
 -- =========================================================================  
 -- CTE 2: S3 Source (Cold & Warm)  
--- Reads historical data with partition pruning and anti-join.  
+-- Reads historical data with the dirty-set anti-join and semijoin pushdown.  
 -- =========================================================================  
 s3_source AS (  
     SELECT   
@@ -166,7 +166,8 @@ s3_source AS (
         -- Logical Columns (Native in Parquet)  
         name,   
         age,   
-        tag  
+        tag,  
+        1 AS source_tier_priority  
     FROM read_parquet($S3_PATHS)  
     WHERE   
         -- 1. Anti-Join: Exclude if a newer version exists in PG  
@@ -199,7 +200,8 @@ pg_source AS (
           
         -- [EAV Pivot] Aggregation for dynamic attributes  
         -- Note: EAV filtering is done in the WHERE clause below, not pushed to EAV scan  
-        MAX(CASE WHEN e.attr_id = 205 THEN e.value_text END) AS tag
+        MAX(CASE WHEN e.attr_id = 205 THEN e.value_text END) AS tag,  
+        3 AS source_tier_priority
 
     FROM postgres_scan($PG_CONN, 'change_log', 'flushed_at = 0') cl  
       
@@ -225,11 +227,10 @@ unified AS (
     SELECT * FROM s3_source  
     UNION ALL  
     SELECT * FROM pg_source  
-)
+),
 
 -- =========================================================================  
--- Final Selection  
--- Deduplication -> Sorting -> Pagination  
+-- CTE 5: Ranked (Last-Write-Wins Deduplication)  
 -- =========================================================================  
 ranked AS (
     SELECT *,

--- a/internal/e2e_harness/production/filter_lww_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_e2e_test.go
@@ -28,6 +28,7 @@ func TestFilterLWW(t *testing.T) {
 		{"stale_filter_base_vs_delta", testStaleFilterBaseVsDelta},
 		{"tombstone_suppresses_stale_filter", testTombstoneSuppressesStaleFilter},
 		{"hot_shadow_stale_filter", testHotShadowStaleFilter},
+		{"stale_filter_operator_matrix", testStaleFilterOperatorMatrix},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {

--- a/internal/e2e_harness/production/filter_lww_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_e2e_test.go
@@ -26,6 +26,7 @@ func TestFilterLWW(t *testing.T) {
 	}{
 		{"stale_filter_delta_generations", testStaleFilterDeltaGenerations},
 		{"stale_filter_base_vs_delta", testStaleFilterBaseVsDelta},
+		{"tombstone_suppresses_stale_filter", testTombstoneSuppressesStaleFilter},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {

--- a/internal/e2e_harness/production/filter_lww_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_e2e_test.go
@@ -27,6 +27,7 @@ func TestFilterLWW(t *testing.T) {
 		{"stale_filter_delta_generations", testStaleFilterDeltaGenerations},
 		{"stale_filter_base_vs_delta", testStaleFilterBaseVsDelta},
 		{"tombstone_suppresses_stale_filter", testTombstoneSuppressesStaleFilter},
+		{"hot_shadow_stale_filter", testHotShadowStaleFilter},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {

--- a/internal/e2e_harness/production/filter_lww_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_e2e_test.go
@@ -1,0 +1,118 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// TestFilterLWW (#178): filter predicates must be applied AFTER last-write-
+// wins deduplication. A newer version that does not match the filter — or a
+// tombstone carrying no attributes at all — must never expose an older
+// version whose stale values still match. The production template guarantees
+// this via the s3_source row_id semijoin + the post-dedup filter in the
+// visible CTE (internal/sqlgen/advanced_query_template_duckdb.go, fixed in
+// #173/PR #191); this suite pins that contract end to end and is the
+// regression gate for the #195 single-scan pushdown rewrite.
+func TestFilterLWW(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	scenarios := []struct {
+		name string
+		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"stale_filter_delta_generations", testStaleFilterDeltaGenerations},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), wide)
+		})
+	}
+}
+
+// assertStrictlyNewer fails fast when any new version's changed_at is not
+// strictly after its predecessor's at millisecond resolution — otherwise an
+// LWW probe degrades into the undefined equal-ver_ts tie tracked by #210.
+func assertStrictlyNewer(t *testing.T, olds, news []*Event) {
+	t.Helper()
+	for i := range olds {
+		if news[i].ChangedAt <= olds[i].ChangedAt {
+			t.Fatalf("row %d: newer changed_at %d not strictly after older %d",
+				i, news[i].ChangedAt, olds[i].ChangedAt)
+		}
+	}
+}
+
+// assertZeroRows runs an oracle-checked query that must return no rows: the
+// predicate matches only a superseded version, so any row in the result is a
+// filter-before-LWW resurrection.
+func assertZeroRows(ctx context.Context, t *testing.T, env *Env, name string, q Query) {
+	t.Helper()
+	if res := env.AssertQueryMatches(ctx, q); res != nil && len(res.Records) != 0 {
+		t.Errorf("%s: stale probe returned %d rows, want 0", name, len(res.Records))
+	}
+}
+
+// testStaleFilterDeltaGenerations is issue #178 scenario 1 in the
+// delta-generation layout: v1 (matching) in delta #1, v2 (non-matching) in
+// delta #2, no hot rows. The semijoin admits every row_id via its v1 match;
+// LWW must pick v2 and the visible filter must then reject it.
+func testStaleFilterDeltaGenerations(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := make([]*Event, 0, 5)
+	for i := 0; i < 5; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("open-%02d", i),
+			"count": float64(100000 + i),
+		}))
+	}
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	mustFlush(ctx, t, env) // delta #1 = v1 @ create-time ver_ts
+
+	// Load-bearing positive: v1 is served from delta #1 by its own value
+	// (guards every zero-row probe below against a broken read path).
+	res := env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "open-03"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 1 {
+		t.Fatalf("v1 positive control returned %d rows, want 1", len(res.Records))
+	}
+
+	v2 := make([]*Event, 0, len(creates))
+	for i, c := range creates {
+		v2 = append(v2, UpdateEvent(wide, c.RowID, map[string]any{
+			"title": fmt.Sprintf("closed-%02d", i),
+			"count": float64(200000 + i),
+		}))
+	}
+	if err := env.ApplyEvents(ctx, v2...); err != nil {
+		t.Fatalf("apply v2 updates: %v", err)
+	}
+	assertStrictlyNewer(t, creates, v2)
+	flush2 := mustFlush(ctx, t, env) // delta #2 = v2 @ update-time ver_ts
+	if got := countTier(flush2.Manifests[wide.ID], "delta"); got != 2 {
+		t.Fatalf("manifest holds %d delta files, want 2 (v1 and v2 generations)", got)
+	}
+
+	// Positive: the winning v2 generation is reachable by its value.
+	env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "closed-03"}},
+		Limit:   10,
+	})
+
+	// Adversarial: predicates matching ONLY the superseded v1 generation.
+	assertZeroRows(ctx, t, env, "equals_stale_title", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-03"}}, Limit: 10})
+	assertZeroRows(ctx, t, env, "starts_with_stale_title", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Op: "starts_with", Value: "open-"}}, Limit: 10})
+	assertZeroRows(ctx, t, env, "range_stale_count", Query{
+		Schema: wide, Filters: []Filter{{Attr: "count", Op: "lt", Value: "200000"}}, Limit: 10})
+}

--- a/internal/e2e_harness/production/filter_lww_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_e2e_test.go
@@ -25,6 +25,7 @@ func TestFilterLWW(t *testing.T) {
 		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
 	}{
 		{"stale_filter_delta_generations", testStaleFilterDeltaGenerations},
+		{"stale_filter_base_vs_delta", testStaleFilterBaseVsDelta},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -114,5 +115,68 @@ func testStaleFilterDeltaGenerations(ctx context.Context, t *testing.T, env *Env
 	assertZeroRows(ctx, t, env, "starts_with_stale_title", Query{
 		Schema: wide, Filters: []Filter{{Attr: "title", Op: "starts_with", Value: "open-"}}, Limit: 10})
 	assertZeroRows(ctx, t, env, "range_stale_count", Query{
+		Schema: wide, Filters: []Filter{{Attr: "count", Op: "lt", Value: "200000"}}, Limit: 10})
+}
+
+// testStaleFilterBaseVsDelta is issue #178 scenario 1 in the base-vs-delta
+// layout: v1 (matching) in base via init + onboarding cleanup, v2
+// (non-matching) in a delta flushed afterwards. Deterministic under #210:
+// base ver_ts = create time < delta ver_ts = update time.
+func testStaleFilterBaseVsDelta(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := make([]*Event, 0, 5)
+	for i := 0; i < 5; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("open-%02d", i),
+			"count": float64(100000 + i),
+		}))
+	}
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	report, err := env.RunInit(ctx, wide) // base = v1 @ create-time ver_ts
+	if err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	if report.RowsExported != 5 {
+		t.Fatalf("init exported %d rows, want 5", report.RowsExported)
+	}
+	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", wide.ID)
+
+	// Load-bearing positive: base serves v1 by its own value.
+	res := env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "open-02"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 1 {
+		t.Fatalf("v1 positive control returned %d rows, want 1", len(res.Records))
+	}
+
+	v2 := make([]*Event, 0, len(creates))
+	for i, c := range creates {
+		v2 = append(v2, UpdateEvent(wide, c.RowID, map[string]any{
+			"title": fmt.Sprintf("closed-%02d", i),
+			"count": float64(200000 + i),
+		}))
+	}
+	if err := env.ApplyEvents(ctx, v2...); err != nil {
+		t.Fatalf("apply v2 updates: %v", err)
+	}
+	assertStrictlyNewer(t, creates, v2)
+	mustFlush(ctx, t, env) // delta = v2 @ update-time ver_ts; rows now clean
+
+	// Positive: v2 reachable.
+	env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "closed-02"}},
+		Limit:   10,
+	})
+
+	// Adversarial: v1-only predicates across base/delta tiers.
+	assertZeroRows(ctx, t, env, "equals_stale_title_base", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-02"}}, Limit: 10})
+	assertZeroRows(ctx, t, env, "starts_with_stale_title_base", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Op: "starts_with", Value: "open-"}}, Limit: 10})
+	assertZeroRows(ctx, t, env, "range_stale_count_base", Query{
 		Schema: wide, Filters: []Filter{{Attr: "count", Op: "lt", Value: "200000"}}, Limit: 10})
 }

--- a/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
@@ -1,0 +1,141 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// matrixV1Creates builds the five v1 rows whose every filterable attribute
+// the v2 updates flip.
+func matrixV1Creates(wide SchemaRef) []*Event {
+	creates := make([]*Event, 0, 5)
+	for i := 0; i < 5; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title":  fmt.Sprintf("alpha-%02d", i),    // text, MAIN text_01
+			"note":   fmt.Sprintf("old-note-%02d", i), // text, EAV
+			"count":  float64(1000 + i),               // integer, MAIN integer_01
+			"qty":    float64(10 + i),                 // integer, EAV
+			"score":  1.5,                             // numeric, MAIN double_01
+			"ratio":  2.25,                            // numeric, EAV
+			"active": true,                            // bool, EAV
+			"born":   "2000-01-01",                    // date, EAV
+			"joined": "2010-06-15",                    // date, MAIN unix_ms
+		}))
+	}
+	return creates
+}
+
+// matrixV2Updates flips every filterable attribute of the v1 rows.
+func matrixV2Updates(wide SchemaRef, creates []*Event) []*Event {
+	v2 := make([]*Event, 0, len(creates))
+	for i, c := range creates {
+		v2 = append(v2, UpdateEvent(wide, c.RowID, map[string]any{
+			"title":  fmt.Sprintf("beta-%02d", i),
+			"note":   fmt.Sprintf("new-note-%02d", i),
+			"count":  float64(5000 + i),
+			"qty":    float64(500 + i),
+			"score":  9.5,
+			"ratio":  8.75,
+			"active": false,
+			"born":   "2020-02-02",
+			"joined": "2030-01-01",
+		}))
+	}
+	return v2
+}
+
+// testStaleFilterOperatorMatrix is issue #178 scenario 4: text, numeric,
+// and bool operators over both MAIN-bound and EAV attributes, where every
+// predicate matches only the superseded v1 generation. Also pins the
+// multi-attribute AND semantics: a conjunction whose legs match different
+// generations must yield zero rows — the winner is resolved first, then the
+// whole conjunction applies to it.
+//
+// Date-operator probes (born/joined) are deliberately absent: federated
+// date predicates binder-error until #200 lands. The v1/v2 data already
+// flips both date attributes so the probes can be added then.
+func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := matrixV1Creates(wide)
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	mustFlush(ctx, t, env) // delta #1 = v1
+
+	// Load-bearing positives across storage classes.
+	res := env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "alpha-02"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 1 {
+		t.Fatalf("MAIN text positive control returned %d rows, want 1", len(res.Records))
+	}
+	res = env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "note", Op: "contains", Value: "old-"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 5 {
+		t.Fatalf("EAV text positive control returned %d rows, want 5", len(res.Records))
+	}
+
+	v2 := matrixV2Updates(wide, creates)
+	if err := env.ApplyEvents(ctx, v2...); err != nil {
+		t.Fatalf("apply v2 updates: %v", err)
+	}
+	assertStrictlyNewer(t, creates, v2)
+	mustFlush(ctx, t, env) // delta #2 = v2; rows clean
+
+	// Positive: winner reachable.
+	env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "beta-02"}},
+		Limit:   10,
+	})
+
+	// Matrix: every probe matches only v1 → zero rows each.
+	probes := []struct {
+		name   string
+		filter Filter
+	}{
+		{"main_text_equals", Filter{Attr: "title", Value: "alpha-02"}},
+		{"main_text_starts_with", Filter{Attr: "title", Op: "starts_with", Value: "alpha"}},
+		{"eav_text_contains", Filter{Attr: "note", Op: "contains", Value: "old-"}},
+		{"main_int_lt", Filter{Attr: "count", Op: "lt", Value: "2000"}},
+		{"eav_int_lt", Filter{Attr: "qty", Op: "lt", Value: "100"}},
+		{"main_numeric_lt", Filter{Attr: "score", Op: "lt", Value: "2"}},
+		{"eav_numeric_lt", Filter{Attr: "ratio", Op: "lt", Value: "3"}},
+		{"eav_bool_equals", Filter{Attr: "active", Value: "1"}},
+		// Date probes deferred to #200 — see the function comment.
+	}
+	for _, p := range probes {
+		assertZeroRows(ctx, t, env, p.name, Query{
+			Schema: wide, Filters: []Filter{p.filter}, Limit: 10})
+	}
+
+	// Straddling AND: title matches v2, active matches v1 — no single
+	// version satisfies both, so the LWW winner fails the conjunction.
+	assertZeroRows(ctx, t, env, "straddling_and", Query{
+		Schema: wide,
+		Filters: []Filter{
+			{Attr: "title", Value: "beta-02"},
+			{Attr: "active", Value: "1"},
+		},
+		Limit: 10,
+	})
+	// Same conjunction anchored fully on the winner: exactly one row.
+	res = env.AssertQueryMatches(ctx, Query{
+		Schema: wide,
+		Filters: []Filter{
+			{Attr: "title", Value: "beta-02"},
+			{Attr: "active", Value: "0"},
+		},
+		Limit: 10,
+	})
+	if res != nil && len(res.Records) != 1 {
+		t.Fatalf("winner AND probe returned %d rows, want 1", len(res.Records))
+	}
+}

--- a/internal/e2e_harness/production/filter_lww_tombstone_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_tombstone_e2e_test.go
@@ -79,3 +79,76 @@ func testTombstoneSuppressesStaleFilter(ctx context.Context, t *testing.T, env *
 		t.Fatalf("post-delete total is %d rows, want 2", len(res.Records))
 	}
 }
+
+// testHotShadowStaleFilter is issue #178 scenario 3: the newer version is a
+// dirty (unflushed) hot row. The anti-join must evict the warm delta v1
+// before the filter could match it, and the non-matching hot version must
+// not reintroduce the row. Complements testDirtyHotShadowsCold (dirty over
+// base, single equality probe) with a warm-delta layout, range/prefix
+// operators, and a hot-tombstone arm.
+func testHotShadowStaleFilter(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := make([]*Event, 0, 5)
+	for i := 0; i < 5; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("open-%02d", i),
+			"count": float64(100000 + i),
+		}))
+	}
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	mustFlush(ctx, t, env) // delta = v1 for all five rows (warm tier)
+
+	// Load-bearing positive: warm delta serves v1 by its value.
+	res := env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "open-00"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 1 {
+		t.Fatalf("warm positive control returned %d rows, want 1", len(res.Records))
+	}
+
+	upd := UpdateEvent(wide, creates[0].RowID, map[string]any{
+		"title": "closed-00",
+		"count": float64(200000),
+	})
+	if err := env.ApplyEvents(ctx, upd); err != nil {
+		t.Fatalf("apply shadow update: %v", err)
+	}
+	assertStrictlyNewer(t, creates[:1], []*Event{upd})
+
+	// The dirty hot v2 does not match; the warm v1 must not resurface.
+	assertZeroRows(ctx, t, env, "hot_shadow_equals", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+	// Prefix over all v1 titles: only the four unshadowed rows qualify.
+	res = env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Op: "starts_with", Value: "open-"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 4 {
+		t.Fatalf("prefix probe returned %d rows, want 4", len(res.Records))
+	}
+	// The hot v2 is reachable by its own value through the dirty path.
+	res = env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "count", Op: "gte", Value: "200000"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 1 {
+		t.Fatalf("hot-reachability probe returned %d rows, want 1", len(res.Records))
+	}
+
+	// Hot-tombstone shadow over a warm v1.
+	del := DeleteEvent(wide, creates[1].RowID)
+	if err := env.ApplyEvents(ctx, del); err != nil {
+		t.Fatalf("apply shadow delete: %v", err)
+	}
+	assertZeroRows(ctx, t, env, "hot_tombstone_shadow_equals", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-01"}}, Limit: 10})
+	res = env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	if res != nil && len(res.Records) != 4 {
+		t.Fatalf("post-shadow total is %d rows, want 4", len(res.Records))
+	}
+}

--- a/internal/e2e_harness/production/filter_lww_tombstone_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_tombstone_e2e_test.go
@@ -1,0 +1,81 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// testTombstoneSuppressesStaleFilter is issue #178 scenario 2: the newest
+// version is a tombstone with no attributes at all, so the filter can only
+// ever match the superseded live version. The deleted row must not appear —
+// first while the tombstone is hot (dirty-set anti-join), then after it is
+// flushed to delta parquet (LWW + deleted_ts suppression in visible).
+func testTombstoneSuppressesStaleFilter(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := make([]*Event, 0, 4)
+	for i := 0; i < 4; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("open-%02d", i),
+			"count": float64(100000 + i),
+		}))
+	}
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	mustFlush(ctx, t, env) // delta #1 = live v1 for all four rows
+
+	// Load-bearing positive: the victim row is served by its value pre-delete.
+	res := env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "open-00"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 1 {
+		t.Fatalf("pre-delete positive control returned %d rows, want 1", len(res.Records))
+	}
+
+	dels := []*Event{
+		DeleteEvent(wide, creates[0].RowID),
+		DeleteEvent(wide, creates[1].RowID),
+	}
+	if err := env.ApplyEvents(ctx, dels...); err != nil {
+		t.Fatalf("apply deletes: %v", err)
+	}
+	assertStrictlyNewer(t, creates[:2], dels)
+
+	// Hot-tombstone arm: the dirty set evicts the delta v1; the tombstone
+	// itself has no entity_main row, so nothing hot can match either.
+	assertZeroRows(ctx, t, env, "hot_tombstone_equals", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+
+	flush2 := mustFlush(ctx, t, env) // delta #2 = tombstones (NULL attrs)
+	if got := countTier(flush2.Manifests[wide.ID], "delta"); got != 2 {
+		t.Fatalf("manifest holds %d delta files, want 2 (live + tombstone generations)", got)
+	}
+
+	// Flushed-tombstone arm: semijoin admits the row via its live v1 match;
+	// the tombstone wins LWW and visible drops it on deleted_ts.
+	assertZeroRows(ctx, t, env, "flushed_tombstone_equals_0", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+	assertZeroRows(ctx, t, env, "flushed_tombstone_equals_1", Query{
+		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-01"}}, Limit: 10})
+	// Range matching only the two deleted rows' v1 counts (100000, 100001).
+	assertZeroRows(ctx, t, env, "flushed_tombstone_range", Query{
+		Schema: wide, Filters: []Filter{{Attr: "count", Op: "lte", Value: "100001"}}, Limit: 10})
+
+	// Survivors stay reachable — the suppression is per-row, not per-file.
+	res = env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "title", Value: "open-02"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 1 {
+		t.Fatalf("survivor probe returned %d rows, want 1", len(res.Records))
+	}
+	res = env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	if res != nil && len(res.Records) != 2 {
+		t.Fatalf("post-delete total is %d rows, want 2", len(res.Records))
+	}
+}

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -165,8 +165,12 @@ func (e *DBFederatedQueryEngine) executeFederatedKeysetQuery(
 	}
 
 	// Fetch from DuckDB (cold and warm via S3, hot via postgres_scan).
-	// The template applies the keyset WHERE in the unified CTE, so both
-	// Postgres and S3 data are filtered by the cursor before LWW dedup.
+	// The template applies the keyset WHERE in the ranked CTE, BEFORE the
+	// ROW_NUMBER dedup picks rn = 1 — so the cursor filters row versions,
+	// not LWW winners. For cursors over mutable attribute columns this can
+	// resurrect a superseded version (found by #178's keyset probe; tracked
+	// by a follow-up issue). Cursors over version-invariant system columns
+	// (row_id, created_at) are unaffected.
 	if opts != nil && opts.IncludeExecutionPlan && opts.ExecutionPlan != nil {
 		opts.ExecutionPlan.Routing = model.RoutingDecision{
 			Tiers:     []model.DataTier{model.DataTierHot, model.DataTierWarm, model.DataTierCold},
@@ -181,8 +185,8 @@ func (e *DBFederatedQueryEngine) executeFederatedKeysetQuery(
 		return nil, 0, fmt.Errorf("fetch duckdb records: %w", err)
 	}
 
-	// With keyset, the DuckDB template handles LWW dedup via QUALIFY,
-	// so we apply limit directly to the returned records.
+	// With keyset, the DuckDB template handles LWW dedup in the ranked
+	// CTE (rn = 1), so we apply limit directly to the returned records.
 	var page []*model.PersistentRecord
 	if limit > 0 && limit < len(duckRecs) {
 		page = duckRecs[:limit]


### PR DESCRIPTION
Closes #178. Part of epic #172.

Pins filter-after-LWW semantics on the production federated read path with adversarial stale-value probes (the underlying bug was fixed in #173 / PR #191, commit bd1c829 — s3_source row_id semijoin). This suite is the regression gate required before the #195 single-scan pushdown rewrite.

## Scenarios (all oracle-checked via `AssertQueryMatches`, each with load-bearing positive controls before every zero-row probe and strict `changed_at` guards per #210)

- `stale_filter_delta_generations` — v1 matching / v2 non-matching across two delta generations. **Mutation-validated**: reverting the template's semijoin to the pre-#173 direct s3_source filter makes the test fail with a v1 resurrection (`extra=1` on the equals probe), then passes again on the restored template.
- `stale_filter_base_vs_delta` — v1 in base (init before update), v2 in delta; deterministic under #210 (base ver_ts = create time < delta ver_ts = update time).
- `tombstone_suppresses_stale_filter` — attribute-less tombstone vs filters matching only the live v1; hot arm (dirty-set anti-join) and flushed arm (parquet LWW + deleted_ts suppression), plus survivor reachability.
- `hot_shadow_stale_filter` — dirty non-matching update / tombstone over a **warm delta** v1; complements `testDirtyHotShadowsCold`'s base variant with range/prefix operators.
- `stale_filter_operator_matrix` — text/numeric/bool × MAIN/EAV (8 zero probes, every predicate matches only v1), straddling-AND (legs matching different generations → 0 rows) and winner-AND (→ 1 row). Date-operator probes deferred to #200 (federated date predicates binder-error today); the fixture data already flips both date attributes so the probes are a two-line addition once #200 lands.

## Found during implementation (probes not merged; evidence captured)

- **Keyset cursor filters versions before LWW dedup — real production bug.** The plan's decision-gate probe (row A: v1 count=900 → v2 count=100, both flushed; cursor after count=500 sorted by count asc) returned `[C(600), A_v1(900)]` instead of `[C]`; rendered SQL confirms the cursor predicate sits in the `ranked` CTE ahead of `rn = 1`. Additionally, `validateKeysetColumns` only guards the unused `ExecuteFederatedPaginatedQuery` branch — the live `ExecuteDuckDBFederatedQuery` path renders attribute cursors unvalidated. Follow-up issue to be filed (probe code + rendered SQL ready); the failing probe was deliberately not merged.
- **Benchmark harness (`internal/e2e_harness/federated/query.go`) still carries the pre-#173 bug**: per-tier filters before ROW_NUMBER dedup, no post-dedup re-filter (`buildParquetTierQuery`:322-333, `buildHotTierQueryTargeted`:582-613, `buildFinalFederatedSelect`:407-427; shape pinned by `query_unit_test.go:15`). Benchmark results can diverge from production semantics under filtered workloads. Follow-up issue to be filed; not fixed here (harness retirement/migration is #196/#198).

## Docs

- `docs/federated-query/design.md` §5 no longer teaches the pre-dedup filter placement: the sketch now mirrors the production template (dirty-set anti-join + row_id semijoin pushdown in `s3_source`, `ranked` CTE with the full LWW key, post-dedup `rn = 1` → soft-delete → logical filter), and emits `source_tier_priority` from both sources so the sketch is self-consistent SQL.
- `internal/federated/pagination.go` comments corrected: no QUALIFY exists (dedup is the `ranked` CTE), and the pre-dedup keyset placement is now documented as a known hazard for mutable cursor columns (issue reference to be patched in once filed).

## Verification

- `make lint` clean (golangci-lint v1.64.8), `make test` green.
- Full production e2e package: PASS in 31s, all suites including the five new scenarios.
- Mutation validation performed once against the semijoin (see scenario 1 above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
