### PR TITLE
test(e2e): concurrent mutation during flush snapshot (#182)

### DIFF
--- a/internal/cdc/config.go
+++ b/internal/cdc/config.go
@@ -1,6 +1,11 @@
 package cdc
 
-import "time"
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // CDCConfig controls change_log flushing and export behavior.
 // S3 client is injected separately via RunOnce parameter to allow callers to
@@ -52,6 +57,13 @@ type CDCConfig struct {
 	// Manifest (optional - when set, flush updates manifest after export)
 	ManifestPrefix   string // root prefix for manifests in S3
 	ManifestTemplate string // path template, e.g. "manifest/{{.SchemaID}}.json"
+
+	// BeforeExportHook, when non-nil, runs per batch after dirty-ID selection
+	// (the snapshot is already captured) and before the DuckDB export. Test
+	// seam for driving mutations inside the selection->export race window
+	// (#182); always nil in production. A hook error aborts the batch before
+	// any side effect.
+	BeforeExportHook func(ctx context.Context, schemaID int16, batchIDs []uuid.UUID, snapshot int64) error
 }
 
 // CompactionConfig controls Base/Delta maintenance.

--- a/internal/cdc/flush_batch.go
+++ b/internal/cdc/flush_batch.go
@@ -42,6 +42,12 @@ func (e *flushBatchExecutor) executeBatch(ctx context.Context, batchIDs []uuid.U
 		return nil
 	}
 
+	if e.cfg.BeforeExportHook != nil {
+		if err := e.cfg.BeforeExportHook(ctx, e.schemaID, batchIDs, e.snapshot); err != nil {
+			return fmt.Errorf("before-export hook (%s): %w", batchKind, err)
+		}
+	}
+
 	s3TmpPath := fmt.Sprintf("s3://%s/%s", e.cfg.S3Bucket, tmpKey)
 	exportSnapshot := e.exportSnapshot
 	if exportSnapshot == nil {

--- a/internal/cdc/flush_batch_test.go
+++ b/internal/cdc/flush_batch_test.go
@@ -396,3 +396,111 @@ func TestExecuteBatch_DryRunPerformsNoSideEffects(t *testing.T) {
 	require.Zero(t, flushedAt, "dry-run must not mark rows flushed")
 	require.Zero(t, store.saved, "dry-run must not save the manifest")
 }
+
+// TestExecuteBatch_BeforeExportHookRunsBeforeExport pins the #182 seam: the
+// hook fires before the DuckDB export (the selection snapshot is already
+// fixed on the executor) and receives the batch's schema, row IDs, and
+// snapshot, so a test can mutate rows inside the selection->export window.
+func TestExecuteBatch_BeforeExportHookRunsBeforeExport(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
+	snapshot := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
+	require.NoError(t, err)
+
+	var calls []string
+	var hookSchemaID int16
+	var hookIDs []uuid.UUID
+	var hookSnapshot int64
+	executor := &flushBatchExecutor{
+		db:       db,
+		duck:     &DuckExporter{Logger: zap.NewNop()},
+		s3Client: &objectOnlyS3Client{},
+		cfg: CDCConfig{S3Bucket: "test-bucket", S3Prefix: "cdc",
+			BeforeExportHook: func(_ context.Context, schemaID int16, ids []uuid.UUID, snap int64) error {
+				calls = append(calls, "hook")
+				hookSchemaID, hookIDs, hookSnapshot = schemaID, ids, snap
+				return nil
+			}},
+		tableName:        "change_log",
+		schemaID:         7,
+		snapshot:         snapshot,
+		pgConnForDuck:    "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
+		logger:           zap.NewNop(),
+		manifestStore:    newInMemoryManifestStore(),
+		manifestResolver: manifest.PathResolver{Prefix: "cdc", PathTemplate: "manifest/{{.SchemaID}}.json"},
+		exportSnapshot: func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error {
+			calls = append(calls, "export")
+			return nil
+		},
+	}
+
+	err = executor.executeBatch(ctx, []uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
+	require.NoError(t, err)
+	require.Equal(t, []string{"hook", "export"}, calls)
+	require.Equal(t, int16(7), hookSchemaID)
+	require.Equal(t, []uuid.UUID{rowID}, hookIDs)
+	require.Equal(t, snapshot, hookSnapshot)
+}
+
+// TestExecuteBatch_BeforeExportHookErrorAbortsBeforeSideEffects pins the
+// hook's failure contract: an error aborts the batch before any side effect
+// (no export, no flushed_at change, no manifest save).
+func TestExecuteBatch_BeforeExportHookErrorAbortsBeforeSideEffects(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
+	snapshot := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
+	require.NoError(t, err)
+
+	store := newInMemoryManifestStore()
+	hookErr := errors.New("hook failed")
+	exportCalled := false
+	executor := &flushBatchExecutor{
+		db:       db,
+		duck:     &DuckExporter{Logger: zap.NewNop()},
+		s3Client: &objectOnlyS3Client{},
+		cfg: CDCConfig{S3Bucket: "test-bucket", S3Prefix: "cdc",
+			BeforeExportHook: func(context.Context, int16, []uuid.UUID, int64) error {
+				return hookErr
+			}},
+		tableName:     "change_log",
+		schemaID:      7,
+		snapshot:      snapshot,
+		pgConnForDuck: "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
+		logger:        zap.NewNop(),
+		manifestStore: store,
+		exportSnapshot: func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error {
+			exportCalled = true
+			return nil
+		},
+	}
+
+	err = executor.executeBatch(ctx, []uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
+	require.Error(t, err)
+	require.ErrorIs(t, err, hookErr)
+	require.Contains(t, err.Error(), "before-export hook")
+	require.False(t, exportCalled, "hook failure must abort before the export")
+
+	var flushedAt int64
+	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
+	require.NoError(t, err)
+	require.Zero(t, flushedAt, "hook failure must not mark rows flushed")
+	require.Zero(t, store.saved, "hook failure must not save the manifest")
+}

--- a/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
@@ -124,6 +124,24 @@ func assertPausedFlushSplit(ctx context.Context, t *testing.T, env *Env, wide Sc
 	return finals
 }
 
+// assertFederatedRowCount is assertRowCount plus a routing check: the flushed
+// sibling rows are only served by the parquet side (the hot scan reads
+// flushed_at = 0 rows), so the count is meaningful evidence that the cold
+// delta was consulted only if the query actually routed to DuckDB.
+func assertFederatedRowCount(ctx context.Context, t *testing.T, env *Env, name string, q Query, want int) {
+	t.Helper()
+	res := env.AssertQueryMatches(ctx, q)
+	if res == nil {
+		return
+	}
+	if len(res.Records) != want {
+		t.Fatalf("%s returned %d rows, want %d", name, len(res.Records), want)
+	}
+	if !res.Plan.Routing.UseDuckDB {
+		t.Errorf("%s did not route to duckdb: %+v", name, res.Plan.Routing)
+	}
+}
+
 // testUpdateAfterSnapshot is issue #182 scenarios 1 and 4: a row updated
 // between snapshot capture and mark-flushed keeps flushed_at = 0, the
 // federated read serves the hot (new) value, and the exported stale value is
@@ -170,7 +188,7 @@ func testUpdateAfterSnapshot(ctx context.Context, t *testing.T) {
 	// Visibility: the dirty hot version shadows the exported copy. The oracle
 	// expects the victim to carry v2; the stale v1 must be unreachable even by
 	// direct filter (anti-join evicts it before the filter runs).
-	assertRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 4)
+	assertFederatedRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 4)
 	assertRowCount(ctx, t, env, "hot value reachable",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "hot-00"}}, Limit: 10}, 1)
 	assertZeroRows(ctx, t, env, "exported stale value unreachable",
@@ -186,7 +204,7 @@ func testUpdateAfterSnapshot(ctx context.Context, t *testing.T) {
 	assertSameRowIDs(t, "retry parquet vs victim",
 		fetchParquetRowIDs(ctx, t, env, retryFinals), map[string]bool{victim.RowID.String(): true})
 	assertManifestDeltaPaths(t, retry.Manifests, wide, append(finals, retryFinals...))
-	assertRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 4)
+	assertFederatedRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 4)
 	assertRowCount(ctx, t, env, "converged hot value",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "hot-00"}}, Limit: 10}, 1)
 	assertZeroRows(ctx, t, env, "converged stale value",
@@ -206,6 +224,10 @@ func testDeleteAfterSnapshot(ctx context.Context, t *testing.T) {
 	mustApplyEvents(ctx, t, env, "seed creates", creates...)
 	victim := creates[0]
 	assertRowCount(ctx, t, env, "pre-flush rows", Query{Schema: wide, Limit: 10, PreferHot: true}, 4)
+	// Same-filter positive control for the zero-row probes below: the victim
+	// is reachable by this value until the concurrent delete lands.
+	assertRowCount(ctx, t, env, "pre-flush victim by v1",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10, PreferHot: true}, 1)
 
 	report, err := runPausedFlush(ctx, t, env, func() {
 		del := DeleteEvent(wide, victim.RowID)
@@ -220,7 +242,7 @@ func testDeleteAfterSnapshot(ctx context.Context, t *testing.T) {
 
 	// Deletion visible now: 3 rows; the exported live copy must not resurrect
 	// the victim (dirty tombstone anti-joins it out before the filter).
-	assertRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 3)
+	assertFederatedRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 3)
 	assertRowCount(ctx, t, env, "survivor reachable",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-01"}}, Limit: 10}, 1)
 	assertZeroRows(ctx, t, env, "deleted row unreachable by exported value",
@@ -229,7 +251,7 @@ func testDeleteAfterSnapshot(ctx context.Context, t *testing.T) {
 	// Retry flushes the tombstone; LWW + deleted_ts must keep both cold copies
 	// of the victim invisible.
 	runCleanRetry(ctx, t, env)
-	assertRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 3)
+	assertFederatedRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 3)
 	assertZeroRows(ctx, t, env, "deleted row stays unreachable",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
 }
@@ -276,12 +298,12 @@ func testInsertAfterSnapshot(ctx context.Context, t *testing.T) {
 	assertManifestDeltaPaths(t, report.Manifests, wide, finals)
 
 	// The new row is visible through the hot tier right away.
-	assertRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 5)
+	assertFederatedRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 5)
 	assertRowCount(ctx, t, env, "inserted row reachable",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "new-99"}}, Limit: 10}, 1)
 
 	runCleanRetry(ctx, t, env)
-	assertRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 5)
+	assertFederatedRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 5)
 	assertRowCount(ctx, t, env, "converged inserted row",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "new-99"}}, Limit: 10}, 1)
 }

--- a/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
@@ -1,0 +1,287 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestConcurrentFlushSnapshot pins issue #182: rows mutated concurrently with
+// a CDC flush must stay dirty and queries must always see the latest version.
+//
+// Mechanism: PausingS3 holds the flush open at CopyObject — after dirty-ID
+// selection, snapshot capture, and the DuckDB export, before
+// MarkFlushedIDsAtSnapshot — so each scenario mutates inside the real race
+// window. The changed_at <= snapshot guard (internal/cdc/helpers.go) must
+// then skip the mutated row while its untouched siblings flush; the unit
+// twin of that guard is TestMarkFlushedIDsAtSnapshot_SkipsUpdatedRows.
+// Because the pause sits after the export, the delta parquet still carries
+// the pre-mutation value — the visibility probes assert the dirty hot
+// version shadows it (anti-join), and after the retry flush drains the row,
+// LWW on ver_ts keeps suppressing it. The earlier select->export window
+// needs no e2e: the export CTE applies the same changed_at <= snapshot
+// filter (internal/cdc/duckdb_exporter.go), so a row mutated there never
+// enters the parquet at all.
+func TestConcurrentFlushSnapshot(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	t.Run("UpdateAfterSnapshot", func(t *testing.T) {
+		t.Parallel()
+		testUpdateAfterSnapshot(ctx, t)
+	})
+	t.Run("DeleteAfterSnapshot", func(t *testing.T) {
+		t.Parallel()
+		testDeleteAfterSnapshot(ctx, t)
+	})
+	t.Run("InsertAfterSnapshot", func(t *testing.T) {
+		t.Parallel()
+		testInsertAfterSnapshot(ctx, t)
+	})
+}
+
+const pausedFlushTimeout = 60 * time.Second
+
+type flushOutcome struct {
+	report *FlushReport
+	err    error
+}
+
+// runPausedFlush starts one real flush that pauses at its first CopyObject,
+// invokes mutate on the test goroutine while the flush is suspended, then
+// resumes the flush and returns its outcome. The seeds stay small and no
+// chunking config is set, so the single batch issues exactly one CopyObject
+// and the pause fires deterministically once.
+func runPausedFlush(ctx context.Context, t *testing.T, env *Env, mutate func()) (*FlushReport, error) {
+	t.Helper()
+	pauser := NewPausingS3(env.Cluster.S3, S3OpCopy)
+	ctx, cancel := context.WithTimeout(ctx, pausedFlushTimeout)
+
+	// The flush goroutine must not touch t; it reports through done (buffered
+	// so it never leaks even when the test dies before reading it).
+	done := make(chan flushOutcome, 1)
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		report, err := env.RunFlushWith(ctx, FlushOverrides{S3: pauser})
+		done <- flushOutcome{report: report, err: err}
+	}()
+	// Registered after NewEnv's cleanups, so this runs first: any early
+	// t.Fatal (including inside mutate) releases the paused flush and waits
+	// for it to exit while the Env's resources are still alive.
+	t.Cleanup(func() {
+		pauser.Resume()
+		cancel()
+		<-finished
+	})
+
+	select {
+	case <-pauser.Reached():
+	case out := <-done:
+		t.Fatalf("flush finished before reaching the CopyObject pause: err=%v", out.err)
+	}
+	mutate()
+	pauser.Resume()
+	out := <-done
+	return out.report, out.err
+}
+
+// runCleanRetry re-runs the flush without any pause and asserts it drains
+// every dirty row — the issue's retry-convergence criterion.
+func runCleanRetry(ctx context.Context, t *testing.T, env *Env) *FlushReport {
+	t.Helper()
+	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("clean retry flush: %v", err)
+	}
+	if retry.UnflushedAfter != 0 {
+		t.Errorf("retry must drain all dirty rows, unflushed = %d", retry.UnflushedAfter)
+	}
+	return retry
+}
+
+// assertPausedFlushSplit pins the snapshot guard at row level: after the
+// paused flush, exactly the mutated row (which WAS in the selected batch)
+// stays dirty while its siblings carry a flushed_at marker, and the report's
+// counters agree. This is the observable face of "marked fewer rows than
+// requested" — the run still succeeds.
+func assertPausedFlushSplit(ctx context.Context, t *testing.T, env *Env, wide SchemaRef, report *FlushReport, wantFlushed int, wantDirtyID string) (finals []string) {
+	t.Helper()
+	flushed, dirty := fetchChangeLogRowIDs(ctx, t, env, wide)
+	if len(flushed) != wantFlushed || len(dirty) != 1 || !dirty[wantDirtyID] {
+		t.Fatalf("guard must keep exactly the concurrent row dirty: flushed=%v dirty=%v want dirty={%s}",
+			flushed, dirty, wantDirtyID)
+	}
+	if report.UnflushedBefore != 4 || report.UnflushedAfter != 1 {
+		t.Errorf("unflushed before/after = %d/%d, want 4/1", report.UnflushedBefore, report.UnflushedAfter)
+	}
+	finals, _ = splitKeys(report.NewObjects)
+	if len(finals) != 1 {
+		t.Fatalf("paused flush must promote exactly one final delta, got %v", finals)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, wide, finals)
+	return finals
+}
+
+// testUpdateAfterSnapshot is issue #182 scenarios 1 and 4: a row updated
+// between snapshot capture and mark-flushed keeps flushed_at = 0, the
+// federated read serves the hot (new) value, and the exported stale value is
+// unreachable — first via the dirty anti-join, after retry via LWW. The delta
+// parquet written by the paused flush contains the victim's stale value and
+// the manifest tracks that file; both are expected (reads never consult the
+// manifest, and the dirty row_id evicts the stale copy) — do not "fix" this.
+func testUpdateAfterSnapshot(ctx context.Context, t *testing.T) {
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	creates := buildOpenCreates(wide, 4)
+	mustApplyEvents(ctx, t, env, "seed creates", creates...)
+	victim := creates[0]
+	// Positive controls before anything flushes (PreferHot: no parquet yet).
+	assertRowCount(ctx, t, env, "pre-flush rows", Query{Schema: wide, Limit: 10, PreferHot: true}, 4)
+	assertRowCount(ctx, t, env, "pre-flush victim by v1",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10, PreferHot: true}, 1)
+
+	report, err := runPausedFlush(ctx, t, env, func() {
+		update := UpdateEvent(wide, victim.RowID, map[string]any{
+			"title": "hot-00",
+			"count": float64(900000),
+		})
+		mustApplyEvents(ctx, t, env, "update during pause", update)
+		// Guards the degenerate equal-ver_ts tie (#210): the mutation must sit
+		// strictly after the exported version at ms resolution.
+		assertStrictlyNewer(t, []*Event{victim}, []*Event{update})
+	})
+	if err != nil {
+		t.Fatalf("paused flush: %v", err)
+	}
+
+	finals := assertPausedFlushSplit(ctx, t, env, wide, report, 3, victim.RowID.String())
+	// The exported parquet physically contains all 4 selected rows — the
+	// victim with its stale v1 value.
+	wantExported := map[string]bool{}
+	for _, c := range creates {
+		wantExported[c.RowID.String()] = true
+	}
+	assertSameRowIDs(t, "paused-flush parquet vs selected batch",
+		fetchParquetRowIDs(ctx, t, env, finals), wantExported)
+
+	// Visibility: the dirty hot version shadows the exported copy. The oracle
+	// expects the victim to carry v2; the stale v1 must be unreachable even by
+	// direct filter (anti-join evicts it before the filter runs).
+	assertRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 4)
+	assertRowCount(ctx, t, env, "hot value reachable",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "hot-00"}}, Limit: 10}, 1)
+	assertZeroRows(ctx, t, env, "exported stale value unreachable",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+
+	// Retry convergence: the victim drains into a second delta; the two cold
+	// copies now resolve by LWW on ver_ts — still exactly one visible version.
+	retry := runCleanRetry(ctx, t, env)
+	retryFinals, _ := splitKeys(retry.NewObjects)
+	if len(retryFinals) != 1 {
+		t.Fatalf("retry must promote exactly one more final delta, got %v", retryFinals)
+	}
+	assertSameRowIDs(t, "retry parquet vs victim",
+		fetchParquetRowIDs(ctx, t, env, retryFinals), map[string]bool{victim.RowID.String(): true})
+	assertManifestDeltaPaths(t, retry.Manifests, wide, append(finals, retryFinals...))
+	assertRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 4)
+	assertRowCount(ctx, t, env, "converged hot value",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "hot-00"}}, Limit: 10}, 1)
+	assertZeroRows(ctx, t, env, "converged stale value",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+}
+
+// testDeleteAfterSnapshot is issue #182 scenarios 2 and 4: a row soft-deleted
+// between snapshot capture and mark-flushed keeps its tombstone dirty, the
+// deletion is immediately visible (the hot tombstone shadows the live value
+// the paused flush exported), and after retry the flushed tombstone keeps
+// suppressing both cold copies via LWW + deleted_ts.
+func testDeleteAfterSnapshot(ctx context.Context, t *testing.T) {
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	creates := buildOpenCreates(wide, 4)
+	mustApplyEvents(ctx, t, env, "seed creates", creates...)
+	victim := creates[0]
+	assertRowCount(ctx, t, env, "pre-flush rows", Query{Schema: wide, Limit: 10, PreferHot: true}, 4)
+
+	report, err := runPausedFlush(ctx, t, env, func() {
+		del := DeleteEvent(wide, victim.RowID)
+		mustApplyEvents(ctx, t, env, "delete during pause", del)
+		assertStrictlyNewer(t, []*Event{victim}, []*Event{del})
+	})
+	if err != nil {
+		t.Fatalf("paused flush: %v", err)
+	}
+
+	assertPausedFlushSplit(ctx, t, env, wide, report, 3, victim.RowID.String())
+
+	// Deletion visible now: 3 rows; the exported live copy must not resurrect
+	// the victim (dirty tombstone anti-joins it out before the filter).
+	assertRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 3)
+	assertRowCount(ctx, t, env, "survivor reachable",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-01"}}, Limit: 10}, 1)
+	assertZeroRows(ctx, t, env, "deleted row unreachable by exported value",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+
+	// Retry flushes the tombstone; LWW + deleted_ts must keep both cold copies
+	// of the victim invisible.
+	runCleanRetry(ctx, t, env)
+	assertRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 3)
+	assertZeroRows(ctx, t, env, "deleted row stays unreachable",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+}
+
+// testInsertAfterSnapshot is issue #182 scenario 3: a row created while the
+// flush is paused stays dirty because it was never in the selected batch
+// (distinct mechanism from the changed_at guard — mark-flushed only touches
+// batch row IDs), never enters the paused flush's parquet, and is visible
+// through the hot tier immediately.
+func testInsertAfterSnapshot(ctx context.Context, t *testing.T) {
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	creates := buildOpenCreates(wide, 4)
+	mustApplyEvents(ctx, t, env, "seed creates", creates...)
+	assertRowCount(ctx, t, env, "pre-flush rows", Query{Schema: wide, Limit: 10, PreferHot: true}, 4)
+
+	inserted := CreateEvent(wide, map[string]any{
+		"title": "new-99",
+		"count": float64(990000),
+	})
+	report, err := runPausedFlush(ctx, t, env, func() {
+		mustApplyEvents(ctx, t, env, "insert during pause", inserted)
+	})
+	if err != nil {
+		t.Fatalf("paused flush: %v", err)
+	}
+
+	// All 4 selected rows flush; only the concurrent insert stays dirty, and
+	// the exported parquet contains exactly the flushed set (not the insert).
+	flushed, dirty := fetchChangeLogRowIDs(ctx, t, env, wide)
+	if len(flushed) != 4 || len(dirty) != 1 || !dirty[inserted.RowID.String()] {
+		t.Fatalf("only the concurrent insert may stay dirty: flushed=%v dirty=%v", flushed, dirty)
+	}
+	if report.UnflushedBefore != 4 || report.UnflushedAfter != 1 {
+		t.Errorf("unflushed before/after = %d/%d, want 4/1", report.UnflushedBefore, report.UnflushedAfter)
+	}
+	finals, _ := splitKeys(report.NewObjects)
+	if len(finals) != 1 {
+		t.Fatalf("paused flush must promote exactly one final delta, got %v", finals)
+	}
+	assertSameRowIDs(t, "parquet vs flushed set",
+		fetchParquetRowIDs(ctx, t, env, finals), flushed)
+	assertManifestDeltaPaths(t, report.Manifests, wide, finals)
+
+	// The new row is visible through the hot tier right away.
+	assertRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 5)
+	assertRowCount(ctx, t, env, "inserted row reachable",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "new-99"}}, Limit: 10}, 1)
+
+	runCleanRetry(ctx, t, env)
+	assertRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 5)
+	assertRowCount(ctx, t, env, "converged inserted row",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "new-99"}}, Limit: 10}, 1)
+}

--- a/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
@@ -4,29 +4,40 @@ package production
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // TestConcurrentFlushSnapshot pins issue #182: rows mutated concurrently with
 // a CDC flush must stay dirty and queries must always see the latest version.
 //
-// Mechanism: PausingS3 holds the flush open at CopyObject — after dirty-ID
-// selection, snapshot capture, and the DuckDB export, before
-// MarkFlushedIDsAtSnapshot — so each scenario mutates inside the real race
-// window. The changed_at <= snapshot guard (internal/cdc/helpers.go) must
-// then skip the mutated row while its untouched siblings flush; the unit
-// twin of that guard is TestMarkFlushedIDsAtSnapshot_SkipsUpdatedRows.
-// Because the pause sits after the export, the delta parquet still carries
-// the pre-mutation value — the visibility probes assert the dirty hot
-// version shadows it (anti-join), and after the retry flush drains the row,
-// LWW on ver_ts keeps suppressing it. The earlier select->export window
-// needs no e2e: the export CTE applies the same changed_at <= snapshot
-// filter (internal/cdc/duckdb_exporter.go), so a row mutated there never
-// enters the parquet at all.
+// The pipeline has two mutation windows, and both are exercised:
+//
+//   - selection->export ("before export", issue scenario 1's literal pause
+//     point): UpdateBeforeExport drives the mutation through
+//     cdc.CDCConfig.BeforeExportHook. The export CTE's changed_at <= snapshot
+//     filter (internal/cdc/duckdb_exporter.go) must keep the mutated row out
+//     of the parquet entirely, and the identical mark-flushed guard
+//     (internal/cdc/helpers.go) must keep it dirty.
+//   - export->mark-flushed (the harder window: the parquet already carries
+//     the stale value and only the mark-flushed guard saves the row):
+//     the *AfterSnapshot scenarios hold the flush open with PausingS3 at
+//     CopyObject. The visibility probes assert the dirty hot version shadows
+//     the exported stale copy (anti-join), and after the retry flush drains
+//     the row, LWW on ver_ts keeps suppressing it.
+//
+// The unit twin of the mark-flushed guard is
+// TestMarkFlushedIDsAtSnapshot_SkipsUpdatedRows.
 func TestConcurrentFlushSnapshot(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+	t.Run("UpdateBeforeExport", func(t *testing.T) {
+		t.Parallel()
+		testUpdateBeforeExport(ctx, t)
+	})
 	t.Run("UpdateAfterSnapshot", func(t *testing.T) {
 		t.Parallel()
 		testUpdateAfterSnapshot(ctx, t)
@@ -84,7 +95,10 @@ func runPausedFlush(ctx context.Context, t *testing.T, env *Env, mutate func()) 
 	mutate()
 	pauser.Resume()
 	out := <-done
-	return out.report, out.err
+	if out.err != nil {
+		return out.report, fmt.Errorf("flush under CopyObject pause: %w", out.err)
+	}
+	return out.report, nil
 }
 
 // runCleanRetry re-runs the flush without any pause and asserts it drains
@@ -142,6 +156,107 @@ func assertFederatedRowCount(ctx context.Context, t *testing.T, env *Env, name s
 	}
 }
 
+// assertUpdateRetryConverges runs the clean retry after a deferred concurrent
+// update and asserts the issue's convergence criterion: the victim drains as
+// exactly one v2 record (payload and ver_ts, not just ID membership) into one
+// new delta, the manifest tracks both deltas, and the oracle-checked probes
+// see exactly one visible version with v1 unreachable.
+func assertUpdateRetryConverges(ctx context.Context, t *testing.T, env *Env, wide SchemaRef, update *Event, priorFinals []string) {
+	t.Helper()
+	retry := runCleanRetry(ctx, t, env)
+	retryFinals, _ := splitKeys(retry.NewObjects)
+	if len(retryFinals) != 1 {
+		t.Fatalf("retry must promote exactly one more final delta, got %v", retryFinals)
+	}
+	assertLiveParquetRow(ctx, t, env, retryFinals[0], update)
+	assertManifestDeltaPaths(t, retry.Manifests, wide, append(append([]string(nil), priorFinals...), retryFinals...))
+	assertFederatedRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 4)
+	assertRowCount(ctx, t, env, "converged hot value",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "hot-00"}}, Limit: 10}, 1)
+	assertZeroRows(ctx, t, env, "converged stale value",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+}
+
+// testUpdateBeforeExport is issue #182 scenario 1 at its literal pause point,
+// plus scenario 4 asserted against the actual snapshot value: the mutation
+// lands after dirty-ID selection and before the DuckDB export, driven through
+// cdc.CDCConfig.BeforeExportHook riding the FlushOverrides{Config} injection.
+// Both halves of the dual guard must hold: the export CTE's
+// changed_at <= snapshot filter keeps the row out of the parquet entirely,
+// and the identical mark-flushed guard keeps it dirty.
+func testUpdateBeforeExport(ctx context.Context, t *testing.T) {
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	creates := buildOpenCreates(wide, 4)
+	mustApplyEvents(ctx, t, env, "seed creates", creates...)
+	victim := creates[0]
+	assertRowCount(ctx, t, env, "pre-flush rows", Query{Schema: wide, Limit: 10, PreferHot: true}, 4)
+	assertRowCount(ctx, t, env, "pre-flush victim by v1",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10, PreferHot: true}, 1)
+
+	// RunFlushWith is synchronous, so the hook runs inline on this goroutine,
+	// deterministically inside the selection->export window; it reports
+	// failures through the flush error rather than t.*.
+	var update *Event
+	var hookSnapshot int64
+	var hookBatch int
+	cfg := env.CDC
+	cfg.BeforeExportHook = func(hctx context.Context, _ int16, ids []uuid.UUID, snapshot int64) error {
+		hookSnapshot = snapshot
+		hookBatch = len(ids)
+		update = UpdateEvent(wide, victim.RowID, map[string]any{
+			"title": "hot-00",
+			"count": float64(900000),
+		})
+		return env.ApplyEvents(hctx, update)
+	}
+	report, err := env.RunFlushWith(ctx, FlushOverrides{Config: &cfg})
+	if err != nil {
+		t.Fatalf("flush with before-export mutation: %v", err)
+	}
+
+	// Positive control: the hook fired on the full selected batch, and the
+	// mutation's changed_at sits strictly past the very snapshot the guards
+	// compare against (issue scenario 4, asserted directly).
+	if hookBatch != 4 {
+		t.Fatalf("before-export hook saw %d batch ids, want 4", hookBatch)
+	}
+	if victim.ChangedAt > hookSnapshot {
+		t.Fatalf("victim v1 changed_at %d must be <= snapshot %d", victim.ChangedAt, hookSnapshot)
+	}
+	if update.ChangedAt <= hookSnapshot {
+		t.Fatalf("concurrent update changed_at %d must be > snapshot %d", update.ChangedAt, hookSnapshot)
+	}
+
+	// Both guard halves: the mutated row stays dirty and never entered the
+	// parquet — the delta holds exactly the three flushed siblings.
+	flushed, dirty := fetchChangeLogRowIDs(ctx, t, env, wide)
+	if len(flushed) != 3 || len(dirty) != 1 || !dirty[victim.RowID.String()] {
+		t.Fatalf("guard must keep exactly the mutated row dirty: flushed=%v dirty=%v", flushed, dirty)
+	}
+	if report.UnflushedBefore != 4 || report.UnflushedAfter != 1 {
+		t.Errorf("unflushed before/after = %d/%d, want 4/1", report.UnflushedBefore, report.UnflushedAfter)
+	}
+	finals, _ := splitKeys(report.NewObjects)
+	if len(finals) != 1 {
+		t.Fatalf("flush must promote exactly one final delta, got %v", finals)
+	}
+	assertSameRowIDs(t, "pre-export parquet vs flushed siblings",
+		fetchParquetRowIDs(ctx, t, env, finals), flushed)
+	assertManifestDeltaPaths(t, report.Manifests, wide, finals)
+
+	// Visibility: no cold copy of the victim exists; the dirty hot row serves
+	// v2 and v1 is gone everywhere.
+	assertFederatedRowCount(ctx, t, env, "post-flush rows", Query{Schema: wide, Limit: 10}, 4)
+	assertRowCount(ctx, t, env, "hot value reachable",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "hot-00"}}, Limit: 10}, 1)
+	assertZeroRows(ctx, t, env, "v1 value unreachable",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+
+	assertUpdateRetryConverges(ctx, t, env, wide, update, finals)
+}
+
 // testUpdateAfterSnapshot is issue #182 scenarios 1 and 4: a row updated
 // between snapshot capture and mark-flushed keeps flushed_at = 0, the
 // federated read serves the hot (new) value, and the exported stale value is
@@ -161,8 +276,9 @@ func testUpdateAfterSnapshot(ctx context.Context, t *testing.T) {
 	assertRowCount(ctx, t, env, "pre-flush victim by v1",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10, PreferHot: true}, 1)
 
+	var update *Event
 	report, err := runPausedFlush(ctx, t, env, func() {
-		update := UpdateEvent(wide, victim.RowID, map[string]any{
+		update = UpdateEvent(wide, victim.RowID, map[string]any{
 			"title": "hot-00",
 			"count": float64(900000),
 		})
@@ -172,18 +288,19 @@ func testUpdateAfterSnapshot(ctx context.Context, t *testing.T) {
 		assertStrictlyNewer(t, []*Event{victim}, []*Event{update})
 	})
 	if err != nil {
-		t.Fatalf("paused flush: %v", err)
+		t.Fatal(err)
 	}
 
 	finals := assertPausedFlushSplit(ctx, t, env, wide, report, 3, victim.RowID.String())
-	// The exported parquet physically contains all 4 selected rows — the
-	// victim with its stale v1 value.
+	// The exported parquet physically contains all 4 selected rows, and the
+	// victim's record is exactly one stale v1 version (payload and ver_ts).
 	wantExported := map[string]bool{}
 	for _, c := range creates {
 		wantExported[c.RowID.String()] = true
 	}
 	assertSameRowIDs(t, "paused-flush parquet vs selected batch",
 		fetchParquetRowIDs(ctx, t, env, finals), wantExported)
+	assertLiveParquetRow(ctx, t, env, finals[0], victim)
 
 	// Visibility: the dirty hot version shadows the exported copy. The oracle
 	// expects the victim to carry v2; the stale v1 must be unreachable even by
@@ -196,19 +313,7 @@ func testUpdateAfterSnapshot(ctx context.Context, t *testing.T) {
 
 	// Retry convergence: the victim drains into a second delta; the two cold
 	// copies now resolve by LWW on ver_ts — still exactly one visible version.
-	retry := runCleanRetry(ctx, t, env)
-	retryFinals, _ := splitKeys(retry.NewObjects)
-	if len(retryFinals) != 1 {
-		t.Fatalf("retry must promote exactly one more final delta, got %v", retryFinals)
-	}
-	assertSameRowIDs(t, "retry parquet vs victim",
-		fetchParquetRowIDs(ctx, t, env, retryFinals), map[string]bool{victim.RowID.String(): true})
-	assertManifestDeltaPaths(t, retry.Manifests, wide, append(finals, retryFinals...))
-	assertFederatedRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 4)
-	assertRowCount(ctx, t, env, "converged hot value",
-		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "hot-00"}}, Limit: 10}, 1)
-	assertZeroRows(ctx, t, env, "converged stale value",
-		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
+	assertUpdateRetryConverges(ctx, t, env, wide, update, finals)
 }
 
 // testDeleteAfterSnapshot is issue #182 scenarios 2 and 4: a row soft-deleted
@@ -229,16 +334,20 @@ func testDeleteAfterSnapshot(ctx context.Context, t *testing.T) {
 	assertRowCount(ctx, t, env, "pre-flush victim by v1",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10, PreferHot: true}, 1)
 
+	var del *Event
 	report, err := runPausedFlush(ctx, t, env, func() {
-		del := DeleteEvent(wide, victim.RowID)
+		del = DeleteEvent(wide, victim.RowID)
 		mustApplyEvents(ctx, t, env, "delete during pause", del)
 		assertStrictlyNewer(t, []*Event{victim}, []*Event{del})
 	})
 	if err != nil {
-		t.Fatalf("paused flush: %v", err)
+		t.Fatal(err)
 	}
 
-	assertPausedFlushSplit(ctx, t, env, wide, report, 3, victim.RowID.String())
+	finals := assertPausedFlushSplit(ctx, t, env, wide, report, 3, victim.RowID.String())
+	// The paused flush exported the victim as exactly one LIVE v1 record —
+	// the delete landed after the export, so no tombstone is cold yet.
+	assertLiveParquetRow(ctx, t, env, finals[0], victim)
 
 	// Deletion visible now: 3 rows; the exported live copy must not resurrect
 	// the victim (dirty tombstone anti-joins it out before the filter).
@@ -248,9 +357,15 @@ func testDeleteAfterSnapshot(ctx context.Context, t *testing.T) {
 	assertZeroRows(ctx, t, env, "deleted row unreachable by exported value",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
 
-	// Retry flushes the tombstone; LWW + deleted_ts must keep both cold copies
-	// of the victim invisible.
-	runCleanRetry(ctx, t, env)
+	// Retry flushes the tombstone as exactly one all-NULL record carrying the
+	// delete's timestamps; LWW + deleted_ts must keep both cold copies of the
+	// victim invisible.
+	retry := runCleanRetry(ctx, t, env)
+	retryFinals, _ := splitKeys(retry.NewObjects)
+	if len(retryFinals) != 1 {
+		t.Fatalf("retry must promote exactly one more final delta, got %v", retryFinals)
+	}
+	assertTombstoneParquet(ctx, t, env, retryFinals[0], del)
 	assertFederatedRowCount(ctx, t, env, "converged rows", Query{Schema: wide, Limit: 10}, 3)
 	assertZeroRows(ctx, t, env, "deleted row stays unreachable",
 		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "open-00"}}, Limit: 10})
@@ -277,7 +392,7 @@ func testInsertAfterSnapshot(ctx context.Context, t *testing.T) {
 		mustApplyEvents(ctx, t, env, "insert during pause", inserted)
 	})
 	if err != nil {
-		t.Fatalf("paused flush: %v", err)
+		t.Fatal(err)
 	}
 
 	// All 4 selected rows flush; only the concurrent insert stays dirty, and

--- a/internal/e2e_harness/production/doc.go
+++ b/internal/e2e_harness/production/doc.go
@@ -31,6 +31,7 @@
 //	#179 flush failure matrix      -> FaultInjectingS3, RunFlushWith, ExecSQL
 //	#180 dry-run semantics         -> RunFlushDry, RunInitWith(InitOverrides{DryRun})
 //	#181 failure-state injection   -> Env.ExecSQL escape hatch
+//	#182 mid-flush concurrency     -> PausingS3, RunFlushWith(FlushOverrides{S3})
 //	#185 circuit breaker           -> WithBreaker
 //	#189 multi-schema isolation    -> schemas/e2e_simple + e2e_second, per-test DB
 //

--- a/internal/e2e_harness/production/pausing.go
+++ b/internal/e2e_harness/production/pausing.go
@@ -70,14 +70,14 @@ func (p *PausingS3) intercept(ctx context.Context, op S3Op, key string) error {
 	case <-p.resume:
 		return nil
 	case <-ctx.Done():
-		return fmt.Errorf("paused s3 %s %q: %w", op, key, ctx.Err())
+		return ctx.Err()
 	}
 }
 
 func (p *PausingS3) CopyObject(ctx context.Context, in *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
 	key := aws.ToString(in.Key)
 	if err := p.intercept(ctx, S3OpCopy, key); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pause CopyObject %q: %w", key, err)
 	}
 	out, err := p.Inner.CopyObject(ctx, in, optFns...)
 	if err != nil {
@@ -89,7 +89,7 @@ func (p *PausingS3) CopyObject(ctx context.Context, in *s3.CopyObjectInput, optF
 func (p *PausingS3) DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
 	key := aws.ToString(in.Key)
 	if err := p.intercept(ctx, S3OpDelete, key); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pause DeleteObject %q: %w", key, err)
 	}
 	out, err := p.Inner.DeleteObject(ctx, in, optFns...)
 	if err != nil {
@@ -101,7 +101,7 @@ func (p *PausingS3) DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, 
 func (p *PausingS3) GetObject(ctx context.Context, in *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
 	key := aws.ToString(in.Key)
 	if err := p.intercept(ctx, S3OpGet, key); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pause GetObject %q: %w", key, err)
 	}
 	out, err := p.Inner.GetObject(ctx, in, optFns...)
 	if err != nil {
@@ -113,7 +113,7 @@ func (p *PausingS3) GetObject(ctx context.Context, in *s3.GetObjectInput, optFns
 func (p *PausingS3) PutObject(ctx context.Context, in *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	key := aws.ToString(in.Key)
 	if err := p.intercept(ctx, S3OpPut, key); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pause PutObject %q: %w", key, err)
 	}
 	out, err := p.Inner.PutObject(ctx, in, optFns...)
 	if err != nil {

--- a/internal/e2e_harness/production/pausing.go
+++ b/internal/e2e_harness/production/pausing.go
@@ -1,0 +1,110 @@
+package production
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/lychee-technology/forma/internal/cdc"
+)
+
+// PausingS3 wraps the cluster's real S3 client and blocks the first call
+// matching Op/KeyContains until Resume is called, holding a real CDC flush
+// open mid-pipeline so a test can mutate rows inside the race window (#182).
+// Pausing on S3OpCopy suspends the flush after dirty-ID selection, snapshot
+// capture, and the DuckDB export, but before MarkFlushedIDsAtSnapshot — the
+// window the changed_at <= snapshot guard protects.
+//
+// Only the first matching call pauses; later matches pass straight through.
+// The paused call also unblocks when its context is cancelled, so a timed-out
+// flush returns instead of leaking a goroutine.
+type PausingS3 struct {
+	Inner       cdc.S3FullClient
+	Op          S3Op
+	KeyContains string
+
+	reached    chan struct{}
+	resume     chan struct{}
+	pauseOnce  sync.Once
+	resumeOnce sync.Once
+}
+
+// NewPausingS3 returns a decorator that pauses the first call matching op on
+// any key.
+func NewPausingS3(inner cdc.S3FullClient, op S3Op) *PausingS3 {
+	return &PausingS3{
+		Inner:   inner,
+		Op:      op,
+		reached: make(chan struct{}),
+		resume:  make(chan struct{}),
+	}
+}
+
+// Reached is closed when the paused call has been intercepted; the test waits
+// on it before mutating.
+func (p *PausingS3) Reached() <-chan struct{} {
+	return p.reached
+}
+
+// Resume releases the paused call. It is idempotent so tests can register it
+// with t.Cleanup as a safety net against hangs on early failures.
+func (p *PausingS3) Resume() {
+	p.resumeOnce.Do(func() { close(p.resume) })
+}
+
+func (p *PausingS3) intercept(ctx context.Context, op S3Op, key string) error {
+	if op != p.Op {
+		return nil
+	}
+	if p.KeyContains != "" && !strings.Contains(key, p.KeyContains) {
+		return nil
+	}
+	first := false
+	p.pauseOnce.Do(func() {
+		first = true
+		close(p.reached)
+	})
+	if !first {
+		return nil
+	}
+	select {
+	case <-p.resume:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("paused s3 %s %q: %w", op, key, ctx.Err())
+	}
+}
+
+func (p *PausingS3) CopyObject(ctx context.Context, in *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
+	if err := p.intercept(ctx, S3OpCopy, aws.ToString(in.Key)); err != nil {
+		return nil, err
+	}
+	return p.Inner.CopyObject(ctx, in, optFns...)
+}
+
+func (p *PausingS3) DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	if err := p.intercept(ctx, S3OpDelete, aws.ToString(in.Key)); err != nil {
+		return nil, err
+	}
+	return p.Inner.DeleteObject(ctx, in, optFns...)
+}
+
+func (p *PausingS3) GetObject(ctx context.Context, in *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if err := p.intercept(ctx, S3OpGet, aws.ToString(in.Key)); err != nil {
+		return nil, err
+	}
+	return p.Inner.GetObject(ctx, in, optFns...)
+}
+
+func (p *PausingS3) PutObject(ctx context.Context, in *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if err := p.intercept(ctx, S3OpPut, aws.ToString(in.Key)); err != nil {
+		return nil, err
+	}
+	return p.Inner.PutObject(ctx, in, optFns...)
+}
+
+var _ cdc.S3FullClient = (*PausingS3)(nil)

--- a/internal/e2e_harness/production/pausing.go
+++ b/internal/e2e_harness/production/pausing.go
@@ -3,7 +3,6 @@ package production
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,7 +12,7 @@ import (
 )
 
 // PausingS3 wraps the cluster's real S3 client and blocks the first call
-// matching Op/KeyContains until Resume is called, holding a real CDC flush
+// matching Op until Resume is called, holding a real CDC flush
 // open mid-pipeline so a test can mutate rows inside the race window (#182).
 // Pausing on S3OpCopy suspends the flush after dirty-ID selection, snapshot
 // capture, and the DuckDB export, but before MarkFlushedIDsAtSnapshot — the
@@ -23,9 +22,8 @@ import (
 // The paused call also unblocks when its context is cancelled, so a timed-out
 // flush returns instead of leaking a goroutine.
 type PausingS3 struct {
-	Inner       cdc.S3FullClient
-	Op          S3Op
-	KeyContains string
+	Inner cdc.S3FullClient
+	Op    S3Op
 
 	reached    chan struct{}
 	resume     chan struct{}
@@ -60,9 +58,6 @@ func (p *PausingS3) intercept(ctx context.Context, op S3Op, key string) error {
 	if op != p.Op {
 		return nil
 	}
-	if p.KeyContains != "" && !strings.Contains(key, p.KeyContains) {
-		return nil
-	}
 	first := false
 	p.pauseOnce.Do(func() {
 		first = true
@@ -80,31 +75,51 @@ func (p *PausingS3) intercept(ctx context.Context, op S3Op, key string) error {
 }
 
 func (p *PausingS3) CopyObject(ctx context.Context, in *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error) {
-	if err := p.intercept(ctx, S3OpCopy, aws.ToString(in.Key)); err != nil {
+	key := aws.ToString(in.Key)
+	if err := p.intercept(ctx, S3OpCopy, key); err != nil {
 		return nil, err
 	}
-	return p.Inner.CopyObject(ctx, in, optFns...)
+	out, err := p.Inner.CopyObject(ctx, in, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("s3 CopyObject %q: %w", key, err)
+	}
+	return out, nil
 }
 
 func (p *PausingS3) DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
-	if err := p.intercept(ctx, S3OpDelete, aws.ToString(in.Key)); err != nil {
+	key := aws.ToString(in.Key)
+	if err := p.intercept(ctx, S3OpDelete, key); err != nil {
 		return nil, err
 	}
-	return p.Inner.DeleteObject(ctx, in, optFns...)
+	out, err := p.Inner.DeleteObject(ctx, in, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("s3 DeleteObject %q: %w", key, err)
+	}
+	return out, nil
 }
 
 func (p *PausingS3) GetObject(ctx context.Context, in *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-	if err := p.intercept(ctx, S3OpGet, aws.ToString(in.Key)); err != nil {
+	key := aws.ToString(in.Key)
+	if err := p.intercept(ctx, S3OpGet, key); err != nil {
 		return nil, err
 	}
-	return p.Inner.GetObject(ctx, in, optFns...)
+	out, err := p.Inner.GetObject(ctx, in, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("s3 GetObject %q: %w", key, err)
+	}
+	return out, nil
 }
 
 func (p *PausingS3) PutObject(ctx context.Context, in *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
-	if err := p.intercept(ctx, S3OpPut, aws.ToString(in.Key)); err != nil {
+	key := aws.ToString(in.Key)
+	if err := p.intercept(ctx, S3OpPut, key); err != nil {
 		return nil, err
 	}
-	return p.Inner.PutObject(ctx, in, optFns...)
+	out, err := p.Inner.PutObject(ctx, in, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("s3 PutObject %q: %w", key, err)
+	}
+	return out, nil
 }
 
 var _ cdc.S3FullClient = (*PausingS3)(nil)


### PR DESCRIPTION
Closes #182 (epic #172, Phase 3).

Pins the CDC snapshot-guard contract end to end: a real flush is held open inside each race window while the test mutates rows through the real EntityManager, then the guard's row-level effects, tier visibility, and retry convergence are asserted against the event-fold oracle. The only production-code change is the `BeforeExportHook` test seam added in review round 2 (nil in production).

## Mechanism

New `PausingS3` decorator (mirrors `FaultInjectingS3`/`RecordingS3`, injected via `Env.RunFlushWith(FlushOverrides{S3})` from #179): the first matching `CopyObject` closes a `reached` channel and blocks until `Resume()`. `CopyObject` fires after dirty-ID selection, snapshot capture, and the DuckDB export, but before `MarkFlushedIDsAtSnapshot` — exactly the window the `changed_at <= snapshot` guard (`internal/cdc/helpers.go`) protects. The paused call also unblocks on context cancellation, and the orchestration helper releases it via `t.Cleanup`, so no failure mode hangs the suite.

## Scenario map (issue → test)

| Issue scenario | Test | Pinned contract |
|---|---|---|
| 1. Update after snapshot, before export | `TestConcurrentFlushSnapshot/UpdateBeforeExport` *(review round 2)* | Mutation inside the selection→export window via `cdc.CDCConfig.BeforeExportHook`: the row is neither exported (delta holds exactly the 3 flushed siblings) nor marked flushed; `victim.changed_at <= snapshot < update.changed_at` asserted against the actual snapshot the hook exposes |
| 1. Update after export (harder window) | `TestConcurrentFlushSnapshot/UpdateAfterSnapshot` | Updated row keeps `flushed_at = 0` while its 3 siblings flush (row-level split via `fetchChangeLogRowIDs`); federated read serves the hot value; the exported stale value is unreachable even by direct filter (anti-join) |
| 2. Delete after snapshot | `.../DeleteAfterSnapshot` | Concurrent tombstone stays dirty; deletion immediately visible; the live copy in the just-written delta never resurrects the row |
| 3. Insert after snapshot | `.../InsertAfterSnapshot` | New row stays dirty (never in the selected batch — distinct mechanism from the guard, doc-commented), absent from the parquet, visible via hot tier |
| 4. Snapshot guard vs real concurrent write | row-level split assertions in scenarios 1–2 | Exactly the mutated row (which WAS in `batchIDs`) stays dirty = "only rows with `changed_at <= snapshot` are marked flushed"; `assertStrictlyNewer` guards the degenerate equal-ver_ts tie (#210); unit twin: `TestMarkFlushedIDsAtSnapshot_SkipsUpdatedRows` |

Retry convergence (issue success criterion 3): scenarios 1–2 re-run a clean flush — all dirty rows drain (`UnflushedAfter == 0`), the victim lands in a second delta, and the oracle-checked probes confirm exactly one visible version (now via LWW on ver_ts instead of the anti-join). `assertNoRowExportedTwice` is deliberately **not** used across the two flushes: the victim legitimately appears in both deltas at different ver_ts (that helper is documented create-only).

## Spec adjudications

1. **Both mutation windows are now exercised (review round 2 superseded the original adjudication).** The `*AfterSnapshot` scenarios pause at `CopyObject` — the *harder* window, where the parquet already holds the stale value and only the mark-flushed guard saves the row (the physical shape the issue's assertion describes: "sees the NEW value, not the **exported old value**"). The literal "before export" window has no external seam (the DuckDB export bypasses the injected S3 client; Postgres lock barriers are nondeterministic because `postgres_scan` reads each table with its own statement snapshot), so review round 2 added a minimal production seam: `cdc.CDCConfig.BeforeExportHook`, nil in production, unit-pinned both ways (ordering; a hook error aborts before any side effect). `UpdateBeforeExport` drives it through the existing `FlushOverrides{Config}` injection.
2. **The paused flush's manifest tracks a delta whose parquet physically contains the victim's stale value (row-id bounds exclude it).** Expected, doc-commented in the test: reads never consult the manifest, the dirty row_id anti-joins the stale copy out, and after retry LWW suppresses it.
3. **The federated-harness flush reimplementation (`internal/e2e_harness/federated/cdc.go`) is not used** — its hand-rolled mark-flushed has no snapshot guard; only the production harness drives the real `cdc.Runner.RunOnce`.

All scenarios passed on first run — the dual guard (export CTE + mark-flushed) behaves as designed, so this lands as characterization with no production bug fix.

## Verification

- `go test -v ./internal/e2e_harness/production/ -tags=e2e -run TestConcurrentFlushSnapshot -timeout=10m` — 3/3 PASS (~6s each, shared cluster)
- same with `-race` — clean
- `make lint` (golangci-lint v1.64.8) — clean
- `make test` — all packages ok
- full production e2e suite (`-tags=e2e`, Docker) — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 1 (49a6187)

Two-axis review (standards + spec) surfaced three items, all applied:

- `PausingS3` delegate methods now wrap `Inner` errors with op+key context (coding-standard §3, matching `FaultInjectingS3`); the unused `KeyContains` field is removed.
- `DeleteAfterSnapshot` gained the same-filter positive control its zero-row probes lean on (mirrors `UpdateAfterSnapshot`).
- The post-flush/converged count probes now also assert `Plan.Routing.UseDuckDB` (`assertFederatedRowCount`): the flushed siblings are only served by the parquet side (the hot scan reads `flushed_at = 0` rows), so the counts now prove the cold delta was genuinely consulted rather than the whole page coming from Postgres.

## Review round 2 (81d4dcb, 6b8ccd4)

All four findings applied:

- **High (spec):** new `cdc.CDCConfig.BeforeExportHook` seam + `UpdateBeforeExport` scenario covering the literal selection→export window — the mutated row is neither exported nor marked flushed, with `changed_at` ordering asserted against the actual snapshot. Adjudication 1 above rewritten accordingly.
- **Medium (assertion strength):** parquet checks upgraded to record level — exactly one stale live v1 record in the paused flush's delta (`assertLiveParquetRow`), exactly one v2 record in the update retry delta, exactly one all-NULL tombstone in the delete retry delta (`assertTombstoneParquet`).
- **Standards (×2):** `PausingS3` delegates wrap the interceptor error with op+key context (single-layered — `intercept` returns bare `ctx.Err()`); `runPausedFlush` wraps the flush error.

Verification: unit `TestExecuteBatch_BeforeExportHook*` green; 4/4 e2e scenarios green incl. `-race`; `make lint` / `make test` clean; full production e2e suite 34s PASS.
