### PR TITLE
docs(cn): document the NULLS LAST sort contract (#183)

### DIFF
--- a/docs/cn/api.md
+++ b/docs/cn/api.md
@@ -25,6 +25,8 @@ Base URL: `http://localhost:8080` (configurable via `PORT` env var).
 | `sort_order` | string | `asc` | Sort direction (`asc` or `desc`) |
 | `attrs` | string | — | Comma-separated attribute names for projection |
 
+**NULL placement in sorted results:** records whose sort attribute is NULL always appear at the end of the result set (NULLS LAST), for both `asc` and `desc`, and regardless of whether the query is served by the Postgres OLTP path or the DuckDB federated path (adopted in #183; before that change, DESC sorts on the OLTP path followed the PostgreSQL default of NULLS FIRST).
+
 ## Advanced Query DSL
 
 Reference: [Advanced Query documentation](./advanced_query.md)

--- a/docs/cn/query.md
+++ b/docs/cn/query.md
@@ -139,8 +139,15 @@ Data Plane提供基于Schema的CRUD查询API。
 
 ## 查询指定Schema的记录 （分页）
 
+### 排序与 NULL 值位置
 
+排序键的 NULL 值位置是一个稳定契约（#183 采纳，PR #239 落地）：
 
+* **NULL 值始终排在结果末尾（NULLS LAST）**，无论排序方向是 `asc` 还是 `desc`。
+* 该契约与查询路由无关：Postgres OLTP 路径与 DuckDB 联邦路径行为一致。查询走哪条路径是系统内部决策，调用方不可观测，因此 NULL 位置不允许随路由变化。
+* 实现上，PG 优化模板对 DESC 排序键显式追加 `NULLS LAST`（`internal/advanced_query_template.go`），覆盖 PostgreSQL 在 DESC 下默认 NULLS FIRST 的行为；DuckDB 路径本身默认 NULLS LAST。
+
+兼容性注意：在此契约落地之前，仅走 OLTP 路径的 DESC 排序遵循 PostgreSQL 默认行为（NULL 排最前）。依赖旧行为的调用方在升级后会看到 NULL 记录移动到结果末尾。该契约由 e2e 套件 `TestSortNulls` 在两条路径、两个方向上钉住。
 
 ## 更新指定RowID的属性值
 


### PR DESCRIPTION
Records the NULLS LAST adjudication from #183 / PR #239 in the user-facing CN docs.

- `docs/cn/query.md`: new 排序与 NULL 值位置 section under the paginated-query docs — NULLs always place last in both directions, on both the Postgres OLTP path and the DuckDB federated path (routing must not change NULL placement); notes the compatibility impact (OLTP DESC previously followed the PG default NULLS FIRST) and the `TestSortNulls` pin.
- `docs/cn/api.md`: NULL-placement note under the query-parameter table.

Docs-only; the behavior itself merged in #239 (F2, `internal/advanced_query_template.go`).

Refs #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)