### PR TITLE
fix(federated): apply keyset cursor after LWW dedup; unify cursor placeholders (#212)

### DIFF
--- a/internal/e2e_harness/production/keyset_lww_e2e_test.go
+++ b/internal/e2e_harness/production/keyset_lww_e2e_test.go
@@ -1,0 +1,92 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+
+	forma "github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// TestKeysetLWW (#212): the keyset cursor must be applied AFTER last-write-
+// wins deduplication. Pre-fix, the DuckDB template injected the cursor into
+// the ranked CTE — before ROW_NUMBER picked rn = 1 — so a superseded version
+// that satisfied the cursor could win its partition and resurrect. This is
+// the keyset twin of the #173/#178 filter-before-LWW bug and, with #178's
+// suite, the regression gate for the #195 single-scan rewrite.
+func TestKeysetLWW(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	scenarios := []struct {
+		name string
+		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"attribute_cursor_resurrection", testKeysetAttributeCursorResurrection},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), wide)
+		})
+	}
+}
+
+// pageRowIDs renders a page's row IDs for failure messages.
+func pageRowIDs(page *QueryResult) []string {
+	ids := make([]string, 0, len(page.Records))
+	for _, r := range page.Records {
+		ids = append(ids, r.RowID.String())
+	}
+	return ids
+}
+
+// testKeysetAttributeCursorResurrection is the issue #212 reproduction (the
+// #178 Task 6 decision-gate probe): row A is superseded from count=900 to
+// count=100 across two flushed delta generations; a cursor after count=500
+// must return exactly C(600) — A's live version sorts before the cursor, and
+// its stale 900 version must not resurrect.
+func testKeysetAttributeCursorResurrection(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	a := CreateEvent(wide, map[string]any{"title": "ks-a", "count": float64(900)})
+	b := CreateEvent(wide, map[string]any{"title": "ks-b", "count": float64(400)})
+	c := CreateEvent(wide, map[string]any{"title": "ks-c", "count": float64(600)})
+	if err := env.ApplyEvents(ctx, a, b, c); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	mustFlush(ctx, t, env) // delta #1: a=900, b=400, c=600
+
+	upd := UpdateEvent(wide, a.RowID, map[string]any{"count": float64(100)})
+	if err := env.ApplyEvents(ctx, upd); err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+	assertStrictlyNewer(t, []*Event{a}, []*Event{upd})
+	mustFlush(ctx, t, env) // delta #2: a=100; all rows clean
+
+	// Positive control (oracle-checked): ascending count = a(100), b(400), c(600).
+	res := env.AssertQueryMatches(ctx, Query{
+		Schema: wide, Sorts: []Sort{{Attr: "count"}}, Limit: 10})
+	if res != nil && len(res.Records) != 3 {
+		t.Fatalf("sorted control returned %d rows, want 3", len(res.Records))
+	}
+
+	// Cursor after count=500: only C(600) qualifies among LWW winners.
+	page, err := env.Query(ctx, Query{
+		Schema: wide,
+		Sorts:  []Sort{{Attr: "count"}},
+		Keyset: &model.KeysetCursor{
+			Columns: []model.KeysetColumn{{Attribute: "count", Direction: forma.SortOrderAsc}},
+			Values:  []any{float64(500)},
+			Mode:    model.KeysetCursorModeAfter,
+		},
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("keyset query: %v", err)
+	}
+	if len(page.Records) != 1 || page.Records[0].RowID != c.RowID {
+		t.Fatalf("keyset page = %v, want exactly [%s]: a stale pre-dedup version leaked through the cursor",
+			pageRowIDs(page), c.RowID)
+	}
+}

--- a/internal/e2e_harness/production/keyset_lww_e2e_test.go
+++ b/internal/e2e_harness/production/keyset_lww_e2e_test.go
@@ -25,6 +25,7 @@ func TestKeysetLWW(t *testing.T) {
 		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
 	}{
 		{"attribute_cursor_resurrection", testKeysetAttributeCursorResurrection},
+		{"created_at_cursor_resurrection", testKeysetCreatedAtCursorResurrection},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -88,5 +89,60 @@ func testKeysetAttributeCursorResurrection(ctx context.Context, t *testing.T, en
 	if len(page.Records) != 1 || page.Records[0].RowID != c.RowID {
 		t.Fatalf("keyset page = %v, want exactly [%s]: a stale pre-dedup version leaked through the cursor",
 			pageRowIDs(page), c.RowID)
+	}
+}
+
+// testKeysetCreatedAtCursorResurrection pins the #212 comment-thread finding:
+// created_at is NOT version-invariant in the federated path — the S3
+// projection maps changed_at AS created_at (duckdb_schema_projection.go), so
+// an update moves the winner's created_at forward and a created_at cursor
+// could resurrect the predecessor exactly like a business attribute. This
+// scenario pins "no version resurrection" only; the projection's
+// creation-time drift itself is out of scope for #212.
+func testKeysetCreatedAtCursorResurrection(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	a := CreateEvent(wide, map[string]any{"title": "ca-a", "count": float64(900)})
+	if err := env.ApplyEvents(ctx, a); err != nil {
+		t.Fatalf("apply create a: %v", err)
+	}
+	mustFlush(ctx, t, env) // delta #1: A@t1
+
+	b := CreateEvent(wide, map[string]any{"title": "ca-b", "count": float64(400)})
+	c := CreateEvent(wide, map[string]any{"title": "ca-c", "count": float64(600)})
+	if err := env.ApplyEvents(ctx, b, c); err != nil {
+		t.Fatalf("apply creates b, c: %v", err)
+	}
+	upd := UpdateEvent(wide, a.RowID, map[string]any{"count": float64(100)})
+	if err := env.ApplyEvents(ctx, upd); err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+	// t1 < t2 < t3 < t4 strictly, or the probe degrades into a ver_ts tie (#210).
+	assertStrictlyNewer(t, []*Event{a, b, c}, []*Event{b, c, upd})
+	mustFlush(ctx, t, env) // delta #2: B@t2, C@t3, A_v2@t4; all rows clean
+
+	// Positive control (oracle-checked): all three rows visible.
+	res := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
+	if res != nil && len(res.Records) != 3 {
+		t.Fatalf("control returned %d rows, want 3", len(res.Records))
+	}
+
+	// created_at DESC, cursor after C(t3) → created_at < t3. Among LWW
+	// winners only B(t2) qualifies: A's winner carries created_at = t4
+	// (update-time changed_at). Pre-#212 the superseded A@t1 version passed
+	// the cursor pre-dedup, won rn = 1, and resurrected as a second row.
+	page, err := env.Query(ctx, Query{
+		Schema: wide,
+		Keyset: &model.KeysetCursor{
+			Columns: []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}},
+			Values:  []any{c.ChangedAt},
+			Mode:    model.KeysetCursorModeAfter,
+		},
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("created_at keyset query: %v", err)
+	}
+	if len(page.Records) != 1 || page.Records[0].RowID != b.RowID {
+		t.Fatalf("created_at keyset page = %v, want exactly [%s]: a stale pre-dedup version leaked through the cursor",
+			pageRowIDs(page), b.RowID)
 	}
 }

--- a/internal/e2e_harness/production/keyset_lww_e2e_test.go
+++ b/internal/e2e_harness/production/keyset_lww_e2e_test.go
@@ -4,6 +4,7 @@ package production
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	forma "github.com/lychee-technology/forma"
@@ -26,6 +27,7 @@ func TestKeysetLWW(t *testing.T) {
 	}{
 		{"attribute_cursor_resurrection", testKeysetAttributeCursorResurrection},
 		{"created_at_cursor_resurrection", testKeysetCreatedAtCursorResurrection},
+		{"cursor_with_mixed_filters", testKeysetCursorWithMixedFilters},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -144,5 +146,93 @@ func testKeysetCreatedAtCursorResurrection(ctx context.Context, t *testing.T, en
 	if len(page.Records) != 1 || page.Records[0].RowID != b.RowID {
 		t.Fatalf("created_at keyset page = %v, want exactly [%s]: a stale pre-dedup version leaked through the cursor",
 			pageRowIDs(page), b.RowID)
+	}
+}
+
+// testKeysetCursorWithMixedFilters drives a mixed MAIN+EAV composite filter
+// (DuckArgs + PgMainArgs) together with a keyset cursor through the real
+// engine: one statement, one placeholder style, args bound in appearance
+// order (#161/#212). Phase 2 supersedes a row so the cursor must also drop
+// its live version without resurrecting the old one.
+func testKeysetCursorWithMixedFilters(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	rows := make([]*Event, 0, 5)
+	for i := 0; i < 5; i++ {
+		rows = append(rows, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("grp-%02d", i),  // MAIN text_01 → PgMain pushdown
+			"note":  fmt.Sprintf("keep-%02d", i), // EAV text → DuckDB clause
+			"count": float64(100 * (i + 1)),      // 100..500
+		}))
+	}
+	if err := env.ApplyEvents(ctx, rows...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	mustFlush(ctx, t, env) // single generation, all rows clean
+
+	filters := []Filter{
+		{Attr: "title", Op: "starts_with", Value: "grp-"},
+		{Attr: "note", Op: "contains", Value: "keep"},
+	}
+
+	// Positive control (oracle-checked): the composite matches all five rows.
+	res := env.AssertQueryMatches(ctx, Query{Schema: wide, Filters: filters, Limit: 10})
+	if res != nil && len(res.Records) != 5 {
+		t.Fatalf("filter control returned %d rows, want 5", len(res.Records))
+	}
+
+	keysetQuery := Query{
+		Schema:  wide,
+		Filters: filters,
+		Sorts:   []Sort{{Attr: "count"}},
+		Keyset: &model.KeysetCursor{
+			Columns: []model.KeysetColumn{{Attribute: "count", Direction: forma.SortOrderAsc}},
+			Values:  []any{float64(250)},
+			Mode:    model.KeysetCursorModeAfter,
+		},
+		Limit: 10,
+	}
+
+	assertKeysetPage(ctx, t, env, keysetQuery, rows[2], rows[3], rows[4]) // 300, 400, 500
+
+	// Supersede 300 → 50: the winner now sorts before the cursor and must
+	// vanish; its 300 version must not resurrect.
+	upd := UpdateEvent(wide, rows[2].RowID, map[string]any{"count": float64(50)})
+	if err := env.ApplyEvents(ctx, upd); err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+	assertStrictlyNewer(t, []*Event{rows[2]}, []*Event{upd})
+	mustFlush(ctx, t, env)
+
+	// Winner still matches the filters (flush snapshots the full row).
+	res = env.AssertQueryMatches(ctx, Query{Schema: wide, Filters: filters, Limit: 10})
+	if res != nil && len(res.Records) != 5 {
+		t.Fatalf("post-update filter control returned %d rows, want 5", len(res.Records))
+	}
+
+	assertKeysetPage(ctx, t, env, keysetQuery, rows[3], rows[4]) // 400, 500
+}
+
+// assertKeysetPage runs a keyset query (no oracle support for cursors) and
+// requires the page to equal exactly the given events, in order.
+func assertKeysetPage(ctx context.Context, t *testing.T, env *Env, q Query, want ...*Event) {
+	t.Helper()
+	page, err := env.Query(ctx, q)
+	if err != nil {
+		t.Fatalf("keyset query: %v", err)
+	}
+	ok := len(page.Records) == len(want)
+	if ok {
+		for i := range want {
+			if page.Records[i].RowID != want[i].RowID {
+				ok = false
+				break
+			}
+		}
+	}
+	if !ok {
+		wantIDs := make([]string, 0, len(want))
+		for _, w := range want {
+			wantIDs = append(wantIDs, w.RowID.String())
+		}
+		t.Fatalf("keyset page = %v, want exactly %v", pageRowIDs(page), wantIDs)
 	}
 }

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -136,10 +136,10 @@ func (e *DBFederatedQueryEngine) ExecuteFederatedPaginatedQuery(
 }
 
 // executeFederatedKeysetQuery performs a keyset-cursor-based federated query.
-// It delegates to DuckDB's federated template which applies the keyset WHERE
-// clause to the unified source (both S3 parquet and Postgres via postgres_scan).
-// Results are merged with LWW semantics via the template's QUALIFY clause and
-// the requested page is returned along with the total count and next cursor.
+// It delegates to DuckDB's federated template, which applies the keyset WHERE
+// clause in the visible CTE after LWW dedup (rn = 1), so the cursor filters
+// LWW winners rather than row versions (#212). The requested page is
+// returned along with the total count and next cursor.
 func (e *DBFederatedQueryEngine) executeFederatedKeysetQuery(
 	ctx context.Context,
 	tables model.StorageTables,
@@ -165,12 +165,12 @@ func (e *DBFederatedQueryEngine) executeFederatedKeysetQuery(
 	}
 
 	// Fetch from DuckDB (cold and warm via S3, hot via postgres_scan).
-	// The template applies the keyset WHERE in the ranked CTE, BEFORE the
-	// ROW_NUMBER dedup picks rn = 1 — so the cursor filters row versions,
-	// not LWW winners. For cursors over mutable attribute columns this can
-	// resurrect a superseded version (found by #178's keyset probe; tracked
-	// by a follow-up issue). Cursors over version-invariant system columns
-	// (row_id, created_at) are unaffected.
+	// The template applies the keyset WHERE in the visible CTE AFTER the
+	// ROW_NUMBER dedup picks rn = 1, so the cursor filters LWW winners, not
+	// row versions. Applying it pre-dedup resurrected superseded versions
+	// for cursors over any version-varying column — business attributes and
+	// created_at alike, since the S3 projection maps changed_at AS
+	// created_at (#212). Only row_id is version-invariant.
 	if opts != nil && opts.IncludeExecutionPlan && opts.ExecutionPlan != nil {
 		opts.ExecutionPlan.Routing = model.RoutingDecision{
 			Tiers:     []model.DataTier{model.DataTierHot, model.DataTierWarm, model.DataTierCold},
@@ -185,8 +185,9 @@ func (e *DBFederatedQueryEngine) executeFederatedKeysetQuery(
 		return nil, 0, fmt.Errorf("fetch duckdb records: %w", err)
 	}
 
-	// With keyset, the DuckDB template handles LWW dedup in the ranked
-	// CTE (rn = 1), so we apply limit directly to the returned records.
+	// With keyset, the DuckDB template dedups via rn = 1 and applies the
+	// cursor post-dedup in the visible CTE (#212), so we apply limit
+	// directly to the returned records.
 	var page []*model.PersistentRecord
 	if limit > 0 && limit < len(duckRecs) {
 		page = duckRecs[:limit]

--- a/internal/sqlgen/advanced_query_template_duckdb.go
+++ b/internal/sqlgen/advanced_query_template_duckdb.go
@@ -80,9 +80,6 @@ ranked AS (
       ORDER BY ver_ts DESC, source_tier_priority DESC, deleted_ts DESC, row_id ASC
     ) AS rn
   FROM unified
-  WHERE
-    {{if .HAS_KEYSET}}({{.KEYSET_WHERE_CLAUSE}}) AND{{end}}
-    1=1
 ),
 
 visible AS (
@@ -91,6 +88,13 @@ visible AS (
   WHERE rn = 1
     AND (deleted_ts IS NULL OR deleted_ts = 0)
     AND ({{.LOGICAL_WHERE_CLAUSE}})
+    -- Keyset cursor evaluates post-dedup: a WHERE in ranked would filter row
+    -- versions before ROW_NUMBER, letting a superseded version win rn = 1
+    -- and resurrect for cursors over any version-varying column — business
+    -- attributes and created_at alike (#212), the keyset twin of #173. It
+    -- renders after the logical clause so positional placeholder order keeps
+    -- matching arg order (keyset args are appended last).
+    {{if .HAS_KEYSET}}AND ({{.KEYSET_WHERE_CLAUSE}}){{end}}
 )
 
 SELECT

--- a/internal/sqlgen/duckdb_compiled_query.go
+++ b/internal/sqlgen/duckdb_compiled_query.go
@@ -59,9 +59,7 @@ func CompileDuckDBQuery(tpl *template.Template, params map[string]any, q *model.
 	m["LOGICAL_WHERE_CLAUSE"] = dual.DuckClause
 	m["PG_WHERE_CLAUSE"] = defaultIfEmpty(dual.PgMainClause, "1=1")
 
-	// whereArgs length at inject time: DuckArgs + PgMainArgs + DuckArgs.
-	keysetOffset := 2*len(dual.DuckArgs) + len(dual.PgMainArgs)
-	injectDuckDBTemplateParams(m, q, dual, keysetOffset)
+	injectDuckDBTemplateParams(m, q, dual)
 	// Compile-time keyset arg values are discarded; Bind re-derives them from
 	// the request cursor.
 	delete(m, "KEYSET_ARGS")
@@ -95,7 +93,7 @@ func (c *DuckDBCompiledQuery) Bind(q *model.FederatedAttributeQuery, dual DualCl
 	args = append(args, dual.PgMainArgs...)
 	args = append(args, dual.DuckArgs...)
 	if q != nil && q.KeysetCursor != nil && len(q.KeysetCursor.Columns) > 0 {
-		_, keysetArgs := generateKeysetWhereClause(q.KeysetCursor, "", 0)
+		_, keysetArgs := generateKeysetWhereClause(q.KeysetCursor, "")
 		args = append(args, keysetArgs...)
 	}
 	args = append(args, c.TplArgs...)

--- a/internal/sqlgen/duckdb_mixed_placeholder_regression_test.go
+++ b/internal/sqlgen/duckdb_mixed_placeholder_regression_test.go
@@ -48,3 +48,40 @@ func TestDuckDBMixedComposite_NoPlaceholderStyleMixing(t *testing.T) {
 	// visible WHERE); pin it so a future reordering can't silently mis-bind.
 	require.Equal(t, 2*len(dual.DuckArgs)+len(dual.PgMainArgs), len(args))
 }
+
+// TestDuckDBMixedComposite_KeysetNoPlaceholderStyleMixing extends the #161
+// invariant to keyset pagination (#212): a mixed main+EAV composite PLUS a
+// two-column cursor must render a single-style ("?") statement whose
+// placeholder count equals its arg count. Pre-#212 the cursor rendered "$n"
+// inside the ranked CTE — before visible's "?" placeholders — mis-binding
+// every logical-filter arg that followed it.
+func TestDuckDBMixedComposite_KeysetNoPlaceholderStyleMixing(t *testing.T) {
+	cache := dualPlanTestCache()
+	mixed := &forma.CompositeCondition{Logic: forma.LogicAnd, Conditions: []forma.Condition{
+		&forma.KvCondition{Attr: "age", Value: "gt:10"},
+		&forma.KvCondition{Attr: "tag", Value: "equals:x"},
+	}}
+	q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7, Condition: mixed}}
+	q.KeysetCursor = &model.KeysetCursor{
+		Mode: model.KeysetCursorModeAfter,
+		Columns: []model.KeysetColumn{
+			{Attribute: "created_at", Direction: forma.SortOrderDesc},
+			{Attribute: "row_id", Direction: forma.SortOrderDesc},
+		},
+		Values: []any{int64(1700000000000), "11111111-1111-1111-1111-111111111111"},
+	}
+
+	dual := parityDual(t, mixed, cache)
+	require.NotEmpty(t, dual.PgMainClause)
+	require.NotEmpty(t, dual.DuckClause)
+
+	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), q, nil, &dual)
+	require.NoError(t, err)
+
+	require.NotContains(t, sql, "$", "keyset clause must obey the single-style invariant (#161/#212)")
+	require.Equal(t, strings.Count(sql, "?"), len(args),
+		"placeholder count must equal arg count for positional binding")
+	// DuckArgs twice (s3 semijoin + visible), PgMainArgs once, then the
+	// 2-column cursor's 3 occurrence-args.
+	require.Equal(t, 2*len(dual.DuckArgs)+len(dual.PgMainArgs)+3, len(args))
+}

--- a/internal/sqlgen/duckdb_render_and_dirtyids_test.go
+++ b/internal/sqlgen/duckdb_render_and_dirtyids_test.go
@@ -58,15 +58,17 @@ func TestAppendDirtyExclusion(t *testing.T) {
 	require.Equal(t, u1.String(), args[0])
 }
 
-// TestInjectDuckDBTemplateParams_KeysetParamOffset verifies that when a non-zero
-// keysetParamOffset is passed, the keyset WHERE clause uses $offset+1, $offset+2, …
-// placeholders so they align with keyset values appended after existing whereArgs.
-func TestInjectDuckDBTemplateParams_KeysetParamOffset_NonZero(t *testing.T) {
+// TestInjectDuckDBTemplateParams_KeysetPositionalPlaceholders pins the #212
+// placeholder contract: the keyset clause uses positional "?" only (never
+// "$n" — see the #161 regression test for why mixing mis-binds), and prefix
+// columns that repeat across disjuncts contribute one arg per occurrence.
+func TestInjectDuckDBTemplateParams_KeysetPositionalPlaceholders(t *testing.T) {
 	cursor := &model.KeysetCursor{
 		Columns: []model.KeysetColumn{
-			{Attribute: "created_at", Direction: forma.SortOrderAsc},
+			{Attribute: "created_at", Direction: forma.SortOrderDesc},
+			{Attribute: "row_id", Direction: forma.SortOrderDesc},
 		},
-		Values: []interface{}{int64(999)},
+		Values: []interface{}{int64(999), "11111111-1111-1111-1111-111111111111"},
 		Mode:   model.KeysetCursorModeAfter,
 	}
 	q := &model.FederatedAttributeQuery{
@@ -74,24 +76,24 @@ func TestInjectDuckDBTemplateParams_KeysetParamOffset_NonZero(t *testing.T) {
 		KeysetCursor:   cursor,
 	}
 	params := map[string]any{}
+	injectDuckDBTemplateParams(params, q, nil)
 
-	// Simulate 3 args already accumulated in whereArgs before keyset args are appended.
-	injectDuckDBTemplateParams(params, q, nil, 3)
-
-	// Keyset clause should start at $4 (offset=3 means first keyset param is $4).
-	keysetClause, ok := params["KEYSET_WHERE_CLAUSE"].(string)
+	clause, ok := params["KEYSET_WHERE_CLAUSE"].(string)
 	require.True(t, ok, "KEYSET_WHERE_CLAUSE should be a string")
-	require.Contains(t, keysetClause, "$4",
-		"keyset placeholder must start at paramOffset+1 = $4")
-	require.NotContains(t, keysetClause, "$1",
-		"keyset placeholder must not collide with prior arg positions")
+	require.Equal(t, "(created_at < ?) OR (created_at = ? AND row_id < ?)", clause)
+	require.NotContains(t, clause, "$")
+
+	args, ok := params["KEYSET_ARGS"].([]interface{})
+	require.True(t, ok, "KEYSET_ARGS should be a slice")
+	require.Equal(t, []interface{}{
+		int64(999), int64(999), "11111111-1111-1111-1111-111111111111",
+	}, args, "prefix values repeat once per placeholder occurrence")
 }
 
-// TestBuildDuckDBQuery_KeysetArgPositionIsCorrect verifies that when a dual-clause
-// query with 2 DuckDB filter args is combined with a keyset cursor, the keyset
-// placeholder in the rendered SQL starts at the correct position and the keyset
-// value appears at the matching position in the returned args slice.
-func TestBuildDuckDBQuery_KeysetArgPositionIsCorrect(t *testing.T) {
+// TestBuildDuckDBQuery_KeysetArgsBindLast pins the end-to-end interleave for
+// a keyset query: [DuckArgs, PgMainArgs, DuckArgs, keysetArgs], one "?" per
+// arg in appearance order, no "$n" anywhere (#212).
+func TestBuildDuckDBQuery_KeysetArgsBindLast(t *testing.T) {
 	cursor := &model.KeysetCursor{
 		Columns: []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}},
 		Values:  []interface{}{int64(1000)},
@@ -101,22 +103,18 @@ func TestBuildDuckDBQuery_KeysetArgPositionIsCorrect(t *testing.T) {
 		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0},
 		KeysetCursor:   cursor,
 	}
-	// Two DuckDB filter args; no PG-main args.
 	dual := &DualClauses{
 		DuckClause: "age > ? AND name = ?",
 		DuckArgs:   []any{int64(25), "Alice"},
 	}
-	params := map[string]any{}
 
-	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
+	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, nil, dual)
 	require.NoError(t, err)
 
-	// For the advanced dual path args are:
-	//   [DuckArgs(2), PgMainArgs(0), DuckArgs(2), keysetArgs(1)]
-	// So keyset is at position 4 (0-indexed) → $5.
-	require.GreaterOrEqual(t, len(args), 5, "args must include keyset value at position 4")
-	require.Equal(t, int64(1000), args[4], "keyset value must be at args[4]")
-	require.True(t,
-		strings.Contains(sql, "$5"),
-		"rendered SQL must reference keyset value as $5, got SQL:\n%s", sql)
+	// [DuckArgs(2), PgMainArgs(0), DuckArgs(2), keyset(1)]
+	require.Len(t, args, 5)
+	require.Equal(t, int64(1000), args[4], "keyset value must be the last arg")
+	require.NotContains(t, sql, "$", "keyset queries must not reintroduce $n placeholders")
+	require.Equal(t, 5, strings.Count(sql, "?"),
+		"placeholder count must equal arg count for positional binding")
 }

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -81,7 +81,7 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 				whereArgs = append(whereArgs, dual.DuckArgs...)
 			}
 		}
-		injectDuckDBTemplateParams(m, q, dual, len(whereArgs))
+		injectDuckDBTemplateParams(m, q, dual)
 		if !isAdvancedTemplate && len(dual.PgMainArgs) > 0 {
 			whereArgs = append(whereArgs, dual.PgMainArgs...)
 		}
@@ -113,7 +113,7 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 			whereArgs = append(whereArgs, whereArgs...)
 		}
 	}
-	injectDuckDBTemplateParams(m, q, nil, len(whereArgs))
+	injectDuckDBTemplateParams(m, q, nil)
 	whereArgs = appendKeysetArgs(m, whereArgs)
 
 	merged := MergeTemplateParamsWithDirtyIDs(m, dirtyIDs)
@@ -127,7 +127,7 @@ func defaultIfEmpty(s, fallback string) string {
 	return s
 }
 
-func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttributeQuery, dual *DualClauses, keysetParamOffset int) {
+func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttributeQuery, dual *DualClauses) {
 	if q == nil {
 		return
 	}
@@ -200,10 +200,11 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	}
 
 	// Keyset pagination: inject cursor-derived WHERE clause and ORDER BY.
-	// keysetParamOffset is the number of args already accumulated in whereArgs so
-	// the generated $n placeholders correctly reference the appended keyset values.
+	// The clause uses positional "?" placeholders; its args are appended after
+	// all condition args by appendKeysetArgs, matching the clause's position at
+	// the end of the visible CTE.
 	if q.KeysetCursor != nil && len(q.KeysetCursor.Columns) > 0 {
-		keysetClause, keysetArgs := generateKeysetWhereClause(q.KeysetCursor, "", keysetParamOffset)
+		keysetClause, keysetArgs := generateKeysetWhereClause(q.KeysetCursor, "")
 		params["HAS_KEYSET"] = true
 		params["KEYSET_WHERE_CLAUSE"] = keysetClause
 		params["KEYSET_ARGS"] = keysetArgs

--- a/internal/sqlgen/keyset_placement_test.go
+++ b/internal/sqlgen/keyset_placement_test.go
@@ -1,0 +1,44 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdvancedTemplate_KeysetAppliedAfterDedup pins the #212 fix: the keyset
+// cursor predicate must render in the visible CTE after rn = 1, never in the
+// ranked CTE, where it would filter row versions before LWW dedup and let a
+// superseded version resurrect (the keyset twin of #173).
+func TestAdvancedTemplate_KeysetAppliedAfterDedup(t *testing.T) {
+	q := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10},
+		KeysetCursor: &model.KeysetCursor{
+			Columns: []model.KeysetColumn{{Attribute: "count", Direction: forma.SortOrderAsc}},
+			Values:  []any{float64(500)},
+			Mode:    model.KeysetCursorModeAfter,
+		},
+	}
+	dual := &DualClauses{DuckClause: "1=1"}
+
+	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, nil, dual)
+	require.NoError(t, err)
+
+	rankedStart := strings.Index(sql, "ranked AS")
+	visibleStart := strings.Index(sql, "visible AS")
+	require.Greater(t, rankedStart, -1)
+	require.Greater(t, visibleStart, rankedStart)
+
+	rankedBody := sql[rankedStart:visibleStart]
+	require.NotContains(t, rankedBody, "count >",
+		"cursor must not filter row versions before ROW_NUMBER dedup (#212)")
+
+	visibleBody := sql[visibleStart:]
+	rnIdx := strings.Index(visibleBody, "rn = 1")
+	keysetIdx := strings.Index(visibleBody, "count >")
+	require.Greater(t, rnIdx, -1)
+	require.Greater(t, keysetIdx, rnIdx, "cursor must apply after rn = 1 (#212)")
+}

--- a/internal/sqlgen/keyset_where.go
+++ b/internal/sqlgen/keyset_where.go
@@ -9,7 +9,15 @@ import (
 	"github.com/lychee-technology/forma"
 )
 
-func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string, paramOffset int) (string, []interface{}) {
+// generateKeysetWhereClause builds the composite keyset cursor predicate for
+// the DuckDB dialect. It emits positional "?" placeholders — never "$n" —
+// because the federated statement binds strictly by appearance order and
+// DuckDB treats "$n" as an absolute parameter index, shifting every "?"
+// after it (#161); the clause renders last in the visible CTE (#212) and
+// its args are appended last. Prefix columns repeat across disjuncts, so
+// each value is appended once per occurrence: an n-column cursor yields
+// n(n+1)/2 args.
+func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (string, []interface{}) {
 	if cursor == nil || len(cursor.Columns) == 0 {
 		return "1=1", nil
 	}
@@ -19,6 +27,12 @@ func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string, pa
 			return col
 		}
 		return tableAlias + col
+	}
+	valueAt := func(i int) interface{} {
+		if i < len(cursor.Values) {
+			return cursor.Values[i]
+		}
+		return nil
 	}
 
 	var clauses []string
@@ -30,19 +44,13 @@ func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string, pa
 
 		var parts []string
 		for j := 0; j < i; j++ {
-			parts = append(parts, fmt.Sprintf("%s = $%d", colRef(cursor.Columns[j].Attribute), paramOffset+j+1))
+			parts = append(parts, fmt.Sprintf("%s = ?", colRef(cursor.Columns[j].Attribute)))
+			args = append(args, valueAt(j))
 		}
-		parts = append(parts, fmt.Sprintf("%s %s $%d", colRef(col.Attribute), op, paramOffset+i+1))
+		parts = append(parts, fmt.Sprintf("%s %s ?", colRef(col.Attribute), op))
+		args = append(args, valueAt(i))
 
 		clauses = append(clauses, "("+strings.Join(parts, " AND ")+")")
-	}
-
-	for i := range cursor.Columns {
-		if i < len(cursor.Values) {
-			args = append(args, cursor.Values[i])
-		} else {
-			args = append(args, nil)
-		}
 	}
 
 	if len(clauses) == 1 {


### PR DESCRIPTION
Fixes #212.

## What

- Moves the keyset cursor predicate from the `ranked` CTE to the `visible` CTE, after `rn = 1`, so it filters LWW winners instead of row versions — mirroring the #173 fix for logical filter predicates (pinned by #178).
- Unifies the keyset clause on positional `?` placeholders (it rendered `$n` inside an otherwise `?`-only statement; per the #161 finding DuckDB treats `$n` as an absolute parameter index and shifts every `?` after it, so keyset + filter queries mis-bound). Multi-column cursors now append prefix values once per placeholder occurrence (n(n+1)/2 args for n columns).
- Lands the #178 keyset decision-gate probe as `TestKeysetLWW/attribute_cursor_resurrection`, plus a `created_at` cursor case (NOT version-invariant — the S3 projection maps `changed_at AS created_at`, per the issue's comment thread) and a mixed main+EAV filters + cursor binding case.
- Corrects the stale `pagination.go` comments (no QUALIFY exists; `created_at` is not exempt; concrete #212 reference as requested in the issue comments).

## Out of scope

- Rewiring `validateKeysetColumns` into the live path (after this fix, business-attribute cursors are correct; the validating branch remains unused).
- The `changed_at AS created_at` projection's creation-time ordering drift (#210-adjacent) — this PR pins only that no superseded version resurrects.
- The duplicate `$n`-emitting `generateKeysetWhereClause` in `internal/federated/keyset.go` (unused branch, kept alive by its own unit test). Final review flags it as a latent trap worth a follow-up: deleting it would close the last place the mixed-placeholder pattern can regrow.
- #195 must preserve both invariants; `TestKeysetLWW` + `TestFilterLWW` are the gate. Note for #195: the cursor is deliberately NOT pushed into the s3_source semijoin (correctness first) — `ranked` windows all versions before the cursor filters; recovering pushdown belongs to the rewrite.

## Testing

- `make test`, `make lint`
- `go test ./internal/e2e_harness/production/ -tags=e2e -run 'TestKeysetLWW|TestFilterLWW'` (real DuckDB engine, three-tier) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)