### PR TITLE
fix(federated): recount totalRecords on empty deep pages (#181)

### DIFF
--- a/internal/e2e_harness/production/deep_pagination_e2e_test.go
+++ b/internal/e2e_harness/production/deep_pagination_e2e_test.go
@@ -129,6 +129,17 @@ func testHotOnlyDeepOffset(ctx context.Context, t *testing.T, env *Env, wide Sch
 		Query{Schema: wide, PreferHot: true, Sorts: sorts, Limit: 10, Offset: 25}, 25)
 	assertEmptyPageTotal(ctx, t, env, "hot offset>total",
 		Query{Schema: wide, PreferHot: true, Sorts: sorts, Limit: 10, Offset: 35}, 25)
+
+	// Scenario 4 on the OLTP route: the recount must carry a real filter
+	// clause through the hot path too, not just the DuckDB one — count < 80
+	// keeps ordinals 0..7 = 8 of the 25 rows visible.
+	filters := []Filter{{Attr: "count", Op: "lt", Value: "80"}}
+	assertShallowPage(ctx, t, env, "hot filtered control",
+		Query{Schema: wide, PreferHot: true, Filters: filters, Sorts: sorts, Limit: 5}, 5, 8)
+	assertEmptyPageTotal(ctx, t, env, "hot filtered offset==total",
+		Query{Schema: wide, PreferHot: true, Filters: filters, Sorts: sorts, Limit: 5, Offset: 8}, 8)
+	assertEmptyPageTotal(ctx, t, env, "hot filtered offset>total",
+		Query{Schema: wide, PreferHot: true, Filters: filters, Sorts: sorts, Limit: 5, Offset: 20}, 8)
 }
 
 // testMultiTierDeepOffset is issue scenario 3: rows spread across base

--- a/internal/e2e_harness/production/deep_pagination_e2e_test.go
+++ b/internal/e2e_harness/production/deep_pagination_e2e_test.go
@@ -1,0 +1,197 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+)
+
+// TestDeepPagination (#181): offset pagination must preserve totalRecords
+// when the requested page is empty (offset >= matching total). Both engines
+// read COUNT(*) OVER() off the returned data rows, so an empty page returns
+// zero rows and the count is unreadable — without a fallback, deep pages
+// report totalRecords=0 while matches exist. The oracle computes Total before
+// slicing offset/limit, so AssertQueryMatches pins the contract on every
+// probe. Red-first per #213: committed before the engine fix.
+func TestDeepPagination(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide: count is unique per ordinal
+
+	scenarios := []struct {
+		name string
+		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"offset_equals_total", testOffsetEqualsTotal},
+		{"offset_beyond_total", testOffsetBeyondTotal},
+		{"hot_only_oltp", testHotOnlyDeepOffset},
+		{"multi_tier", testMultiTierDeepOffset},
+		{"after_filter", testFilteredDeepOffset},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), wide)
+		})
+	}
+}
+
+// seedFlushed creates n rows and flushes them all to delta parquet, so the
+// default-tier query routes through the DuckDB federated path (an empty
+// parquet glob would error instead).
+func seedFlushed(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, n int) {
+	t.Helper()
+	creates := env.GenerateScript(ScriptSpec{Schema: schema, Creates: n})
+	mustApplyEvents(ctx, t, env, "apply creates", creates...)
+	mustFlush(ctx, t, env)
+}
+
+// assertShallowPage is the load-bearing positive control: the first page must
+// come back full with the true total, proving the read path works before any
+// empty-page probe runs. Fail-fast so a broken seed cannot fake a green probe.
+func assertShallowPage(ctx context.Context, t *testing.T, env *Env, name string, q Query, wantRows int, wantTotal int64) *QueryResult {
+	t.Helper()
+	res := env.AssertQueryMatches(ctx, q)
+	if res == nil {
+		return nil
+	}
+	if len(res.Records) != wantRows {
+		t.Fatalf("%s: shallow page returned %d rows, want %d", name, len(res.Records), wantRows)
+	}
+	if res.Total != wantTotal {
+		t.Fatalf("%s: shallow page reports total %d, want %d", name, res.Total, wantTotal)
+	}
+	return res
+}
+
+// assertEmptyPageTotal probes a page at or beyond the last matching row: the
+// page must be empty while totalRecords still reports the full matching
+// count. AssertQueryMatches already diffs the total against the oracle; the
+// explicit checks keep the failure message on the issue #181 contract.
+func assertEmptyPageTotal(ctx context.Context, t *testing.T, env *Env, name string, q Query, wantTotal int64) {
+	t.Helper()
+	res := env.AssertQueryMatches(ctx, q)
+	if res == nil {
+		return
+	}
+	if len(res.Records) != 0 {
+		t.Errorf("%s: page beyond total returned %d rows, want 0", name, len(res.Records))
+	}
+	if res.Total != wantTotal {
+		t.Errorf("%s: empty page reports total %d, want %d", name, res.Total, wantTotal)
+	}
+}
+
+// testOffsetEqualsTotal is issue scenario 1: offset == total must return an
+// empty page that still reports the full count, through the DuckDB path.
+func testOffsetEqualsTotal(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	seedFlushed(ctx, t, env, wide, 25)
+
+	sorts := []Sort{{Attr: "count"}}
+	res := assertShallowPage(ctx, t, env, "offset_equals_total control",
+		Query{Schema: wide, Sorts: sorts, Limit: 10}, 10, 25)
+	if res != nil && !res.Plan.Routing.UseDuckDB {
+		t.Errorf("control query did not route to duckdb: %+v", res.Plan.Routing)
+	}
+
+	assertEmptyPageTotal(ctx, t, env, "offset==total",
+		Query{Schema: wide, Sorts: sorts, Limit: 10, Offset: 25}, 25)
+}
+
+// testOffsetBeyondTotal is issue scenario 2: offset past the last row behaves
+// like scenario 1 — empty page, full count.
+func testOffsetBeyondTotal(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	seedFlushed(ctx, t, env, wide, 25)
+
+	sorts := []Sort{{Attr: "count"}}
+	assertShallowPage(ctx, t, env, "offset_beyond_total control",
+		Query{Schema: wide, Sorts: sorts, Limit: 10}, 10, 25)
+
+	assertEmptyPageTotal(ctx, t, env, "offset>total",
+		Query{Schema: wide, Sorts: sorts, Limit: 10, Offset: 35}, 25)
+}
+
+// testHotOnlyDeepOffset covers the Postgres OLTP path: unflushed rows with
+// PreferHot route through queryPostgresOnly → runOptimizedQuery, which reads
+// the window count off returned rows exactly like the DuckDB reader.
+func testHotOnlyDeepOffset(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 25})
+	mustApplyEvents(ctx, t, env, "apply hot creates", creates...)
+
+	sorts := []Sort{{Attr: "count"}}
+	res := assertShallowPage(ctx, t, env, "hot_only control",
+		Query{Schema: wide, PreferHot: true, Sorts: sorts, Limit: 10}, 10, 25)
+	if res != nil && res.Plan.Routing.UseDuckDB {
+		t.Errorf("hot-only control unexpectedly routed to duckdb: %+v", res.Plan.Routing)
+	}
+
+	assertEmptyPageTotal(ctx, t, env, "hot offset==total",
+		Query{Schema: wide, PreferHot: true, Sorts: sorts, Limit: 10, Offset: 25}, 25)
+	assertEmptyPageTotal(ctx, t, env, "hot offset>total",
+		Query{Schema: wide, PreferHot: true, Sorts: sorts, Limit: 10, Offset: 35}, 25)
+}
+
+// testMultiTierDeepOffset is issue scenario 3: rows spread across base
+// (init), delta (flush), and hot (unflushed) — the post-dedup cross-tier
+// count must survive an empty deep page. Seeding recipe mirrors
+// testThreeTierUnion (#177).
+func testMultiTierDeepOffset(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	old := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 10})
+	mustApplyEvents(ctx, t, env, "apply base creates", old...)
+	report, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	if report.RowsExported != 10 {
+		t.Fatalf("init exported %d rows, want 10", report.RowsExported)
+	}
+	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", wide.ID)
+
+	mid := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 8})
+	mustApplyEvents(ctx, t, env, "apply delta creates", mid...)
+	mustFlush(ctx, t, env)
+
+	fresh := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 7})
+	mustApplyEvents(ctx, t, env, "apply hot creates", fresh...)
+
+	// Tier precondition: exactly the 7 hot rows are dirty.
+	var dirty int64
+	if err := env.Pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM change_log WHERE flushed_at = 0 AND schema_id = $1", wide.ID).Scan(&dirty); err != nil {
+		t.Fatalf("count dirty rows: %v", err)
+	}
+	if dirty != 7 {
+		t.Fatalf("dirty set has %d rows, want 7 (hot batch only)", dirty)
+	}
+
+	sorts := []Sort{{Attr: "count"}}
+	res := assertShallowPage(ctx, t, env, "multi_tier control",
+		Query{Schema: wide, Sorts: sorts, Limit: 10}, 10, 25)
+	if res != nil && !res.Plan.Routing.UseDuckDB {
+		t.Errorf("multi-tier control did not route to duckdb: %+v", res.Plan.Routing)
+	}
+
+	assertEmptyPageTotal(ctx, t, env, "multi-tier offset==total",
+		Query{Schema: wide, Sorts: sorts, Limit: 10, Offset: 25}, 25)
+	assertEmptyPageTotal(ctx, t, env, "multi-tier offset>total",
+		Query{Schema: wide, Sorts: sorts, Limit: 10, Offset: 35}, 25)
+}
+
+// testFilteredDeepOffset is issue scenario 4: a filter shrinks the visible
+// set below the offset — the empty page must report the filtered count, not
+// the raw table size. FullTypeProfile assigns count = ordinal*10 + [0,9], so
+// with 25 creates (ordinals 0..24) the predicate count < 80 matches exactly
+// ordinals 0..7 = 8 rows.
+func testFilteredDeepOffset(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	seedFlushed(ctx, t, env, wide, 25)
+
+	filters := []Filter{{Attr: "count", Op: "lt", Value: "80"}}
+	sorts := []Sort{{Attr: "count"}}
+	assertShallowPage(ctx, t, env, "after_filter control",
+		Query{Schema: wide, Filters: filters, Sorts: sorts, Limit: 5}, 5, 8)
+
+	assertEmptyPageTotal(ctx, t, env, "filtered offset==total",
+		Query{Schema: wide, Filters: filters, Sorts: sorts, Limit: 5, Offset: 8}, 8)
+	assertEmptyPageTotal(ctx, t, env, "filtered offset>total",
+		Query{Schema: wide, Filters: filters, Sorts: sorts, Limit: 5, Offset: 20}, 8)
+}

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -137,6 +137,18 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 		return nil, fmt.Errorf("duckdb federated query: %w", err)
 	}
 
+	// The template carries COUNT(*) OVER() on the data rows, so a page at or
+	// beyond the last match returns zero rows and the count is unreadable —
+	// totalRecords would misreport 0 while matches exist (#181). Recount with
+	// offset 0 (cannot recurse); at offset 0 an empty result is a genuine 0.
+	if len(records) == 0 && fq.Offset > 0 {
+		countTotal, cerr := e.computeFederatedCount(ctx, tables, fq)
+		if cerr != nil {
+			return nil, fmt.Errorf("compute empty-page federated count: %w", cerr)
+		}
+		totalRecords = countTotal
+	}
+
 	limit := fq.Limit
 	if limit <= 0 {
 		limit = model.DefaultPageSize

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -144,6 +144,13 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 	if len(records) == 0 && fq.Offset > 0 {
 		countTotal, cerr := e.computeFederatedCount(ctx, tables, fq)
 		if cerr != nil {
+			// The recount is a DuckDB query like the page fetch above, so it
+			// degrades under the same policy (and the same metadata-cache
+			// exception): a transient failure here must not fail a request
+			// the degraded mode contract promises to serve Postgres-only.
+			if opts != nil && opts.AllowPartialDegradedMode && !errors.Is(cerr, ErrSchemaMetadataCacheRequired) {
+				return e.queryPostgresOnly(ctx, tables, fq)
+			}
 			return nil, fmt.Errorf("compute empty-page federated count: %w", cerr)
 		}
 		totalRecords = countTotal

--- a/internal/federated/engine_empty_page_test.go
+++ b/internal/federated/engine_empty_page_test.go
@@ -1,0 +1,134 @@
+package federated
+
+import (
+	"context"
+	"testing"
+	"text/template"
+
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/stretchr/testify/require"
+)
+
+// sequencedDuckDBExecutor returns one prepared iterator per Query call, so a
+// test can hand the paged query an empty result and the fallback recount a
+// row that carries the window total.
+type sequencedDuckDBExecutor struct {
+	calls int
+	rows  []duckDBRowsIterator
+}
+
+func (f *sequencedDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
+	idx := f.calls
+	f.calls++
+	if idx >= len(f.rows) {
+		return &emptyDuckDBRows{}, nil
+	}
+	return f.rows[idx], nil
+}
+
+type emptyDuckDBRows struct{}
+
+func (e *emptyDuckDBRows) Next() bool             { return false }
+func (e *emptyDuckDBRows) Scan(dest ...any) error { return nil }
+func (e *emptyDuckDBRows) Err() error             { return nil }
+func (e *emptyDuckDBRows) Close() error           { return nil }
+
+// totalOnlyDuckDBRow yields a single row whose total_records column carries
+// the given count — the shape the limit-1/offset-0 recount comes back in.
+type totalOnlyDuckDBRow struct {
+	total   int64
+	scanned bool
+}
+
+func (r *totalOnlyDuckDBRow) Next() bool {
+	if r.scanned {
+		return false
+	}
+	r.scanned = true
+	return true
+}
+
+func (r *totalOnlyDuckDBRow) Scan(dest ...any) error {
+	return populateDuckDBRow(dest, 7, uuid.New(), 10, 20, nil, "[]", r.total)
+}
+
+func (r *totalOnlyDuckDBRow) Err() error   { return nil }
+func (r *totalOnlyDuckDBRow) Close() error { return nil }
+
+func newEmptyPageTestEngine(t *testing.T, duck DuckDBQueryExecutor, builtQueries *[]model.FederatedAttributeQuery) *DBFederatedQueryEngine {
+	t.Helper()
+	engine := NewDBFederatedQueryEngine(&fakePostgresFederatedSource{}, &fakeDirtyIDFetcher{}, duck, nil,
+		forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}},
+		testMetadataCacheSchema7(t), "")
+	engine.buildDuckSQL = func(tpl *template.Template, params any, q *model.FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *sqlgen.DualClauses) (string, []any, error) {
+		*builtQueries = append(*builtQueries, *q)
+		return "SELECT fake", nil, nil
+	}
+	return engine
+}
+
+// TestDBFederatedQueryEngine_EmptyPageRecountsTotal pins the #181 fallback:
+// the DuckDB template carries COUNT(*) OVER() on data rows, so a page beyond
+// the last match streams zero rows and the engine must recount via
+// computeFederatedCount instead of reporting totalRecords=0.
+func TestDBFederatedQueryEngine_EmptyPageRecountsTotal(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &sequencedDuckDBExecutor{rows: []duckDBRowsIterator{
+		&emptyDuckDBRows{},
+		&totalOnlyDuckDBRow{total: 42},
+	}}
+	var built []model.FederatedAttributeQuery
+	engine := newEmptyPageTestEngine(t, duck, &built)
+
+	page, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		&model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10, Offset: 50},
+			// Cold-only tiers force the DuckDB route under the hybrid
+			// strategy regardless of page size.
+			PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
+		}, nil)
+
+	require.NoError(t, err)
+	require.Empty(t, page.Records)
+	require.Equal(t, int64(42), page.TotalRecords)
+	require.Equal(t, model.ComputeTotalPages(42, 10), page.TotalPages)
+	require.Equal(t, 2, duck.calls, "empty deep page must trigger exactly one recount")
+	// The advanced template renders LIMIT/OFFSET from the query object, so the
+	// recount must reach the builder with the pagination zeroed — passing
+	// limit/offset only as call parameters re-renders the deep offset (#181).
+	require.Len(t, built, 2)
+	require.Equal(t, 50, built[0].Offset)
+	require.Equal(t, 1, built[1].Limit, "recount must render LIMIT 1")
+	require.Equal(t, 0, built[1].Offset, "recount must render OFFSET 0")
+}
+
+// TestDBFederatedQueryEngine_EmptyResultAtOffsetZeroSkipsRecount guards the
+// other half of the #181 condition: at offset 0 an empty result is a genuine
+// total of 0 and no second query may fire.
+func TestDBFederatedQueryEngine_EmptyResultAtOffsetZeroSkipsRecount(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &sequencedDuckDBExecutor{rows: []duckDBRowsIterator{&emptyDuckDBRows{}}}
+	var built []model.FederatedAttributeQuery
+	engine := newEmptyPageTestEngine(t, duck, &built)
+
+	page, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		&model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10},
+			PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
+		}, nil)
+
+	require.NoError(t, err)
+	require.Empty(t, page.Records)
+	require.Equal(t, int64(0), page.TotalRecords)
+	require.Equal(t, 1, duck.calls, "offset 0 empty result must not recount")
+}

--- a/internal/federated/engine_empty_page_test.go
+++ b/internal/federated/engine_empty_page_test.go
@@ -2,6 +2,7 @@ package federated
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"text/template"
 
@@ -13,17 +14,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// sequencedDuckDBExecutor returns one prepared iterator per Query call, so a
-// test can hand the paged query an empty result and the fallback recount a
-// row that carries the window total.
+// sequencedDuckDBExecutor returns one prepared iterator (or error) per Query
+// call, so a test can hand the paged query an empty result and the fallback
+// recount a row that carries the window total — or a failure.
 type sequencedDuckDBExecutor struct {
 	calls int
 	rows  []duckDBRowsIterator
+	errs  []error
 }
 
 func (f *sequencedDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
 	idx := f.calls
 	f.calls++
+	if idx < len(f.errs) && f.errs[idx] != nil {
+		return nil, f.errs[idx]
+	}
 	if idx >= len(f.rows) {
 		return &emptyDuckDBRows{}, nil
 	}
@@ -59,9 +64,9 @@ func (r *totalOnlyDuckDBRow) Scan(dest ...any) error {
 func (r *totalOnlyDuckDBRow) Err() error   { return nil }
 func (r *totalOnlyDuckDBRow) Close() error { return nil }
 
-func newEmptyPageTestEngine(t *testing.T, duck DuckDBQueryExecutor, builtQueries *[]model.FederatedAttributeQuery) *DBFederatedQueryEngine {
+func newEmptyPageTestEngine(t *testing.T, pg *fakePostgresFederatedSource, duck DuckDBQueryExecutor, builtQueries *[]model.FederatedAttributeQuery) *DBFederatedQueryEngine {
 	t.Helper()
-	engine := NewDBFederatedQueryEngine(&fakePostgresFederatedSource{}, &fakeDirtyIDFetcher{}, duck, nil,
+	engine := NewDBFederatedQueryEngine(pg, &fakeDirtyIDFetcher{}, duck, nil,
 		forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}},
 		testMetadataCacheSchema7(t), "")
 	engine.buildDuckSQL = func(tpl *template.Template, params any, q *model.FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *sqlgen.DualClauses) (string, []any, error) {
@@ -84,7 +89,7 @@ func TestDBFederatedQueryEngine_EmptyPageRecountsTotal(t *testing.T) {
 		&totalOnlyDuckDBRow{total: 42},
 	}}
 	var built []model.FederatedAttributeQuery
-	engine := newEmptyPageTestEngine(t, duck, &built)
+	engine := newEmptyPageTestEngine(t, &fakePostgresFederatedSource{}, duck, &built)
 
 	page, err := engine.Query(context.Background(),
 		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
@@ -118,7 +123,7 @@ func TestDBFederatedQueryEngine_EmptyResultAtOffsetZeroSkipsRecount(t *testing.T
 
 	duck := &sequencedDuckDBExecutor{rows: []duckDBRowsIterator{&emptyDuckDBRows{}}}
 	var built []model.FederatedAttributeQuery
-	engine := newEmptyPageTestEngine(t, duck, &built)
+	engine := newEmptyPageTestEngine(t, &fakePostgresFederatedSource{}, duck, &built)
 
 	page, err := engine.Query(context.Background(),
 		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
@@ -131,4 +136,58 @@ func TestDBFederatedQueryEngine_EmptyResultAtOffsetZeroSkipsRecount(t *testing.T
 	require.Empty(t, page.Records)
 	require.Equal(t, int64(0), page.TotalRecords)
 	require.Equal(t, 1, duck.calls, "offset 0 empty result must not recount")
+}
+
+// TestDBFederatedQueryEngine_RecountFailureDegradesToPostgres pins that a
+// recount failure honors the same AllowPartialDegradedMode contract as the
+// page fetch: the request degrades to Postgres-only instead of erroring.
+func TestDBFederatedQueryEngine_RecountFailureDegradesToPostgres(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &sequencedDuckDBExecutor{
+		rows: []duckDBRowsIterator{&emptyDuckDBRows{}},
+		errs: []error{nil, fmt.Errorf("forced recount failure")},
+	}
+	var built []model.FederatedAttributeQuery
+	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 7}}
+	engine := newEmptyPageTestEngine(t, pg, duck, &built)
+
+	page, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		&model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10, Offset: 50},
+			PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
+		}, &model.FederatedQueryOptions{AllowPartialDegradedMode: true})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(7), page.TotalRecords)
+	require.Equal(t, 2, duck.calls)
+	require.Equal(t, 1, pg.queryCalls, "recount failure under degraded mode must fall back to postgres")
+}
+
+// TestDBFederatedQueryEngine_RecountFailureErrorsWithoutDegradedMode pins the
+// counterpart: without AllowPartialDegradedMode the recount failure surfaces
+// as an error and never silently returns a partial result.
+func TestDBFederatedQueryEngine_RecountFailureErrorsWithoutDegradedMode(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &sequencedDuckDBExecutor{
+		rows: []duckDBRowsIterator{&emptyDuckDBRows{}},
+		errs: []error{nil, fmt.Errorf("forced recount failure")},
+	}
+	var built []model.FederatedAttributeQuery
+	pg := &fakePostgresFederatedSource{}
+	engine := newEmptyPageTestEngine(t, pg, duck, &built)
+
+	_, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		&model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10, Offset: 50},
+			PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
+		}, nil)
+
+	require.ErrorContains(t, err, "compute empty-page federated count")
+	require.Equal(t, 0, pg.queryCalls)
 }

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -215,6 +215,12 @@ func (e *DBFederatedQueryEngine) computeFederatedCount(
 ) (int64, error) {
 	strippedQuery := *fq
 	strippedQuery.KeysetCursor = nil
+	// The advanced template renders LIMIT/OFFSET from the query object, not
+	// from the call parameters (injectDuckDBTemplateParams), so the count
+	// query must zero the pagination on the copy — otherwise a deep offset
+	// re-renders into the recount and it streams zero rows again (#181).
+	strippedQuery.Limit = 1
+	strippedQuery.Offset = 0
 
 	_, total, err := e.ExecuteDuckDBFederatedQuery(ctx, tables, &strippedQuery, 1, 0, nil, &model.FederatedQueryOptions{MaxRows: 1})
 	if err != nil {

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -224,7 +224,7 @@ func (e *DBFederatedQueryEngine) computeFederatedCount(
 
 	_, total, err := e.ExecuteDuckDBFederatedQuery(ctx, tables, &strippedQuery, 1, 0, nil, &model.FederatedQueryOptions{MaxRows: 1})
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("federated count query (schema %d): %w", fq.SchemaID, err)
 	}
 	return total, nil
 }

--- a/internal/postgres_persistent_repository_query.go
+++ b/internal/postgres_persistent_repository_query.go
@@ -182,7 +182,35 @@ func (r *DBPersistentRecordRepository) runOptimizedQuery(
 		return nil, 0, appendErr
 	}
 
+	// The template carries COUNT(*) OVER() on the data rows, so a page at or
+	// beyond the last match returns zero rows and the count is unreadable —
+	// totalRecords would misreport 0 while matches exist (#181). Recount with
+	// offset 0 (cannot recurse); at offset 0 an empty result is a genuine 0.
+	if len(records) == 0 && offset > 0 {
+		total, countErr := r.countOptimizedQuery(ctx, tables, schemaID, clause, args, attributeOrders, useMainTableAsAnchor)
+		if countErr != nil {
+			return nil, 0, fmt.Errorf("compute empty-page total: %w", countErr)
+		}
+		totalRecords = total
+	}
+
 	return records, totalRecords, nil
+}
+
+// countOptimizedQuery reads the matching total through the same optimized
+// query at limit 1, offset 0: any match then carries the window count back on
+// the returned row. Identical clause/args/orders reuse the cached plan —
+// limit and offset are bind parameters, not part of the rendered SQL.
+func (r *DBPersistentRecordRepository) countOptimizedQuery(
+	ctx context.Context,
+	tables model.StorageTables,
+	schemaID int16,
+	clause string,
+	args []any,
+	attributeOrders []model.AttributeOrder,
+	useMainTableAsAnchor bool,
+) (int64, error) {
+	return r.StreamOptimizedQuery(ctx, tables, schemaID, clause, args, 1, 0, attributeOrders, useMainTableAsAnchor, nil)
 }
 
 // RunOptimizedQuery exposes the optimized single-query path (prebuilt WHERE

--- a/internal/postgres_persistent_repository_query.go
+++ b/internal/postgres_persistent_repository_query.go
@@ -179,7 +179,7 @@ func (r *DBPersistentRecordRepository) runOptimizedQuery(
 		return nil
 	})
 	if appendErr != nil {
-		return nil, 0, appendErr
+		return nil, 0, fmt.Errorf("stream optimized query (schema %d): %w", schemaID, appendErr)
 	}
 
 	// The template carries COUNT(*) OVER() on the data rows, so a page at or
@@ -210,7 +210,11 @@ func (r *DBPersistentRecordRepository) countOptimizedQuery(
 	attributeOrders []model.AttributeOrder,
 	useMainTableAsAnchor bool,
 ) (int64, error) {
-	return r.StreamOptimizedQuery(ctx, tables, schemaID, clause, args, 1, 0, attributeOrders, useMainTableAsAnchor, nil)
+	total, err := r.StreamOptimizedQuery(ctx, tables, schemaID, clause, args, 1, 0, attributeOrders, useMainTableAsAnchor, nil)
+	if err != nil {
+		return 0, fmt.Errorf("optimized count query (schema %d): %w", schemaID, err)
+	}
+	return total, nil
 }
 
 // RunOptimizedQuery exposes the optimized single-query path (prebuilt WHERE

--- a/internal/postgres_persistent_repository_query_test.go
+++ b/internal/postgres_persistent_repository_query_test.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunOptimizedQueryEmptyPageRecountsTotal pins the #181 fallback: a page
+// at or beyond the last match returns zero rows (the window count travels on
+// data rows), so the repository must recount at limit 1, offset 0 and report
+// the true total instead of 0.
+func TestRunOptimizedQueryEmptyPageRecountsTotal(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+	mock.MatchExpectationsInOrder(true)
+
+	repo := NewDBPersistentRecordRepository(mock, nil)
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	columns, values := optimizedQueryFixtureColumnsAndValues(
+		uuid.MustParse("11111111-1111-1111-1111-111111111111"), int64(25))
+
+	// Deep page: offset past the 25 matches returns no rows.
+	mock.ExpectQuery("WITH anchor").
+		WithArgs(int16(1), 10, 30).
+		WillReturnRows(pgxmock.NewRows(columns))
+	// Fallback recount: same shape at limit 1, offset 0 carries the count back.
+	mock.ExpectQuery("WITH anchor").
+		WithArgs(int16(1), 1, 0).
+		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
+
+	records, total, err := repo.runOptimizedQuery(ctx, tables, 1, "1=1", nil, 10, 30, nil, true)
+	require.NoError(t, err)
+	assert.Empty(t, records)
+	assert.Equal(t, int64(25), total)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestRunOptimizedQueryEmptyResultAtOffsetZeroSkipsRecount guards the other
+// half of the #181 condition: with offset 0 an empty result is a genuine
+// total of 0, and the fallback must not burn a second query.
+func TestRunOptimizedQueryEmptyResultAtOffsetZeroSkipsRecount(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, nil)
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	columns, _ := optimizedQueryFixtureColumnsAndValues(uuid.New(), 0)
+	mock.ExpectQuery("WITH anchor").
+		WithArgs(int16(1), 10, 0).
+		WillReturnRows(pgxmock.NewRows(columns))
+
+	records, total, err := repo.runOptimizedQuery(ctx, tables, 1, "1=1", nil, 10, 0, nil, true)
+	require.NoError(t, err)
+	assert.Empty(t, records)
+	assert.Equal(t, int64(0), total)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Closes #181. Part of epic #172 (Phase 2, final item).

## Problem

Offset pagination misreported `totalRecords=0` whenever the requested page was empty (`offset >= matching total`). Both query paths carry `COUNT(*) OVER()` on the data rows and read the total off the first returned row — an empty page returns zero rows, so the (correctly computed) count was unreadable:

- **DuckDB federated path**: the final SELECT in `advanced_query_template_duckdb.go` emits `total_records` alongside `LIMIT/OFFSET`; `streamDuckDBRows` returns 0 on an empty page.
- **Postgres OLTP path**: `StreamOptimizedQuery` reads `m.total` off returned rows the same way. This path also serves the federated engine's hot-only/degraded routing, so `PreferHot` queries hit the same bug.

## Fix

Recount at limit 1 / offset 0 — the pattern the keyset path (`computeFederatedCount`) and cross-schema search (`countSchemaRecords`) already use — gated on `len(records) == 0 && offset > 0`, so a genuinely empty result at offset 0 costs nothing and the fallback cannot recurse.

- `federated/engine.go` `Query()`: reuses `computeFederatedCount` after an empty DuckDB page.
- `federated/pagination.go` `computeFederatedCount`: must also zero `Limit`/`Offset` on the query copy — the advanced template renders pagination from the query object, not the call parameters (`injectDuckDBTemplateParams`), so a deep offset re-rendered into the recount and streamed zero rows again. Latent for keyset because keyset queries always carry offset 0; now pinned at the `buildDuckSQL` seam in the unit test.
- `postgres_persistent_repository_query.go` `runOptimizedQuery`: recounts via new `countOptimizedQuery` (same cached plan — limit/offset are bind parameters), covering `QueryPersistentRecords` and the federated hot-only seam in one place.

## Tests

- **Red-first e2e** (committed failing, per the #213 convention): `TestDeepPagination` in the production harness — five oracle-checked scenarios: `offset_equals_total`, `offset_beyond_total`, `hot_only_oltp` (PreferHot → OLTP path, including filtered probes), `multi_tier` (base/delta/hot spread per the #177 recipe), `after_filter` (total reflects the filtered count, not the raw table). Each scenario runs a fail-fast shallow-page positive control before the empty-page probes. Pre-fix, all five failed with `expected_total=25 actual_total=0` (after_filter: `8` vs `0`).
- **Unit**: engine-level recount test pins the two-query sequence and — at the `buildDuckSQL` seam — that the recount reaches the renderer with `Limit=1, Offset=0`; the offset-0 counterpart pins that no second query fires. pgxmock twins cover the Postgres fallback and its offset-0 guard.

## Verification

- `make test` green, `-race` on `./internal ./internal/federated` green, `make lint` clean (pinned v1.64.8).
- E2E: `TestDeepPagination` green post-fix; `TestKeysetLWW` + `TestFilterLWW` (#195 gates — `computeFederatedCount` is shared with the keyset path), `TestQueryAcrossTiers`, `TestThreeTierMerge` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)