### PR TITLE
test(e2e): CDC flush failure boundary matrix & idempotency (#179)

### DIFF
--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -131,6 +131,14 @@ where cdc-init bootstraps base files before federated reads. Use
   unflushed counts, new S3 objects, and parsed manifests. Note the
   mainline dry-run still writes parquet objects — it skips `flushed_at`
   marking and manifest updates (#180).
+- `RunFlushWith(FlushOverrides{S3, Config, DryRun})` runs one flush pass
+  with per-run overrides and reports observable state *even when the run
+  fails* (report is non-nil unless the pre-run capture fails), so
+  failure-boundary tests can assert partial side effects alongside the
+  error. Pair it with `FaultInjectingS3` — a decorator over the real S3
+  client that fails calls matching an `S3Fault{Op, KeyContains,
+  SkipMatches}` — to break exactly one step of the flush pipeline and pin
+  the failure matrix (#179).
 - `RunInit` wraps `cdc.RunInit` (base file export + manifest base entries).
   Base keys are deterministic (`<prefix>/<id>/<minRowID>_<maxRowID>.parquet`),
   and init replaces the manifest's base tier with each run's output, so
@@ -195,7 +203,7 @@ On failure (or `KEEP_E2E_ENV=1`) the Env writes
 | #174 full-type coverage | `e2e_wide` + `FullTypeProfile` |
 | #176 init handoff | `RunInit` + `RunFlush` (`init_handoff_e2e_test.go`, `init_delete_e2e_test.go`, `init_rerun_e2e_test.go`, `init_concurrent_e2e_test.go`) |
 | #175 lifecycle sequences | `Event` model + `ApplyEvents` + `InjectRestore` + `RestartPostgres` (`lifecycle_e2e_test.go`, `restart_e2e_test.go`) |
-| #179 flush thresholds | `WithFlushThresholds` + `FlushReport` |
+| #179 flush failure matrix | `FaultInjectingS3` + `RunFlushWith` + `ExecSQL` |
 | #180 dry-run semantics | `RunFlushDry` |
 | #181 failure injection | `ExecSQL` |
 | #185 circuit breaker | `WithBreaker` |

--- a/internal/e2e_harness/production/cdc.go
+++ b/internal/e2e_harness/production/cdc.go
@@ -52,7 +52,7 @@ type FlushOverrides struct {
 func (e *Env) runFlush(ctx context.Context, dryRun bool) (*FlushReport, error) {
 	report, err := e.RunFlushWith(ctx, FlushOverrides{DryRun: dryRun})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("run flush (dry=%t): %w", dryRun, err)
 	}
 	return report, nil
 }
@@ -64,11 +64,11 @@ func (e *Env) runFlush(ctx context.Context, dryRun bool) (*FlushReport, error) {
 func (e *Env) RunFlushWith(ctx context.Context, ov FlushOverrides) (*FlushReport, error) {
 	before, err := e.countUnflushed(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("capture pre-flush change_log state: %w", err)
 	}
 	keysBefore, err := e.listS3Keys(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("capture pre-flush s3 listing: %w", err)
 	}
 
 	cfg := e.CDC

--- a/internal/e2e_harness/production/cdc.go
+++ b/internal/e2e_harness/production/cdc.go
@@ -2,6 +2,7 @@ package production
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -40,7 +41,27 @@ func (e *Env) RunFlushDry(ctx context.Context) (*FlushReport, error) {
 	return e.runFlush(ctx, true)
 }
 
+// FlushOverrides customizes a single flush pass for failure-injection tests
+// (#179). Zero-value fields fall back to the Env defaults RunFlush uses.
+type FlushOverrides struct {
+	S3     cdc.S3FullClient // nil: e.Cluster.S3
+	Config *cdc.CDCConfig   // nil: e.CDC
+	DryRun bool
+}
+
 func (e *Env) runFlush(ctx context.Context, dryRun bool) (*FlushReport, error) {
+	report, err := e.RunFlushWith(ctx, FlushOverrides{DryRun: dryRun})
+	if err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+// RunFlushWith executes one real CDC flush pass with per-run overrides.
+// Unlike RunFlush it reports observable state even when the run fails: the
+// report is always non-nil unless the pre-run state capture itself fails, so
+// failure-boundary tests can assert partial side effects alongside the error.
+func (e *Env) RunFlushWith(ctx context.Context, ov FlushOverrides) (*FlushReport, error) {
 	before, err := e.countUnflushed(ctx)
 	if err != nil {
 		return nil, err
@@ -50,25 +71,35 @@ func (e *Env) runFlush(ctx context.Context, dryRun bool) (*FlushReport, error) {
 		return nil, err
 	}
 
-	runner := cdc.NewRunner(e.logger)
-	defer func() { _ = runner.Close() }()
-	if err := runner.RunOnce(ctx, e.CDC, e.Cluster.S3, dryRun, e.Registry); err != nil {
-		return nil, fmt.Errorf("cdc run once (dry=%t): %w", dryRun, err)
+	cfg := e.CDC
+	if ov.Config != nil {
+		cfg = *ov.Config
+	}
+	var s3Client cdc.S3FullClient = e.Cluster.S3
+	if ov.S3 != nil {
+		s3Client = ov.S3
 	}
 
-	report := &FlushReport{DryRun: dryRun, UnflushedBefore: before}
+	runner := cdc.NewRunner(e.logger)
+	defer func() { _ = runner.Close() }()
+	runErr := runner.RunOnce(ctx, cfg, s3Client, ov.DryRun, e.Registry)
+	if runErr != nil {
+		runErr = fmt.Errorf("cdc run once (dry=%t): %w", ov.DryRun, runErr)
+	}
+
+	report := &FlushReport{DryRun: ov.DryRun, UnflushedBefore: before}
 	if report.UnflushedAfter, err = e.countUnflushed(ctx); err != nil {
-		return nil, err
+		return report, errors.Join(runErr, err)
 	}
 	keysAfter, err := e.listS3Keys(ctx)
 	if err != nil {
-		return nil, err
+		return report, errors.Join(runErr, err)
 	}
 	report.NewObjects = diffKeys(keysBefore, keysAfter)
 	if report.Manifests, err = e.loadManifests(ctx); err != nil {
-		return nil, err
+		return report, errors.Join(runErr, err)
 	}
-	return report, nil
+	return report, runErr
 }
 
 // RunInit exports base parquet files for one schema via the extracted

--- a/internal/e2e_harness/production/cdc_fault_helpers_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_helpers_e2e_test.go
@@ -119,3 +119,79 @@ func assertNoRowExportedTwice(ctx context.Context, t *testing.T, env *Env, schem
 		t.Fatalf("iterate duplicate rows: %v", err)
 	}
 }
+
+// fetchChangeLogRowIDs partitions the schema's change_log rows into flushed
+// (flushed_at != 0) and dirty (flushed_at = 0) row-id sets, so scenarios can
+// assert exactly WHICH rows carry a flushed_at marker, not just how many.
+func fetchChangeLogRowIDs(ctx context.Context, t *testing.T, env *Env, schema SchemaRef) (flushed, dirty map[string]bool) {
+	t.Helper()
+	rows, err := env.Pool.Query(ctx,
+		"SELECT row_id::text, flushed_at FROM change_log WHERE schema_id = $1", schema.ID)
+	if err != nil {
+		t.Fatalf("query change_log rows for schema %d: %v", schema.ID, err)
+	}
+	defer rows.Close()
+	flushed, dirty = map[string]bool{}, map[string]bool{}
+	for rows.Next() {
+		var rowID string
+		var flushedAt int64
+		if err := rows.Scan(&rowID, &flushedAt); err != nil {
+			t.Fatalf("scan change_log row: %v", err)
+		}
+		if flushedAt != 0 {
+			flushed[rowID] = true
+		} else {
+			dirty[rowID] = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate change_log rows: %v", err)
+	}
+	return flushed, dirty
+}
+
+// fetchParquetRowIDs reads the distinct row-id set contained in the given
+// parquet object keys.
+func fetchParquetRowIDs(ctx context.Context, t *testing.T, env *Env, keys []string) map[string]bool {
+	t.Helper()
+	ids := map[string]bool{}
+	if len(keys) == 0 {
+		return ids
+	}
+	paths := make([]string, len(keys))
+	for i, k := range keys {
+		paths[i] = fmt.Sprintf("'s3://%s/%s'", env.Cluster.Bucket, k)
+	}
+	rows, err := env.Duck.DB.QueryContext(ctx, fmt.Sprintf(
+		"SELECT DISTINCT CAST(row_id AS VARCHAR) FROM read_parquet([%s])", strings.Join(paths, ", ")))
+	if err != nil {
+		t.Fatalf("read parquet row_ids from %v: %v", keys, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var rowID string
+		if err := rows.Scan(&rowID); err != nil {
+			t.Fatalf("scan parquet row_id: %v", err)
+		}
+		ids[rowID] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate parquet row_ids: %v", err)
+	}
+	return ids
+}
+
+// assertSameRowIDs asserts two row-id sets are identical.
+func assertSameRowIDs(t *testing.T, label string, got, want map[string]bool) {
+	t.Helper()
+	for id := range want {
+		if !got[id] {
+			t.Errorf("%s: row %s missing", label, id)
+		}
+	}
+	for id := range got {
+		if !want[id] {
+			t.Errorf("%s: unexpected row %s", label, id)
+		}
+	}
+}

--- a/internal/e2e_harness/production/cdc_fault_helpers_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_helpers_e2e_test.go
@@ -1,0 +1,121 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// seedRows creates n rows through the real EntityManager and returns the
+// events (each create adds one dirty change_log row).
+func seedRows(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, n int) []*Event {
+	t.Helper()
+	events := env.GenerateScript(ScriptSpec{Schema: schema, Creates: n})
+	if err := env.ApplyEvents(ctx, events...); err != nil {
+		t.Fatalf("apply %d creates: %v", n, err)
+	}
+	return events
+}
+
+// splitKeys partitions new S3 keys into final delta parquet files and _tmp
+// leftovers; manifest JSON objects fall through both buckets.
+func splitKeys(keys []string) (finals, tmps []string) {
+	for _, k := range keys {
+		switch {
+		case strings.Contains(k, "/_tmp/"):
+			tmps = append(tmps, k)
+		case strings.HasSuffix(k, ".parquet"):
+			finals = append(finals, k)
+		}
+	}
+	return finals, tmps
+}
+
+// assertUntouched asserts a failed flush left no observable side effects: no
+// new S3 objects, the dirty count unchanged, and no manifest for the schema.
+func assertUntouched(t *testing.T, report *FlushReport, schema SchemaRef, wantUnflushed int64) {
+	t.Helper()
+	if len(report.NewObjects) != 0 {
+		t.Errorf("expected no new S3 objects, got %v", report.NewObjects)
+	}
+	if report.UnflushedAfter != wantUnflushed {
+		t.Errorf("unflushed count moved: %d -> %d, want %d", report.UnflushedBefore, report.UnflushedAfter, wantUnflushed)
+	}
+	if m := report.Manifests[schema.ID]; m != nil && len(m.Files) != 0 {
+		t.Errorf("expected no manifest entries for schema %d, got %+v", schema.ID, m.Files)
+	}
+}
+
+// assertManifestDeltaPaths asserts the schema manifest tracks exactly the
+// given delta parquet keys (order-insensitive). Empty wantKeys asserts the
+// manifest has no delta entries (or does not exist).
+func assertManifestDeltaPaths(t *testing.T, manifests map[int16]*manifest.Manifest, schema SchemaRef, wantKeys []string) {
+	t.Helper()
+	var got []string
+	if m := manifests[schema.ID]; m != nil {
+		for _, f := range m.Files {
+			if f.Tier == "delta" {
+				got = append(got, f.Path)
+			}
+		}
+	}
+	want := append([]string(nil), wantKeys...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if !slices.Equal(got, want) {
+		t.Errorf("manifest delta paths mismatch:\n got  %v\n want %v", got, want)
+	}
+}
+
+// poisonMarkFlushed installs a trigger that fails any flushed_at update, so
+// the flush pipeline breaks exactly at the mark-flushed step (step 5). Only
+// the flusher ever updates flushed_at, so no other write path is affected.
+func poisonMarkFlushed(ctx context.Context, t *testing.T, env *Env) {
+	t.Helper()
+	env.ExecSQL(ctx, `CREATE OR REPLACE FUNCTION e2e_poison_mark_flushed() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'e2e injected failure: mark-flushed poisoned';
+END $$`)
+	env.ExecSQL(ctx, `CREATE TRIGGER e2e_poison_flush
+BEFORE UPDATE OF flushed_at ON change_log
+FOR EACH ROW EXECUTE FUNCTION e2e_poison_mark_flushed()`)
+}
+
+// healMarkFlushed removes the mark-flushed poison trigger.
+func healMarkFlushed(ctx context.Context, t *testing.T, env *Env) {
+	t.Helper()
+	env.ExecSQL(ctx, `DROP TRIGGER IF EXISTS e2e_poison_flush ON change_log`)
+}
+
+// assertNoRowExportedTwice reads every delta/base parquet under the schema's
+// glob and fails if any row_id appears more than once. Valid only for
+// create-only fixtures (a single version per row); update flows legitimately
+// export the same row_id at different ver_ts.
+func assertNoRowExportedTwice(ctx context.Context, t *testing.T, env *Env, schema SchemaRef) {
+	t.Helper()
+	glob := fmt.Sprintf("s3://%s/%s/%d/*.parquet", env.Cluster.Bucket, env.S3Prefix, schema.ID)
+	rows, err := env.Duck.DB.QueryContext(ctx, fmt.Sprintf(
+		`SELECT CAST(row_id AS VARCHAR), count(*) FROM read_parquet('%s') GROUP BY 1 HAVING count(*) > 1`, glob))
+	if err != nil {
+		t.Fatalf("scan parquet for duplicate row_ids: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var rowID string
+		var n int64
+		if err := rows.Scan(&rowID, &n); err != nil {
+			t.Fatalf("scan duplicate row: %v", err)
+		}
+		t.Errorf("row %s exported %d times across parquet files", rowID, n)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate duplicate rows: %v", err)
+	}
+}

--- a/internal/e2e_harness/production/cdc_fault_matrix_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_matrix_e2e_test.go
@@ -77,3 +77,82 @@ func assertRetryConverges(ctx context.Context, t *testing.T, env *Env, schema Sc
 	assertManifestDeltaPaths(t, retry.Manifests, schema, finals)
 	env.AssertQueryMatches(ctx, Query{Schema: schema, Limit: 100})
 }
+
+// TestFlushFaultCopyObject breaks step 3 (S3 CopyObject tmp->final). The
+// export succeeded, so the tmp object exists, but no final object, no
+// flushed_at update, and no manifest entry may appear. The failed attempt's
+// tmp object is orphaned forever by design (retry uses fresh UUIDs and
+// CopyTmpToFinal only deletes its own tmp key); correctness holds because
+// the production glob's `*` does not cross `/` and skips _tmp/
+// (production/query.go:52-56) — adjudicating #179's "no orphan temp files"
+// criterion to "orphan temp files never affect correctness".
+func TestFlushFaultCopyObject(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0]
+	seedRows(ctx, t, env, simple, 3)
+
+	faulty := &FaultInjectingS3{Inner: env.Cluster.S3, Fault: S3Fault{Op: S3OpCopy}}
+	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty})
+	if err == nil {
+		t.Fatal("flush with failing CopyObject must fail")
+	}
+	if faulty.Injected() == 0 {
+		t.Fatal("fault never fired")
+	}
+	finals, tmps := splitKeys(report.NewObjects)
+	if len(finals) != 0 {
+		t.Errorf("no final object may exist after CopyObject failure, got %v", finals)
+	}
+	if len(tmps) != 1 {
+		t.Errorf("expected exactly the orphaned tmp object, got %v", tmps)
+	}
+	if report.UnflushedAfter != 3 {
+		t.Errorf("rows must stay dirty, unflushed = %d, want 3", report.UnflushedAfter)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, simple, nil)
+
+	// Clean retry converges; the orphaned tmp object stays behind but is
+	// invisible to both the manifest and the federated glob.
+	assertRetryConverges(ctx, t, env, simple, 3)
+}
+
+// TestFlushFaultTempCleanup breaks step 4 (DeleteObject of the tmp object).
+// CopyTmpToFinal swallows delete failures by design (helpers.go:165-167), so
+// the flush must SUCCEED: rows flushed, manifest updated, query correct —
+// with an orphaned tmp object left behind that must not affect anything.
+func TestFlushFaultTempCleanup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0]
+	seedRows(ctx, t, env, simple, 3)
+
+	faulty := &FaultInjectingS3{Inner: env.Cluster.S3, Fault: S3Fault{Op: S3OpDelete, KeyContains: "/_tmp/"}}
+	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty})
+	if err != nil {
+		t.Fatalf("tmp cleanup failure must be swallowed, got %v", err)
+	}
+	if faulty.Injected() == 0 {
+		t.Fatal("fault never fired")
+	}
+	finals, tmps := splitKeys(report.NewObjects)
+	if len(finals) != 1 || len(tmps) != 1 {
+		t.Errorf("want 1 final + 1 orphaned tmp, got finals %v tmps %v", finals, tmps)
+	}
+	if report.UnflushedAfter != 0 {
+		t.Errorf("flush must complete, unflushed = %d, want 0", report.UnflushedAfter)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, simple, finals)
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
+
+	// A second flush is a no-op: nothing dirty, no new objects.
+	noop, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("no-op flush: %v", err)
+	}
+	if noop.UnflushedBefore != 0 || len(noop.NewObjects) != 0 {
+		t.Errorf("no-op flush moved state: unflushed %d, new %v", noop.UnflushedBefore, noop.NewObjects)
+	}
+}

--- a/internal/e2e_harness/production/cdc_fault_matrix_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_matrix_e2e_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+)
+
+// TestFlushFaultDirtySelection breaks step 1 (dirty ID selection) by
+// pointing the flush config at an unreachable Postgres. The very first
+// pipeline step fails, so there must be zero side effects anywhere, and a
+// clean retry must converge (#179).
+func TestFlushFaultDirtySelection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0]
+	seedRows(ctx, t, env, simple, 3)
+	// Baseline the seeded rows on the hot tier. PreferHot keeps the read on
+	// Postgres; a default federated read here would hit read_parquet on a
+	// schema with zero parquet files (nothing flushed yet) and fail with an
+	// IO "no files match" error — see boundary_roundtrip_e2e_test.go for the
+	// same hot-only-before-flush pattern.
+	env.AssertQueryMatches(ctx, Query{Schema: simple, PreferHot: true, Limit: 100})
+
+	cfg := env.CDC
+	cfg.PGHost, cfg.PGPort = "127.0.0.1", 1
+	report, err := env.RunFlushWith(ctx, FlushOverrides{Config: &cfg})
+	if err == nil {
+		t.Fatal("flush with unreachable postgres must fail")
+	}
+	assertUntouched(t, report, simple, 3)
+
+	assertRetryConverges(ctx, t, env, simple, 3)
+}
+
+// TestFlushFaultDuckExport breaks step 2 (DuckDB COPY to the tmp S3 object)
+// by pointing the DuckDB httpfs endpoint at an unreachable address. The
+// injected-client steps (3+) are never reached; nothing lands in the real
+// bucket and change_log stays dirty.
+func TestFlushFaultDuckExport(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0]
+	seedRows(ctx, t, env, simple, 3)
+
+	cfg := env.CDC
+	cfg.S3Endpoint = "127.0.0.1:1"
+	report, err := env.RunFlushWith(ctx, FlushOverrides{Config: &cfg})
+	if err == nil {
+		t.Fatal("flush with unreachable duckdb s3 endpoint must fail")
+	}
+	assertUntouched(t, report, simple, 3)
+
+	assertRetryConverges(ctx, t, env, simple, 3)
+}
+
+// assertRetryConverges runs a clean flush and asserts full convergence: all
+// rows flushed into exactly one final delta object, the manifest tracking
+// exactly that object, and the federated result matching the fault-free
+// oracle baseline.
+func assertRetryConverges(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, wantRows int64) {
+	t.Helper()
+	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("clean retry flush: %v", err)
+	}
+	if retry.UnflushedBefore != wantRows || retry.UnflushedAfter != 0 {
+		t.Errorf("retry unflushed %d -> %d, want %d -> 0", retry.UnflushedBefore, retry.UnflushedAfter, wantRows)
+	}
+	finals, _ := splitKeys(retry.NewObjects)
+	if len(finals) != 1 {
+		t.Errorf("retry created %d final objects %v, want 1", len(finals), finals)
+	}
+	assertManifestDeltaPaths(t, retry.Manifests, schema, finals)
+	env.AssertQueryMatches(ctx, Query{Schema: schema, Limit: 100})
+}

--- a/internal/e2e_harness/production/cdc_fault_matrix_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_matrix_e2e_test.go
@@ -80,12 +80,12 @@ func assertRetryConverges(ctx context.Context, t *testing.T, env *Env, schema Sc
 
 // TestFlushFaultCopyObject breaks step 3 (S3 CopyObject tmp->final). The
 // export succeeded, so the tmp object exists, but no final object, no
-// flushed_at update, and no manifest entry may appear. The failed attempt's
-// tmp object is orphaned forever by design (retry uses fresh UUIDs and
-// CopyTmpToFinal only deletes its own tmp key); correctness holds because
-// the production glob's `*` does not cross `/` and skips _tmp/
-// (production/query.go:52-56) — adjudicating #179's "no orphan temp files"
-// criterion to "orphan temp files never affect correctness".
+// flushed_at update, and no manifest entry may appear. Today the failed
+// attempt's tmp object is orphaned permanently (retry uses fresh UUIDs and
+// CopyTmpToFinal only deletes its own tmp key) — cleanup is tracked in #226;
+// until it lands this test pins the current behavior. Correctness holds
+// regardless: the production glob's `*` does not cross `/` and skips _tmp/
+// (production/query.go:52-56), and orphans never enter the manifest.
 func TestFlushFaultCopyObject(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -113,8 +113,9 @@ func TestFlushFaultCopyObject(t *testing.T) {
 	}
 	assertManifestDeltaPaths(t, report.Manifests, simple, nil)
 
-	// Clean retry converges; the orphaned tmp object stays behind but is
-	// invisible to both the manifest and the federated glob.
+	// Clean retry converges; the orphaned tmp object stays behind (until
+	// #226 adds cleanup) but is invisible to both the manifest and the
+	// federated glob.
 	assertRetryConverges(ctx, t, env, simple, 3)
 }
 
@@ -122,6 +123,7 @@ func TestFlushFaultCopyObject(t *testing.T) {
 // CopyTmpToFinal swallows delete failures by design (helpers.go:165-167), so
 // the flush must SUCCEED: rows flushed, manifest updated, query correct —
 // with an orphaned tmp object left behind that must not affect anything.
+// Removing such orphans is #226's scope; this test pins today's behavior.
 func TestFlushFaultTempCleanup(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/e2e_harness/production/cdc_fault_multibatch_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_multibatch_e2e_test.go
@@ -41,6 +41,13 @@ func TestFlushFaultMultiBatchMiddleChunk(t *testing.T) {
 		t.Errorf("chunks 2-3 must stay dirty, unflushed = %d, want 6", report.UnflushedAfter)
 	}
 	assertManifestDeltaPaths(t, report.Manifests, simple, finals)
+	// Row-level flushed_at consistency: the flushed set must be exactly the
+	// rows inside the chunk-1 parquet file, everything else stays dirty.
+	flushedAfterFault, dirtyAfterFault := fetchChangeLogRowIDs(ctx, t, env, simple)
+	if len(flushedAfterFault) != 3 || len(dirtyAfterFault) != 6 {
+		t.Errorf("flushed/dirty row split after fault = %d/%d, want 3/6", len(flushedAfterFault), len(dirtyAfterFault))
+	}
+	assertSameRowIDs(t, "chunk-1 parquet vs flushed_at markers", fetchParquetRowIDs(ctx, t, env, finals), flushedAfterFault)
 
 	// Clean retry with the same chunking config re-exports ONLY the 6
 	// remaining rows (2 more chunks).
@@ -56,6 +63,14 @@ func TestFlushFaultMultiBatchMiddleChunk(t *testing.T) {
 		t.Errorf("retry must add exactly 2 chunk objects, got %v", retryFinals)
 	}
 	assertManifestDeltaPaths(t, retry.Manifests, simple, append(append([]string(nil), finals...), retryFinals...))
+	// "Only remaining dirty rows are re-exported": the retry files must
+	// contain exactly the rows that were dirty after the fault, and every
+	// row must now carry a flushed_at marker.
+	assertSameRowIDs(t, "retry parquet vs previously-dirty rows", fetchParquetRowIDs(ctx, t, env, retryFinals), dirtyAfterFault)
+	flushedAfterRetry, dirtyAfterRetry := fetchChangeLogRowIDs(ctx, t, env, simple)
+	if len(flushedAfterRetry) != 9 || len(dirtyAfterRetry) != 0 {
+		t.Errorf("flushed/dirty row split after retry = %d/%d, want 9/0", len(flushedAfterRetry), len(dirtyAfterRetry))
+	}
 	// Create-only fixture: any row_id in two parquet files means a completed
 	// chunk was re-exported — the exact regression this scenario guards.
 	assertNoRowExportedTwice(ctx, t, env, simple)

--- a/internal/e2e_harness/production/cdc_fault_multibatch_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_multibatch_e2e_test.go
@@ -1,0 +1,63 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+)
+
+// TestFlushFaultMultiBatchMiddleChunk forces byte-size splitting (9 rows,
+// maxRows = MaxBatchBytes/EstimatedRowBytes = 3 → 3 chunks) and fails the
+// second chunk's CopyObject. Chunk 1 is already committed (marked flushed +
+// manifest entry) and must NOT be re-exported by the retry; only the
+// remaining 6 dirty rows are. After retry: 3 final objects, 3 manifest
+// entries, zero physically duplicated row_ids, oracle-identical query (#179
+// multi-batch scenario).
+func TestFlushFaultMultiBatchMiddleChunk(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0]
+	seedRows(ctx, t, env, simple, 9)
+
+	cfg := env.CDC
+	cfg.EstimatedRowBytes = 1
+	cfg.MaxBatchBytes = 3
+
+	faulty := &FaultInjectingS3{Inner: env.Cluster.S3, Fault: S3Fault{Op: S3OpCopy, SkipMatches: 1}}
+	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty, Config: &cfg})
+	if err == nil {
+		t.Fatal("flush with failing second-chunk CopyObject must fail")
+	}
+	if faulty.Injected() == 0 {
+		t.Fatal("fault never fired")
+	}
+	finals, _ := splitKeys(report.NewObjects)
+	if len(finals) != 1 {
+		t.Fatalf("exactly chunk 1 must have landed, got finals %v", finals)
+	}
+	if report.UnflushedAfter != 6 {
+		t.Errorf("chunks 2-3 must stay dirty, unflushed = %d, want 6", report.UnflushedAfter)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, simple, finals)
+
+	// Clean retry with the same chunking config re-exports ONLY the 6
+	// remaining rows (2 more chunks).
+	retry, err := env.RunFlushWith(ctx, FlushOverrides{Config: &cfg})
+	if err != nil {
+		t.Fatalf("clean retry flush: %v", err)
+	}
+	if retry.UnflushedAfter != 0 {
+		t.Errorf("retry must flush the rest, unflushed = %d", retry.UnflushedAfter)
+	}
+	retryFinals, _ := splitKeys(retry.NewObjects)
+	if len(retryFinals) != 2 {
+		t.Errorf("retry must add exactly 2 chunk objects, got %v", retryFinals)
+	}
+	assertManifestDeltaPaths(t, retry.Manifests, simple, append(append([]string(nil), finals...), retryFinals...))
+	// Create-only fixture: any row_id in two parquet files means a completed
+	// chunk was re-exported — the exact regression this scenario guards.
+	assertNoRowExportedTwice(ctx, t, env, simple)
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
+}

--- a/internal/e2e_harness/production/cdc_fault_postmark_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_postmark_e2e_test.go
@@ -58,3 +58,64 @@ func TestFlushFaultMarkFlushed(t *testing.T) {
 	// surface as extra result rows here.
 	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
 }
+
+// TestFlushFaultManifestLoad breaks step 6 (manifest GetObject) and
+// TestFlushFaultManifestSave breaks step 7 (manifest PutObject). Both land
+// after mark-flushed, pinning the corrected #197 contract: the run fails
+// with the final key embedded in the error, the retry is a strict no-op
+// (rows are flushed; no re-export, no manifest self-repair — a blind
+// AppendFile retry would duplicate entries), the delta file stays outside
+// the manifest (reconciliation is #203's scope), and federated reads are
+// unaffected because the read path never consults the manifest.
+func TestFlushFaultManifestLoad(t *testing.T) {
+	t.Parallel()
+	testFlushFaultManifest(t, S3OpGet)
+}
+
+func TestFlushFaultManifestSave(t *testing.T) {
+	t.Parallel()
+	testFlushFaultManifest(t, S3OpPut)
+}
+
+func testFlushFaultManifest(t *testing.T, op S3Op) {
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0]
+	seedRows(ctx, t, env, simple, 3)
+
+	faulty := &FaultInjectingS3{Inner: env.Cluster.S3, Fault: S3Fault{Op: op, KeyContains: "manifest/"}}
+	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty})
+	if err == nil {
+		t.Fatalf("flush with failing manifest %s must fail", op)
+	}
+	if faulty.Injected() == 0 {
+		t.Fatal("fault never fired")
+	}
+	finals, _ := splitKeys(report.NewObjects)
+	if len(finals) != 1 {
+		t.Fatalf("the final object must exist when the manifest step fails, got %v", finals)
+	}
+	// #197 contract: the error names the orphaned final key for the operator.
+	if !strings.Contains(err.Error(), "manifest update") || !strings.Contains(err.Error(), finals[0]) {
+		t.Errorf("error must point at the orphaned final key %q, got: %v", finals[0], err)
+	}
+	// Rows are already marked flushed — the partial commit this matrix exists
+	// to pin.
+	if report.UnflushedAfter != 0 {
+		t.Errorf("rows must be marked flushed before the manifest step, unflushed = %d", report.UnflushedAfter)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, simple, nil)
+
+	// Retry is a strict no-op and does NOT self-repair the manifest.
+	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("clean retry flush: %v", err)
+	}
+	if retry.UnflushedBefore != 0 || len(retry.NewObjects) != 0 {
+		t.Errorf("retry must be a no-op: unflushed %d, new objects %v", retry.UnflushedBefore, retry.NewObjects)
+	}
+	assertManifestDeltaPaths(t, retry.Manifests, simple, nil)
+
+	// Reads never consult the manifest; the flushed data stays fully visible.
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
+}

--- a/internal/e2e_harness/production/cdc_fault_postmark_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_postmark_e2e_test.go
@@ -1,0 +1,60 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestFlushFaultMarkFlushed breaks step 5 (UPDATE change_log SET flushed_at)
+// via a poison trigger, after the final S3 object already landed. Retry
+// re-exports the same rows into a second final object; LWW must dedup the
+// identical (row_id, ver_ts) copies so the federated result has no
+// duplicates (#179 known risky boundary 1). The first final object stays
+// outside the manifest forever (its manifest step never ran; retry appends
+// only its own key) — inventory drift owned by #203, invisible to reads.
+func TestFlushFaultMarkFlushed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0]
+	seedRows(ctx, t, env, simple, 3)
+
+	poisonMarkFlushed(ctx, t, env)
+	report, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err == nil {
+		t.Fatal("flush with poisoned mark-flushed must fail")
+	}
+	if !strings.Contains(err.Error(), "mark flushed at snapshot") {
+		t.Errorf("failure must surface at the mark-flushed step, got: %v", err)
+	}
+	firstFinals, _ := splitKeys(report.NewObjects)
+	if len(firstFinals) != 1 {
+		t.Fatalf("the final object must already exist when mark-flushed fails, got %v", firstFinals)
+	}
+	if report.UnflushedAfter != 3 {
+		t.Errorf("rows must stay dirty, unflushed = %d, want 3", report.UnflushedAfter)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, simple, nil)
+
+	healMarkFlushed(ctx, t, env)
+	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("healed retry flush: %v", err)
+	}
+	if retry.UnflushedAfter != 0 {
+		t.Errorf("retry must flush all rows, unflushed = %d", retry.UnflushedAfter)
+	}
+	secondFinals, _ := splitKeys(retry.NewObjects)
+	if len(secondFinals) != 1 {
+		t.Fatalf("retry must create exactly one more final object, got %v", secondFinals)
+	}
+	// Two physical copies of the same rows exist; only the retry's object is
+	// tracked by the manifest.
+	assertManifestDeltaPaths(t, retry.Manifests, simple, secondFinals)
+	// The oracle knows 3 rows; duplicates across the two parquet copies would
+	// surface as extra result rows here.
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
+}

--- a/internal/e2e_harness/production/doc.go
+++ b/internal/e2e_harness/production/doc.go
@@ -28,7 +28,7 @@
 //
 //	#174 full-type coverage        -> schemas/e2e_wide fixture, GenerateScript
 //	#175 lifecycle sequences       -> Event model + ApplyEvents
-//	#179 flush thresholds          -> WithFlushThresholds, RunFlush report
+//	#179 flush failure matrix      -> FaultInjectingS3, RunFlushWith, ExecSQL
 //	#180 dry-run semantics         -> RunFlushDry
 //	#181 failure-state injection   -> Env.ExecSQL escape hatch
 //	#185 circuit breaker           -> WithBreaker

--- a/internal/e2e_harness/production/faults.go
+++ b/internal/e2e_harness/production/faults.go
@@ -16,10 +16,14 @@ import (
 type S3Op string
 
 const (
-	S3OpCopy   S3Op = "CopyObject"
+	// S3OpCopy matches CopyObject (flush step 3: tmp -> final promotion).
+	S3OpCopy S3Op = "CopyObject"
+	// S3OpDelete matches DeleteObject (flush step 4: tmp cleanup).
 	S3OpDelete S3Op = "DeleteObject"
-	S3OpGet    S3Op = "GetObject"
-	S3OpPut    S3Op = "PutObject"
+	// S3OpGet matches GetObject (flush step 6: manifest load).
+	S3OpGet S3Op = "GetObject"
+	// S3OpPut matches PutObject (flush step 7: manifest save).
+	S3OpPut S3Op = "PutObject"
 )
 
 // S3Fault selects which calls fail. A call matches when its operation equals
@@ -70,31 +74,51 @@ func (f *FaultInjectingS3) intercept(op S3Op, key string) error {
 }
 
 func (f *FaultInjectingS3) CopyObject(ctx context.Context, in *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
-	if err := f.intercept(S3OpCopy, aws.ToString(in.Key)); err != nil {
+	key := aws.ToString(in.Key)
+	if err := f.intercept(S3OpCopy, key); err != nil {
 		return nil, err
 	}
-	return f.Inner.CopyObject(ctx, in, optFns...)
+	out, err := f.Inner.CopyObject(ctx, in, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("s3 CopyObject %q: %w", key, err)
+	}
+	return out, nil
 }
 
 func (f *FaultInjectingS3) DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
-	if err := f.intercept(S3OpDelete, aws.ToString(in.Key)); err != nil {
+	key := aws.ToString(in.Key)
+	if err := f.intercept(S3OpDelete, key); err != nil {
 		return nil, err
 	}
-	return f.Inner.DeleteObject(ctx, in, optFns...)
+	out, err := f.Inner.DeleteObject(ctx, in, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("s3 DeleteObject %q: %w", key, err)
+	}
+	return out, nil
 }
 
 func (f *FaultInjectingS3) GetObject(ctx context.Context, in *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-	if err := f.intercept(S3OpGet, aws.ToString(in.Key)); err != nil {
+	key := aws.ToString(in.Key)
+	if err := f.intercept(S3OpGet, key); err != nil {
 		return nil, err
 	}
-	return f.Inner.GetObject(ctx, in, optFns...)
+	out, err := f.Inner.GetObject(ctx, in, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("s3 GetObject %q: %w", key, err)
+	}
+	return out, nil
 }
 
 func (f *FaultInjectingS3) PutObject(ctx context.Context, in *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
-	if err := f.intercept(S3OpPut, aws.ToString(in.Key)); err != nil {
+	key := aws.ToString(in.Key)
+	if err := f.intercept(S3OpPut, key); err != nil {
 		return nil, err
 	}
-	return f.Inner.PutObject(ctx, in, optFns...)
+	out, err := f.Inner.PutObject(ctx, in, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("s3 PutObject %q: %w", key, err)
+	}
+	return out, nil
 }
 
 var _ cdc.S3FullClient = (*FaultInjectingS3)(nil)

--- a/internal/e2e_harness/production/faults.go
+++ b/internal/e2e_harness/production/faults.go
@@ -1,0 +1,100 @@
+package production
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/lychee-technology/forma/internal/cdc"
+)
+
+// S3Op names one cdc.S3FullClient operation for fault matching.
+type S3Op string
+
+const (
+	S3OpCopy   S3Op = "CopyObject"
+	S3OpDelete S3Op = "DeleteObject"
+	S3OpGet    S3Op = "GetObject"
+	S3OpPut    S3Op = "PutObject"
+)
+
+// S3Fault selects which calls fail. A call matches when its operation equals
+// Op and its destination key contains KeyContains (empty matches any key).
+// The first SkipMatches matching calls pass through; every later match fails.
+type S3Fault struct {
+	Op          S3Op
+	KeyContains string
+	SkipMatches int
+}
+
+// FaultInjectingS3 wraps the cluster's real S3 client and fails calls
+// matching Fault, breaking exactly one step of the CDC flush pipeline
+// (#179). The injected error text deliberately avoids the not-found phrases
+// manifest.LoadOrCreate interprets as "create a fresh manifest".
+type FaultInjectingS3 struct {
+	Inner cdc.S3FullClient
+	Fault S3Fault
+
+	mu       sync.Mutex
+	matched  int
+	injected int
+}
+
+// Injected reports how many calls have been failed so far; scenarios assert
+// it is non-zero as a positive control that the fault actually fired.
+func (f *FaultInjectingS3) Injected() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.injected
+}
+
+func (f *FaultInjectingS3) intercept(op S3Op, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if op != f.Fault.Op {
+		return nil
+	}
+	if f.Fault.KeyContains != "" && !strings.Contains(key, f.Fault.KeyContains) {
+		return nil
+	}
+	f.matched++
+	if f.matched <= f.Fault.SkipMatches {
+		return nil
+	}
+	f.injected++
+	return fmt.Errorf("e2e injected s3 fault: %s %s", op, key)
+}
+
+func (f *FaultInjectingS3) CopyObject(ctx context.Context, in *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	if err := f.intercept(S3OpCopy, aws.ToString(in.Key)); err != nil {
+		return nil, err
+	}
+	return f.Inner.CopyObject(ctx, in, optFns...)
+}
+
+func (f *FaultInjectingS3) DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	if err := f.intercept(S3OpDelete, aws.ToString(in.Key)); err != nil {
+		return nil, err
+	}
+	return f.Inner.DeleteObject(ctx, in, optFns...)
+}
+
+func (f *FaultInjectingS3) GetObject(ctx context.Context, in *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if err := f.intercept(S3OpGet, aws.ToString(in.Key)); err != nil {
+		return nil, err
+	}
+	return f.Inner.GetObject(ctx, in, optFns...)
+}
+
+func (f *FaultInjectingS3) PutObject(ctx context.Context, in *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if err := f.intercept(S3OpPut, aws.ToString(in.Key)); err != nil {
+		return nil, err
+	}
+	return f.Inner.PutObject(ctx, in, optFns...)
+}
+
+var _ cdc.S3FullClient = (*FaultInjectingS3)(nil)

--- a/internal/e2e_harness/production/faults_test.go
+++ b/internal/e2e_harness/production/faults_test.go
@@ -1,0 +1,76 @@
+package production
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// stubS3 always succeeds, standing in for the real client.
+type stubS3 struct{}
+
+func (s *stubS3) CopyObject(_ context.Context, _ *s3.CopyObjectInput, _ ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	return &s3.CopyObjectOutput{}, nil
+}
+
+func (s *stubS3) DeleteObject(_ context.Context, _ *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+func (s *stubS3) GetObject(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return &s3.GetObjectOutput{}, nil
+}
+
+func (s *stubS3) PutObject(_ context.Context, _ *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	return &s3.PutObjectOutput{}, nil
+}
+
+func TestFaultInjectingS3MatchesOpAndKey(t *testing.T) {
+	ctx := context.Background()
+	f := &FaultInjectingS3{Inner: &stubS3{}, Fault: S3Fault{Op: S3OpPut, KeyContains: "manifest/"}}
+
+	if _, err := f.GetObject(ctx, &s3.GetObjectInput{Key: aws.String("p/manifest/20.json")}); err != nil {
+		t.Fatalf("op mismatch must pass through, got %v", err)
+	}
+	if _, err := f.PutObject(ctx, &s3.PutObjectInput{Key: aws.String("p/20/data.parquet")}); err != nil {
+		t.Fatalf("key mismatch must pass through, got %v", err)
+	}
+	_, err := f.PutObject(ctx, &s3.PutObjectInput{Key: aws.String("p/manifest/20.json")})
+	if err == nil {
+		t.Fatal("matching PutObject must fail")
+	}
+	if !strings.Contains(err.Error(), "e2e injected s3 fault") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+	// manifest.LoadOrCreate treats these phrases as "manifest does not exist
+	// yet" and would silently continue — the injected text must avoid them.
+	for _, phrase := range []string{"nosuchkey", "not found", "does not exist"} {
+		if strings.Contains(strings.ToLower(err.Error()), phrase) {
+			t.Fatalf("injected error text %q must not contain %q", err, phrase)
+		}
+	}
+	if f.Injected() != 1 {
+		t.Fatalf("Injected() = %d, want 1", f.Injected())
+	}
+}
+
+func TestFaultInjectingS3SkipMatches(t *testing.T) {
+	ctx := context.Background()
+	f := &FaultInjectingS3{Inner: &stubS3{}, Fault: S3Fault{Op: S3OpCopy, SkipMatches: 1}}
+
+	if _, err := f.CopyObject(ctx, &s3.CopyObjectInput{Key: aws.String("a.parquet")}); err != nil {
+		t.Fatalf("first match must be skipped, got %v", err)
+	}
+	if _, err := f.CopyObject(ctx, &s3.CopyObjectInput{Key: aws.String("b.parquet")}); err == nil {
+		t.Fatal("second match must fail")
+	}
+	if _, err := f.CopyObject(ctx, &s3.CopyObjectInput{Key: aws.String("c.parquet")}); err == nil {
+		t.Fatal("later matches must keep failing")
+	}
+	if f.Injected() != 2 {
+		t.Fatalf("Injected() = %d, want 2", f.Injected())
+	}
+}


### PR DESCRIPTION
Closes #179 (epic #172, Phase 2).

Injects a failure at every step of the CDC flush pipeline and verifies that retry produces a correct, deduplicated, consistent result — with **zero production-code changes**: every fault is injected from outside `internal/cdc`/`internal/manifest`/`internal/federated`.

## Fault matrix

| # | Pipeline step | Injection | Scenario |
|---|--------------|-----------|----------|
| 1 | Dirty ID selection | Config poison: `PGHost/PGPort = 127.0.0.1:1` | `TestFlushFaultDirtySelection` — zero side effects, clean retry converges |
| 2 | DuckDB COPY → tmp | Config poison: `S3Endpoint = 127.0.0.1:1` (httpfs unreachable, fails fast ~3s) | `TestFlushFaultDuckExport` — zero side effects, clean retry converges |
| 3 | S3 CopyObject tmp→final | `FaultInjectingS3{Op: S3OpCopy}` | `TestFlushFaultCopyObject` — tmp orphan only, rows stay dirty, retry converges |
| 4 | S3 DeleteObject (tmp cleanup) | `FaultInjectingS3{Op: S3OpDelete, KeyContains: "/_tmp/"}` | `TestFlushFaultTempCleanup` — flush **succeeds** (swallow is by design, `helpers.go:165-167`), orphan invisible to reads |
| 5 | Postgres mark-flushed | `ExecSQL` poison trigger `BEFORE UPDATE OF flushed_at ON change_log` | `TestFlushFaultMarkFlushed` — final object already landed, retry creates a second identical one, LWW dedups |
| 6 | Manifest load | `FaultInjectingS3{Op: S3OpGet, KeyContains: "manifest/"}` | `TestFlushFaultManifestLoad` — corrected #197 contract (below) |
| 7 | Manifest save | `FaultInjectingS3{Op: S3OpPut, KeyContains: "manifest/"}` | `TestFlushFaultManifestSave` — corrected #197 contract (below) |
| — | Multi-batch middle chunk | `EstimatedRowBytes=1, MaxBatchBytes=3` (9 rows → 3 chunks) + `SkipMatches: 1` on CopyObject | `TestFlushFaultMultiBatchMiddleChunk` — committed chunk 1 not re-exported; `assertNoRowExportedTwice` guards physical duplication |

Every scenario carries a positive control (`faulty.Injected() == 0 → Fatal`) and closes with the fault-independent event-fold oracle (`AssertQueryMatches`) — the issue's "identical to no-failure baseline" criterion.

New harness surface: `FaultInjectingS3` (implements `cdc.S3FullClient`; injected error text deliberately avoids the not-found phrases `manifest.LoadOrCreate` treats as "fresh manifest" — unit-pinned) and `Env.RunFlushWith(ctx, FlushOverrides{S3, Config, DryRun})`, which returns a best-effort non-nil report even when the flush fails so partial side effects can be asserted. `RunFlush`/`RunFlushDry` semantics unchanged.

## Spec adjudications (issue text vs. current contracts)

1. **"Manifest failure is non-fatal / self-repairs on next flush" is superseded by #197 (PR #202).** The corrected contract is pinned instead: the run fails with the orphaned final key embedded in the error, rows are already marked flushed, and the retry is a strict no-op that does **not** re-append the manifest entry (blind `AppendFile` retry would duplicate entries). Reconciliation is #203's scope; federated reads are unaffected because the read path never consults the manifest.
2. **"No orphan temp files" — deferred to #226 (review round 1 decision).** A step-3 failure orphans its tmp object permanently (retry uses fresh UUIDs; `CopyTmpToFinal` deletes only its own key), and step-4 delete failures are swallowed. Review adjudicated that the #197/#203 supersession does **not** extend to this criterion, so restoring the invariant is production work tracked in #226 (tmp GC design: flush holds the schema advisory lock but `RunInit` does not and shares `_tmp/`, so a naive sweep is unsafe). Until #226 lands, the tests pin the current behavior and assert correctness is unaffected: the production glob's `*` does not cross `/`, so `_tmp/` is excluded from reads (`production/query.go:52-56`), and orphans never enter the manifest.
3. **"One final object per batch" is intentionally violated in the mark-flushed scenario.** As the issue itself acknowledges, retry after a step-5 failure creates a second final object with identical `(row_id, ver_ts)` content; the assertion is at the query layer (LWW `rn=1` dedups, no duplicate rows).
4. **`production/doc.go` consumer-map drift**: the `#179 flush thresholds` label predated this issue's actual scope and is fixed here. The `#181`/`#189` rows have similar drift (actual #181 = deep pagination, #189 = schema evolution per epic #172) — left untouched in this PR.

## Review round 1 (c46a291)

- Bare error returns in `runFlush`/`RunFlushWith` pre-capture and the `FaultInjectingS3` forwarders now wrapped with operation + key context; `S3Op` constants godoc'd.
- Multi-batch scenario now asserts **row-level** `flushed_at` consistency: after the fault the flushed set equals the chunk-1 parquet contents (3/6 split), and the retry files contain exactly the previously-dirty 6 rows — pinning "only remaining dirty rows are re-exported" at row granularity.
- Orphan-tmp adjudication replaced by #226 (see above).

## Test notes

- One characterization finding en route: a federated query against a schema with zero parquet files errors on the empty `read_parquet` glob, so S1's pre-flush baseline uses `PreferHot: true` (established pattern: `boundary_roundtrip_e2e_test.go`). Fault and convergence assertions are untouched.
- Follow-up candidates (non-blocking, from final review): a `requireReport` nil-guard for `RunFlushWith` fault call sites (pre-run capture failure currently panics instead of printing a diagnostic — still a test failure, never a false green); `loadManifests` swallows `manifest.Load` errors (pre-existing; relevant to #203's reconciliation tests).

## Verification

- `make lint` (golangci-lint v1.64.8) — clean
- `make test` — all packages ok
- Full production e2e suite (`-tags=e2e`, Docker): 54 top-level tests PASS in ~30s — the 8 new `TestFlushFault*` tests co-exist with the pre-existing suite under the shared cluster + `t.Parallel()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
