### PR TITLE
fix(sqlgen): bind federated date predicates as epoch-ms BIGINT (#200)

### DIFF
--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -340,9 +340,9 @@ func benchmarkParquetProjection(schemaID int16, tier, path string, tradeTimeOnly
 		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, '' as exchange, '' as region, 0 as tradeType, 0 as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
 	default:
 		if tradeTimeOnlyProjection {
-			return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, '' as name, version, '' as symbol, '' as exchange, '' as region, 0 as tradeType, COALESCE(TRY_CAST(tradeTime AS BIGINT), epoch_ms(TRY_CAST(tradeTime AS TIMESTAMP))) as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
+			return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, '' as name, version, '' as symbol, '' as exchange, '' as region, 0 as tradeType, tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
 		}
-		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, COALESCE(TRY_CAST(tradeTime AS BIGINT), epoch_ms(TRY_CAST(tradeTime AS TIMESTAMP))) as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
+		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
 	}
 }
 
@@ -696,7 +696,7 @@ func buildTradeTimeFilterClause(opts *QueryOptions) string {
 }
 
 func parquetTradeTimeFilterExpression() string {
-	return "COALESCE(TRY_CAST(tradeTime AS BIGINT), epoch_ms(TRY_CAST(tradeTime AS TIMESTAMP)))"
+	return "tradeTime"
 }
 
 func buildHotTradeTimeFilterClauseTargeted(opts *QueryOptions) string {

--- a/internal/e2e_harness/federated/query_unit_test.go
+++ b/internal/e2e_harness/federated/query_unit_test.go
@@ -61,11 +61,11 @@ func TestBuildFederatedCombinedQueryUsesHotFilterExpressions(t *testing.T) {
 
 func TestBuildParquetTierQuerySupportsSchemaSpecificProjection(t *testing.T) {
 	customerQuery := buildParquetTierQuery("customer-path", benchmarkSchemaIDCustomer, "base", "", "", "AND region = 'NA'", "", true, false)
-	if !strings.Contains(customerQuery, "region") || strings.Contains(customerQuery, "epoch_ms(tradeTime)") {
+	if !strings.Contains(customerQuery, "region") {
 		t.Fatalf("expected customer projection without trade time conversion: %s", customerQuery)
 	}
 	securityQuery := buildParquetTierQuery("security-path", benchmarkSchemaIDSecurity, "base", "", "", "AND symbol = 'SYM00001'", "", true, false)
-	if !strings.Contains(securityQuery, "symbol") || strings.Contains(securityQuery, "epoch_ms(tradeTime)") {
+	if !strings.Contains(securityQuery, "symbol") {
 		t.Fatalf("expected security projection with symbol only: %s", securityQuery)
 	}
 }
@@ -96,7 +96,7 @@ func TestBuildFederatedDeduplicatedCTEUsesStableTieBreaks(t *testing.T) {
 func TestBuildFederatedCombinedQuerySupportsTradeTimeWindow(t *testing.T) {
 	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade, PGHost: "localhost", PGPort: "5432"}
 	query := h.buildFederatedCombinedQuery("base-path", "delta-path", true, true, nil, &QueryOptions{TradeTimeStart: 1000, TradeTimeEnd: 2000, SortBy: "tradeTime", SortDesc: true}, true, false)
-	for _, expected := range []string{"COALESCE(TRY_CAST(tradeTime AS BIGINT), epoch_ms(TRY_CAST(tradeTime AS TIMESTAMP))) >= 1000", "COALESCE(TRY_CAST(tradeTime AS BIGINT), epoch_ms(TRY_CAST(tradeTime AS TIMESTAMP))) <= 2000", "COALESCE(hot_vals.tradeTime, em.bigint_02) >= 1000", "COALESCE(hot_vals.tradeTime, em.bigint_02) <= 2000"} {
+	for _, expected := range []string{"tradeTime >= 1000", "tradeTime <= 2000", "COALESCE(hot_vals.tradeTime, em.bigint_02) >= 1000", "COALESCE(hot_vals.tradeTime, em.bigint_02) <= 2000"} {
 		if !strings.Contains(query, expected) {
 			t.Fatalf("expected combined query to include %q: %s", expected, query)
 		}
@@ -141,12 +141,9 @@ func TestProjectionSelectionHelpers(t *testing.T) {
 }
 
 func TestBuildParquetTierQueryAppliesProjectedTradeTimeFilter(t *testing.T) {
-	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "base", "", "", "", "AND COALESCE(TRY_CAST(tradeTime AS BIGINT), epoch_ms(TRY_CAST(tradeTime AS TIMESTAMP))) <= 2000", true, false)
-	if !strings.Contains(query, "COALESCE(TRY_CAST(tradeTime AS BIGINT), epoch_ms(TRY_CAST(tradeTime AS TIMESTAMP))) <= 2000") {
+	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "base", "", "", "", "AND tradeTime <= 2000", true, false)
+	if !strings.Contains(query, "AND tradeTime <= 2000") {
 		t.Fatalf("expected projected trade time filter in parquet query: %s", query)
-	}
-	if strings.Contains(query, "AND tradeTime <= epoch_ms(2000)") {
-		t.Fatalf("expected parquet query to avoid raw tradeTime timestamp comparison: %s", query)
 	}
 }
 
@@ -168,7 +165,7 @@ func TestBuildPostgresOnlyQueriesSupportBenchmarkFilters(t *testing.T) {
 
 func TestBuildParquetTierQueryTradeTimeOnlyProjection(t *testing.T) {
 	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "base", "", "", "", "", true, true)
-	for _, expected := range []string{"'' as name", "'' as symbol", "'' as exchange", "'' as region", "0 as tradeType", "COALESCE(TRY_CAST(tradeTime AS BIGINT), epoch_ms(TRY_CAST(tradeTime AS TIMESTAMP))) as tradeTime"} {
+	for _, expected := range []string{"'' as name", "'' as symbol", "'' as exchange", "'' as region", "0 as tradeType, tradeTime,"} {
 		if !strings.Contains(query, expected) {
 			t.Fatalf("expected tradeTime-only parquet projection to include %q: %s", expected, query)
 		}

--- a/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
@@ -90,6 +90,15 @@ func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, 
 	if res != nil && len(res.Records) != 5 {
 		t.Fatalf("EAV date positive control returned %d rows, want 5", len(res.Records))
 	}
+	// MAIN date positive control (#200): all five v1 rows carry joined=2010-06-15.
+	res = env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "joined", Op: "lt", Value: "2020-01-01T00:00:00Z"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 5 {
+		t.Fatalf("MAIN date positive control returned %d rows, want 5", len(res.Records))
+	}
 
 	v2 := matrixV2Updates(wide, creates)
 	if err := env.ApplyEvents(ctx, v2...); err != nil {

--- a/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
@@ -54,9 +54,9 @@ func matrixV2Updates(wide SchemaRef, creates []*Event) []*Event {
 // generations must yield zero rows — the winner is resolved first, then the
 // whole conjunction applies to it.
 //
-// Date-operator probes (born/joined) are deliberately absent: federated
-// date predicates binder-error until #200 lands. The v1/v2 data already
-// flips both date attributes so the probes can be added then.
+// Date-operator probes over both storage classes (born in the EAV table,
+// joined bound to a MAIN unix_ms column) are covered since #200 fixed
+// federated date-predicate binding.
 func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
 	creates := matrixV1Creates(wide)
 	if err := env.ApplyEvents(ctx, creates...); err != nil {
@@ -80,6 +80,15 @@ func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, 
 	})
 	if res != nil && len(res.Records) != 5 {
 		t.Fatalf("EAV text positive control returned %d rows, want 5", len(res.Records))
+	}
+	// Date positive control (#200): all five v1 rows carry born=2000-01-01.
+	res = env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "born", Op: "lt", Value: "2010-01-01T00:00:00Z"}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) != 5 {
+		t.Fatalf("EAV date positive control returned %d rows, want 5", len(res.Records))
 	}
 
 	v2 := matrixV2Updates(wide, creates)
@@ -109,7 +118,8 @@ func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, 
 		{"main_numeric_lt", Filter{Attr: "score", Op: "lt", Value: "2"}},
 		{"eav_numeric_lt", Filter{Attr: "ratio", Op: "lt", Value: "3"}},
 		{"eav_bool_equals", Filter{Attr: "active", Value: "1"}},
-		// Date probes deferred to #200 — see the function comment.
+		{"eav_date_lt", Filter{Attr: "born", Op: "lt", Value: "2010-01-01T00:00:00Z"}},
+		{"main_date_lt", Filter{Attr: "joined", Op: "lt", Value: "2020-01-01T00:00:00Z"}},
 	}
 	for _, p := range probes {
 		assertZeroRows(ctx, t, env, p.name, Query{

--- a/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
@@ -47,6 +47,31 @@ func matrixV2Updates(wide SchemaRef, creates []*Event) []*Event {
 	return v2
 }
 
+// assertMatrixV1PositiveControls guards the zero-row matrix probes against
+// false greens: at the v1-only stage, every probed storage class must return
+// rows through the same predicate paths the matrix later expects to be empty.
+func assertMatrixV1PositiveControls(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	t.Helper()
+	controls := []struct {
+		name   string
+		filter Filter
+		want   int
+	}{
+		{"MAIN text", Filter{Attr: "title", Value: "alpha-02"}, 1},
+		{"EAV text", Filter{Attr: "note", Op: "contains", Value: "old-"}, 5},
+		// Date controls (#200): all five v1 rows carry born=2000-01-01 and
+		// joined=2010-06-15.
+		{"EAV date", Filter{Attr: "born", Op: "lt", Value: "2010-01-01T00:00:00Z"}, 5},
+		{"MAIN date", Filter{Attr: "joined", Op: "lt", Value: "2020-01-01T00:00:00Z"}, 5},
+	}
+	for _, c := range controls {
+		res := env.AssertQueryMatches(ctx, Query{Schema: wide, Filters: []Filter{c.filter}, Limit: 10})
+		if res != nil && len(res.Records) != c.want {
+			t.Fatalf("%s positive control returned %d rows, want %d", c.name, len(res.Records), c.want)
+		}
+	}
+}
+
 // testStaleFilterOperatorMatrix is issue #178 scenario 4: text, numeric,
 // and bool operators over both MAIN-bound and EAV attributes, where every
 // predicate matches only the superseded v1 generation. Also pins the
@@ -65,40 +90,7 @@ func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, 
 	mustFlush(ctx, t, env) // delta #1 = v1
 
 	// Load-bearing positives across storage classes.
-	res := env.AssertQueryMatches(ctx, Query{
-		Schema:  wide,
-		Filters: []Filter{{Attr: "title", Value: "alpha-02"}},
-		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 1 {
-		t.Fatalf("MAIN text positive control returned %d rows, want 1", len(res.Records))
-	}
-	res = env.AssertQueryMatches(ctx, Query{
-		Schema:  wide,
-		Filters: []Filter{{Attr: "note", Op: "contains", Value: "old-"}},
-		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 5 {
-		t.Fatalf("EAV text positive control returned %d rows, want 5", len(res.Records))
-	}
-	// Date positive control (#200): all five v1 rows carry born=2000-01-01.
-	res = env.AssertQueryMatches(ctx, Query{
-		Schema:  wide,
-		Filters: []Filter{{Attr: "born", Op: "lt", Value: "2010-01-01T00:00:00Z"}},
-		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 5 {
-		t.Fatalf("EAV date positive control returned %d rows, want 5", len(res.Records))
-	}
-	// MAIN date positive control (#200): all five v1 rows carry joined=2010-06-15.
-	res = env.AssertQueryMatches(ctx, Query{
-		Schema:  wide,
-		Filters: []Filter{{Attr: "joined", Op: "lt", Value: "2020-01-01T00:00:00Z"}},
-		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 5 {
-		t.Fatalf("MAIN date positive control returned %d rows, want 5", len(res.Records))
-	}
+	assertMatrixV1PositiveControls(ctx, t, env, wide)
 
 	v2 := matrixV2Updates(wide, creates)
 	if err := env.ApplyEvents(ctx, v2...); err != nil {
@@ -146,7 +138,7 @@ func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, 
 		Limit: 10,
 	})
 	// Same conjunction anchored fully on the winner: exactly one row.
-	res = env.AssertQueryMatches(ctx, Query{
+	res := env.AssertQueryMatches(ctx, Query{
 		Schema: wide,
 		Filters: []Filter{
 			{Attr: "title", Value: "beta-02"},

--- a/internal/e2e_harness/production/smoke_test.go
+++ b/internal/e2e_harness/production/smoke_test.go
@@ -171,7 +171,8 @@ func assertTierHits(ctx context.Context, t *testing.T, env *Env, wide SchemaRef,
 }
 
 // runSmokeQueries is the oracle-checked query battery: unfiltered,
-// equality, range, sorted, page 2, and PreferHot.
+// equality, range, sorted, page 2, date filters (main-column-bound and
+// EAV-only) across all three tiers, and PreferHot.
 func runSmokeQueries(ctx context.Context, t *testing.T, env *Env, wide SchemaRef, creates []*Event) {
 	t.Helper()
 
@@ -196,13 +197,39 @@ func runSmokeQueries(ctx context.Context, t *testing.T, env *Env, wide SchemaRef
 		Limit:  8,
 		Offset: 8, // page 2
 	})
-	// Sort on the main-column-bound datetime attribute (#194). Sorting only
-	// references the projected column; date filter parameters are not yet
-	// supported on the federated DuckClause side.
+	// Sort on the main-column-bound datetime attribute (#194).
 	env.AssertQueryMatches(ctx, Query{
 		Schema: wide,
 		Sorts:  []Sort{{Attr: "touched"}},
 		Limit:  10,
+	})
+	// Date predicates (#200): the DuckClause binds epoch-ms BIGINT params.
+	// Values must be RFC3339 or epoch-ms — the engine's date parser rejects
+	// bare "2006-01-02" literals (the oracle alone accepts them).
+	// Range on the main-column-bound (unix_ms, bigint_02) date attribute.
+	res := env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "joined", Op: "gte", Value: "1999-01-01T00:00:00Z"}},
+		Limit:   100,
+	})
+	if res != nil && len(res.Records) == 0 {
+		t.Error("joined date-range filter matched zero rows; want a non-empty subset")
+	}
+	// Equality + range on the EAV-only date attribute. creates[3] is a live
+	// cold-tier row the smoke flow never mutates, so its born value must hit.
+	bornEq := creates[3].Attrs["born"].(string) + "T00:00:00Z"
+	res = env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "born", Value: bornEq}},
+		Limit:   10,
+	})
+	if res != nil && len(res.Records) == 0 {
+		t.Error("born equality filter matched zero rows; creates[3] is live in the cold tier")
+	}
+	env.AssertQueryMatches(ctx, Query{
+		Schema:  wide,
+		Filters: []Filter{{Attr: "born", Op: "lt", Value: "2005-06-15T00:00:00Z"}},
+		Limit:   100,
 	})
 	env.AssertQueryMatches(ctx, Query{Schema: wide, PreferHot: true, Limit: 100})
 }

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -126,10 +126,11 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		return nil, fmt.Errorf("invalid numeric literal for %s: %s", attr, valStr)
 
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
+		// Epoch-ms int64: date columns in the federated CTEs are BIGINT (#200).
 		if t, e := time.Parse(time.RFC3339Nano, valStr); e == nil {
-			return t.UTC(), nil
+			return t.UTC().UnixMilli(), nil
 		} else if i, e := strconv.ParseInt(valStr, 10, 64); e == nil {
-			return time.UnixMilli(i).UTC(), nil
+			return i, nil
 		}
 		return nil, fmt.Errorf("invalid date literal for %s: %s", attr, valStr)
 

--- a/internal/sqlgen/duck_clause_test.go
+++ b/internal/sqlgen/duck_clause_test.go
@@ -20,20 +20,21 @@ func TestBuildDuckClause_NoMetadata_InferTypeAndCast(t *testing.T) {
 	clause, args, err := buildDuckClause(cond, cache)
 	require.NoError(t, err)
 
-	// Expect a CAST(? AS TIMESTAMP) because the value should be inferred as a datetime
-	require.Contains(t, clause, "CAST(? AS TIMESTAMP)")
+	// Expect CAST(? AS BIGINT): the value is inferred as a datetime, and
+	// federated date columns are epoch-ms BIGINT (#200).
+	require.Contains(t, clause, "CAST(? AS BIGINT)")
 	// Column name should be the attribute name when no metadata is present
 	require.Contains(t, clause, "unknown_ts")
 
 	require.Len(t, args, 1)
 
-	// The argument should be a time.Time equal to the parsed RFC3339 value (in UTC)
+	// The argument should be the epoch-ms of the parsed RFC3339 value.
 	parsedWant, err := time.Parse(time.RFC3339Nano, "2020-01-02T03:04:05Z")
 	require.NoError(t, err)
 
-	gotTime, ok := args[0].(time.Time)
-	require.True(t, ok, "expected DuckDB arg to be time.Time")
-	require.True(t, gotTime.Equal(parsedWant.UTC()), "expected parsed time to match")
+	gotMs, ok := args[0].(int64)
+	require.True(t, ok, "expected DuckDB arg to be epoch-ms int64")
+	require.Equal(t, parsedWant.UTC().UnixMilli(), gotMs)
 }
 
 // Given a LIKE-style operator such as starts_with or contains,

--- a/internal/sqlgen/duckdb_schema_projection.go
+++ b/internal/sqlgen/duckdb_schema_projection.go
@@ -609,7 +609,7 @@ func BuildBenchmarkProjections(schemaID int16) *SchemaProjection {
 			{name: "quantity", colName: "bigint_01", eavJSON: false, attrID: 3, s3Expr: "quantity"},
 			{name: "region", colName: "text_02", eavJSON: false, attrID: 7, s3Expr: "region"},
 			{name: "symbol", colName: "text_01", eavJSON: false, attrID: 1, s3Expr: "symbol"},
-			{name: "tradeTime", colName: "bigint_02", eavJSON: false, attrID: 5, s3Expr: "COALESCE(try_cast(tradeTime AS BIGINT), epoch_ms(try_cast(tradeTime AS TIMESTAMP))) as tradeTime"},
+			{name: "tradeTime", colName: "bigint_02", eavJSON: false, attrID: 5, s3Expr: "tradeTime"},
 			{name: "tradeType", colName: "smallint_01", eavJSON: false, attrID: 2, s3Expr: "tradeType"},
 		}
 	}

--- a/internal/sqlgen/duckdb_sql_generator_test.go
+++ b/internal/sqlgen/duckdb_sql_generator_test.go
@@ -3,7 +3,6 @@ package sqlgen
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/lychee-technology/forma/internal/model"
 
@@ -351,12 +350,12 @@ func TestBuildSchemaProjection_BoolColumnBound_TextCOALESCE(t *testing.T) {
 
 // ============================================================================
 // Exact-output tests restored from the retired legacy generator (issue #127
-// review): the datetime cases port with a DateTime cache entry so the
-// CAST(? AS TIMESTAMP) expectation is preserved; the nested case ports with
-// no cache (dual walker's literal type inference).
+// review): the datetime cases port with a DateTime cache entry and now pin the
+// CAST(? AS BIGINT) epoch-ms contract (#200); the nested case ports with no
+// cache (dual walker's literal type inference).
 // ============================================================================
 
-func TestBuildDuckClause_GivenBareRFC3339Literal_WhenClauseBuilt_ThenItDefaultsToEqualsTimestamp(t *testing.T) {
+func TestBuildDuckClause_GivenBareRFC3339Literal_WhenClauseBuilt_ThenItDefaultsToEqualsEpochMs(t *testing.T) {
 	cache := forma.SchemaAttributeCache{
 		"created_at": forma.AttributeMetadata{AttributeID: 7, ValueType: forma.ValueTypeDateTime},
 	}
@@ -364,12 +363,12 @@ func TestBuildDuckClause_GivenBareRFC3339Literal_WhenClauseBuilt_ThenItDefaultsT
 
 	clause, args, err := buildDuckClause(cond, cache)
 	require.NoError(t, err)
-	require.Equal(t, "created_at = CAST(? AS TIMESTAMP)", clause)
+	require.Equal(t, "created_at = CAST(? AS BIGINT)", clause)
 	require.Len(t, args, 1)
-	require.Equal(t, time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC), args[0])
+	require.Equal(t, int64(1577934245000), args[0])
 }
 
-func TestBuildDuckClause_GivenEpochMillisLiteral_WhenClauseBuilt_ThenItUsesTimestampCast(t *testing.T) {
+func TestBuildDuckClause_GivenEpochMillisLiteral_WhenClauseBuilt_ThenItUsesBigintCast(t *testing.T) {
 	cache := forma.SchemaAttributeCache{
 		"created_at": forma.AttributeMetadata{AttributeID: 7, ValueType: forma.ValueTypeDateTime},
 	}
@@ -377,9 +376,9 @@ func TestBuildDuckClause_GivenEpochMillisLiteral_WhenClauseBuilt_ThenItUsesTimes
 
 	clause, args, err := buildDuckClause(cond, cache)
 	require.NoError(t, err)
-	require.Equal(t, "created_at = CAST(? AS TIMESTAMP)", clause)
+	require.Equal(t, "created_at = CAST(? AS BIGINT)", clause)
 	require.Len(t, args, 1)
-	require.Equal(t, time.UnixMilli(1700000000000).UTC(), args[0])
+	require.Equal(t, int64(1700000000000), args[0])
 }
 
 func TestBuildDuckClause_GivenNestedAndOrConditions_WhenClauseBuilt_ThenGroupingAndArgumentOrderArePreserved(t *testing.T) {

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -30,8 +30,12 @@ func MapValueTypeToDuckDBType(v forma.ValueType) string {
 		// and scientific use-cases without default truncation.
 		return "DECIMAL(38,10)"
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
-		// Use TIMESTAMP for temporal types (configurable in future)
-		return "TIMESTAMP"
+		// Date/datetime attribute columns in the federated CTEs are epoch-ms
+		// BIGINT on all three sides — EAV pivot TRY_CAST(value_numeric AS
+		// BIGINT) (#173), main-column unix_ms export (#194), and the reader
+		// projection CAST(attr AS BIGINT) — so predicates must compare
+		// BIGINT, never TIMESTAMP (#200).
+		return "BIGINT"
 	case forma.ValueTypeBool:
 		return "BOOLEAN"
 	case forma.ValueTypeList:
@@ -65,7 +69,7 @@ func CastExpression(columnOrExpr string, v forma.ValueType) string {
 // ToDuckDBParam converts a Go value to the form expected by DuckDB drivers for the given value type.
 // Examples:
 //   - uuid.UUID -> string
-//   - time.Time -> time.Time (TIMESTAMP)
+//   - time.Time -> int64 epoch-ms (BIGINT)
 //   - numeric types -> float64
 func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 	if value == nil {
@@ -88,18 +92,20 @@ func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 			return nil, fmt.Errorf("cannot convert %T to UUID param", value)
 		}
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
-		// Expect a time.Time for TIMESTAMP mapping; accept epoch strings/numbers handled elsewhere if needed.
+		// Bind epoch-ms int64 to match the BIGINT storage convention (#200).
 		switch t := value.(type) {
 		case time.Time:
-			return t.UTC(), nil
+			return t.UTC().UnixMilli(), nil
 		case *time.Time:
 			timeValue, isNil := numutil.OptionalPointerValue(t)
 			if isNil {
 				return nil, nil
 			}
-			return timeValue.UTC(), nil
+			return timeValue.UTC().UnixMilli(), nil
+		case int64:
+			return t, nil
 		default:
-			return nil, fmt.Errorf("cannot convert %T to TIMESTAMP param", value)
+			return nil, fmt.Errorf("cannot convert %T to epoch-ms BIGINT param", value)
 		}
 	case forma.ValueTypeBool:
 		switch b := value.(type) {

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -130,57 +130,7 @@ func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 		}
 		return numeric, nil
 	case forma.ValueTypeBigInt, forma.ValueTypeNumeric:
-		// Preserve exact precision by converting to string — DuckDB accepts
-		// string representations for DECIMAL and HUGEINT column bindings.
-		if s, ok := value.(string); ok {
-			return s, nil
-		}
-		switch v := value.(type) {
-		case *float64:
-			if v == nil {
-				return nil, nil
-			}
-			return decimalString(*v), nil
-		case *float32:
-			if v == nil {
-				return nil, nil
-			}
-			return decimalString(float64(*v)), nil
-		case *int:
-			if v == nil {
-				return nil, nil
-			}
-			return fmt.Sprintf("%d", *v), nil
-		case *int16:
-			if v == nil {
-				return nil, nil
-			}
-			return fmt.Sprintf("%d", *v), nil
-		case *int32:
-			if v == nil {
-				return nil, nil
-			}
-			return fmt.Sprintf("%d", *v), nil
-		case *int64:
-			if v == nil {
-				return nil, nil
-			}
-			return fmt.Sprintf("%d", *v), nil
-		case float64:
-			return decimalString(v), nil
-		case float32:
-			return decimalString(float64(v)), nil
-		case int64:
-			return fmt.Sprintf("%d", v), nil
-		case int:
-			return fmt.Sprintf("%d", v), nil
-		case int32:
-			return fmt.Sprintf("%d", v), nil
-		case int16:
-			return fmt.Sprintf("%d", v), nil
-		default:
-			return nil, fmt.Errorf("cannot convert %T to bigint/numeric param", value)
-		}
+		return toDuckDBDecimalParam(value)
 	case forma.ValueTypeText:
 		switch s := value.(type) {
 		case string:
@@ -197,6 +147,61 @@ func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 	default:
 		// Fallback: return as-is
 		return value, nil
+	}
+}
+
+// toDuckDBDecimalParam converts a bigint/numeric value to its exact-precision
+// string form — DuckDB accepts string representations for DECIMAL and HUGEINT
+// column bindings.
+func toDuckDBDecimalParam(value any) (any, error) {
+	if s, ok := value.(string); ok {
+		return s, nil
+	}
+	switch v := value.(type) {
+	case *float64:
+		if v == nil {
+			return nil, nil
+		}
+		return decimalString(*v), nil
+	case *float32:
+		if v == nil {
+			return nil, nil
+		}
+		return decimalString(float64(*v)), nil
+	case *int:
+		if v == nil {
+			return nil, nil
+		}
+		return fmt.Sprintf("%d", *v), nil
+	case *int16:
+		if v == nil {
+			return nil, nil
+		}
+		return fmt.Sprintf("%d", *v), nil
+	case *int32:
+		if v == nil {
+			return nil, nil
+		}
+		return fmt.Sprintf("%d", *v), nil
+	case *int64:
+		if v == nil {
+			return nil, nil
+		}
+		return fmt.Sprintf("%d", *v), nil
+	case float64:
+		return decimalString(v), nil
+	case float32:
+		return decimalString(float64(v)), nil
+	case int64:
+		return fmt.Sprintf("%d", v), nil
+	case int:
+		return fmt.Sprintf("%d", v), nil
+	case int32:
+		return fmt.Sprintf("%d", v), nil
+	case int16:
+		return fmt.Sprintf("%d", v), nil
+	default:
+		return nil, fmt.Errorf("cannot convert %T to bigint/numeric param", value)
 	}
 }
 

--- a/internal/sqlgen/duckdb_type_mapper_test.go
+++ b/internal/sqlgen/duckdb_type_mapper_test.go
@@ -52,12 +52,12 @@ func TestMapValueTypeToDuckDBType_AllSupportedTypes(t *testing.T) {
 		{
 			name:     "ValueTypeDate",
 			vt:       forma.ValueTypeDate,
-			expected: "TIMESTAMP",
+			expected: "BIGINT",
 		},
 		{
 			name:     "ValueTypeDateTime",
 			vt:       forma.ValueTypeDateTime,
-			expected: "TIMESTAMP",
+			expected: "BIGINT",
 		},
 		{
 			name:     "ValueTypeBool",
@@ -105,10 +105,10 @@ func TestCastExpression_SimpleColumn(t *testing.T) {
 			expected: "CAST(is_active AS BOOLEAN)",
 		},
 		{
-			name:     "CastColumnToTimestamp",
+			name:     "CastColumnToEpochMsBigint",
 			column:   "created_at",
 			vt:       forma.ValueTypeDateTime,
-			expected: "CAST(created_at AS TIMESTAMP)",
+			expected: "CAST(created_at AS BIGINT)",
 		},
 		{
 			name:     "CastColumnToVarchar",
@@ -183,14 +183,20 @@ func TestToDuckDBParam_DateTime_FromTime(t *testing.T) {
 	now := time.Now()
 	result, err := ToDuckDBParam(now, forma.ValueTypeDateTime)
 	require.NoError(t, err)
-	require.Equal(t, now.UTC(), result)
+	require.Equal(t, now.UTC().UnixMilli(), result)
 }
 
 func TestToDuckDBParam_DateTime_FromPointerTime(t *testing.T) {
 	now := time.Now()
 	result, err := ToDuckDBParam(&now, forma.ValueTypeDateTime)
 	require.NoError(t, err)
-	require.Equal(t, now.UTC(), result)
+	require.Equal(t, now.UTC().UnixMilli(), result)
+}
+
+func TestToDuckDBParam_DateTime_FromEpochMsInt64(t *testing.T) {
+	result, err := ToDuckDBParam(int64(1700000000000), forma.ValueTypeDateTime)
+	require.NoError(t, err)
+	require.Equal(t, int64(1700000000000), result)
 }
 
 func TestToDuckDBParam_DateTime_FromNilPointer(t *testing.T) {
@@ -211,7 +217,7 @@ func TestToDuckDBParam_Date_FromTime(t *testing.T) {
 	now := time.Now()
 	result, err := ToDuckDBParam(now, forma.ValueTypeDate)
 	require.NoError(t, err)
-	require.Equal(t, now.UTC(), result)
+	require.Equal(t, now.UTC().UnixMilli(), result)
 }
 
 func TestToDuckDBParam_Bool_FromBool(t *testing.T) {
@@ -381,9 +387,9 @@ func TestMapValueTypeToListDuckDBType_BoolElement(t *testing.T) {
 	require.Equal(t, "LIST(BOOLEAN)", result)
 }
 
-func TestMapValueTypeToListDuckDBType_TimestampElement(t *testing.T) {
+func TestMapValueTypeToListDuckDBType_DateTimeElement(t *testing.T) {
 	result := MapValueTypeToListDuckDBType(forma.ValueTypeDateTime)
-	require.Equal(t, "LIST(TIMESTAMP)", result)
+	require.Equal(t, "LIST(BIGINT)", result)
 }
 
 func TestIsListType_True(t *testing.T) {

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -2,7 +2,6 @@ package sqlgen
 
 import (
 	"testing"
-	"time"
 
 	"github.com/lychee-technology/forma"
 	"github.com/stretchr/testify/require"
@@ -188,35 +187,34 @@ func buildCharNumericBoolCases() []charCase {
 // unbound) and the uuid storage class.
 func buildCharTemporalUuidCases() []charCase {
 	iso := "2024-01-02T03:04:05Z"
-	isoTime := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
 	return []charCase{
 		{
-			name: "date unix-ms encoding: main/eav int64 ms, duck time.Time",
+			name: "date unix-ms encoding: main/eav int64 ms, duck epoch-ms int64",
 			cond: charKv("born", "gte:1700000000000"),
 			want: DualClauses{
 				PgMainClause: "m.bigint_01 >= ?", PgMainArgs: []any{int64(1700000000000)},
 				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(8), int64(1700000000000)},
-				DuckClause: "born >= CAST(? AS TIMESTAMP)", DuckArgs: []any{time.UnixMilli(1700000000000).UTC()},
+				DuckClause: "born >= CAST(? AS BIGINT)", DuckArgs: []any{int64(1700000000000)},
 			},
 			span: 3,
 		},
 		{
-			name: "datetime ISO8601 encoding: main/eav bind ISO string, duck time.Time",
+			name: "datetime ISO8601 encoding: main/eav bind ISO string, duck epoch-ms int64",
 			cond: charKv("joined", "gte:"+iso),
 			want: DualClauses{
 				PgMainClause: "m.text_03 >= ?", PgMainArgs: []any{iso},
 				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(9), iso},
-				DuckClause: "joined >= CAST(? AS TIMESTAMP)", DuckArgs: []any{isoTime},
+				DuckClause: "joined >= CAST(? AS BIGINT)", DuckArgs: []any{int64(1704164645000)},
 			},
 			span: 3,
 		},
 		{
-			name: "datetime unbound: eav unix-ms int64, duck time.Time",
+			name: "datetime unbound: eav unix-ms int64, duck epoch-ms int64",
 			cond: charKv("seen", "gte:"+iso),
 			want: DualClauses{
 				PgMainClause: "", PgMainArgs: nil,
 				PgClause: charEavClause("$1", "value_numeric", ">=", "$2"), PgArgs: []any{int16(10), int64(1704164645000)},
-				DuckClause: "seen >= CAST(? AS TIMESTAMP)", DuckArgs: []any{isoTime},
+				DuckClause: "seen >= CAST(? AS BIGINT)", DuckArgs: []any{int64(1704164645000)},
 			},
 			span: 2,
 		},
@@ -395,7 +393,6 @@ func TestToDualClauses_Characterization_Errors(t *testing.T) {
 // inherit the EAV path's strict parse or its error surface.
 func TestStandaloneBuilders_Characterization(t *testing.T) {
 	cache := characterizationCache()
-	isoTime := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
 
 	t.Run("duck lenient keeps malformed pair as equals(raw)", func(t *testing.T) {
 		clause, args, err := BuildDuckClause(charKv("tag", "equals:"), cache)
@@ -421,8 +418,8 @@ func TestStandaloneBuilders_Characterization(t *testing.T) {
 			{"numeric literal", "equals:42", "ghost = CAST(? AS DECIMAL(38,10))", []any{"42"}},
 			{"bool literal", "equals:true", "ghost = CAST(? AS BOOLEAN)", []any{true}},
 			{"uuid literal", "equals:0b210f52-1f4d-4f47-9799-1e2f2c0efc07", "ghost = CAST(? AS VARCHAR)", []any{"0b210f52-1f4d-4f47-9799-1e2f2c0efc07"}},
-			{"iso literal", "gte:2024-01-02T03:04:05Z", "ghost >= CAST(? AS TIMESTAMP)", []any{isoTime}},
-			{"bare iso literal", "2024-01-02T03:04:05Z", "ghost = CAST(? AS TIMESTAMP)", []any{isoTime}},
+			{"iso literal", "gte:2024-01-02T03:04:05Z", "ghost >= CAST(? AS BIGINT)", []any{int64(1704164645000)}},
+			{"bare iso literal", "2024-01-02T03:04:05Z", "ghost = CAST(? AS BIGINT)", []any{int64(1704164645000)}},
 			{"text literal", "equals:hello", "ghost = ?", []any{"hello"}},
 		}
 		for _, tc := range cases {


### PR DESCRIPTION
Closes #200.

## What

- `MapValueTypeToDuckDBType`/`ToDuckDBParam`/`parseDuckDBRawParam` now treat date/datetime as epoch-ms BIGINT/int64; the DuckClause renders `attr <op> CAST(? AS BIGINT)`, matching the storage convention on all three sides (EAV pivot #173, unix_ms main export #194, reader projection).
- Re-pinned characterization/clause tests to the new contract.
- Production smoke now filters on `joined` (main-bound) and `born` (EAV-only) with oracle verification across all three tiers (acceptance).
- Added the #178-deferred `eav_date_lt`/`main_date_lt` stale-filter probes with same-path v1 positive controls for both storage classes.
- Retired the benchmark `tradeTime` TIMESTAMP-fallback COALESCE.

## Notes

- Filter literals must be RFC3339 or epoch-ms — the engine's `ParseRFC3339OrUnixMs` rejects bare `2006-01-02` (only the test oracle accepts them); the new e2e values use RFC3339.
- **Heavy-live operators:** benchmark runs against pre-generated datasets — any dataset old enough to store `tradeTime` as parquet TIMESTAMP must be regenerated after the COALESCE retirement.

## Verification

- `make lint` clean; `make test` all ok; full production e2e harness (`-tags=e2e`) 0 failures.

## Follow-ups

- #219: non-unix_ms date main-column encodings (ISO8601 text, `castMainValue` default `TRY_CAST(... AS TIMESTAMP)` branch at `internal/cdc/duckdb_exporter.go:413`) still misalign with the reader's `CAST(attr AS BIGINT)` contract — recorded in #200's discussion, unexercised by any fixture today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
