### PR TITLE
test(e2e): consolidate filter-LWW fixture setup, verb-first helper names (#215)

### DIFF
--- a/internal/e2e_harness/production/filter_lww_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_e2e_test.go
@@ -4,7 +4,6 @@ package production
 
 import (
 	"context"
-	"fmt"
 	"testing"
 )
 
@@ -38,67 +37,25 @@ func TestFilterLWW(t *testing.T) {
 	}
 }
 
-// assertStrictlyNewer fails fast when any new version's changed_at is not
-// strictly after its predecessor's at millisecond resolution — otherwise an
-// LWW probe degrades into the undefined equal-ver_ts tie tracked by #210.
-func assertStrictlyNewer(t *testing.T, olds, news []*Event) {
-	t.Helper()
-	for i := range olds {
-		if news[i].ChangedAt <= olds[i].ChangedAt {
-			t.Fatalf("row %d: newer changed_at %d not strictly after older %d",
-				i, news[i].ChangedAt, olds[i].ChangedAt)
-		}
-	}
-}
-
-// assertZeroRows runs an oracle-checked query that must return no rows: the
-// predicate matches only a superseded version, so any row in the result is a
-// filter-before-LWW resurrection.
-func assertZeroRows(ctx context.Context, t *testing.T, env *Env, name string, q Query) {
-	t.Helper()
-	if res := env.AssertQueryMatches(ctx, q); res != nil && len(res.Records) != 0 {
-		t.Errorf("%s: stale probe returned %d rows, want 0", name, len(res.Records))
-	}
-}
-
 // testStaleFilterDeltaGenerations is issue #178 scenario 1 in the
 // delta-generation layout: v1 (matching) in delta #1, v2 (non-matching) in
 // delta #2, no hot rows. The semijoin admits every row_id via its v1 match;
 // LWW must pick v2 and the visible filter must then reject it.
 func testStaleFilterDeltaGenerations(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
-	creates := make([]*Event, 0, 5)
-	for i := 0; i < 5; i++ {
-		creates = append(creates, CreateEvent(wide, map[string]any{
-			"title": fmt.Sprintf("open-%02d", i),
-			"count": float64(100000 + i),
-		}))
-	}
-	if err := env.ApplyEvents(ctx, creates...); err != nil {
-		t.Fatalf("apply creates: %v", err)
-	}
+	creates := buildOpenCreates(wide, 5)
+	mustApplyEvents(ctx, t, env, "apply creates", creates...)
 	mustFlush(ctx, t, env) // delta #1 = v1 @ create-time ver_ts
 
 	// Load-bearing positive: v1 is served from delta #1 by its own value
 	// (guards every zero-row probe below against a broken read path).
-	res := env.AssertQueryMatches(ctx, Query{
+	assertRowCount(ctx, t, env, "v1 positive control", Query{
 		Schema:  wide,
 		Filters: []Filter{{Attr: "title", Value: "open-03"}},
 		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 1 {
-		t.Fatalf("v1 positive control returned %d rows, want 1", len(res.Records))
-	}
+	}, 1)
 
-	v2 := make([]*Event, 0, len(creates))
-	for i, c := range creates {
-		v2 = append(v2, UpdateEvent(wide, c.RowID, map[string]any{
-			"title": fmt.Sprintf("closed-%02d", i),
-			"count": float64(200000 + i),
-		}))
-	}
-	if err := env.ApplyEvents(ctx, v2...); err != nil {
-		t.Fatalf("apply v2 updates: %v", err)
-	}
+	v2 := buildClosedUpdates(wide, creates)
+	mustApplyEvents(ctx, t, env, "apply v2 updates", v2...)
 	assertStrictlyNewer(t, creates, v2)
 	flush2 := mustFlush(ctx, t, env) // delta #2 = v2 @ update-time ver_ts
 	if got := countTier(flush2.Manifests[wide.ID], "delta"); got != 2 {
@@ -126,16 +83,8 @@ func testStaleFilterDeltaGenerations(ctx context.Context, t *testing.T, env *Env
 // (non-matching) in a delta flushed afterwards. Deterministic under #210:
 // base ver_ts = create time < delta ver_ts = update time.
 func testStaleFilterBaseVsDelta(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
-	creates := make([]*Event, 0, 5)
-	for i := 0; i < 5; i++ {
-		creates = append(creates, CreateEvent(wide, map[string]any{
-			"title": fmt.Sprintf("open-%02d", i),
-			"count": float64(100000 + i),
-		}))
-	}
-	if err := env.ApplyEvents(ctx, creates...); err != nil {
-		t.Fatalf("apply creates: %v", err)
-	}
+	creates := buildOpenCreates(wide, 5)
+	mustApplyEvents(ctx, t, env, "apply creates", creates...)
 	report, err := env.RunInit(ctx, wide) // base = v1 @ create-time ver_ts
 	if err != nil {
 		t.Fatalf("run init: %v", err)
@@ -146,25 +95,14 @@ func testStaleFilterBaseVsDelta(ctx context.Context, t *testing.T, env *Env, wid
 	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", wide.ID)
 
 	// Load-bearing positive: base serves v1 by its own value.
-	res := env.AssertQueryMatches(ctx, Query{
+	assertRowCount(ctx, t, env, "v1 positive control", Query{
 		Schema:  wide,
 		Filters: []Filter{{Attr: "title", Value: "open-02"}},
 		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 1 {
-		t.Fatalf("v1 positive control returned %d rows, want 1", len(res.Records))
-	}
+	}, 1)
 
-	v2 := make([]*Event, 0, len(creates))
-	for i, c := range creates {
-		v2 = append(v2, UpdateEvent(wide, c.RowID, map[string]any{
-			"title": fmt.Sprintf("closed-%02d", i),
-			"count": float64(200000 + i),
-		}))
-	}
-	if err := env.ApplyEvents(ctx, v2...); err != nil {
-		t.Fatalf("apply v2 updates: %v", err)
-	}
+	v2 := buildClosedUpdates(wide, creates)
+	mustApplyEvents(ctx, t, env, "apply v2 updates", v2...)
 	assertStrictlyNewer(t, creates, v2)
 	mustFlush(ctx, t, env) // delta = v2 @ update-time ver_ts; rows now clean
 

--- a/internal/e2e_harness/production/filter_lww_helpers_test.go
+++ b/internal/e2e_harness/production/filter_lww_helpers_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// Shared fixture for the filter-LWW production suites (#178, #215).
+// filter_lww_e2e_test.go, filter_lww_matrix_e2e_test.go, and
+// filter_lww_tombstone_e2e_test.go build their row generations and controls
+// from this single implementation so fixtures and timing guards cannot drift
+// between scenarios. Scenario-specific assertions stay in their own files.
+
+// buildOpenCreates builds n v1 rows in the canonical "open" shape shared by
+// the stale-filter scenarios: title open-%02d and count 100000+i.
+func buildOpenCreates(wide SchemaRef, n int) []*Event {
+	creates := make([]*Event, 0, n)
+	for i := 0; i < n; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("open-%02d", i),
+			"count": float64(100000 + i),
+		}))
+	}
+	return creates
+}
+
+// buildClosedUpdates flips each create to its non-matching v2 on the same
+// row_id: title closed-%02d and count 200000+i.
+func buildClosedUpdates(wide SchemaRef, creates []*Event) []*Event {
+	v2 := make([]*Event, 0, len(creates))
+	for i, c := range creates {
+		v2 = append(v2, UpdateEvent(wide, c.RowID, map[string]any{
+			"title": fmt.Sprintf("closed-%02d", i),
+			"count": float64(200000 + i),
+		}))
+	}
+	return v2
+}
+
+// mustApplyEvents applies events, failing the test with the given label.
+func mustApplyEvents(ctx context.Context, t *testing.T, env *Env, label string, events ...*Event) {
+	t.Helper()
+	if err := env.ApplyEvents(ctx, events...); err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+}
+
+// assertRowCount runs an oracle-checked query and fails fast unless it
+// returns exactly want rows. The load-bearing positive controls use this to
+// guard the zero-row probes against a broken read path returning false
+// greens.
+func assertRowCount(ctx context.Context, t *testing.T, env *Env, name string, q Query, want int) {
+	t.Helper()
+	if res := env.AssertQueryMatches(ctx, q); res != nil && len(res.Records) != want {
+		t.Fatalf("%s returned %d rows, want %d", name, len(res.Records), want)
+	}
+}
+
+// assertStrictlyNewer fails fast when any new version's changed_at is not
+// strictly after its predecessor's at millisecond resolution — otherwise an
+// LWW probe degrades into the undefined equal-ver_ts tie tracked by #210.
+func assertStrictlyNewer(t *testing.T, olds, news []*Event) {
+	t.Helper()
+	for i := range olds {
+		if news[i].ChangedAt <= olds[i].ChangedAt {
+			t.Fatalf("row %d: newer changed_at %d not strictly after older %d",
+				i, news[i].ChangedAt, olds[i].ChangedAt)
+		}
+	}
+}
+
+// assertZeroRows runs an oracle-checked query that must return no rows: the
+// predicate matches only a superseded version, so any row in the result is a
+// filter-before-LWW resurrection.
+func assertZeroRows(ctx context.Context, t *testing.T, env *Env, name string, q Query) {
+	t.Helper()
+	if res := env.AssertQueryMatches(ctx, q); res != nil && len(res.Records) != 0 {
+		t.Errorf("%s: stale probe returned %d rows, want 0", name, len(res.Records))
+	}
+}

--- a/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_matrix_e2e_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 )
 
-// matrixV1Creates builds the five v1 rows whose every filterable attribute
-// the v2 updates flip.
-func matrixV1Creates(wide SchemaRef) []*Event {
+// buildMatrixV1Creates builds the five v1 rows whose every filterable
+// attribute the v2 updates flip.
+func buildMatrixV1Creates(wide SchemaRef) []*Event {
 	creates := make([]*Event, 0, 5)
 	for i := 0; i < 5; i++ {
 		creates = append(creates, CreateEvent(wide, map[string]any{
@@ -28,8 +28,8 @@ func matrixV1Creates(wide SchemaRef) []*Event {
 	return creates
 }
 
-// matrixV2Updates flips every filterable attribute of the v1 rows.
-func matrixV2Updates(wide SchemaRef, creates []*Event) []*Event {
+// buildMatrixV2Updates flips every filterable attribute of the v1 rows.
+func buildMatrixV2Updates(wide SchemaRef, creates []*Event) []*Event {
 	v2 := make([]*Event, 0, len(creates))
 	for i, c := range creates {
 		v2 = append(v2, UpdateEvent(wide, c.RowID, map[string]any{
@@ -65,10 +65,8 @@ func assertMatrixV1PositiveControls(ctx context.Context, t *testing.T, env *Env,
 		{"MAIN date", Filter{Attr: "joined", Op: "lt", Value: "2020-01-01T00:00:00Z"}, 5},
 	}
 	for _, c := range controls {
-		res := env.AssertQueryMatches(ctx, Query{Schema: wide, Filters: []Filter{c.filter}, Limit: 10})
-		if res != nil && len(res.Records) != c.want {
-			t.Fatalf("%s positive control returned %d rows, want %d", c.name, len(res.Records), c.want)
-		}
+		assertRowCount(ctx, t, env, c.name+" positive control",
+			Query{Schema: wide, Filters: []Filter{c.filter}, Limit: 10}, c.want)
 	}
 }
 
@@ -83,19 +81,15 @@ func assertMatrixV1PositiveControls(ctx context.Context, t *testing.T, env *Env,
 // joined bound to a MAIN unix_ms column) are covered since #200 fixed
 // federated date-predicate binding.
 func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
-	creates := matrixV1Creates(wide)
-	if err := env.ApplyEvents(ctx, creates...); err != nil {
-		t.Fatalf("apply creates: %v", err)
-	}
+	creates := buildMatrixV1Creates(wide)
+	mustApplyEvents(ctx, t, env, "apply creates", creates...)
 	mustFlush(ctx, t, env) // delta #1 = v1
 
 	// Load-bearing positives across storage classes.
 	assertMatrixV1PositiveControls(ctx, t, env, wide)
 
-	v2 := matrixV2Updates(wide, creates)
-	if err := env.ApplyEvents(ctx, v2...); err != nil {
-		t.Fatalf("apply v2 updates: %v", err)
-	}
+	v2 := buildMatrixV2Updates(wide, creates)
+	mustApplyEvents(ctx, t, env, "apply v2 updates", v2...)
 	assertStrictlyNewer(t, creates, v2)
 	mustFlush(ctx, t, env) // delta #2 = v2; rows clean
 
@@ -138,15 +132,12 @@ func testStaleFilterOperatorMatrix(ctx context.Context, t *testing.T, env *Env, 
 		Limit: 10,
 	})
 	// Same conjunction anchored fully on the winner: exactly one row.
-	res := env.AssertQueryMatches(ctx, Query{
+	assertRowCount(ctx, t, env, "winner AND probe", Query{
 		Schema: wide,
 		Filters: []Filter{
 			{Attr: "title", Value: "beta-02"},
 			{Attr: "active", Value: "0"},
 		},
 		Limit: 10,
-	})
-	if res != nil && len(res.Records) != 1 {
-		t.Fatalf("winner AND probe returned %d rows, want 1", len(res.Records))
-	}
+	}, 1)
 }

--- a/internal/e2e_harness/production/filter_lww_tombstone_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_tombstone_e2e_test.go
@@ -4,7 +4,6 @@ package production
 
 import (
 	"context"
-	"fmt"
 	"testing"
 )
 
@@ -14,35 +13,22 @@ import (
 // first while the tombstone is hot (dirty-set anti-join), then after it is
 // flushed to delta parquet (LWW + deleted_ts suppression in visible).
 func testTombstoneSuppressesStaleFilter(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
-	creates := make([]*Event, 0, 4)
-	for i := 0; i < 4; i++ {
-		creates = append(creates, CreateEvent(wide, map[string]any{
-			"title": fmt.Sprintf("open-%02d", i),
-			"count": float64(100000 + i),
-		}))
-	}
-	if err := env.ApplyEvents(ctx, creates...); err != nil {
-		t.Fatalf("apply creates: %v", err)
-	}
+	creates := buildOpenCreates(wide, 4)
+	mustApplyEvents(ctx, t, env, "apply creates", creates...)
 	mustFlush(ctx, t, env) // delta #1 = live v1 for all four rows
 
 	// Load-bearing positive: the victim row is served by its value pre-delete.
-	res := env.AssertQueryMatches(ctx, Query{
+	assertRowCount(ctx, t, env, "pre-delete positive control", Query{
 		Schema:  wide,
 		Filters: []Filter{{Attr: "title", Value: "open-00"}},
 		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 1 {
-		t.Fatalf("pre-delete positive control returned %d rows, want 1", len(res.Records))
-	}
+	}, 1)
 
 	dels := []*Event{
 		DeleteEvent(wide, creates[0].RowID),
 		DeleteEvent(wide, creates[1].RowID),
 	}
-	if err := env.ApplyEvents(ctx, dels...); err != nil {
-		t.Fatalf("apply deletes: %v", err)
-	}
+	mustApplyEvents(ctx, t, env, "apply deletes", dels...)
 	assertStrictlyNewer(t, creates[:2], dels)
 
 	// Hot-tombstone arm: the dirty set evicts the delta v1; the tombstone
@@ -66,18 +52,12 @@ func testTombstoneSuppressesStaleFilter(ctx context.Context, t *testing.T, env *
 		Schema: wide, Filters: []Filter{{Attr: "count", Op: "lte", Value: "100001"}}, Limit: 10})
 
 	// Survivors stay reachable — the suppression is per-row, not per-file.
-	res = env.AssertQueryMatches(ctx, Query{
+	assertRowCount(ctx, t, env, "survivor probe", Query{
 		Schema:  wide,
 		Filters: []Filter{{Attr: "title", Value: "open-02"}},
 		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 1 {
-		t.Fatalf("survivor probe returned %d rows, want 1", len(res.Records))
-	}
-	res = env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-	if res != nil && len(res.Records) != 2 {
-		t.Fatalf("post-delete total is %d rows, want 2", len(res.Records))
-	}
+	}, 1)
+	assertRowCount(ctx, t, env, "post-delete total", Query{Schema: wide, Limit: 10}, 2)
 }
 
 // testHotShadowStaleFilter is issue #178 scenario 3: the newer version is a
@@ -87,68 +67,44 @@ func testTombstoneSuppressesStaleFilter(ctx context.Context, t *testing.T, env *
 // base, single equality probe) with a warm-delta layout, range/prefix
 // operators, and a hot-tombstone arm.
 func testHotShadowStaleFilter(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
-	creates := make([]*Event, 0, 5)
-	for i := 0; i < 5; i++ {
-		creates = append(creates, CreateEvent(wide, map[string]any{
-			"title": fmt.Sprintf("open-%02d", i),
-			"count": float64(100000 + i),
-		}))
-	}
-	if err := env.ApplyEvents(ctx, creates...); err != nil {
-		t.Fatalf("apply creates: %v", err)
-	}
+	creates := buildOpenCreates(wide, 5)
+	mustApplyEvents(ctx, t, env, "apply creates", creates...)
 	mustFlush(ctx, t, env) // delta = v1 for all five rows (warm tier)
 
 	// Load-bearing positive: warm delta serves v1 by its value.
-	res := env.AssertQueryMatches(ctx, Query{
+	assertRowCount(ctx, t, env, "warm positive control", Query{
 		Schema:  wide,
 		Filters: []Filter{{Attr: "title", Value: "open-00"}},
 		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 1 {
-		t.Fatalf("warm positive control returned %d rows, want 1", len(res.Records))
-	}
+	}, 1)
 
 	upd := UpdateEvent(wide, creates[0].RowID, map[string]any{
 		"title": "closed-00",
 		"count": float64(200000),
 	})
-	if err := env.ApplyEvents(ctx, upd); err != nil {
-		t.Fatalf("apply shadow update: %v", err)
-	}
+	mustApplyEvents(ctx, t, env, "apply shadow update", upd)
 	assertStrictlyNewer(t, creates[:1], []*Event{upd})
 
 	// The dirty hot v2 does not match; the warm v1 must not resurface.
 	assertZeroRows(ctx, t, env, "hot_shadow_equals", Query{
 		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
 	// Prefix over all v1 titles: only the four unshadowed rows qualify.
-	res = env.AssertQueryMatches(ctx, Query{
+	assertRowCount(ctx, t, env, "prefix probe", Query{
 		Schema:  wide,
 		Filters: []Filter{{Attr: "title", Op: "starts_with", Value: "open-"}},
 		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 4 {
-		t.Fatalf("prefix probe returned %d rows, want 4", len(res.Records))
-	}
+	}, 4)
 	// The hot v2 is reachable by its own value through the dirty path.
-	res = env.AssertQueryMatches(ctx, Query{
+	assertRowCount(ctx, t, env, "hot-reachability probe", Query{
 		Schema:  wide,
 		Filters: []Filter{{Attr: "count", Op: "gte", Value: "200000"}},
 		Limit:   10,
-	})
-	if res != nil && len(res.Records) != 1 {
-		t.Fatalf("hot-reachability probe returned %d rows, want 1", len(res.Records))
-	}
+	}, 1)
 
 	// Hot-tombstone shadow over a warm v1.
 	del := DeleteEvent(wide, creates[1].RowID)
-	if err := env.ApplyEvents(ctx, del); err != nil {
-		t.Fatalf("apply shadow delete: %v", err)
-	}
+	mustApplyEvents(ctx, t, env, "apply shadow delete", del)
 	assertZeroRows(ctx, t, env, "hot_tombstone_shadow_equals", Query{
 		Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-01"}}, Limit: 10})
-	res = env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 10})
-	if res != nil && len(res.Records) != 4 {
-		t.Fatalf("post-shadow total is %d rows, want 4", len(res.Records))
-	}
+	assertRowCount(ctx, t, env, "post-shadow total", Query{Schema: wide, Limit: 10}, 4)
 }


### PR DESCRIPTION
Closes #215.

Extracts the duplicated create/apply/flush/positive-control fixture shared by the three production filter-LWW test files into `filter_lww_helpers_test.go` (one authoritative implementation), and renames `matrixV1Creates`/`matrixV2Updates` to verb-first `buildMatrixV1Creates`/`buildMatrixV2Updates` per `coding-standard.md` §4.

Behavior-preserving: every scenario keeps its own flush sequencing, `countTier` manifest checks, `assertStrictlyNewer` timing guards, and adversarial zero-row probes. `assertRowCount` (Fatalf) and `assertZeroRows` (Errorf) stay deliberately asymmetric — positive controls fail fast, adversarial probes accumulate. `testHotShadowStaleFilter` stays in the tombstone file (original layout); only fixture construction moved.

Verified: `make lint` + `make test` pass; `TestFilterLWW` e2e gate green 5/5 subtests (`stale_filter_delta_generations`, `stale_filter_base_vs_delta`, `tombstone_suppresses_stale_filter`, `hot_shadow_stale_filter`, `stale_filter_operator_matrix`).

Refs #178, #211. Part of epic #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)