### PR TITLE
test(e2e): warm/cold tiebreaking & sort/pagination stability (#183)

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -264,6 +264,15 @@ ORDER BY created_at DESC, row_id ASC
 LIMIT $PAGE_SIZE OFFSET $OFFSET;
 ```
 
+Keyset (cursor) pagination carries the same total-order requirement, and it is
+now **enforced**, not merely documented: the engine rejects any cursor whose
+final column is not `row_id` (`validateKeysetTiebreak`, guarding both the live
+renderer path in `DBFederatedQueryEngine.Query` and the `KeysetEnabled`
+`executeFederatedKeysetQuery` seam). A cursor ending on a non-unique key applies
+a strict inequality on that key at the boundary, which silently skips every row
+tied there; the trailing `row_id` gives the composite key a unique tiebreak so
+each boundary tie is resolvable (#183).
+
 ## **6. Optimization Strategies**
 
 ### **6.1 Predicate Pushdown (Critical)**

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -255,8 +255,12 @@ WHERE rn = 1
     -- a newer non-matching version must never expose an older matching one.
     AND (age > 18 AND name LIKE 'John%' AND tag = 'developer')
 
--- Sorting & Pagination  
-ORDER BY created_at DESC  
+-- Sorting & Pagination
+-- A trailing row_id ASC tiebreak gives equal-key rows a total order, so
+-- LIMIT/OFFSET page windows stay stable across requests (#183). This mirrors
+-- buildNonKeysetOrderBy, the PG optimized template's trailing m.ltbase_row_id,
+-- and the production-harness oracle.
+ORDER BY created_at DESC, row_id ASC
 LIMIT $PAGE_SIZE OFFSET $OFFSET;
 ```
 

--- a/internal/advanced_query_template.go
+++ b/internal/advanced_query_template.go
@@ -85,7 +85,7 @@ var optimizedQuerySQLTemplate = template.Must(template.New("optimizedQuery").Fun
             ORDER BY
                 {{- if gt (len .SortKeys) 0 }}
                 {{- range $i, $k := .SortKeys }}
-                k{{$i}} {{ if $k.Desc }}DESC{{ else }}ASC{{ end }}{{ if lt (add $i 1) (len $.SortKeys) }},{{ end }}
+                k{{$i}} {{ if $k.Desc }}DESC NULLS LAST{{ else }}ASC{{ end }}{{ if lt (add $i 1) (len $.SortKeys) }},{{ end }}
                 {{- end }}
                 {{- if gt (len .SortKeys) 0 }},{{ end }}
                 {{- end }}
@@ -136,7 +136,7 @@ var optimizedQuerySQLTemplate = template.Must(template.New("optimizedQuery").Fun
         ORDER BY
             {{- if gt (len .SortKeys) 0 }}
             {{- range $i, $k := .SortKeys }}
-            m.k{{$i}} {{ if $k.Desc }}DESC{{ else }}ASC{{ end }}{{ if lt (add $i 1) (len $.SortKeys) }},{{ end }}
+            m.k{{$i}} {{ if $k.Desc }}DESC NULLS LAST{{ else }}ASC{{ end }}{{ if lt (add $i 1) (len $.SortKeys) }},{{ end }}
             {{- end }}
             {{- if gt (len .SortKeys) 0 }},{{ end }}
             {{- end }}

--- a/internal/e2e_harness/production/keyset_lww_e2e_test.go
+++ b/internal/e2e_harness/production/keyset_lww_e2e_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/lychee-technology/forma/internal/model"
 )
 
+// keysetZeroRowID is the canonical zero UUID, used as the row_id arg for a
+// keyset cursor pinned to a synthetic boundary value: the row_id disjunct only
+// fires on an exact tie with the preceding key, which a synthetic boundary
+// (a value no seeded row carries) never hits, so the arm is inert. Every cursor
+// must still END on row_id — the engine now rejects cursors lacking that
+// trailing tiebreak (validateKeysetTiebreak, #183).
+const keysetZeroRowID = "00000000-0000-0000-0000-000000000000"
+
 // TestKeysetLWW (#212): the keyset cursor must be applied AFTER last-write-
 // wins deduplication. Pre-fix, the DuckDB template injected the cursor into
 // the ranked CTE — before ROW_NUMBER picked rn = 1 — so a superseded version
@@ -79,9 +87,12 @@ func testKeysetAttributeCursorResurrection(ctx context.Context, t *testing.T, en
 		Schema: wide,
 		Sorts:  []Sort{{Attr: "count"}},
 		Keyset: &model.KeysetCursor{
-			Columns: []model.KeysetColumn{{Attribute: "count", Direction: forma.SortOrderAsc}},
-			Values:  []any{float64(500)},
-			Mode:    model.KeysetCursorModeAfter,
+			Columns: []model.KeysetColumn{
+				{Attribute: "count", Direction: forma.SortOrderAsc},
+				{Attribute: "row_id", Direction: forma.SortOrderAsc}, // required trailing tiebreak (#183)
+			},
+			Values: []any{float64(500), keysetZeroRowID}, // 500 matches no row ⇒ row_id arm inert
+			Mode:   model.KeysetCursorModeAfter,
 		},
 		Limit: 10,
 	})
@@ -134,9 +145,15 @@ func testKeysetCreatedAtCursorResurrection(ctx context.Context, t *testing.T, en
 	page, err := env.Query(ctx, Query{
 		Schema: wide,
 		Keyset: &model.KeysetCursor{
-			Columns: []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}},
-			Values:  []any{c.ChangedAt},
-			Mode:    model.KeysetCursorModeAfter,
+			Columns: []model.KeysetColumn{
+				{Attribute: "created_at", Direction: forma.SortOrderDesc},
+				{Attribute: "row_id", Direction: forma.SortOrderAsc}, // required trailing tiebreak (#183)
+			},
+			// Record-derived boundary at C: the row_id arm (created_at = t3 AND
+			// row_id > c.RowID) excludes C itself while B(t2) qualifies via the
+			// leading created_at < t3 disjunct.
+			Values: []any{c.ChangedAt, c.RowID.String()},
+			Mode:   model.KeysetCursorModeAfter,
 		},
 		Limit: 10,
 	})
@@ -184,9 +201,12 @@ func testKeysetCursorWithMixedFilters(ctx context.Context, t *testing.T, env *En
 		Filters: filters,
 		Sorts:   []Sort{{Attr: "count"}},
 		Keyset: &model.KeysetCursor{
-			Columns: []model.KeysetColumn{{Attribute: "count", Direction: forma.SortOrderAsc}},
-			Values:  []any{float64(250)},
-			Mode:    model.KeysetCursorModeAfter,
+			Columns: []model.KeysetColumn{
+				{Attribute: "count", Direction: forma.SortOrderAsc},
+				{Attribute: "row_id", Direction: forma.SortOrderAsc}, // required trailing tiebreak (#183)
+			},
+			Values: []any{float64(250), keysetZeroRowID}, // 250 matches no row ⇒ row_id arm inert
+			Mode:   model.KeysetCursorModeAfter,
 		},
 		Limit: 10,
 	}

--- a/internal/e2e_harness/production/pagination_mutation_e2e_test.go
+++ b/internal/e2e_harness/production/pagination_mutation_e2e_test.go
@@ -5,6 +5,7 @@ package production
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	forma "github.com/lychee-technology/forma"
@@ -12,14 +13,16 @@ import (
 )
 
 // TestPaginationUnderInsert (#183, epic #172 Phase 3) contrasts the two
-// pagination strategies under a concurrent front-insert. OFFSET windows
-// re-base on every request, so a row inserted before the current position
-// duplicates a boundary row and shifts the tail — deterministic only thanks
-// to Task 1's total order, but never a no-dup/no-skip guarantee. Keyset
-// cursors carry that guarantee: a row inserted into already-visited territory
-// is neither duplicated nor able to displace an unread row. The third
-// scenario pins the one place the keyset guarantee lapses — a cursor whose
-// last column is not row_id silently skips a tie group.
+// pagination strategies under a concurrent insert. OFFSET windows re-base on
+// every request, so a row inserted before the current position duplicates a
+// boundary row and shifts the tail — deterministic only thanks to Task 1's
+// total order, but never a no-dup/no-skip guarantee. Keyset cursors carry that
+// guarantee: with an ascending scan a row inserted at the tail surfaces on a
+// future page exactly once (keyset_insert_into_future_page); with a descending
+// scan the same row sorts into already-visited territory and cannot be re-served
+// without snapshot isolation (keyset_insert_front_desc_unreachable). The last
+// scenario pins the enforced tiebreak contract: a cursor whose final column is
+// not row_id is now REJECTED rather than allowed to silently skip a tie group.
 func TestPaginationUnderInsert(t *testing.T) {
 	cluster := SharedCluster(t)
 	wide := DefaultSchemaFixtures()[1] // e2e_wide
@@ -29,8 +32,9 @@ func TestPaginationUnderInsert(t *testing.T) {
 		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
 	}{
 		{"offset_insert_characterization", testOffsetInsertCharacterization},
-		{"keyset_insert_no_dup_no_skip", testKeysetInsertNoDupNoSkip},
-		{"keyset_tie_omission_probe", testKeysetTieOmissionProbe},
+		{"keyset_insert_into_future_page", testKeysetInsertIntoFuturePage},
+		{"keyset_insert_front_desc_unreachable", testKeysetInsertNoDupNoSkip},
+		{"keyset_incomplete_cursor_rejected", testKeysetIncompleteCursorRejected},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -160,14 +164,20 @@ func testOffsetInsertCharacterization(ctx context.Context, t *testing.T, env *En
 	}
 }
 
-// testKeysetInsertNoDupNoSkip pins the no-dup/no-skip guarantee the issue asks
-// for: keyset pagination over [created_at DESC, row_id DESC] survives a
-// front-insert cleanly. After page 1 a new row with the newest created_at is
-// inserted; it sorts into already-visited front territory, so the cursor
-// (positioned after page 1's last record) excludes it and pages 2-3 return the
-// remaining originals. Every original appears exactly once; the new row appears
-// zero times — "current or future page" is vacuously satisfied and it is never
-// duplicated. A duplicate or omission here would be a keyset engine bug.
+// testKeysetInsertNoDupNoSkip (scenario keyset_insert_front_desc_unreachable) is
+// the DESC half of the #183 liveness contract, and the deliberate spec tension:
+// keyset pagination over [created_at DESC, row_id DESC] survives a front-insert
+// cleanly, but the inserted row is UNREACHABLE. After page 1 a new row with the
+// newest created_at is inserted; under DESC it sorts to the front — into
+// already-visited territory the cursor (positioned after page 1's last record)
+// can never re-serve. So every original appears exactly once and the new row
+// appears zero times: no dup, no skip of a pre-existing row, but "row appears in
+// a current or future page" is NOT satisfiable without snapshot isolation. The
+// zero-count assertion is kept as the characterization of that gap. The liveness
+// half of #183 — an inserted row that DOES surface on a later page — is pinned
+// by testKeysetInsertIntoFuturePage, where an ascending scan sends the newest
+// row into an unvisited window. A duplicate or a skipped original here would be
+// a keyset engine bug.
 func testKeysetInsertNoDupNoSkip(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
 	const n = 30
 	creates := make([]*Event, 0, n)
@@ -223,55 +233,132 @@ func testKeysetInsertNoDupNoSkip(ctx context.Context, t *testing.T, env *Env, wi
 	assertRowCount(ctx, t, env, "post-insert full requery", Query{Schema: wide, Limit: 40}, 31)
 }
 
-// testKeysetTieOmissionProbe pins the lossy edge of keyset pagination: a cursor
-// whose last column is NOT row_id silently skips a tie group. Five rows are
-// collapsed onto one created_at (cold, identical timestamps); after reading the
-// first keyset page over [created_at DESC], the continuation predicate is
-// created_at < T — but every remaining tied row also has created_at = T, so all
-// three unread rows are excluded and the next page is empty. This is PINNED as
-// the current behavior, not asserted as correct: the keyset contract requires
-// callers to end cursors with row_id (internal/federated/keyset.go:98-113
-// documents the row comparison but nothing enforces the tiebreak). Tracked by
-// follow-up #NNN.
-func testKeysetTieOmissionProbe(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+// testKeysetInsertIntoFuturePage is the liveness half of #183: an ascending
+// keyset scan over [created_at ASC, row_id ASC] paginates 30 pre-seeded rows;
+// after page 1 a new row with the NEWEST created_at is inserted. Under ASC it
+// sorts past every already-served window, into unvisited tail territory, so it
+// MUST surface on a later page — exactly once, alongside all 30 originals,
+// with no duplicate anywhere. This is the guarantee the front-insert DESC
+// scenario cannot demonstrate (there the row sorts into visited territory).
+func testKeysetInsertIntoFuturePage(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	const n = 30
+	creates := make([]*Event, 0, n)
+	for i := 0; i < n; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("fut-%02d", i),
+			"count": float64(2000 + i),
+		}))
+	}
+	mustApplyEvents(ctx, t, env, "future-page creates", creates...)
+	mustFlush(ctx, t, env) // originals cold; the tail insert below stays hot
+
+	cols := []model.KeysetColumn{
+		{Attribute: "created_at", Direction: forma.SortOrderAsc},
+		{Attribute: "row_id", Direction: forma.SortOrderAsc},
+	}
+	// Open first page: a boundary below every real row (created_at 0, zero
+	// row_id) so the ascending "after" predicate admits the whole set.
+	cursor := &model.KeysetCursor{
+		Columns: cols,
+		Values:  []any{int64(0), keysetZeroRowID},
+		Mode:    model.KeysetCursorModeAfter,
+	}
+
+	seen := make(map[string]int, n+1)
+	var newID string
+	// 30 originals + 1 insert over pages of 10 ⇒ the inserted tail row lands on
+	// page 4; cap iterations well above that and stop on the first empty page.
+	for p := 0; p < 8; p++ {
+		page := mustQuery(ctx, t, env, Query{Schema: wide, Keyset: cursor, Limit: 10})
+		if len(page.Records) == 0 {
+			break
+		}
+		for _, id := range pageRowIDs(page) {
+			seen[id]++
+		}
+		if p == 0 {
+			// Newest created_at ⇒ sorts to the tail, into an unvisited window.
+			newEv := CreateEvent(wide, map[string]any{"title": "fut-inserted", "count": float64(9999)})
+			mustApplyEvents(ctx, t, env, "tail-insert new row", newEv)
+			newID = newEv.RowID.String()
+		}
+		cursor = nextKeysetCursor(cols, page.Records[len(page.Records)-1])
+	}
+
+	for _, c := range creates {
+		if id := c.RowID.String(); seen[id] != 1 {
+			t.Fatalf("original row %s appeared %d times across keyset pages, want exactly 1 (ascending keyset dup/skip — engine bug)", id, seen[id])
+		}
+	}
+	if seen[newID] != 1 {
+		t.Fatalf("tail-inserted row %s appeared %d times, want exactly 1 (ascending insert must surface on a future page)", newID, seen[newID])
+	}
+
+	// Positive control: the full set is exactly the 30 originals plus the insert.
+	assertRowCount(ctx, t, env, "post-insert full requery", Query{Schema: wide, Limit: 40}, n+1)
+}
+
+// testKeysetIncompleteCursorRejected pins the enforced tiebreak contract (#183):
+// a cursor whose final column is NOT row_id would silently skip every row tied
+// at the page boundary, so the engine now REJECTS it rather than serving a lossy
+// page. Pre-fix this was pinned as a lossy empty continuation page; enforcement
+// supersedes that follow-up. The rejection is structural (independent of the
+// data), so the positive control drives the identical query with a trailing
+// row_id appended and requires it to succeed — proving only the missing tiebreak
+// is refused, not the underlying read.
+func testKeysetIncompleteCursorRejected(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
 	const n = 5
 	events := make([]*Event, 0, n)
 	for i := 0; i < n; i++ {
 		events = append(events, CreateEvent(wide, map[string]any{
-			"title": fmt.Sprintf("tie-%02d", i),
+			"title": fmt.Sprintf("rej-%02d", i),
 			"count": float64(10 + i),
 		}))
 	}
-	mustApplyEvents(ctx, t, env, "tie-omission creates", events...)
-
-	// Collapse all five unflushed slots onto one created_at so the cursor tie
-	// group is exact; mirror into the events for the oracle (folds by ChangedAt).
-	tied := events[0].ChangedAt
-	env.ExecSQL(ctx, "UPDATE change_log SET changed_at = $1 WHERE schema_id = $2 AND flushed_at = 0", tied, wide.ID)
-	for _, ev := range events {
-		ev.ChangedAt = tied
-	}
-
+	mustApplyEvents(ctx, t, env, "incomplete-cursor creates", events...)
 	mustFlush(ctx, t, env)
-	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only; all five share created_at = tied
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only
 
-	// Positive control: the read path returns all five tied rows, so a later
-	// empty page cannot be a false green from a broken read path.
-	assertRowCount(ctx, t, env, "tie control", Query{Schema: wide, Limit: 10}, n)
+	// Positive control: the read path returns all five rows.
+	assertRowCount(ctx, t, env, "reject control", Query{Schema: wide, Limit: 10}, n)
 
-	cols := []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}}
-	page1 := mustQuery(ctx, t, env, Query{
+	// A created_at-only cursor lacks the trailing row_id tiebreak ⇒ rejected.
+	_, err := env.Query(ctx, Query{
 		Schema: wide,
-		Keyset: &model.KeysetCursor{Columns: cols, Values: []any{paginationFarFutureMs}, Mode: model.KeysetCursorModeAfter},
-		Limit:  2,
+		Keyset: &model.KeysetCursor{
+			Columns: []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}},
+			Values:  []any{paginationFarFutureMs},
+			Mode:    model.KeysetCursorModeAfter,
+		},
+		Limit: 2,
 	})
-	if len(page1.Records) != 2 {
-		t.Fatalf("tie page 1 returned %d rows, want 2", len(page1.Records))
+	if err == nil {
+		t.Fatal("expected the created_at-only keyset cursor to be rejected, got nil error")
+	}
+	// Substring match (the validator returns a plain wrapped error, not a
+	// sentinel): the message must name the offending column and the tiebreak.
+	msg := err.Error()
+	if !strings.Contains(msg, "created_at") || !strings.Contains(msg, "row_id") {
+		t.Fatalf("rejection error must name the offending column and the row_id tiebreak, got: %v", err)
 	}
 
-	// Continue from page 1's last created_at WITHOUT a row_id tiebreak: the next
-	// predicate is created_at < T, which excludes all three remaining tied rows.
-	// PIN exactly that lossy behavior as an empty page (follow-up #NNN).
-	probe := Query{Schema: wide, Keyset: nextKeysetCursor(cols, page1.Records[len(page1.Records)-1]), Limit: 2}
-	assertKeysetPage(ctx, t, env, probe) // no want events ⇒ the omission is the empty page
+	// Positive control: the same scan WITH a trailing row_id is accepted.
+	page, err := env.Query(ctx, Query{
+		Schema: wide,
+		Keyset: &model.KeysetCursor{
+			Columns: []model.KeysetColumn{
+				{Attribute: "created_at", Direction: forma.SortOrderDesc},
+				{Attribute: "row_id", Direction: forma.SortOrderAsc},
+			},
+			Values: []any{paginationFarFutureMs, paginationMaxRowID},
+			Mode:   model.KeysetCursorModeAfter,
+		},
+		Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("cursor with trailing row_id must be accepted, got: %v", err)
+	}
+	if len(page.Records) != 2 {
+		t.Fatalf("accepted cursor page returned %d rows, want 2", len(page.Records))
+	}
 }

--- a/internal/e2e_harness/production/pagination_mutation_e2e_test.go
+++ b/internal/e2e_harness/production/pagination_mutation_e2e_test.go
@@ -1,0 +1,277 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	forma "github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// TestPaginationUnderInsert (#183, epic #172 Phase 3) contrasts the two
+// pagination strategies under a concurrent front-insert. OFFSET windows
+// re-base on every request, so a row inserted before the current position
+// duplicates a boundary row and shifts the tail — deterministic only thanks
+// to Task 1's total order, but never a no-dup/no-skip guarantee. Keyset
+// cursors carry that guarantee: a row inserted into already-visited territory
+// is neither duplicated nor able to displace an unread row. The third
+// scenario pins the one place the keyset guarantee lapses — a cursor whose
+// last column is not row_id silently skips a tie group.
+func TestPaginationUnderInsert(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	scenarios := []struct {
+		name string
+		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"offset_insert_characterization", testOffsetInsertCharacterization},
+		{"keyset_insert_no_dup_no_skip", testKeysetInsertNoDupNoSkip},
+		{"keyset_tie_omission_probe", testKeysetTieOmissionProbe},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), wide)
+		})
+	}
+}
+
+const (
+	// paginationFarFutureMs is a created_at sentinel comfortably past any real
+	// row timestamp (~1.75e12 ms in 2026) yet float64-exact (< 2^53), so an
+	// "after" cursor at [created_at DESC] carrying it admits every row. It is
+	// the idiomatic open first page for a descending keyset scan, which the
+	// engine otherwise only positions from a prior page's last record.
+	paginationFarFutureMs = int64(4_000_000_000_000) // ~year 2096
+	// paginationMaxRowID is the largest canonical UUID string; paired with the
+	// created_at sentinel it never matches (the created_at disjunct already
+	// admits everything), so its only job is to be a valid row_id arg.
+	paginationMaxRowID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+)
+
+// mustQuery runs a raw (non-oracle) query and fails fast on error.
+func mustQuery(ctx context.Context, t *testing.T, env *Env, q Query) *QueryResult {
+	t.Helper()
+	res, err := env.Query(ctx, q)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	return res
+}
+
+// nextKeysetCursor builds an "after" cursor from a page's last record for the
+// given system columns, mirroring the engine's own extractCursorFromRecord
+// value types (created_at → int64 CreatedAt, row_id → RowID.String()).
+func nextKeysetCursor(cols []model.KeysetColumn, rec *model.PersistentRecord) *model.KeysetCursor {
+	vals := make([]any, len(cols))
+	for i, c := range cols {
+		switch c.Attribute {
+		case "created_at":
+			vals[i] = rec.CreatedAt
+		case "row_id":
+			vals[i] = rec.RowID.String()
+		}
+	}
+	return &model.KeysetCursor{Columns: cols, Values: vals, Mode: model.KeysetCursorModeAfter}
+}
+
+// assertOffsetPage pins one OFFSET window to an exact ordered row-id set and
+// its reported Total.
+func assertOffsetPage(t *testing.T, page *QueryResult, want []*Event, wantTotal int64) {
+	t.Helper()
+	got := pageRowIDs(page)
+	wantIDs := make([]string, len(want))
+	for i, w := range want {
+		wantIDs[i] = w.RowID.String()
+	}
+	if !equalStrings(got, wantIDs) {
+		t.Fatalf("offset window = %v, want exactly %v (fixture non-determinism or engine re-base drift)", got, wantIDs)
+	}
+	if page.Total != wantTotal {
+		t.Fatalf("offset window total = %d, want %d", page.Total, wantTotal)
+	}
+}
+
+// testOffsetInsertCharacterization is an honest characterization of OFFSET
+// pagination under a front-insert, NOT a bug pin. OFFSET windows re-base on
+// every request by design: inserting a row that sorts before the current
+// position duplicates the page-1/page-2 boundary row and shifts the tail, and
+// the freshly inserted row — sorting into an already-served window — is never
+// seen. This is inherent to OFFSET; it is deterministic here only because
+// Task 1 appended row_id ASC to give equal keys a total order (counts are
+// unique so no ties even arise). The no-dup/no-skip guarantee the issue asks
+// for is a keyset property, pinned by keyset_insert_no_dup_no_skip.
+func testOffsetInsertCharacterization(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	const n = 30
+	creates := make([]*Event, 0, n)
+	for i := 0; i < n; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("off-%02d", i),
+			"count": float64(100 + 10*i), // 100..390, unique ⇒ count ASC = creation order
+		}))
+	}
+	mustApplyEvents(ctx, t, env, "offset-characterization creates", creates...)
+	mustFlush(ctx, t, env) // rows cold; the shifter below is the only hot row
+
+	base := Query{Schema: wide, Sorts: []Sort{{Attr: "count"}}, Limit: 10}
+
+	// Page 1 read BEFORE the insert: the untouched [r0..r9] window over 30 rows.
+	p1 := mustQuery(ctx, t, env, base) // Offset 0
+	assertOffsetPage(t, p1, creates[0:10], 30)
+
+	// The shifter sorts before every original and stays hot (no flush): the
+	// federated pg_source picks it up, re-basing every later OFFSET window by
+	// one position over the order [shifter, r0..r29].
+	shifter := CreateEvent(wide, map[string]any{"title": "shifter", "count": float64(50)})
+	mustApplyEvents(ctx, t, env, "front-insert shifter", shifter)
+
+	q := base
+	q.Offset = 10
+	p2 := mustQuery(ctx, t, env, q)
+	q.Offset = 20
+	p3 := mustQuery(ctx, t, env, q)
+	q.Offset = 30
+	p4 := mustQuery(ctx, t, env, q)
+
+	assertOffsetPage(t, p2, creates[9:19], 31)  // r9..r18 — r9 duplicated at the boundary
+	assertOffsetPage(t, p3, creates[19:29], 31) // r19..r28
+	assertOffsetPage(t, p4, creates[29:30], 31) // [r29]
+
+	// The new row never surfaces; every original appears at least once.
+	pages := [][]string{pageRowIDs(p1), pageRowIDs(p2), pageRowIDs(p3), pageRowIDs(p4)}
+	newID := shifter.RowID.String()
+	seen := make(map[string]bool, n)
+	for _, page := range pages {
+		for _, id := range page {
+			if id == newID {
+				t.Fatalf("front-inserted row %s surfaced in an OFFSET window; under a front-insert it never should", newID)
+			}
+			seen[id] = true
+		}
+	}
+	for _, c := range creates {
+		if !seen[c.RowID.String()] {
+			t.Fatalf("original row %s missing from OFFSET windows 1-4", c.RowID.String())
+		}
+	}
+}
+
+// testKeysetInsertNoDupNoSkip pins the no-dup/no-skip guarantee the issue asks
+// for: keyset pagination over [created_at DESC, row_id DESC] survives a
+// front-insert cleanly. After page 1 a new row with the newest created_at is
+// inserted; it sorts into already-visited front territory, so the cursor
+// (positioned after page 1's last record) excludes it and pages 2-3 return the
+// remaining originals. Every original appears exactly once; the new row appears
+// zero times — "current or future page" is vacuously satisfied and it is never
+// duplicated. A duplicate or omission here would be a keyset engine bug.
+func testKeysetInsertNoDupNoSkip(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	const n = 30
+	creates := make([]*Event, 0, n)
+	for i := 0; i < n; i++ {
+		creates = append(creates, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("ks-%02d", i),
+			"count": float64(1000 + i),
+		}))
+	}
+	mustApplyEvents(ctx, t, env, "keyset no-dup creates", creates...)
+	mustFlush(ctx, t, env)
+
+	cols := []model.KeysetColumn{
+		{Attribute: "created_at", Direction: forma.SortOrderDesc},
+		{Attribute: "row_id", Direction: forma.SortOrderDesc},
+	}
+	cursor := &model.KeysetCursor{
+		Columns: cols,
+		Values:  []any{paginationFarFutureMs, paginationMaxRowID}, // open first page
+		Mode:    model.KeysetCursorModeAfter,
+	}
+
+	seen := make(map[string]int, n+1)
+	var newID string
+	for p := 0; p < 3; p++ {
+		page := mustQuery(ctx, t, env, Query{Schema: wide, Keyset: cursor, Limit: 10})
+		if len(page.Records) != 10 {
+			t.Fatalf("keyset page %d returned %d rows, want 10", p+1, len(page.Records))
+		}
+		for _, id := range pageRowIDs(page) {
+			seen[id]++
+		}
+		if p == 0 {
+			// Newest created_at ⇒ sorts to the front, into already-visited
+			// territory a correct keyset never re-serves.
+			newEv := CreateEvent(wide, map[string]any{"title": "ks-inserted", "count": float64(9999)})
+			mustApplyEvents(ctx, t, env, "front-insert new row", newEv)
+			newID = newEv.RowID.String()
+		}
+		cursor = nextKeysetCursor(cols, page.Records[len(page.Records)-1])
+	}
+
+	for _, c := range creates {
+		if id := c.RowID.String(); seen[id] != 1 {
+			t.Fatalf("original row %s appeared %d times across keyset pages, want exactly 1 (keyset dup/skip under front insert — engine bug)", id, seen[id])
+		}
+	}
+	if seen[newID] != 0 {
+		t.Fatalf("front-inserted row %s appeared %d times across keyset pages, want 0 (it sorted into visited territory)", newID, seen[newID])
+	}
+
+	// Positive control: the new row is real and visible outside the cursor window.
+	assertRowCount(ctx, t, env, "post-insert full requery", Query{Schema: wide, Limit: 40}, 31)
+}
+
+// testKeysetTieOmissionProbe pins the lossy edge of keyset pagination: a cursor
+// whose last column is NOT row_id silently skips a tie group. Five rows are
+// collapsed onto one created_at (cold, identical timestamps); after reading the
+// first keyset page over [created_at DESC], the continuation predicate is
+// created_at < T — but every remaining tied row also has created_at = T, so all
+// three unread rows are excluded and the next page is empty. This is PINNED as
+// the current behavior, not asserted as correct: the keyset contract requires
+// callers to end cursors with row_id (internal/federated/keyset.go:98-113
+// documents the row comparison but nothing enforces the tiebreak). Tracked by
+// follow-up #NNN.
+func testKeysetTieOmissionProbe(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	const n = 5
+	events := make([]*Event, 0, n)
+	for i := 0; i < n; i++ {
+		events = append(events, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("tie-%02d", i),
+			"count": float64(10 + i),
+		}))
+	}
+	mustApplyEvents(ctx, t, env, "tie-omission creates", events...)
+
+	// Collapse all five unflushed slots onto one created_at so the cursor tie
+	// group is exact; mirror into the events for the oracle (folds by ChangedAt).
+	tied := events[0].ChangedAt
+	env.ExecSQL(ctx, "UPDATE change_log SET changed_at = $1 WHERE schema_id = $2 AND flushed_at = 0", tied, wide.ID)
+	for _, ev := range events {
+		ev.ChangedAt = tied
+	}
+
+	mustFlush(ctx, t, env)
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only; all five share created_at = tied
+
+	// Positive control: the read path returns all five tied rows, so a later
+	// empty page cannot be a false green from a broken read path.
+	assertRowCount(ctx, t, env, "tie control", Query{Schema: wide, Limit: 10}, n)
+
+	cols := []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}}
+	page1 := mustQuery(ctx, t, env, Query{
+		Schema: wide,
+		Keyset: &model.KeysetCursor{Columns: cols, Values: []any{paginationFarFutureMs}, Mode: model.KeysetCursorModeAfter},
+		Limit:  2,
+	})
+	if len(page1.Records) != 2 {
+		t.Fatalf("tie page 1 returned %d rows, want 2", len(page1.Records))
+	}
+
+	// Continue from page 1's last created_at WITHOUT a row_id tiebreak: the next
+	// predicate is created_at < T, which excludes all three remaining tied rows.
+	// PIN exactly that lossy behavior as an empty page (follow-up #NNN).
+	probe := Query{Schema: wide, Keyset: nextKeysetCursor(cols, page1.Records[len(page1.Records)-1]), Limit: 2}
+	assertKeysetPage(ctx, t, env, probe) // no want events ⇒ the omission is the empty page
+}

--- a/internal/e2e_harness/production/sort_nulls_e2e_test.go
+++ b/internal/e2e_harness/production/sort_nulls_e2e_test.go
@@ -1,0 +1,142 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestSortNulls (#183): NULL sort values must land in the same position (last,
+// both directions) on every routing path. DuckDB defaults to NULLS LAST for
+// ASC and DESC; PostgreSQL treats NULL as largest (ASC→last, DESC→FIRST), so
+// pre-fix the PG-only/OLTP path diverges from the federated path and from the
+// oracle on DESC sorts. Fixed by explicit NULLS LAST in the optimized-query
+// template's ORDER BYs (both the ordered CTE — its LIMIT window depends on
+// placement — and the final select).
+func TestSortNulls(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	scenarios := []struct {
+		name string
+		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"federated_nulls_last_asc_desc", testFederatedNullsLast},
+		{"hot_oltp_nulls_last_desc", testHotOLTPNullsLastDesc},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), wide)
+		})
+	}
+}
+
+// buildSparseNoteRows returns creates where the first withNote rows carry the
+// pure-EAV "note" attribute and the remainder omit it entirely (no eav_data
+// row ⇒ NULL in the DuckDB pivot / PG sort subquery). count stays unique so
+// only the note column exercises tie/NULL handling.
+func buildSparseNoteRows(wide SchemaRef, withNote, withoutNote int) []*Event {
+	events := make([]*Event, 0, withNote+withoutNote)
+	for i := 0; i < withNote; i++ {
+		events = append(events, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("noted-%02d", i),
+			"count": float64(100 + i),
+			"note":  fmt.Sprintf("n-%02d", i),
+		}))
+	}
+	for i := 0; i < withoutNote; i++ {
+		events = append(events, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("bare-%02d", i),
+			"count": float64(200 + i),
+		}))
+	}
+	return events
+}
+
+// testHotOLTPNullsLastDesc pins NULLS LAST on the PG-only path (PreferHot).
+// Pre-fix this is a deterministic red: PG's default DESC places NULLs FIRST,
+// the oracle (and the DuckDB path) place them LAST.
+func testHotOLTPNullsLastDesc(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	events := buildSparseNoteRows(wide, 4, 4)
+	mustApplyEvents(ctx, t, env, "sparse creates", events...)
+	// No flush: rows stay hot; PreferHot forces the OLTP template.
+	res := env.AssertQueryMatches(ctx, Query{
+		Schema: wide, Sorts: []Sort{{Attr: "note", Desc: true}}, Limit: 20, PreferHot: true})
+	if res == nil {
+		t.Fatal("hot DESC sort on nullable attribute diverged from the oracle (NULLS FIRST vs NULLS LAST)")
+	}
+	if res.Plan.Routing.UseDuckDB {
+		t.Fatal("expected PG-only routing under PreferHot")
+	}
+	assertNoteNullsLast(t, res, 4)
+}
+
+// testFederatedNullsLast pins NULLS LAST on the federated/DuckDB path for both
+// directions, and that repeated runs return the same order (stability, not
+// just placement).
+func testFederatedNullsLast(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	events := buildSparseNoteRows(wide, 4, 4)
+	mustApplyEvents(ctx, t, env, "sparse creates", events...)
+	mustFlush(ctx, t, env)
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing
+	for _, desc := range []bool{false, true} {
+		q := Query{Schema: wide, Sorts: []Sort{{Attr: "note", Desc: desc}}, Limit: 20}
+		res := env.AssertQueryMatches(ctx, q)
+		if res == nil {
+			t.Fatalf("federated note sort desc=%v diverged from oracle", desc)
+		}
+		if !res.Plan.Routing.UseDuckDB {
+			t.Fatalf("expected DuckDB routing, got OLTP (desc=%v)", desc)
+		}
+		assertNoteNullsLast(t, res, 4)
+		first := pageRowIDs(res)
+		for i := 0; i < 4; i++ { // repeat-N: same order every run
+			again, err := env.Query(ctx, q)
+			if err != nil {
+				t.Fatalf("repeat %d: %v", i, err)
+			}
+			if got := pageRowIDs(again); !equalStrings(got, first) {
+				t.Fatalf("repeat %d order flapped:\n first=%v\n again=%v", i, first, got)
+			}
+		}
+	}
+}
+
+// assertNoteNullsLast pins that the nNoted rows carrying "note" lead the page
+// and the nNoted NULL-note rows trail it, on either sort direction. Titles
+// carry the shape (noted-* vs bare-*), so a title-prefix check is a faithful
+// proxy for note-NULL placement without re-deriving EAV values.
+func assertNoteNullsLast(t *testing.T, res *QueryResult, nNoted int) {
+	t.Helper()
+	if got := len(res.Records); got != nNoted*2 {
+		t.Fatalf("want %d records, got %d", nNoted*2, got)
+	}
+	for i, rec := range res.Records {
+		title := rec.TextItems["text_01"]
+		wantPrefix := "noted-"
+		if i >= nNoted {
+			wantPrefix = "bare-"
+		}
+		if !strings.HasPrefix(title, wantPrefix) {
+			t.Fatalf("record %d title %q: want prefix %q (note NULLs must sort last)",
+				i, title, wantPrefix)
+		}
+	}
+}
+
+// equalStrings reports whether two string slices are element-wise equal.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/e2e_harness/production/sort_stability_e2e_test.go
+++ b/internal/e2e_harness/production/sort_stability_e2e_test.go
@@ -1,0 +1,296 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// TestSortStability (#183): sort order must be a *total* order, stable across
+// page boundaries and repeated runs, on every routing path. Task 1 appended
+// `row_id ASC` to the federated non-keyset ORDER BY so equal sort keys break
+// ties deterministically; without it, duplicate-key tie groups reorder by
+// physical scan order and split across OFFSET windows (rows duplicated or
+// dropped) and reshuffle run to run. These scenarios pin the per-page oracle
+// order, the page-union invariant (every created row appears on exactly one
+// page), repeat-N determinism, and the internal multi-key AttributeOrders
+// contract. Expected GREEN: Tasks 1-2 already landed.
+func TestSortStability(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	scenarios := []struct {
+		name string
+		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"duplicate_key_page_union", testDuplicateKeyPageUnion},
+		{"repeat_n_stable_order", testRepeatNStableOrder},
+		{"hot_oltp_page_union", testHotOLTPPageUnion},
+		{"multi_key_mixed_directions", testMultiKeyMixedDirections},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), wide)
+		})
+	}
+}
+
+// buildDuplicateQtyRows builds 21 creates whose pure-EAV "qty" repeats across
+// {10,20,30} (7 rows each), forming three 7-way tie groups; "count" stays
+// unique for row identity.
+func buildDuplicateQtyRows(wide SchemaRef) []*Event {
+	events := make([]*Event, 0, 21)
+	for i := 0; i < 21; i++ {
+		events = append(events, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("dup-%02d", i),
+			"count": float64(1000 + i),       // unique identity aid
+			"qty":   float64(10 * (1 + i%3)), // 10/20/30 — 7-way ties per value
+		}))
+	}
+	return events
+}
+
+// reverseOrderUpdates re-sends every create as an update in reverse creation
+// order, keeping qty (the tie key) intact but refreshing the title. This makes
+// the delta parquet's physical row order disagree with row_id order — an
+// adversarial fixture that exposes scan-order-dependent tie breaking.
+func reverseOrderUpdates(wide SchemaRef, creates []*Event) []*Event {
+	updates := make([]*Event, 0, len(creates))
+	for i := len(creates) - 1; i >= 0; i-- {
+		ev := creates[i]
+		updates = append(updates, UpdateEvent(wide, ev.RowID, map[string]any{
+			"title": fmt.Sprintf("dup-v2-%02d", i),
+			"qty":   ev.Attrs["qty"], // keep the tie groups intact
+		}))
+	}
+	return updates
+}
+
+// buildMixedRankRows builds 12 creates with main-bound smallint "rank" drawn
+// from {1,2} (6 each, alternating) and unique main-bound integer "count", for
+// the two-key mixed-direction sort.
+func buildMixedRankRows(wide SchemaRef) []*Event {
+	events := make([]*Event, 0, 12)
+	for i := 0; i < 12; i++ {
+		events = append(events, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("mk-%02d", i),
+			"rank":  float64(1 + i%2), // 1,2,1,2,… → six 1s, six 2s
+			"count": float64(500 + i), // unique per row
+		}))
+	}
+	return events
+}
+
+// seedDuplicateQty applies the 21 duplicate-qty creates then re-applies them as
+// reverse-creation-order updates, guarding the update generation with
+// assertStrictlyNewer so no create/update pair collapses into a ver_ts tie
+// (#210). Rows are left hot; the caller flushes if it wants the DuckDB path.
+// Returns the create events (row identity + qty tie groups).
+func seedDuplicateQty(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) []*Event {
+	t.Helper()
+	creates := buildDuplicateQtyRows(wide)
+	mustApplyEvents(ctx, t, env, "duplicate-qty creates", creates...)
+	updates := reverseOrderUpdates(wide, creates)
+	mustApplyEvents(ctx, t, env, "reverse-order updates", updates...)
+	// updates[k] targets creates[len-1-k]; align the slices for the guard.
+	revCreates := make([]*Event, len(creates))
+	for i := range creates {
+		revCreates[i] = creates[len(creates)-1-i]
+	}
+	assertStrictlyNewer(t, revCreates, updates)
+	return creates
+}
+
+// collectPages pages through base in OFFSET windows of pageSize across the
+// first upTo rows, returning each page's row IDs and asserting no page exceeds
+// pageSize. Plain (non-oracle) reads so cursor-based callers can reuse it;
+// reused by a later pagination-stability task.
+func collectPages(ctx context.Context, t *testing.T, env *Env, base Query, pageSize, upTo int) [][]string {
+	t.Helper()
+	pages := make([][]string, 0, (upTo+pageSize-1)/pageSize)
+	for offset := 0; offset < upTo; offset += pageSize {
+		q := base
+		q.Limit = pageSize
+		q.Offset = offset
+		res, err := env.Query(ctx, q)
+		if err != nil {
+			t.Fatalf("collectPages offset=%d: %v", offset, err)
+		}
+		ids := pageRowIDs(res)
+		if len(ids) > pageSize {
+			t.Fatalf("collectPages offset=%d returned %d rows, exceeds page size %d",
+				offset, len(ids), pageSize)
+		}
+		pages = append(pages, ids)
+	}
+	return pages
+}
+
+// assertPageUnion pins the page-union invariant: concatenated across all
+// windows the pages must cover exactly the created row set — no row on two
+// pages (a split tie group duplicating) and none dropped at a boundary.
+func assertPageUnion(t *testing.T, pages [][]string, creates []*Event) {
+	t.Helper()
+	want := make(map[string]bool, len(creates))
+	for _, c := range creates {
+		want[c.RowID.String()] = true
+	}
+	seen := make(map[string]bool, len(creates))
+	for _, page := range pages {
+		for _, id := range page {
+			if seen[id] {
+				t.Fatalf("row %s appeared on more than one page: a split tie group duplicated a row", id)
+			}
+			seen[id] = true
+			if !want[id] {
+				t.Fatalf("row %s is not in the created set", id)
+			}
+		}
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("page union covered %d distinct rows, want %d: a tie-group boundary dropped rows",
+			len(seen), len(want))
+	}
+}
+
+// assertRankThenCountDesc verifies, by direct record inspection, that rank
+// ascends monotonically (so all rank-1 rows precede all rank-2 rows) and that
+// count descends strictly within each rank group — belt-and-braces beyond the
+// oracle's order diff. Typed-map keys verified against mainColumnValue
+// (assert.go): smallint→Int16Items, integer→Int32Items.
+func assertRankThenCountDesc(t *testing.T, records []*model.PersistentRecord) {
+	t.Helper()
+	var prevRank int16
+	var prevCount int32
+	started := false
+	for i, rec := range records {
+		rank, ok := rec.Int16Items["smallint_01"]
+		if !ok {
+			t.Fatalf("record %d missing rank (smallint_01)", i)
+		}
+		count, ok := rec.Int32Items["integer_01"]
+		if !ok {
+			t.Fatalf("record %d missing count (integer_01)", i)
+		}
+		if started {
+			if rank < prevRank {
+				t.Fatalf("record %d rank %d < previous %d: rank must ascend", i, rank, prevRank)
+			}
+			if rank == prevRank && count >= prevCount {
+				t.Fatalf("record %d count %d not strictly below previous %d within rank %d",
+					i, count, prevCount, rank)
+			}
+		}
+		prevRank, prevCount, started = rank, count, true
+	}
+}
+
+// testDuplicateKeyPageUnion pins per-page oracle order AND the page-union
+// invariant on the DuckDB path: with 7-way qty ties and delta rows physically
+// out of row_id order, only Task 1's row_id tiebreak keeps the six-row windows
+// non-overlapping and complete.
+func testDuplicateKeyPageUnion(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := seedDuplicateQty(ctx, t, env, wide)
+	mustFlush(ctx, t, env)
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing
+
+	base := Query{Schema: wide, Sorts: []Sort{{Attr: "qty"}}}
+	for _, off := range []int{0, 6, 12, 18} {
+		q := base
+		q.Limit = 6
+		q.Offset = off
+		res := env.AssertQueryMatches(ctx, q)
+		if off == 0 && res != nil && !res.Plan.Routing.UseDuckDB {
+			t.Fatalf("first page did not route to duckdb: %+v", res.Plan.Routing)
+		}
+	}
+
+	pages := collectPages(ctx, t, env, base, 6, 21)
+	assertPageUnion(t, pages, creates)
+}
+
+// testRepeatNStableOrder pins repeat-N determinism (the issue's "same order
+// each time"): the full sorted page must come back byte-identical across ten
+// runs on the DuckDB path.
+func testRepeatNStableOrder(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	seedDuplicateQty(ctx, t, env, wide)
+	mustFlush(ctx, t, env)
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing
+
+	q := Query{Schema: wide, Sorts: []Sort{{Attr: "qty"}}, Limit: 25}
+	res := env.AssertQueryMatches(ctx, q)
+	if res == nil {
+		return
+	}
+	if !res.Plan.Routing.UseDuckDB {
+		t.Fatalf("expected DuckDB routing, got OLTP: %+v", res.Plan.Routing)
+	}
+	first := pageRowIDs(res)
+	if len(first) != 21 {
+		t.Fatalf("sorted page returned %d rows, want 21", len(first))
+	}
+	for i := 0; i < 9; i++ {
+		again, err := env.Query(ctx, q)
+		if err != nil {
+			t.Fatalf("repeat %d: %v", i, err)
+		}
+		if got := pageRowIDs(again); !equalStrings(got, first) {
+			t.Fatalf("repeat %d order flapped:\n first=%v\n again=%v", i, first, got)
+		}
+	}
+}
+
+// testHotOLTPPageUnion is the OLTP twin of duplicate_key_page_union: unflushed
+// rows under PreferHot route through the Postgres path (which already carried
+// the row_id tiebreak), pinning cross-path parity for the page-union invariant.
+func testHotOLTPPageUnion(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := seedDuplicateQty(ctx, t, env, wide)
+	// No flush: rows stay hot; PreferHot forces the OLTP template.
+
+	base := Query{Schema: wide, Sorts: []Sort{{Attr: "qty"}}, PreferHot: true}
+	for _, off := range []int{0, 6, 12, 18} {
+		q := base
+		q.Limit = 6
+		q.Offset = off
+		res := env.AssertQueryMatches(ctx, q)
+		if off == 0 && res != nil && res.Plan.Routing.UseDuckDB {
+			t.Fatalf("hot page unexpectedly routed to duckdb: %+v", res.Plan.Routing)
+		}
+	}
+
+	pages := collectPages(ctx, t, env, base, 6, 21)
+	assertPageUnion(t, pages, creates)
+}
+
+// testMultiKeyMixedDirections pins the two-key sort (rank ASC, count DESC) on
+// the DuckDB path against the oracle and by direct inspection.
+//
+// Adjudication A6: mixed per-key directions are unreachable through the public
+// QueryRequest — entity_query_service.go:79-104 threads a single shared
+// SortOrder across all keys. This scenario drives the internal AttributeOrders
+// contract the federated engine actually implements, where each key carries its
+// own direction, so the coverage is deliberately below the public API.
+func testMultiKeyMixedDirections(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := buildMixedRankRows(wide)
+	mustApplyEvents(ctx, t, env, "mixed-rank creates", creates...)
+	mustFlush(ctx, t, env)
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing
+
+	q := Query{Schema: wide, Sorts: []Sort{{Attr: "rank"}, {Attr: "count", Desc: true}}, Limit: 20}
+	res := env.AssertQueryMatches(ctx, q)
+	if res == nil {
+		return
+	}
+	if !res.Plan.Routing.UseDuckDB {
+		t.Fatalf("expected DuckDB routing, got OLTP: %+v", res.Plan.Routing)
+	}
+	if len(res.Records) != 12 {
+		t.Fatalf("multi-key sort returned %d rows, want 12", len(res.Records))
+	}
+	assertRankThenCountDesc(t, res.Records)
+}

--- a/internal/e2e_harness/production/sort_stability_e2e_test.go
+++ b/internal/e2e_harness/production/sort_stability_e2e_test.go
@@ -5,8 +5,10 @@ package production
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
+	forma "github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/model"
 )
 
@@ -31,6 +33,7 @@ func TestSortStability(t *testing.T) {
 		{"repeat_n_stable_order", testRepeatNStableOrder},
 		{"hot_oltp_page_union", testHotOLTPPageUnion},
 		{"multi_key_mixed_directions", testMultiKeyMixedDirections},
+		{"multi_key_public_api_desc", testMultiKeyPublicAPIDesc},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -274,7 +277,9 @@ func testHotOLTPPageUnion(ctx context.Context, t *testing.T, env *Env, wide Sche
 // QueryRequest — entity_query_service.go:79-104 threads a single shared
 // SortOrder across all keys. This scenario drives the internal AttributeOrders
 // contract the federated engine actually implements, where each key carries its
-// own direction, so the coverage is deliberately below the public API.
+// own direction, so it remains the pin for the per-key-direction contract. The
+// publicly expressible slice — a uniform-direction multi-key sort — is covered
+// by testMultiKeyPublicAPIDesc through the real EntityManager.Query surface.
 func testMultiKeyMixedDirections(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
 	creates := buildMixedRankRows(wide)
 	mustApplyEvents(ctx, t, env, "mixed-rank creates", creates...)
@@ -293,4 +298,62 @@ func testMultiKeyMixedDirections(ctx context.Context, t *testing.T, env *Env, wi
 		t.Fatalf("multi-key sort returned %d rows, want 12", len(res.Records))
 	}
 	assertRankThenCountDesc(t, res.Records)
+}
+
+// testMultiKeyPublicAPIDesc covers the publicly expressible half of #183's
+// (status, created_at DESC) ask: a two-key sort through the real
+// forma.EntityManager.Query surface. The public QueryRequest threads a single
+// shared SortOrder across all SortBy keys (entity_query_service.go:79-104), so
+// mixed per-key directions are unreachable — but a uniform-DESC multi-key sort
+// is. Here (rank DESC, count DESC) stands in for the categorical-primary +
+// distinct-secondary shape: rank repeats (six 1s, six 2s) so the count key is
+// load-bearing, and count is unique so the pair is a total order. The rows are
+// cold-only and the request opts into the federated path, so a correct ordered
+// result can only come back through DuckDB.
+//
+// Note: e2e_wide has no "status"/"created_at" public attributes, so the
+// scenario uses rank+count — both main-bound schema attributes — as the
+// faithful categorical+distinct analog of #183's key pair.
+func testMultiKeyPublicAPIDesc(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := buildMixedRankRows(wide)
+	mustApplyEvents(ctx, t, env, "public-api multi-key creates", creates...)
+	mustFlush(ctx, t, env)
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold/warm-only ⇒ federated DuckDB path
+
+	// Oracle: uniform DESC over (rank, count), row_id irrelevant (count unique).
+	want := make([]*Event, len(creates))
+	copy(want, creates)
+	sort.SliceStable(want, func(i, j int) bool {
+		ri, rj := want[i].Attrs["rank"].(float64), want[j].Attrs["rank"].(float64)
+		if ri != rj {
+			return ri > rj // rank DESC
+		}
+		return want[i].Attrs["count"].(float64) > want[j].Attrs["count"].(float64) // count DESC
+	})
+
+	res, err := env.EntityManager().Query(ctx, &forma.QueryRequest{
+		SchemaName:   wide.Name,
+		Page:         1,
+		ItemsPerPage: 20,
+		SortBy:       []string{"rank", "count"},
+		SortOrder:    forma.SortOrderDesc,
+		Federated: &forma.FederatedQueryRequest{
+			Enabled:               true,
+			PreferredTiers:        []string{"hot", "warm", "cold"},
+			S3ParquetPathTemplate: env.ParquetGlob(),
+			IncludeExecutionPlan:  true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("public-api federated query: %v", err)
+	}
+	if len(res.Data) != len(want) {
+		t.Fatalf("public-api multi-key sort returned %d rows, want %d", len(res.Data), len(want))
+	}
+	for i := range want {
+		if res.Data[i].RowID != want[i].RowID {
+			t.Fatalf("public-api row %d = %s, want %s: (rank DESC, count DESC) order drift through EntityManager.Query",
+				i, res.Data[i].RowID, want[i].RowID)
+		}
+	}
 }

--- a/internal/e2e_harness/production/tiebreak_lww_e2e_test.go
+++ b/internal/e2e_harness/production/tiebreak_lww_e2e_test.go
@@ -147,7 +147,6 @@ func testEqualVertsDivergentProbe(ctx context.Context, t *testing.T, env *Env, w
 	if winners["fresh-v2"] != 20 {
 		t.Fatalf("equal-ver_ts base/delta tie: fresh-v2 (base) won %d/20 runs, want 20 — the deterministic deleted_ts 0 < NULL tiebreak regressed (revisit against #210)", winners["fresh-v2"])
 	}
-	_ = bystander
 }
 
 // testEqualVertsTombstoneWins pins the deterministic side of the tie: on an
@@ -176,6 +175,21 @@ func testEqualVertsTombstoneWins(ctx context.Context, t *testing.T, env *Env, wi
 		"UPDATE change_log SET changed_at = $1, deleted_at = $2 WHERE schema_id = $3 AND row_id = $4 AND flushed_at = 0",
 		victimT, victimT, wide.ID, victim.RowID)
 	del.ChangedAt, del.DeletedAt = victimT, victimT // mirror for the oracle (Seq breaks the tie)
+
+	// Guard: prove the restamp hit the unflushed tombstone slot. Without this,
+	// a silent no-op (e.g. after a flush-semantics change) would leave the
+	// tombstone at its real, later ver_ts — the victim would still be hidden by
+	// strict recency and the equal-ver_ts deleted_ts tie this scenario exists
+	// to pin would never be exercised.
+	var restamped int
+	if err := env.Pool.QueryRow(ctx,
+		"SELECT count(*) FROM change_log WHERE row_id = $1 AND schema_id = $2 AND flushed_at = 0 AND changed_at = $3 AND deleted_at = $3",
+		victim.RowID, wide.ID, victimT).Scan(&restamped); err != nil {
+		t.Fatalf("restamp verification query: %v", err)
+	}
+	if restamped != 1 {
+		t.Fatalf("tombstone restamp matched %d rows, want 1 — the equal-ver_ts construction did not take", restamped)
+	}
 
 	mustFlush(ctx, t, env)                     // tombstone parquet @ ver_ts T1, deleted_ts T1
 	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing

--- a/internal/e2e_harness/production/tiebreak_lww_e2e_test.go
+++ b/internal/e2e_harness/production/tiebreak_lww_e2e_test.go
@@ -1,0 +1,206 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+)
+
+// TestWarmColdTiebreak (#183, epic #172 Phase 3) probes the federated LWW
+// tiebreak when a live BASE (cold init) copy and a live DELTA (cold flush)
+// copy of the same row_id carry an EQUAL ver_ts — the tie #210 calls
+// "undefined". The dedup ranks
+//
+//	ORDER BY ver_ts DESC, source_tier_priority DESC, deleted_ts DESC, row_id ASC
+//	(advanced_query_template_duckdb.go:76-83)
+//
+// All parquet rows share tier priority 1; live BASE rows carry deleted_ts = 0
+// (init COALESCEs ltbase_deleted_at, init_exporter.go:36) while live DELTA
+// rows carry deleted_ts = NULL. Under DuckDB's default NULLS LAST, 0 sorts
+// before NULL in a DESC key, so on an equal-ver_ts tie the BASE copy wins
+// deterministically. cdc-init stamps base ver_ts from ltbase_created_at
+// (init_exporter.go:35) and delta from changed_at, so create->flush->init with
+// no intervening update yields identical ver_ts (scenario 1) while
+// create->flush->update->init yields equal-ver_ts DIVERGENT values (scenario
+// 2). Scenario 3 pins the same asymmetry from the deleted-row side.
+func TestWarmColdTiebreak(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	scenarios := []struct {
+		name string
+		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"equal_verts_identical_copies", testEqualVertsIdenticalCopies},
+		{"equal_verts_divergent_values_probe", testEqualVertsDivergentProbe},
+		{"equal_verts_tombstone_wins", testEqualVertsTombstoneWins},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), wide)
+		})
+	}
+}
+
+// testEqualVertsIdenticalCopies pins the hard invariant of the identical-copy
+// tie: create -> flush (delta @ create-ts) -> RunInit (base @ ltbase_created_at
+// = the same ts) leaves each row with two cold copies sharing ver_ts AND
+// attribute values. Whichever copy wins rn = 1, the row set must be exactly the
+// three v1 rows — no duplication (both copies surfacing) and no drop. The
+// winner identity is irrelevant here (copies are identical), so this is a
+// multiplicity invariant, not a scan-order pin.
+func testEqualVertsIdenticalCopies(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	creates := []*Event{
+		CreateEvent(wide, map[string]any{"title": "copy-a", "count": float64(10)}),
+		CreateEvent(wide, map[string]any{"title": "copy-b", "count": float64(20)}),
+		CreateEvent(wide, map[string]any{"title": "copy-c", "count": float64(30)}),
+	}
+	mustApplyEvents(ctx, t, env, "identical-copy creates", creates...)
+	mustFlush(ctx, t, env) // delta copies @ create-ts
+	if _, err := env.RunInit(ctx, wide); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing
+
+	q := Query{Schema: wide, Sorts: []Sort{{Attr: "count"}}, Limit: 10}
+	res := env.AssertQueryMatches(ctx, q) // oracle also pins v1 values
+	if res == nil {
+		return
+	}
+	if len(res.Records) != 3 {
+		t.Fatalf("identical-copy tie returned %d rows, want exactly 3 (a base/delta copy duplicated or dropped)", len(res.Records))
+	}
+	if !res.Plan.Routing.UseDuckDB {
+		t.Fatalf("expected DuckDB routing, got OLTP: %+v", res.Plan.Routing)
+	}
+	for i := 0; i < 10; i++ { // no flapping at the row-multiplicity level
+		again, err := env.Query(ctx, q)
+		if err != nil {
+			t.Fatalf("repeat %d: %v", i, err)
+		}
+		if len(again.Records) != 3 || again.Total != 3 {
+			t.Fatalf("repeat %d returned %d records / total %d, want 3/3 (equal-ver_ts tie flapped row multiplicity — engine finding)",
+				i, len(again.Records), again.Total)
+		}
+	}
+}
+
+// testEqualVertsDivergentProbe is #210's failure-mode-2 construction, built
+// entirely from production verbs: create stale-v1 + a bystander -> flush (delta
+// v1 @ T1, deleted_ts NULL) -> update to fresh-v2 -> RunInit (base carries the
+// v2 attrs but ver_ts = ltbase_created_at = T1, deleted_ts 0). After clearing
+// change_log the row is cold-only with two live copies at an EQUAL ver_ts and
+// DIVERGENT values. The probe settles empirically whether the tie is
+// deterministic; it deliberately does NOT route through AssertQueryMatches
+// because the oracle's Seq tiebreak would declare v2 the truth and beg the
+// question. The only hard invariant is exactly-once (rn = 1).
+func testEqualVertsDivergentProbe(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	target := CreateEvent(wide, map[string]any{"title": "stale-v1", "count": float64(111)})
+	bystander := CreateEvent(wide, map[string]any{"title": "bystander", "count": float64(999)})
+	mustApplyEvents(ctx, t, env, "divergent create + bystander", target, bystander)
+	mustFlush(ctx, t, env) // delta v1 @ T1
+
+	upd := UpdateEvent(wide, target.RowID, map[string]any{"title": "fresh-v2", "count": float64(222)})
+	mustApplyEvents(ctx, t, env, "divergent update", upd)
+	assertStrictlyNewer(t, []*Event{target}, []*Event{upd}) // v2 is a genuinely later write
+
+	if _, err := env.RunInit(ctx, wide); err != nil { // base v2 attrs @ ver_ts = create T1
+		t.Fatalf("run init: %v", err)
+	}
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing
+
+	q := Query{Schema: wide, Sorts: []Sort{{Attr: "count"}}, Limit: 10}
+	winners := make(map[string]int)
+	for i := 0; i < 20; i++ {
+		res, err := env.Query(ctx, q)
+		if err != nil {
+			t.Fatalf("probe run %d: %v", i, err)
+		}
+		if i == 0 && !res.Plan.Routing.UseDuckDB {
+			t.Fatalf("expected DuckDB routing, got OLTP: %+v", res.Plan.Routing)
+		}
+		seen := 0
+		title := ""
+		for _, rec := range res.Records {
+			if rec.RowID == target.RowID {
+				seen++
+				title = rec.TextItems["text_01"]
+			}
+		}
+		if seen != 1 { // hard invariant: rn = 1 must yield exactly one surviving copy
+			t.Fatalf("probe run %d: target row_id appeared %d times, want exactly 1 (rn = 1 broke)", i, seen)
+		}
+		winners[title]++
+	}
+
+	// Adjudication A3 — arm A (finalized from the 20-run probe: fresh-v2 won
+	// 20/20). The base copy (fresh-v2, deleted_ts 0) beats the live delta
+	// (stale-v1, deleted_ts NULL) on every run: 0 sorts before NULL under
+	// deleted_ts DESC + DuckDB's default NULLS LAST, so on an equal ver_ts the
+	// base wins deterministically. This is a CHARACTERIZATION of the
+	// #174-pinned init/flush export asymmetry, NOT a designed contract — #210
+	// still calls this tie undefined, so this assertion must be revisited when
+	// #210 lands a deliberate tie rule.
+	t.Logf("arm A: equal-ver_ts winner distribution %v", winners)
+	if winners["fresh-v2"] != 20 {
+		t.Fatalf("equal-ver_ts base/delta tie: fresh-v2 (base) won %d/20 runs, want 20 — the deterministic deleted_ts 0 < NULL tiebreak regressed (revisit against #210)", winners["fresh-v2"])
+	}
+	_ = bystander
+}
+
+// testEqualVertsTombstoneWins pins the deterministic side of the tie: on an
+// equal ver_ts a tombstone (deleted_ts = T1) must beat a live copy (deleted_ts
+// NULL/0) under deleted_ts DESC, hiding the row. Construction: create victim +
+// bystander -> flush (delta live v1 @ T1) -> delete victim -> restamp the
+// unflushed tombstone slot back to the create ts (forcing the equal-ver_ts tie
+// production's monotonic clock would not) -> flush (tombstone parquet @ ver_ts
+// T1, deleted_ts T1) -> clear change_log. This pins InjectRestore's documented
+// same-millisecond assumption (restore.go: "ts must be > DeletedAt") from the
+// read side.
+func testEqualVertsTombstoneWins(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	victim := CreateEvent(wide, map[string]any{"title": "victim", "count": float64(10)})
+	bystander := CreateEvent(wide, map[string]any{"title": "bystander", "count": float64(20)})
+	mustApplyEvents(ctx, t, env, "tombstone creates", victim, bystander)
+	mustFlush(ctx, t, env) // delta: live v1 @ T1
+
+	del := DeleteEvent(wide, victim.RowID)
+	mustApplyEvents(ctx, t, env, "tombstone delete", del)
+
+	// Restamp the unflushed tombstone slot to the create ts so its ver_ts ties
+	// the flushed live delta; change_log columns/schema-ID verified against
+	// restore.go:49-54 (schema_id int16, changed_at, deleted_at, flushed_at).
+	victimT := victim.ChangedAt // T1, read back at apply time
+	env.ExecSQL(ctx,
+		"UPDATE change_log SET changed_at = $1, deleted_at = $2 WHERE schema_id = $3 AND row_id = $4 AND flushed_at = 0",
+		victimT, victimT, wide.ID, victim.RowID)
+	del.ChangedAt, del.DeletedAt = victimT, victimT // mirror for the oracle (Seq breaks the tie)
+
+	mustFlush(ctx, t, env)                     // tombstone parquet @ ver_ts T1, deleted_ts T1
+	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing
+
+	// Positive control first: the bystander is visible on the DuckDB path, so a
+	// zero-row victim probe cannot be a false green from a broken read path.
+	bystanderQ := Query{Schema: wide, Filters: []Filter{{Attr: "title", Op: "equals", Value: "bystander"}}, Limit: 10}
+	assertRowCount(ctx, t, env, "bystander control", bystanderQ, 1)
+	if res, err := env.Query(ctx, bystanderQ); err != nil {
+		t.Fatalf("routing probe: %v", err)
+	} else if !res.Plan.Routing.UseDuckDB {
+		t.Fatalf("expected DuckDB routing, got OLTP: %+v", res.Plan.Routing)
+	}
+
+	// Probe: the tombstone (deleted_ts T1 > NULL/0) wins deleted_ts DESC on the
+	// ver_ts tie, so the victim is invisible.
+	victimQ := Query{Schema: wide, Filters: []Filter{{Attr: "title", Op: "equals", Value: "victim"}}, Limit: 10}
+	assertZeroRows(ctx, t, env, "victim tombstone", victimQ)
+	for i := 0; i < 5; i++ { // no flapping: the tombstone must never lose the tie
+		res, err := env.Query(ctx, victimQ)
+		if err != nil {
+			t.Fatalf("repeat %d: %v", i, err)
+		}
+		if len(res.Records) != 0 {
+			t.Fatalf("repeat %d: victim visible (%d rows) — tombstone lost the equal-ver_ts tie (engine finding)", i, len(res.Records))
+		}
+	}
+}

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -106,6 +106,15 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 	if e == nil || e.pgSource == nil {
 		return nil, fmt.Errorf("postgres federated source is not available")
 	}
+	// Guard the live renderer path: ExecuteDuckDBFederatedQuery below consumes
+	// the cursor unvalidated (duckdb_template_renderer.go), so reject a cursor
+	// lacking the trailing row_id tiebreak here, before it can silently skip a
+	// boundary tie group (#183).
+	if fq.KeysetCursor != nil && len(fq.KeysetCursor.Columns) > 0 {
+		if err := validateKeysetTiebreak(fq.KeysetCursor); err != nil {
+			return nil, err
+		}
+	}
 	if len(fq.PreferredTiers) == 0 || fq.PreferHot || (len(fq.PreferredTiers) == 1 && fq.PreferredTiers[0] == model.DataTierHot) {
 		return e.queryPostgresOnly(ctx, tables, fq)
 	}

--- a/internal/federated/keyset.go
+++ b/internal/federated/keyset.go
@@ -96,7 +96,11 @@ func keysetComparisonOp(direction forma.SortOrder, mode model.KeysetCursorMode) 
 }
 
 // extractCursorFromRecord builds a model.KeysetCursor from the last row of a page.
-// The columns must match the query's sort columns plus a row_id tiebreaker.
+// The columns must match the query's sort columns and MUST end with a row_id
+// tiebreaker: a cursor whose final column is a non-unique key silently skips
+// every row tied at the boundary (see validateKeysetTiebreak, #183). That
+// requirement is no longer merely documented — both federated seams reject a
+// cursor lacking the trailing row_id before it reaches the renderer.
 func extractCursorFromRecord(record *model.PersistentRecord, columns []model.KeysetColumn) *model.KeysetCursor {
 	if record == nil || len(columns) == 0 {
 		return nil
@@ -166,6 +170,27 @@ func validateKeysetColumns(columns []model.KeysetColumn) error {
 		if !isSupportedKeysetColumn(col.Attribute) {
 			return fmt.Errorf("keyset pagination on attribute %q is not supported (EAV attributes require schema cache)", col.Attribute)
 		}
+	}
+	return nil
+}
+
+// validateKeysetTiebreak enforces the keyset caller contract: the final cursor
+// column MUST be row_id. The continuation predicate for the last cursor key is
+// a strict inequality, so a cursor ending on a non-unique key (created_at, a
+// business attribute, ...) excludes every row sharing that key's value at the
+// page boundary — an entire tie group is silently skipped (#183). row_id is the
+// only version-invariant unique column, so ending the cursor there gives the
+// composite key a total order and makes each boundary tie resolvable. Empty and
+// nil cursors are a no-op (the open first page carries no tiebreak obligation).
+// Mirrors validateKeysetColumns: a plain read-path error, not an
+// ErrInvalidInput-wrapped write-path validation.
+func validateKeysetTiebreak(cursor *model.KeysetCursor) error {
+	if cursor == nil || len(cursor.Columns) == 0 {
+		return nil
+	}
+	last := cursor.Columns[len(cursor.Columns)-1].Attribute
+	if last != "row_id" {
+		return fmt.Errorf("keyset cursor final column is %q, expected \"row_id\": a cursor not ending on the unique row_id tiebreak silently skips every row tied on the composite key at the page boundary", last)
 	}
 	return nil
 }

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -57,6 +57,66 @@ func TestValidateKeysetColumns_EmptyColumnsValid(t *testing.T) {
 	}
 }
 
+func TestValidateKeysetTiebreak_TrailingRowIDAccepted(t *testing.T) {
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{
+			{Attribute: "created_at", Direction: forma.SortOrderDesc},
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+		},
+	}
+	if err := validateKeysetTiebreak(cursor); err != nil {
+		t.Errorf("expected no error for cursor ending on row_id, got: %v", err)
+	}
+}
+
+func TestValidateKeysetTiebreak_RowIDOnlyAccepted(t *testing.T) {
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
+	}
+	if err := validateKeysetTiebreak(cursor); err != nil {
+		t.Errorf("expected no error for row_id-only cursor, got: %v", err)
+	}
+}
+
+func TestValidateKeysetTiebreak_MissingRowIDRejected(t *testing.T) {
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}},
+	}
+	err := validateKeysetTiebreak(cursor)
+	if err == nil {
+		t.Fatal("expected error for cursor lacking trailing row_id, got nil")
+	}
+	// The message must name the offending column and the expected state.
+	if !strings.Contains(err.Error(), "created_at") {
+		t.Errorf("expected error to name the offending column %q, got: %v", "created_at", err)
+	}
+	if !strings.Contains(err.Error(), "row_id") {
+		t.Errorf("expected error to name the expected \"row_id\" tiebreak, got: %v", err)
+	}
+}
+
+func TestValidateKeysetTiebreak_NonTrailingRowIDRejected(t *testing.T) {
+	// row_id present but not last: the trailing "count" is still non-unique.
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+			{Attribute: "created_at", Direction: forma.SortOrderDesc},
+		},
+	}
+	if err := validateKeysetTiebreak(cursor); err == nil {
+		t.Fatal("expected error when row_id is not the final column, got nil")
+	}
+}
+
+func TestValidateKeysetTiebreak_EmptyAndNilNoOp(t *testing.T) {
+	if err := validateKeysetTiebreak(nil); err != nil {
+		t.Errorf("expected no error for nil cursor, got: %v", err)
+	}
+	if err := validateKeysetTiebreak(&model.KeysetCursor{}); err != nil {
+		t.Errorf("expected no error for empty cursor, got: %v", err)
+	}
+}
+
 func TestGenerateKeysetWhereClause_SingleColumnAsc(t *testing.T) {
 	cursor := &model.KeysetCursor{
 		Columns: []model.KeysetColumn{

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -148,9 +148,14 @@ func (e *DBFederatedQueryEngine) executeFederatedKeysetQuery(
 	attributeOrders []model.AttributeOrder,
 	opts *model.FederatedQueryOptions,
 ) ([]*model.PersistentRecord, int64, error) {
-	// Validate keyset cursor columns are supported
+	// Validate keyset cursor columns are supported and end on the row_id
+	// tiebreak (#183): an unsupported column or a missing trailing row_id would
+	// otherwise be consumed silently by the DuckDB template below.
 	if fq.KeysetCursor != nil {
 		if err := validateKeysetColumns(fq.KeysetCursor.Columns); err != nil {
+			return nil, 0, err
+		}
+		if err := validateKeysetTiebreak(fq.KeysetCursor); err != nil {
 			return nil, 0, err
 		}
 	}

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -233,10 +233,13 @@ func formatDuckDBPathList(paths []string) string {
 // buildNonKeysetOrderBy constructs an ORDER BY fragment from a query's AttributeOrders.
 // Main-table attributes are sorted by their bound ColumnName; EAV attributes are sorted
 // by their logical AttrName, which the unified CTE exposes as a named column via the
-// EAV pivot. When no resolvable columns remain the default "created_at DESC" is returned.
+// EAV pivot. A trailing "row_id ASC" tiebreak is always appended so equal-key rows have
+// a total order — mirroring the PG optimized template's trailing m.ltbase_row_id —
+// keeping LIMIT/OFFSET windows stable across requests (#183).
 func buildNonKeysetOrderBy(q *model.FederatedAttributeQuery) string {
+	const stableTiebreak = "row_id ASC"
 	if q == nil || len(q.AttributeOrders) == 0 {
-		return "created_at DESC"
+		return "created_at DESC, " + stableTiebreak
 	}
 	var parts []string
 	for _, ao := range q.AttributeOrders {
@@ -254,9 +257,9 @@ func buildNonKeysetOrderBy(q *model.FederatedAttributeQuery) string {
 		// If neither ColumnName nor AttrName is set the attribute is unresolvable; skip it.
 	}
 	if len(parts) == 0 {
-		return "created_at DESC"
+		return "created_at DESC, " + stableTiebreak
 	}
-	return strings.Join(parts, ", ")
+	return strings.Join(parts, ", ") + ", " + stableTiebreak
 }
 
 // appendKeysetArgs extracts KEYSET_ARGS from the params map and appends them

--- a/internal/sqlgen/duckdb_template_renderer_test.go
+++ b/internal/sqlgen/duckdb_template_renderer_test.go
@@ -15,13 +15,13 @@ import (
 
 func TestBuildNonKeysetOrderBy_NilQuery_ReturnsDefault(t *testing.T) {
 	got := buildNonKeysetOrderBy(nil)
-	require.Equal(t, "created_at DESC", got)
+	require.Equal(t, "created_at DESC, row_id ASC", got)
 }
 
 func TestBuildNonKeysetOrderBy_NoOrders_ReturnsDefault(t *testing.T) {
 	q := &model.FederatedAttributeQuery{}
 	got := buildNonKeysetOrderBy(q)
-	require.Equal(t, "created_at DESC", got)
+	require.Equal(t, "created_at DESC, row_id ASC", got)
 }
 
 func TestBuildNonKeysetOrderBy_MainColumn_ASC(t *testing.T) {
@@ -38,7 +38,7 @@ func TestBuildNonKeysetOrderBy_MainColumn_ASC(t *testing.T) {
 		},
 	}
 	got := buildNonKeysetOrderBy(q)
-	require.Equal(t, "text_01 ASC", got)
+	require.Equal(t, "text_01 ASC, row_id ASC", got)
 }
 
 func TestBuildNonKeysetOrderBy_MainColumn_DESC(t *testing.T) {
@@ -55,7 +55,7 @@ func TestBuildNonKeysetOrderBy_MainColumn_DESC(t *testing.T) {
 		},
 	}
 	got := buildNonKeysetOrderBy(q)
-	require.Equal(t, "num_01 DESC", got)
+	require.Equal(t, "num_01 DESC, row_id ASC", got)
 }
 
 // TestBuildNonKeysetOrderBy_EAVColumn uses the attribute's logical name (AttrName)
@@ -73,7 +73,7 @@ func TestBuildNonKeysetOrderBy_EAVColumn_UsesAttrName(t *testing.T) {
 		},
 	}
 	got := buildNonKeysetOrderBy(q)
-	require.Equal(t, "tag ASC", got)
+	require.Equal(t, "tag ASC, row_id ASC", got)
 }
 
 // TestBuildNonKeysetOrderBy_EAVColumn_NoAttrName_FallsBackToDefault ensures that
@@ -90,7 +90,7 @@ func TestBuildNonKeysetOrderBy_EAVColumn_NoAttrName_FallsBackToDefault(t *testin
 		},
 	}
 	got := buildNonKeysetOrderBy(q)
-	require.Equal(t, "created_at DESC", got)
+	require.Equal(t, "created_at DESC, row_id ASC", got)
 }
 
 // TestBuildNonKeysetOrderBy_Mixed_MainAndEAV confirms that both main-column and
@@ -114,5 +114,24 @@ func TestBuildNonKeysetOrderBy_Mixed_MainAndEAV(t *testing.T) {
 		},
 	}
 	got := buildNonKeysetOrderBy(q)
-	require.Equal(t, "text_01 ASC, priority DESC", got)
+	require.Equal(t, "text_01 ASC, priority DESC, row_id ASC", got)
+}
+
+// TestBuildNonKeysetOrderBy_AlwaysAppendsRowIDTiebreak pins the stable-sort
+// contract (#183): equal user-sort keys must not leave page windows to DuckDB
+// scan order. Mirrors the PG optimized template (trailing m.ltbase_row_id) and
+// the production-harness oracle (row_id ASC).
+func TestBuildNonKeysetOrderBy_AlwaysAppendsRowIDTiebreak(t *testing.T) {
+	q := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{
+			AttributeOrders: []model.AttributeOrder{
+				{
+					StorageLocation: forma.AttributeStorageLocationEAV,
+					AttrName:        "qty",
+					SortOrder:       forma.SortOrderAsc,
+				},
+			},
+		},
+	}
+	require.Equal(t, "qty ASC, row_id ASC", buildNonKeysetOrderBy(q))
 }


### PR DESCRIPTION
Closes #183 (epic #172, Phase 3).

## What this delivers

Three production determinism fixes (landed red-first) plus four new oracle-checked e2e suites in `internal/e2e_harness/production` pinning warm/cold LWW tiebreaking and sort/pagination stability.

### Production fixes

**F1 — DuckDB federated ORDER BY gains a stable `row_id ASC` tiebreak** (`buildNonKeysetOrderBy`, `internal/sqlgen/duckdb_template_renderer.go`). The issue body's "pagination lacks a stable `row_id` tiebreaker" was real on the DuckDB path only: the PG optimized template already ends both ORDER BYs with `row_id`, and the harness oracle tiebreaks `row_id ASC`. Equal-sort-key rows previously fell to DuckDB scan order, so LIMIT/OFFSET windows could duplicate/skip rows across page boundaries. `design.md` §5 updated in lockstep (#214 executable-doc guard green).

**F2 — PG optimized template: explicit `NULLS LAST` on DESC sort keys** (`internal/advanced_query_template.go`, both the `ordered` CTE — whose LIMIT window depends on NULL placement — and the final ORDER BY).

> **Scope note (user-visible behavior change, accepted at plan adjudication A2, recorded on #183):** on the Postgres-only/OLTP path, a DESC sort over a nullable attribute previously placed NULL rows FIRST (PG default); they now place LAST, matching the DuckDB federated path, giving one NULL-placement contract regardless of routing. The red commit (03cf2b9) demonstrates the pre-fix divergence via the oracle.

**F3 — keyset cursors lacking a trailing `row_id` tiebreak are rejected** (`validateKeysetTiebreak`, `internal/federated/keyset.go`; added in review round 1). A cursor whose final column is a non-unique key applies a strict inequality at the page boundary and silently skips every row tied there. The validator runs at both federated seams that consume a cursor: `DBFederatedQueryEngine.Query` entry (guarding the live DuckDB renderer path, which read the cursor unvalidated) and `executeFederatedKeysetQuery` (alongside `validateKeysetColumns`, whose plain read-path error convention it mirrors). All in-repo cursor constructors already ended (or now end) with `row_id`.

### New e2e suites

- **`TestSortNulls`** — NULLS LAST pinned on both routing paths, both directions, with repeat-N order stability.
- **`TestSortStability`** — duplicate-key page-union (no dup/omission across windows that split tie groups, adversarial reverse-order-update fixture), repeat-N determinism, hot-OLTP parity, multi-key sort on both surfaces: `multi_key_public_api_desc` drives the real `EntityManager.Query` with a uniform-DESC two-key sort over the federated path (the publicly expressible slice — `QueryRequest` threads one shared `SortOrder` across all `SortBy` keys), and `multi_key_mixed_directions` pins the internal per-key-direction `AttributeOrders` contract. The public per-key-direction API gap is tracked in a follow-up issue.
- **`TestWarmColdTiebreak`** — equal-ver_ts constructions through pure production verbs (create→flush→init): identical-copies hard invariant, tombstone-wins-on-tie (read-side pin of `InjectRestore`'s same-millisecond assumption, with a select-back guard proving the restamp took), and the **#210 failure-mode-2 probe**.
- **`TestPaginationUnderInsert`** — OFFSET shift characterization (inherent window re-basing, exact shifted pages pinned; adjudication A5: the issue's "never duplicated" criterion is structurally a keyset property), and the keyset liveness contract split by direction: `keyset_insert_into_future_page` proves an ascending scan surfaces a mid-pagination insert on a later page exactly once, while `keyset_insert_front_desc_unreachable` characterizes the DESC half (a front-inserted row sorts into already-visited territory — unreachable without snapshot isolation). `keyset_incomplete_cursor_rejected` pins F3 with a positive control (the identical query with a trailing `row_id` succeeds).

### Empirical finding for #210

The plan's reconnaissance hypothesized — and the 20-run probe confirmed (**base won 20/20**) — that #210 failure mode 2's "undefined" equal-ver_ts tie is deterministic today: live base rows export `deleted_at = 0` (init COALESCE) while live delta rows export `NULL`, and under `deleted_ts DESC` + DuckDB NULLS LAST the base copy wins. The winner pin is explicitly commented as a **characterization of the #174-pinned export asymmetry, not a designed contract**, flagged for revisit when #210 lands. A comment draft for #210 is prepared (pending approval to post).

## Verification

`make test`, `make lint`, all four new suites, regression gates (`TestDeepPagination`/`TestKeysetLWW`/`TestFilterLWW`/`TestThreeTierMerge`/`TestThreeTierIsolation`/`TestQueryAcrossTiers`), and `go test -race` over `internal/sqlgen` + `internal/federated` — all green, re-run in full after the review-round commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
