### PR TITLE
docs(federated): make §5 LWW SQL template executable and match the runtime source schema (#214)

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -91,7 +91,7 @@ The translator must traverse the filter tree and generate two distinct SQL fragm
 
 **A. PostgreSQL Pushdown Fragment ($PG_WHERE_CLAUSE)**
 
-* **Target:** postgres_scan string argument.  
+* **Target:** pg_source `WHERE` clause (DuckDB's postgres scanner pushes it down into the scan).  
 * **Scope:** Only attributes mapping to entity_main.  
 * **Syntax:** Physical Column Names.  
 * **Sanitization:** Strict literal escaping to prevent SQL injection.  
@@ -130,6 +130,8 @@ These controls are part of the request payload; they are not conveyed via HTTP h
 
 This SQL template represents the core logic of the Federated Query Engine.
 
+It is a simplified sketch of the runtime template (`internal/sqlgen/advanced_query_template_duckdb.go`) and is kept executable: `internal/federated/design_doc_sql_test.go` extracts this block, runs it on DuckDB, and pins its scan shapes, source aliases, and LWW/filter semantics — update that test when editing this section.
+
 ```SQL
 
 -- 1. Configuration  
@@ -149,8 +151,9 @@ WITH
 -- =========================================================================  
 dirty_ids AS (  
     SELECT row_id   
-    FROM postgres_scan($PG_CONN, 'change_log', 'flushed_at = 0')  
+    FROM postgres_scan($PG_CONN, 'public', 'change_log')  
     WHERE schema_id = $SCHEMA_ID  
+        AND flushed_at = 0  
 ),
 
 -- =========================================================================  
@@ -160,9 +163,9 @@ dirty_ids AS (
 s3_source AS (  
     SELECT   
         row_id,   
-        ltbase_created_at AS created_at,  
-        ltbase_updated_at AS ver_ts,  
-        ltbase_deleted_at AS deleted_ts,  
+        changed_at AS created_at,  
+        changed_at AS ver_ts,  
+        deleted_at AS deleted_ts,  
         -- Logical Columns (Native in Parquet)  
         name,   
         age,   
@@ -203,20 +206,21 @@ pg_source AS (
         MAX(CASE WHEN e.attr_id = 205 THEN e.value_text END) AS tag,  
         3 AS source_tier_priority
 
-    FROM postgres_scan($PG_CONN, 'change_log', 'flushed_at = 0') cl  
+    FROM postgres_scan($PG_CONN, 'public', 'change_log') cl  
       
-    -- [Optimization] PUSHDOWN: Filter entity_main INSIDE the scan string  
-    JOIN postgres_scan($PG_CONN,   
-        'SELECT * FROM entity_main_dev   
-         WHERE ltbase_schema_id = ' || $SCHEMA_ID || '   
-         AND (' || $PG_WHERE_CLAUSE || ')'   
-    ) m   
+    -- [Optimization] PUSHDOWN: $PG_WHERE_CLAUSE is a plain predicate in the  
+    -- WHERE clause below; DuckDB's postgres scanner pushes it down to  
+    -- PostgreSQL so entity_main is filtered by PG indexes, not in DuckDB.  
+    JOIN postgres_scan($PG_CONN, 'public', 'entity_main_dev') m   
       ON cl.schema_id = m.ltbase_schema_id AND cl.row_id = m.ltbase_row_id  
         
-    LEFT JOIN postgres_scan($PG_CONN, 'eav_data_dev') e   
+    LEFT JOIN postgres_scan($PG_CONN, 'public', 'eav_data_dev') e   
       ON cl.schema_id = e.schema_id AND cl.row_id = e.row_id  
       
     WHERE cl.schema_id = $SCHEMA_ID  
+        AND cl.flushed_at = 0  
+        AND m.ltbase_schema_id = $SCHEMA_ID  
+        AND ($PG_WHERE_CLAUSE)  
     GROUP BY m.ltbase_row_id, m.ltbase_created_at, cl.changed_at, cl.deleted_at, m.text_01, m.integer_01  
 ),
 
@@ -260,7 +264,7 @@ LIMIT $PAGE_SIZE OFFSET $OFFSET;
 
 ### **6.1 Predicate Pushdown (Critical)**
 
-* **Mechanism:** Injecting SQL strings into postgres_scan's second argument.  
+* **Mechanism:** `$PG_WHERE_CLAUSE` is rendered as a plain predicate in the pg_source `WHERE` clause; DuckDB's postgres scanner pushes supported predicates down into the PostgreSQL scan.  
 * **Rationale:** entity_main may contain millions of rows. Pulling all rows to DuckDB for filtering is unacceptable. Pushdown leverages PostgreSQL indexes.  
 * **Limitation:** Only applicable to entity_main columns. EAV columns and complex functions must be filtered in DuckDB memory after the join.
 

--- a/internal/federated/design_doc_sql_test.go
+++ b/internal/federated/design_doc_sql_test.go
@@ -1,0 +1,257 @@
+package federated
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests are the #214 executable-documentation guard for the §5 "SQL
+// Execution Template" sketch in docs/federated-query/design.md. The sketch
+// calls itself the core logic of the Federated Query Engine, so it must stay
+// executable against the runtime source contract:
+//
+//   - every postgres_scan is the 3-arg (connection, schema, table) form used
+//     by AdvancedQueryTemplateDuckDB — never a 2-arg form or a predicate/query
+//     smuggled into the table argument;
+//   - the S3 projection uses the runtime parquet columns from
+//     buildS3Projection (changed_at AS created_at / ver_ts, deleted_at AS
+//     deleted_ts), not phantom ltbase_* columns;
+//   - the documented query preserves the #173/#178 filter-after-LWW
+//     semantics that PR #211 encoded.
+//
+// TestDesignDocSQL_ExecutesWithLWWFilterSemantics enforces the above
+// behaviorally: postgres_scan calls are mapped to same-named local relations
+// (a malformed call maps to nothing and fails the parse assertion), the
+// $S3_PATHS placeholder points at a real parquet file, and the whole block
+// runs on an in-memory DuckDB against seed data built for the #173 scenarios.
+
+const designDocRelPath = "../../docs/federated-query/design.md"
+
+// extractDesignDocSection5SQL returns the fenced SQL block of design.md §5.
+// It anchors on the section heading (not line numbers, which drift) and
+// captures the first ```sql fence after it.
+func extractDesignDocSection5SQL(t *testing.T) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Clean(designDocRelPath))
+	require.NoError(t, err, "design.md must be readable from internal/federated")
+	doc := string(raw)
+
+	heading := regexp.MustCompile(`(?m)^##\s+\*\*5\..*$`)
+	loc := heading.FindStringIndex(doc)
+	require.NotNil(t, loc, "design.md must contain the §5 heading (## **5. ...**)")
+
+	fence := regexp.MustCompile("(?is)```sql\\s*\n(.*?)```")
+	m := fence.FindStringSubmatch(doc[loc[1]:])
+	require.NotNil(t, m, "design.md §5 must contain a fenced SQL block")
+	return m[1]
+}
+
+// findPostgresScanCalls returns the raw argument text of every postgres_scan
+// invocation in sqlText, matching parentheses so multi-line and nested forms
+// are captured whole.
+func findPostgresScanCalls(sqlText string) []string {
+	const marker = "postgres_scan("
+	var calls []string
+	for i := 0; ; {
+		idx := strings.Index(sqlText[i:], marker)
+		if idx < 0 {
+			break
+		}
+		start := i + idx + len(marker)
+		depth := 1
+		j := start
+		for ; j < len(sqlText) && depth > 0; j++ {
+			switch sqlText[j] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+		}
+		calls = append(calls, strings.TrimSpace(sqlText[start:j-1]))
+		i = j
+	}
+	return calls
+}
+
+// threeArgScanRe is the only valid documented postgres_scan shape: the
+// $PG_CONN placeholder plus two single-quoted identifiers (schema, table).
+// A predicate or a dynamic SELECT in any argument does not match.
+var threeArgScanRe = regexp.MustCompile(
+	`^\$PG_CONN\s*,\s*'([A-Za-z_][A-Za-z0-9_]*)'\s*,\s*'([A-Za-z_][A-Za-z0-9_]*)'$`)
+
+// TestDesignDocSQL_PostgresScanIsThreeArg pins the runtime scan arity: every
+// documented postgres_scan must be the 3-arg (connection, schema, table) form
+// of AdvancedQueryTemplateDuckDB.
+func TestDesignDocSQL_PostgresScanIsThreeArg(t *testing.T) {
+	sqlText := extractDesignDocSection5SQL(t)
+
+	calls := findPostgresScanCalls(sqlText)
+	require.NotEmpty(t, calls, "§5 must document postgres_scan usage")
+
+	for _, args := range calls {
+		require.Regexp(t, threeArgScanRe, args,
+			"every §5 postgres_scan must be the 3-arg ($PG_CONN, 'schema', 'table') runtime form; "+
+				"predicates such as flushed_at = 0 belong in WHERE, not in a scan argument")
+	}
+}
+
+// TestDesignDocSQL_S3ProjectionAliasesMatchRuntime pins the §5 S3 source
+// projection to the runtime parquet schema from buildS3Projection
+// (duckdb_schema_projection.go): one physical changed_at column feeds both
+// created_at and ver_ts, and deleted_at feeds deleted_ts.
+func TestDesignDocSQL_S3ProjectionAliasesMatchRuntime(t *testing.T) {
+	sqlText := extractDesignDocSection5SQL(t)
+
+	for _, alias := range []string{
+		"changed_at AS created_at",
+		"changed_at AS ver_ts",
+		"deleted_at AS deleted_ts",
+	} {
+		require.Contains(t, sqlText, alias,
+			"§5 S3 projection must use the runtime parquet column aliases")
+	}
+	for _, phantom := range []string{"ltbase_updated_at", "ltbase_deleted_at"} {
+		require.NotContains(t, sqlText, phantom,
+			"parquet files have no %s column; §5 must not project it", phantom)
+	}
+}
+
+// rewriteDocSQLForLocalExecution turns the §5 sketch into a self-contained
+// DuckDB statement: each postgres_scan($PG_CONN, 'schema', 'table') collapses
+// to its table name (bound to a local seed relation), and the remaining $
+// placeholders get concrete values. The table-name mapping is derived from
+// the call itself, so renames in the doc adapt automatically — while any
+// malformed scan form fails the arity assertion here.
+func rewriteDocSQLForLocalExecution(t *testing.T, sqlText, parquetPath string) string {
+	t.Helper()
+
+	for _, args := range findPostgresScanCalls(sqlText) {
+		m := threeArgScanRe.FindStringSubmatch(args)
+		require.NotNil(t, m,
+			"cannot map postgres_scan(%s) to a local relation: not the 3-arg runtime form", args)
+		sqlText = strings.Replace(sqlText, "postgres_scan("+args+")", m[2], 1)
+	}
+
+	replacements := [][2]string{
+		{"$S3_PATHS", "['" + parquetPath + "']"},
+		{"$SCHEMA_ID", "1"},
+		{"$PG_WHERE_CLAUSE", "1 = 1"},
+		{"$PAGE_SIZE", "100"},
+		{"$OFFSET", "0"},
+		// Scan calls collapse to local relations above; this only clears the
+		// parameter-legend comment lines.
+		{"$PG_CONN", "(local)"},
+	}
+	for _, r := range replacements {
+		sqlText = strings.ReplaceAll(sqlText, r[0], r[1])
+	}
+	require.NotContains(t, sqlText, "$",
+		"all §5 placeholders must be substituted before execution")
+	return sqlText
+}
+
+// seedDesignDocScenario builds the local relations the rewritten §5 SQL scans
+// and a real parquet file for read_parquet. The data encodes the #173/#178
+// scenarios; the documented logical filter is
+// (age > 18 AND name LIKE 'John%' AND tag = 'developer'):
+//
+//   - s1: old parquet version matches, newer one fails the filter — the newer
+//     version must win LWW and the row must NOT surface (#173).
+//   - s2: old live version matches, newer version is a tombstone — the
+//     tombstone must win dedup and then be dropped.
+//   - s3: single matching parquet version, plus an already-flushed change_log
+//     row — it must surface from S3 (flushed_at = 0 keeps it out of the
+//     dirty set).
+//   - s4: single non-matching parquet version — the semijoin excludes it.
+//   - d1: stale matching parquet version AND an unflushed hot version — the
+//     dirty-set anti-join must serve the hot values (age 30, created_at 90).
+//   - d2: unflushed hot version that fails the filter — dropped post-LWW.
+func seedDesignDocScenario(t *testing.T, db *sql.DB, parquetPath string) {
+	t.Helper()
+
+	stmts := []string{
+		`CREATE TABLE change_log (
+			row_id VARCHAR, schema_id INTEGER, flushed_at BIGINT,
+			changed_at BIGINT, deleted_at BIGINT)`,
+		`INSERT INTO change_log VALUES
+			('d1', 1, 0, 300, 0),
+			('d2', 1, 0, 300, 0),
+			('s3', 1, 500, 100, 0)`,
+		`CREATE TABLE entity_main_dev (
+			ltbase_row_id VARCHAR, ltbase_schema_id INTEGER, ltbase_created_at BIGINT,
+			text_01 VARCHAR, integer_01 INTEGER)`,
+		`INSERT INTO entity_main_dev VALUES
+			('d1', 1, 90, 'John Dirty', 30),
+			('d2', 1, 95, 'Bob', 40)`,
+		`CREATE TABLE eav_data_dev (
+			row_id VARCHAR, schema_id INTEGER, attr_id INTEGER, value_text VARCHAR)`,
+		`INSERT INTO eav_data_dev VALUES
+			('d1', 1, 205, 'developer'),
+			('d2', 1, 205, 'developer')`,
+		`COPY (
+			SELECT * FROM (VALUES
+				('s1', CAST(100 AS BIGINT), CAST(0 AS BIGINT), 'John Stale', 25, 'developer'),
+				('s1', CAST(200 AS BIGINT), CAST(0 AS BIGINT), 'John Newer', 15, 'developer'),
+				('s2', CAST(100 AS BIGINT), CAST(0 AS BIGINT), 'John Alive', 30, 'developer'),
+				('s2', CAST(200 AS BIGINT), CAST(200 AS BIGINT), 'John Gone', 30, 'developer'),
+				('s3', CAST(100 AS BIGINT), CAST(0 AS BIGINT), 'John Base', 40, 'developer'),
+				('s4', CAST(100 AS BIGINT), CAST(0 AS BIGINT), 'Alice', 50, 'developer'),
+				('d1', CAST(100 AS BIGINT), CAST(0 AS BIGINT), 'John Flushed', 25, 'developer')
+			) AS t(row_id, changed_at, deleted_at, name, age, tag)
+		) TO '` + parquetPath + `' (FORMAT PARQUET)`,
+	}
+	for _, stmt := range stmts {
+		_, err := db.Exec(stmt)
+		require.NoError(t, err, "seed statement failed: %s", stmt)
+	}
+}
+
+// TestDesignDocSQL_ExecutesWithLWWFilterSemantics executes the §5 sketch on a
+// real DuckDB engine and asserts the #173/#178 filter-after-LWW semantics it
+// documents. See seedDesignDocScenario for the per-row expectations.
+func TestDesignDocSQL_ExecutesWithLWWFilterSemantics(t *testing.T) {
+	docSQL := extractDesignDocSection5SQL(t)
+	parquetPath := filepath.Join(t.TempDir(), "base.parquet")
+
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	seedDesignDocScenario(t, db, parquetPath)
+
+	query := rewriteDocSQLForLocalExecution(t, docSQL, parquetPath)
+	rows, err := db.Query(query)
+	require.NoError(t, err, "the documented §5 SQL must execute as written (query=%s)", query)
+	defer rows.Close()
+
+	type resultRow struct {
+		rowID, name, tag string
+		age              int
+		createdAt        int64
+	}
+	var got []resultRow
+	for rows.Next() {
+		var r resultRow
+		require.NoError(t, rows.Scan(&r.rowID, &r.name, &r.age, &r.tag, &r.createdAt))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+
+	// ORDER BY created_at DESC: s3 (100, from parquet changed_at) precedes
+	// d1 (90, from entity_main.ltbase_created_at).
+	require.Equal(t, []resultRow{
+		{rowID: "s3", name: "John Base", age: 40, tag: "developer", createdAt: 100},
+		{rowID: "d1", name: "John Dirty", age: 30, tag: "developer", createdAt: 90},
+	}, got,
+		"§5 must keep filter-after-LWW: s1 (newer non-matching version) and s2 "+
+			"(tombstone winner) must not resurface; d1 must carry hot-tier values")
+}

--- a/internal/federated/design_doc_sql_test.go
+++ b/internal/federated/design_doc_sql_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/lychee-technology/forma/internal/sqlgen/sqlgentest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,34 +57,6 @@ func extractDesignDocSection5SQL(t *testing.T) string {
 	return m[1]
 }
 
-// findPostgresScanCalls returns the raw argument text of every postgres_scan
-// invocation in sqlText, matching parentheses so multi-line and nested forms
-// are captured whole.
-func findPostgresScanCalls(sqlText string) []string {
-	const marker = "postgres_scan("
-	var calls []string
-	for i := 0; ; {
-		idx := strings.Index(sqlText[i:], marker)
-		if idx < 0 {
-			break
-		}
-		start := i + idx + len(marker)
-		depth := 1
-		j := start
-		for ; j < len(sqlText) && depth > 0; j++ {
-			switch sqlText[j] {
-			case '(':
-				depth++
-			case ')':
-				depth--
-			}
-		}
-		calls = append(calls, strings.TrimSpace(sqlText[start:j-1]))
-		i = j
-	}
-	return calls
-}
-
 // threeArgScanRe is the only valid documented postgres_scan shape: the
 // $PG_CONN placeholder plus two single-quoted identifiers (schema, table).
 // A predicate or a dynamic SELECT in any argument does not match.
@@ -94,7 +69,7 @@ var threeArgScanRe = regexp.MustCompile(
 func TestDesignDocSQL_PostgresScanIsThreeArg(t *testing.T) {
 	sqlText := extractDesignDocSection5SQL(t)
 
-	calls := findPostgresScanCalls(sqlText)
+	calls := sqlgentest.FindPostgresScanCalls(sqlText)
 	require.NotEmpty(t, calls, "§5 must document postgres_scan usage")
 
 	for _, args := range calls {
@@ -104,25 +79,66 @@ func TestDesignDocSQL_PostgresScanIsThreeArg(t *testing.T) {
 	}
 }
 
+// extractDocS3ProjectionItems returns the individual SELECT items of the §5
+// s3_source CTE, with SQL comments stripped. The doc's source_tier_priority
+// literal is kept: the runtime template appends it outside SchemaProjection,
+// so the caller decides how to treat it.
+func extractDocS3ProjectionItems(t *testing.T, sqlText string) []string {
+	t.Helper()
+
+	block := regexp.MustCompile(`(?s)s3_source AS \(\s*SELECT\b(.*?)FROM read_parquet`).
+		FindStringSubmatch(sqlText)
+	require.NotNil(t, block, "§5 must contain an s3_source CTE selecting from read_parquet")
+
+	var cleaned []string
+	for _, line := range strings.Split(block[1], "\n") {
+		if idx := strings.Index(line, "--"); idx >= 0 {
+			line = line[:idx]
+		}
+		cleaned = append(cleaned, line)
+	}
+
+	var items []string
+	for _, item := range strings.Split(strings.Join(cleaned, "\n"), ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
 // TestDesignDocSQL_S3ProjectionAliasesMatchRuntime pins the §5 S3 source
-// projection to the runtime parquet schema from buildS3Projection
-// (duckdb_schema_projection.go): one physical changed_at column feeds both
-// created_at and ver_ts, and deleted_at feeds deleted_ts.
+// projection to the runtime projection itself: it derives the expected
+// SELECT items from sqlgen.BuildSchemaProjection for the schema the doc
+// example uses (name/age main-bound, tag pure-EAV), so a change to
+// buildS3Projection fails this guard instead of leaving §5 silently stale.
 func TestDesignDocSQL_S3ProjectionAliasesMatchRuntime(t *testing.T) {
 	sqlText := extractDesignDocSection5SQL(t)
 
-	for _, alias := range []string{
-		"changed_at AS created_at",
-		"changed_at AS ver_ts",
-		"deleted_at AS deleted_ts",
-	} {
-		require.Contains(t, sqlText, alias,
-			"§5 S3 projection must use the runtime parquet column aliases")
+	items := extractDocS3ProjectionItems(t, sqlText)
+	require.Contains(t, items, "1 AS source_tier_priority",
+		"§5 s3_source must emit source_tier_priority: the ranked ORDER BY consumes it (#211)")
+
+	docProjection := make([]string, 0, len(items)-1)
+	for _, item := range items {
+		if item != "1 AS source_tier_priority" {
+			docProjection = append(docProjection, item)
+		}
 	}
-	for _, phantom := range []string{"ltbase_updated_at", "ltbase_deleted_at"} {
-		require.NotContains(t, sqlText, phantom,
-			"parquet files have no %s column; §5 must not project it", phantom)
+
+	cache := forma.SchemaAttributeCache{
+		"name": {AttributeID: 1, ValueType: forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_01")}},
+		"age": {AttributeID: 2, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("integer_01")}},
+		"tag": {AttributeID: 205, ValueType: forma.ValueTypeText},
 	}
+	sp, err := sqlgen.BuildSchemaProjection(1, cache)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, strings.Split(sp.S3SourceSelect, ", "), docProjection,
+		"§5 s3_source projection must match the runtime SchemaProjection.S3SourceSelect "+
+			"for the documented name/age/tag schema (attribute order aside)")
 }
 
 // rewriteDocSQLForLocalExecution turns the §5 sketch into a self-contained
@@ -134,7 +150,7 @@ func TestDesignDocSQL_S3ProjectionAliasesMatchRuntime(t *testing.T) {
 func rewriteDocSQLForLocalExecution(t *testing.T, sqlText, parquetPath string) string {
 	t.Helper()
 
-	for _, args := range findPostgresScanCalls(sqlText) {
+	for _, args := range sqlgentest.FindPostgresScanCalls(sqlText) {
 		m := threeArgScanRe.FindStringSubmatch(args)
 		require.NotNil(t, m,
 			"cannot map postgres_scan(%s) to a local relation: not the 3-arg runtime form", args)
@@ -224,14 +240,18 @@ func TestDesignDocSQL_ExecutesWithLWWFilterSemantics(t *testing.T) {
 
 	db, err := sql.Open("duckdb", "")
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() {
+		require.NoError(t, db.Close(), "failed to close in-memory DuckDB")
+	})
 
 	seedDesignDocScenario(t, db, parquetPath)
 
 	query := rewriteDocSQLForLocalExecution(t, docSQL, parquetPath)
 	rows, err := db.Query(query)
 	require.NoError(t, err, "the documented §5 SQL must execute as written (query=%s)", query)
-	defer rows.Close()
+	defer func() {
+		require.NoError(t, rows.Close(), "failed to close §5 query result rows")
+	}()
 
 	type resultRow struct {
 		rowID, name, tag string

--- a/internal/sqlgen/duckdb_scan_contract_test.go
+++ b/internal/sqlgen/duckdb_scan_contract_test.go
@@ -1,0 +1,87 @@
+package sqlgen
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// findRenderedScanCalls returns the raw argument text of every postgres_scan
+// invocation in sqlText, matching parentheses so multi-line calls are
+// captured whole. (design_doc_sql_test.go in internal/federated keeps the
+// documentation side of this contract; this file pins the runtime side.)
+func findRenderedScanCalls(sqlText string) []string {
+	const marker = "postgres_scan("
+	var calls []string
+	for i := 0; ; {
+		idx := strings.Index(sqlText[i:], marker)
+		if idx < 0 {
+			break
+		}
+		start := i + idx + len(marker)
+		depth := 1
+		j := start
+		for ; j < len(sqlText) && depth > 0; j++ {
+			switch sqlText[j] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+		}
+		calls = append(calls, strings.TrimSpace(sqlText[start:j-1]))
+		i = j
+	}
+	return calls
+}
+
+// TestAdvancedTemplate_PostgresScanContract pins the runtime scan contract
+// that docs/federated-query/design.md §5 documents (#214): every rendered
+// postgres_scan is the 3-arg (connection, schema, table) form with plain
+// identifiers, and flushed_at = 0 is expressed only as a WHERE predicate —
+// never smuggled into a scan argument as a predicate or dynamic SELECT.
+func TestAdvancedTemplate_PostgresScanContract(t *testing.T) {
+	q := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0},
+	}
+	dual := &DualClauses{DuckClause: "1=1"}
+	// Mirror the production params from buildDuckDBQueryWithPlan
+	// (internal/federated/duckdb_query.go); injectDuckDBTemplateParams fills
+	// the projection defaults, including HasEAVPivot = true.
+	params := map[string]any{
+		"PG_CONN":              "dbname=forma host=localhost",
+		"ChangeLogSchema":      "public",
+		"ChangeLogScanTable":   "change_log",
+		"MainSchema":           "public",
+		"MainScanTable":        "entity_main_dev",
+		"EAVSchema":            "public",
+		"EAVScanTable":         "eav_data_dev",
+		"S3_PATHS":             "['s3://bucket/base/*.parquet']",
+		"LOGICAL_WHERE_CLAUSE": "1=1",
+	}
+
+	sqlText, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
+	require.NoError(t, err)
+
+	calls := findRenderedScanCalls(sqlText)
+	require.Len(t, calls, 4,
+		"dirty_ids, pg_source change_log, entity_main, and the EAV pivot must all scan via postgres_scan")
+
+	threeArg := regexp.MustCompile(
+		`^'[^']*'\s*,\s*'[A-Za-z_][A-Za-z0-9_]*'\s*,\s*'[A-Za-z_][A-Za-z0-9_]*'$`)
+	for _, args := range calls {
+		require.Regexp(t, threeArg, args,
+			"postgres_scan must stay the 3-arg (connection, schema, table) form; "+
+				"predicates and dynamic SELECTs never belong in scan arguments")
+		require.NotContains(t, args, "flushed_at",
+			"flushed_at = 0 is a WHERE predicate, not a scan argument")
+	}
+
+	require.Contains(t, sqlText, "AND flushed_at = 0",
+		"dirty_ids must restrict to unflushed rows via a WHERE predicate")
+	require.Contains(t, sqlText, "AND cl.flushed_at = 0",
+		"pg_source must restrict to unflushed rows via a WHERE predicate")
+}

--- a/internal/sqlgen/duckdb_scan_contract_test.go
+++ b/internal/sqlgen/duckdb_scan_contract_test.go
@@ -2,41 +2,12 @@ package sqlgen
 
 import (
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/sqlgen/sqlgentest"
 	"github.com/stretchr/testify/require"
 )
-
-// findRenderedScanCalls returns the raw argument text of every postgres_scan
-// invocation in sqlText, matching parentheses so multi-line calls are
-// captured whole. (design_doc_sql_test.go in internal/federated keeps the
-// documentation side of this contract; this file pins the runtime side.)
-func findRenderedScanCalls(sqlText string) []string {
-	const marker = "postgres_scan("
-	var calls []string
-	for i := 0; ; {
-		idx := strings.Index(sqlText[i:], marker)
-		if idx < 0 {
-			break
-		}
-		start := i + idx + len(marker)
-		depth := 1
-		j := start
-		for ; j < len(sqlText) && depth > 0; j++ {
-			switch sqlText[j] {
-			case '(':
-				depth++
-			case ')':
-				depth--
-			}
-		}
-		calls = append(calls, strings.TrimSpace(sqlText[start:j-1]))
-		i = j
-	}
-	return calls
-}
 
 // TestAdvancedTemplate_PostgresScanContract pins the runtime scan contract
 // that docs/federated-query/design.md §5 documents (#214): every rendered
@@ -66,7 +37,7 @@ func TestAdvancedTemplate_PostgresScanContract(t *testing.T) {
 	sqlText, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
 	require.NoError(t, err)
 
-	calls := findRenderedScanCalls(sqlText)
+	calls := sqlgentest.FindPostgresScanCalls(sqlText)
 	require.Len(t, calls, 4,
 		"dirty_ids, pg_source change_log, entity_main, and the EAV pivot must all scan via postgres_scan")
 

--- a/internal/sqlgen/sqlgentest/scan_calls.go
+++ b/internal/sqlgen/sqlgentest/scan_calls.go
@@ -1,0 +1,35 @@
+// Package sqlgentest provides shared helpers for tests that pin the
+// postgres_scan contract on both sides: the runtime template
+// (internal/sqlgen) and the executable §5 sketch in
+// docs/federated-query/design.md (internal/federated).
+package sqlgentest
+
+import "strings"
+
+// FindPostgresScanCalls returns the raw argument text of every postgres_scan
+// invocation in sqlText, matching parentheses so multi-line and nested forms
+// are captured whole.
+func FindPostgresScanCalls(sqlText string) []string {
+	const marker = "postgres_scan("
+	var calls []string
+	for i := 0; ; {
+		idx := strings.Index(sqlText[i:], marker)
+		if idx < 0 {
+			break
+		}
+		start := i + idx + len(marker)
+		depth := 1
+		j := start
+		for ; j < len(sqlText) && depth > 0; j++ {
+			switch sqlText[j] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+		}
+		calls = append(calls, strings.TrimSpace(sqlText[start:j-1]))
+		i = j
+	}
+	return calls
+}


### PR DESCRIPTION
## Summary

Follow-up from #211: the §5 "SQL Execution Template" in `docs/federated-query/design.md` could not execute against the runtime source contract. This PR aligns the sketch with the actual DuckDB template and adds two anti-drift guards so its table-function arity and projected columns cannot drift again.

### Doc changes (`docs/federated-query/design.md`)

- Every `postgres_scan` now uses the runtime 3-arg `(connection, schema, table)` form (`advanced_query_template_duckdb.go`); `flushed_at = 0` and `$PG_WHERE_CLAUSE` moved into `WHERE` predicates. Previously `:152`/`:206` passed `'flushed_at = 0'` as the table argument, `:209-213` used a 2-arg dynamic-`SELECT` form, and `:216` scanned EAV with 2 args.
- S3 projection aliases replaced with the runtime parquet columns from `buildS3Projection` (`duckdb_schema_projection.go:141-152`): `changed_at AS created_at`, `changed_at AS ver_ts`, `deleted_at AS deleted_ts` — the `ltbase_*` columns do not exist in parquet.
- §4.2 and §6.1 carried the same stale "inject SQL into postgres_scan's argument" wording; both now describe the predicate-in-WHERE pushdown the runtime performs.
- The #211 filter-after-LWW semantics are untouched: row_id semijoin, `source_tier_priority`, the `rn = 1` post-dedup logical filter, and tombstone-wins-then-drop. The section remains a deliberately simplified sketch (no `visible` CTE / keyset / pagination metadata).

### Anti-drift guards

- **`internal/federated/design_doc_sql_test.go`** (executable documentation): extracts the §5 fenced block by heading anchor, asserts the 3-arg scan form and the S3 aliases, then executes the sketch on in-memory DuckDB — scan calls map to same-named seed relations, `$S3_PATHS` points at a real parquet file — and asserts the #173/#178 scenarios: a newer non-matching version must not resurrect an older matching one, a tombstone must win dedup and then be dropped, dirty rows are served from the hot tier, and an already-flushed change_log row stays out of the dirty set.
- **`internal/sqlgen/duckdb_scan_contract_test.go`** (runtime side): renders `AdvancedQueryTemplateDuckDB` with production-shaped params and pins the 3-arg scan form and `flushed_at = 0` as a predicate — catching runtime drift the doc-side test cannot see.

Red-green verified: all three doc-side tests fail against the pre-fix document (arity, aliases, and relation mapping), and a mutation of the LWW `ORDER BY` makes the execution test fail, confirming the semantic assertions bite.

### Out of scope (pre-existing, noted during review)

- `internal/sqlgen/duckdb_template_renderer.go:170` — the legacy default `S3SourceSelect` fallback still injects the phantom `ltbase_*` aliases; the real federated path always overrides it from `SchemaProjection`, so it is legacy-only and untouched here.

## Acceptance criteria (#214)

- [x] The documented query uses valid runtime `postgres_scan` invocation forms.
- [x] Its S3 source columns and aliases match the runtime projection.
- [x] The example preserves filter-after-LWW semantics from #173/#178.
- [x] A test / executable documentation check detects future SQL/schema drift.

## Test plan

- `go test ./internal/federated ./internal/sqlgen -run 'TestDesignDocSQL|TestAdvancedTemplate_PostgresScanContract' -v` — all pass
- `make test` — full unit suite passes
- `make lint` — clean

Fixes #214. Refs #173, #178, #211. Part of epic #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)