### PR TITLE
test(e2e): degraded mode & circuit breaker under real failures (#185)

### DIFF
--- a/internal/e2e_harness/harness.go
+++ b/internal/e2e_harness/harness.go
@@ -118,6 +118,22 @@ func (h *TestHarness) RestartPostgres(ctx context.Context) error {
 	return nil
 }
 
+// HaltS3 stops the S3 container in place (docker stop — the container and
+// its data survive, unlike StopS3, which terminates it). The endpoint
+// becomes really unreachable for both the Go S3 client and DuckDB httpfs,
+// which is the only fault vector that reaches DuckDB reads: client-level
+// decorators cannot, because httpfs bypasses the Go S3 client entirely.
+func (h *TestHarness) HaltS3(ctx context.Context) error {
+	if h.S3Container == nil {
+		return fmt.Errorf("halt s3: no container (external infrastructure or already terminated)")
+	}
+	stopTimeout := 30 * time.Second
+	if err := h.S3Container.Stop(ctx, &stopTimeout); err != nil {
+		return fmt.Errorf("stop s3 container: %w", err)
+	}
+	return nil
+}
+
 // StopPostgres stops the Postgres container and closes DB handle.
 func (h *TestHarness) StopPostgres(ctx context.Context) error {
 	if h.PGDB != nil {

--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -79,8 +79,8 @@ needs schema IDs beyond the fixtures can register its own via
 `RegisterSchemas` + `WithSchemaDir`.
 
 Options: `WithSeed`, `WithSchemaDir`, `WithFlushThresholds` (#179),
-`WithDuckMemoryMB`, `WithBreaker` (#185), `WithRoutingStrategy`,
-`WithoutManifest`.
+`WithDuckMemoryMB`, `WithBreaker` (#185), `WithDuckMaxConnections` (#185),
+`WithRoutingStrategy`, `WithoutManifest`.
 
 ## Fixture schemas (`schemas/`)
 
@@ -168,6 +168,26 @@ where cdc-init bootstraps base files before federated reads. Use
   DuckDB client, and lazy engine/manager. Restart tests must own a
   `DedicatedCluster` — restarting the shared cluster would break every
   parallel Env — and are skipped on external infrastructure.
+- `Cluster.HaltS3` (#185) stops the S3 container in place (docker stop) so
+  the endpoint becomes genuinely unreachable — the honest way to fault the
+  DuckDB httpfs read path, which cannot be broken at the Go-client layer.
+  Like `RestartPostgres` it mutates cluster-wide state, so only tests owning
+  a `DedicatedCluster` may call it (halting the shared cluster's S3 would
+  break every parallel Env); external infrastructure cannot be halted. The
+  halted container is reaped by the dedicated cluster's normal shutdown.
+- `Env.ReopenDuckDB` (#185) replaces the Env's (possibly closed) DuckDB
+  client with a fresh one and drops the lazy engine/manager so the next use
+  rebinds them. The cached circuit breaker **deliberately survives** the
+  rebuild — breaker state must span client rebuilds so recovery scenarios can
+  observe the open-to-closed transition against a healthy DuckDB.
+- `WithBreaker(maxFailures, cooldown)` (#185) enables the federated engine's
+  circuit breaker; `WithDuckMaxConnections(n)` overrides the per-test DuckDB
+  pool size (default 2). Pin it to `1` for tests that issue **concurrent**
+  DuckDB queries: `NewDuckDBClient` applies the session-scoped S3 `SET`
+  statements on a single pooled connection (`duckdb_conn.go`), so over
+  `:memory:` a second connection opened under load lacks S3 config and 404s.
+  Set `Query.AllowPartialDegradedMode` to forward the public degraded-mode
+  flag so a tier outage returns a partial result instead of erroring.
 
 ## Diagnostic artifacts
 
@@ -206,5 +226,5 @@ On failure (or `KEEP_E2E_ENV=1`) the Env writes
 | #179 flush failure matrix | `FaultInjectingS3` + `RunFlushWith` + `ExecSQL` |
 | #180 dry-run semantics | `RunFlushDry` |
 | #181 failure injection | `ExecSQL` |
-| #185 circuit breaker | `WithBreaker` |
+| #185 degraded mode & circuit breaker | `WithBreaker`, `Query.AllowPartialDegradedMode`, `Cluster.HaltS3`, `Env.ReopenDuckDB`, `WithDuckMaxConnections` |
 | #189 multi-schema | `e2e_simple`/`e2e_second` + per-test DB |

--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -187,7 +187,8 @@ where cdc-init bootstraps base files before federated reads. Use
   statements on a single pooled connection (`duckdb_conn.go`), so over
   `:memory:` a second connection opened under load lacks S3 config and 404s.
   Set `Query.AllowPartialDegradedMode` to forward the public degraded-mode
-  flag so a tier outage returns a partial result instead of erroring.
+  flag so a tier outage falls back to a postgres-only result (complete in
+  today's PG-retains-all model) instead of erroring.
 
 ## Diagnostic artifacts
 

--- a/internal/e2e_harness/production/circuit_breaker_e2e_test.go
+++ b/internal/e2e_harness/production/circuit_breaker_e2e_test.go
@@ -5,8 +5,11 @@ package production
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/lychee-technology/forma/internal/model"
 )
 
 const breakerRejection = "circuit breaker open"
@@ -81,4 +84,100 @@ func TestCircuitBreaker_OpensAtThresholdAndRecovers(t *testing.T) {
 		t.Fatalf("reopen duckdb after single failure: %v", err)
 	}
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
+}
+
+// TestCircuitBreaker_ConcurrentTransitions is #185 breaker scenario 4:
+// goroutines hammer the engine while the breaker trips, and again after it
+// recovers. During the outage every outcome must be one of the two legal
+// failures — a real DuckDB error or a breaker rejection, never a success or
+// a panic — and after recovery every concurrent query must succeed. Engine
+// calls go through eng.Query directly: Env.Query records results without a
+// lock and is not safe for concurrent use.
+//
+// DuckDB MaxConnections is pinned to 1: NewDuckDBClient applies the
+// session-scoped S3 SET statements to a single pooled connection, so a
+// second :memory: connection opened under concurrency lacks S3 config and
+// 404s — a harness/client gap unrelated to breaker behavior (production
+// defaults to MaxConnections=1 and is unaffected; follow-up issue drafted).
+func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
+	const threshold = 3
+	const cooldown = 3 * time.Second
+	const workers = 8
+	const queriesPerWorker = 5
+
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t), WithBreaker(threshold, cooldown), WithDuckMaxConnections(1))
+	wide := DefaultSchemaFixtures()[1]
+
+	seedTwoTiers(ctx, t, env, wide)
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
+
+	eng := env.Engine() // lazily built once, before any concurrency
+	runOne := func() error {
+		fq, err := env.buildFederatedQuery(Query{Schema: wide, Limit: 20})
+		if err != nil {
+			return err
+		}
+		_, err = eng.Query(ctx, env.Tables, fq, &model.FederatedQueryOptions{})
+		return err
+	}
+
+	if err := env.Duck.Close(); err != nil {
+		t.Fatalf("close duckdb client: %v", err)
+	}
+
+	errCh := make(chan error, workers*queriesPerWorker)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < queriesPerWorker; i++ {
+				errCh <- runOne()
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	var real, rejected int
+	for err := range errCh {
+		switch {
+		case err == nil:
+			t.Error("query succeeded while duckdb was closed")
+		case strings.Contains(err.Error(), breakerRejection):
+			rejected++
+		default:
+			real++
+		}
+	}
+	if rejected == 0 {
+		t.Errorf("no breaker rejections across %d concurrent queries (real failures: %d)", workers*queriesPerWorker, real)
+	}
+	t.Logf("open phase: %d real failures, %d breaker rejections", real, rejected)
+
+	// Recovery under concurrency: healthy client + expired openDuration must
+	// let every worker through. Engine is rebuilt single-threaded first.
+	if err := env.ReopenDuckDB(); err != nil {
+		t.Fatalf("reopen duckdb: %v", err)
+	}
+	eng = env.Engine()
+	time.Sleep(cooldown + time.Second)
+
+	errs2 := make(chan error, workers)
+	var wg2 sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			errs2 <- runOne()
+		}()
+	}
+	wg2.Wait()
+	close(errs2)
+	for err := range errs2 {
+		if err != nil {
+			t.Errorf("post-recovery concurrent query failed: %v", err)
+		}
+	}
 }

--- a/internal/e2e_harness/production/circuit_breaker_e2e_test.go
+++ b/internal/e2e_harness/production/circuit_breaker_e2e_test.go
@@ -4,6 +4,7 @@ package production
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -116,10 +117,12 @@ func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
 	runOne := func() error {
 		fq, err := env.buildFederatedQuery(Query{Schema: wide, Limit: 20})
 		if err != nil {
-			return err
+			return fmt.Errorf("build federated query: %w", err)
 		}
-		_, err = eng.Query(ctx, env.Tables, fq, &model.FederatedQueryOptions{})
-		return err
+		if _, err := eng.Query(ctx, env.Tables, fq, &model.FederatedQueryOptions{}); err != nil {
+			return fmt.Errorf("engine query: %w", err)
+		}
+		return nil
 	}
 
 	if err := env.Duck.Close(); err != nil {

--- a/internal/e2e_harness/production/circuit_breaker_e2e_test.go
+++ b/internal/e2e_harness/production/circuit_breaker_e2e_test.go
@@ -1,0 +1,84 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+const breakerRejection = "circuit breaker open"
+
+// TestCircuitBreaker_OpensAtThresholdAndRecovers covers #185 breaker
+// scenarios 1-3 end to end: exactly N real DuckDB failures (a closed
+// database/sql client) open the breaker, an open breaker rejects queries
+// before reaching DuckDB (rejection persists across a DuckDB rebuild while
+// openDuration lasts), after openDuration the first success closes the
+// breaker immediately, and the cleared failure history means one fresh
+// failure does not reopen it — the documented immediate-forgiveness design
+// with no half-open state accumulation (circuit_breaker.go design note).
+func TestCircuitBreaker_OpensAtThresholdAndRecovers(t *testing.T) {
+	const threshold = 3
+	const cooldown = 5 * time.Second
+
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t), WithBreaker(threshold, cooldown))
+	wide := DefaultSchemaFixtures()[1]
+
+	seedTwoTiers(ctx, t, env, wide)
+
+	// Healthy precondition binds the engine — and the breaker the Env caches
+	// across DuckDB rebuilds — before the client is closed.
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
+
+	if err := env.Duck.Close(); err != nil {
+		t.Fatalf("close duckdb client: %v", err)
+	}
+
+	// Scenario 1: the first `threshold` queries reach DuckDB and fail for
+	// real; none of them may be breaker rejections.
+	for i := 0; i < threshold; i++ {
+		_, err := env.Query(ctx, Query{Schema: wide, Limit: 20})
+		if err == nil {
+			t.Fatalf("failure %d/%d: expected error with duckdb closed, got success", i+1, threshold)
+		}
+		if strings.Contains(err.Error(), breakerRejection) {
+			t.Fatalf("failure %d/%d: breaker opened before the threshold: %v", i+1, threshold, err)
+		}
+	}
+	// ...and the next query is rejected by the breaker, not by DuckDB.
+	if _, err := env.Query(ctx, Query{Schema: wide, Limit: 20}); err == nil || !strings.Contains(err.Error(), breakerRejection) {
+		t.Fatalf("query after threshold: want breaker rejection, got: %v", err)
+	}
+
+	// DuckDB is healthy again, but openDuration has not expired: rejection
+	// must come from breaker state, not from the dead client.
+	if err := env.ReopenDuckDB(); err != nil {
+		t.Fatalf("reopen duckdb: %v", err)
+	}
+	if _, err := env.Query(ctx, Query{Schema: wide, Limit: 20}); err == nil || !strings.Contains(err.Error(), breakerRejection) {
+		t.Fatalf("query while open with healthy duckdb: want breaker rejection, got: %v", err)
+	}
+
+	// Scenario 2: after openDuration the first query flows through, succeeds,
+	// and closes the breaker (oracle-checked result).
+	time.Sleep(cooldown + time.Second)
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
+
+	// Scenario 3: the success cleared the failure history — a single fresh
+	// failure must NOT reopen the breaker (no half-open accumulation).
+	if err := env.Duck.Close(); err != nil {
+		t.Fatalf("close duckdb client again: %v", err)
+	}
+	if _, err := env.Query(ctx, Query{Schema: wide, Limit: 20}); err == nil {
+		t.Fatal("expected one real failure after re-close, got success")
+	} else if strings.Contains(err.Error(), breakerRejection) {
+		t.Fatalf("single failure after recovery reopened the breaker (history not cleared): %v", err)
+	}
+	if err := env.ReopenDuckDB(); err != nil {
+		t.Fatalf("reopen duckdb after single failure: %v", err)
+	}
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
+}

--- a/internal/e2e_harness/production/cluster.go
+++ b/internal/e2e_harness/production/cluster.go
@@ -207,6 +207,21 @@ func (c *Cluster) RestartPostgres(ctx context.Context) error {
 	return nil
 }
 
+// HaltS3 stops the cluster's S3 container in place so the endpoint becomes
+// really unreachable (#185 degraded-mode scenarios). External infrastructure
+// cannot be halted. Only tests owning a DedicatedCluster may call this:
+// halting the SharedCluster's S3 would break every parallel Env. The halted
+// container is terminated by the dedicated cluster's normal Shutdown.
+func (c *Cluster) HaltS3(ctx context.Context) error {
+	if c.external {
+		return fmt.Errorf("halt s3: external infrastructure (%s) cannot be halted", externalS3EndpointVar)
+	}
+	if err := c.Base.HaltS3(ctx); err != nil {
+		return fmt.Errorf("halt cluster s3: %w", err)
+	}
+	return nil
+}
+
 // Shutdown stops the shared containers. Under KEEP_E2E_ENV=1 it prints
 // connection info instead and leaves everything running.
 func (c *Cluster) Shutdown(ctx context.Context) error {

--- a/internal/e2e_harness/production/degraded_mode_e2e_test.go
+++ b/internal/e2e_harness/production/degraded_mode_e2e_test.go
@@ -4,9 +4,12 @@ package production
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
+
+	fedengine "github.com/lychee-technology/forma/internal/federated"
 )
 
 // seedTwoTiers writes flushed (parquet) plus hot rows for schema so a
@@ -85,4 +88,112 @@ func TestDegradedMode_S3Unavailable(t *testing.T) {
 	// fallback-marked plan. No panic is implicit in reaching the assertions.
 	degraded := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20, AllowPartialDegradedMode: true})
 	assertDegradedFallbackPlan(t, degraded)
+}
+
+// TestDegradedMode_DuckDBUnavailable is #185 degraded scenario 3: the
+// embedded DuckDB client is really closed (database/sql rejects every call —
+// the honest way to "stop" an in-process engine). Degraded-on falls back to
+// postgres-only with complete results; degraded-off surfaces the failure.
+// Runs on the shared cluster: closing this Env's DuckDB touches nothing
+// shared.
+func TestDegradedMode_DuckDBUnavailable(t *testing.T) {
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1]
+
+	seedTwoTiers(ctx, t, env, wide)
+
+	// Bind the engine (and its executor) to the client before closing it:
+	// the executor wraps the same *sql.DB that Close invalidates.
+	if _, err := env.Query(ctx, Query{Schema: wide, Limit: 20}); err != nil {
+		t.Fatalf("precondition query: %v", err)
+	}
+	if err := env.Duck.Close(); err != nil {
+		t.Fatalf("close duckdb client: %v", err)
+	}
+
+	if _, err := env.Query(ctx, Query{Schema: wide, Limit: 20}); err == nil {
+		t.Fatal("degraded mode off: expected error with duckdb closed, got success")
+	}
+
+	degraded := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20, AllowPartialDegradedMode: true})
+	assertDegradedFallbackPlan(t, degraded)
+}
+
+// TestDegradedMode_DirtyFetchFailure is #185 degraded scenario 4: the
+// dirty-ID anti-join source is broken for real by renaming change_log out
+// from under the engine. Degraded-off (DuckDB path) propagates the "fetch
+// dirty ids" error.
+//
+// Deviation from the task brief (outside its Step-2 contingency list;
+// flagged for adjudication on #185): the brief assumed the degraded-on half
+// would fall back to a *complete* postgres-only page ("postgres is itself
+// the dirty-set source so the result stays complete"). That is not what the
+// engine does. The postgres OLTP optimized query UNIONs the real-time buffer
+// straight from change_log (advanced_query_template.go: `FROM {{.ChangeLogTable}} cl
+// ... flushed_at = 0`) whenever tables.ChangeLog is set — which it always is
+// in the production harness. So renaming change_log breaks the postgres-only
+// fallback too, and AllowPartialDegradedMode does NOT rescue a change_log
+// outage: degraded-on surfaces the same missing-relation error rather than a
+// clean fallback page. This is a broader break than a pure dirty-ID
+// anti-join outage. The honest characterization below asserts that actual
+// behavior; the brief's assertDegradedFallbackPlan expectation cannot hold
+// here. See the task report / issue for adjudication of whether the harness
+// should isolate the dirty-ID source from the real-time buffer scan.
+func TestDegradedMode_DirtyFetchFailure(t *testing.T) {
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1]
+
+	seedTwoTiers(ctx, t, env, wide)
+
+	if _, err := env.Pool.Exec(ctx, "ALTER TABLE change_log RENAME TO change_log_broken"); err != nil {
+		t.Fatalf("rename change_log: %v", err)
+	}
+	// Registered after NewEnv's cleanups, so it runs first (LIFO) and the
+	// artifact dump still sees a intact change_log on failure.
+	t.Cleanup(func() {
+		_, _ = env.Pool.Exec(context.Background(), "ALTER TABLE change_log_broken RENAME TO change_log")
+	})
+
+	_, err := env.Query(ctx, Query{Schema: wide, Limit: 20})
+	if err == nil {
+		t.Fatal("expected dirty-fetch error with change_log renamed, got success")
+	}
+	if !strings.Contains(err.Error(), "fetch dirty ids") {
+		t.Errorf("error should wrap the dirty-id fetch, got: %v", err)
+	}
+
+	// Degraded-on: the postgres-only fallback also scans change_log (real-time
+	// buffer UNION), so a change_log outage is non-degradable — the flag does
+	// not rescue it. See the function doc for the full deviation rationale.
+	_, degradedErr := env.Query(ctx, Query{Schema: wide, Limit: 20, AllowPartialDegradedMode: true})
+	if degradedErr == nil {
+		t.Fatal("degraded on: expected error (postgres fallback also scans change_log), got success")
+	}
+	if !strings.Contains(degradedErr.Error(), "change_log") {
+		t.Errorf("degraded on: error should reference the missing change_log relation, got: %v", degradedErr)
+	}
+}
+
+// TestDegradedMode_MissingSchemaMetadataNotDegradable is #185 degraded
+// scenario 5: a schema unknown to the load-once metadata snapshot fails with
+// ErrSchemaMetadataCacheRequired even under AllowPartialDegradedMode — the
+// documented non-degradable configuration error (#151). errors.Is must
+// survive the engine's wrapping.
+func TestDegradedMode_MissingSchemaMetadataNotDegradable(t *testing.T) {
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1]
+
+	seedTwoTiers(ctx, t, env, wide)
+
+	ghost := SchemaRef{ID: 9999, Name: "ghost"}
+	_, err := env.Query(ctx, Query{Schema: ghost, Limit: 20, AllowPartialDegradedMode: true})
+	if err == nil {
+		t.Fatal("expected ErrSchemaMetadataCacheRequired for a schema outside the metadata snapshot, got success")
+	}
+	if !errors.Is(err, fedengine.ErrSchemaMetadataCacheRequired) {
+		t.Errorf("error = %v, want errors.Is(ErrSchemaMetadataCacheRequired)", err)
+	}
 }

--- a/internal/e2e_harness/production/degraded_mode_e2e_test.go
+++ b/internal/e2e_harness/production/degraded_mode_e2e_test.go
@@ -1,0 +1,88 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// seedTwoTiers writes flushed (parquet) plus hot rows for schema so a
+// federated query has to touch both Postgres and S3.
+func seedTwoTiers(ctx context.Context, t *testing.T, env *Env, schema SchemaRef) {
+	t.Helper()
+	flushed := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 5})
+	if err := env.ApplyEvents(ctx, flushed...); err != nil {
+		t.Fatalf("apply flushed events: %v", err)
+	}
+	mustFlush(ctx, t, env)
+	hot := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 3})
+	if err := env.ApplyEvents(ctx, hot...); err != nil {
+		t.Fatalf("apply hot events: %v", err)
+	}
+}
+
+// assertDegradedFallbackPlan asserts the execution plan reflects the
+// postgres-only degraded fallback (#185 scenario 6; contract pinned by
+// TestDBFederatedQueryEngine_DegradedFallbackRecordsExecutionPlan).
+func assertDegradedFallbackPlan(t *testing.T, result *QueryResult) {
+	t.Helper()
+	if result == nil {
+		return
+	}
+	if result.Plan == nil {
+		t.Fatal("degraded query returned no execution plan")
+	}
+	if result.Plan.Routing.UseDuckDB {
+		t.Errorf("degraded fallback plan still claims duckdb: %+v", result.Plan.Routing)
+	}
+	if !strings.Contains(result.Plan.Routing.Reason, "degraded fallback") {
+		t.Errorf("degraded fallback plan reason = %q, want a degraded-fallback marker", result.Plan.Routing.Reason)
+	}
+}
+
+// TestDegradedMode_S3Unavailable covers #185 degraded scenarios 1, 2 and 6
+// with the S3 container really stopped (docker stop — DuckDB httpfs gets
+// connection failures, not a harness boolean): degraded-on must fall back to
+// postgres-only with complete, oracle-checked results, correct page metadata
+// and a fallback-marked execution plan; degraded-off must surface the error
+// instead of silently returning partial results. Owns a dedicated cluster:
+// halting the shared S3 would break every parallel Env.
+func TestDegradedMode_S3Unavailable(t *testing.T) {
+	ctx := context.Background()
+	cluster := DedicatedCluster(t)
+	env := NewEnv(t, cluster)
+	wide := DefaultSchemaFixtures()[1]
+
+	seedTwoTiers(ctx, t, env, wide)
+
+	// Precondition: with S3 healthy the query routes through DuckDB, so the
+	// halt below is what forces the fallback (not the routing policy).
+	healthy := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
+	if healthy != nil && !healthy.Plan.Routing.UseDuckDB {
+		t.Fatalf("precondition: healthy query did not route to duckdb: %+v", healthy.Plan.Routing)
+	}
+
+	if err := cluster.HaltS3(ctx); err != nil {
+		t.Fatalf("halt s3 container: %v", err)
+	}
+
+	// Scenario 2 (degraded OFF): the DuckDB/S3 failure must surface as an
+	// error, bounded by a timeout so a hanging httpfs retry fails the test
+	// instead of stalling it.
+	failCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if _, err := env.Query(failCtx, Query{Schema: wide, Limit: 20}); err == nil {
+		t.Fatal("degraded mode off: expected error with S3 halted, got success")
+	} else if !strings.Contains(err.Error(), "duckdb federated query") {
+		t.Errorf("degraded mode off: error should wrap the duckdb failure, got: %v", err)
+	}
+
+	// Scenarios 1+6 (degraded ON): postgres-only fallback returns complete
+	// oracle-checked results (totals, row sets, attribute values) plus a
+	// fallback-marked plan. No panic is implicit in reaching the assertions.
+	degraded := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20, AllowPartialDegradedMode: true})
+	assertDegradedFallbackPlan(t, degraded)
+}

--- a/internal/e2e_harness/production/degraded_mode_e2e_test.go
+++ b/internal/e2e_harness/production/degraded_mode_e2e_test.go
@@ -27,6 +27,35 @@ func seedTwoTiers(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
 	}
 }
 
+// seedAllTiers writes base (RunInit), delta (flush) and hot (unflushed) rows
+// for schema so a federated query has to merge all three tiers. Mirrors the
+// three-tier union recipe (three_tier_merge_e2e_test.go testThreeTierUnion):
+// after RunInit exports the base parquet the change_log entries for that batch
+// must be cleared, otherwise those already-based rows stay flushed_at=0 and are
+// mistaken for dirty/unflushed hot rows.
+func seedAllTiers(ctx context.Context, t *testing.T, env *Env, schema SchemaRef) {
+	t.Helper()
+	base := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 5})
+	if err := env.ApplyEvents(ctx, base...); err != nil {
+		t.Fatalf("apply base events: %v", err)
+	}
+	if _, err := env.RunInit(ctx, schema); err != nil {
+		t.Fatalf("run init (base export): %v", err)
+	}
+	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", schema.ID)
+
+	delta := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 4})
+	if err := env.ApplyEvents(ctx, delta...); err != nil {
+		t.Fatalf("apply delta events: %v", err)
+	}
+	mustFlush(ctx, t, env)
+
+	hot := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 3})
+	if err := env.ApplyEvents(ctx, hot...); err != nil {
+		t.Fatalf("apply hot events: %v", err)
+	}
+}
+
 // assertDegradedFallbackPlan asserts the execution plan reflects the
 // postgres-only degraded fallback (#185 scenario 6; contract pinned by
 // TestDBFederatedQueryEngine_DegradedFallbackRecordsExecutionPlan).
@@ -59,7 +88,7 @@ func TestDegradedMode_S3Unavailable(t *testing.T) {
 	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
-	seedTwoTiers(ctx, t, env, wide)
+	seedAllTiers(ctx, t, env, wide)
 
 	// Precondition: with S3 healthy the query routes through DuckDB, so the
 	// halt below is what forces the fallback (not the routing policy).
@@ -86,8 +115,23 @@ func TestDegradedMode_S3Unavailable(t *testing.T) {
 	// Scenarios 1+6 (degraded ON): postgres-only fallback returns complete
 	// oracle-checked results (totals, row sets, attribute values) plus a
 	// fallback-marked plan. No panic is implicit in reaching the assertions.
-	degraded := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20, AllowPartialDegradedMode: true})
+	const degradedLimit = 20
+	degraded := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: degradedLimit, AllowPartialDegradedMode: true})
 	assertDegradedFallbackPlan(t, degraded)
+
+	// The degraded page must still carry correct pagination metadata computed
+	// from the (oracle-checked) total: total pages = ceil(Total/limit) and, at
+	// offset 0, current page = 1.
+	if degraded != nil {
+		wantPages := int((degraded.Total + degradedLimit - 1) / degradedLimit)
+		if degraded.TotalPages != wantPages {
+			t.Errorf("degraded page TotalPages = %d, want %d (ceil(%d/%d))",
+				degraded.TotalPages, wantPages, degraded.Total, degradedLimit)
+		}
+		if degraded.CurrentPage != 1 {
+			t.Errorf("degraded page CurrentPage = %d, want 1 (offset 0)", degraded.CurrentPage)
+		}
+	}
 }
 
 // TestDegradedMode_DuckDBUnavailable is #185 degraded scenario 3: the
@@ -153,7 +197,9 @@ func TestDegradedMode_DirtyFetchFailure(t *testing.T) {
 	// Registered after NewEnv's cleanups, so it runs first (LIFO) and the
 	// artifact dump still sees an intact change_log on failure.
 	t.Cleanup(func() {
-		_, _ = env.Pool.Exec(context.Background(), "ALTER TABLE change_log_broken RENAME TO change_log")
+		if _, err := env.Pool.Exec(context.Background(), "ALTER TABLE change_log_broken RENAME TO change_log"); err != nil {
+			t.Logf("restore change_log: %v", err)
+		}
 	})
 
 	_, err := env.Query(ctx, Query{Schema: wide, Limit: 20})

--- a/internal/e2e_harness/production/degraded_mode_e2e_test.go
+++ b/internal/e2e_harness/production/degraded_mode_e2e_test.go
@@ -151,7 +151,7 @@ func TestDegradedMode_DirtyFetchFailure(t *testing.T) {
 		t.Fatalf("rename change_log: %v", err)
 	}
 	// Registered after NewEnv's cleanups, so it runs first (LIFO) and the
-	// artifact dump still sees a intact change_log on failure.
+	// artifact dump still sees an intact change_log on failure.
 	t.Cleanup(func() {
 		_, _ = env.Pool.Exec(context.Background(), "ALTER TABLE change_log_broken RENAME TO change_log")
 	})

--- a/internal/e2e_harness/production/doc.go
+++ b/internal/e2e_harness/production/doc.go
@@ -32,7 +32,7 @@
 //	#180 dry-run semantics         -> RunFlushDry, RunInitWith(InitOverrides{DryRun})
 //	#181 failure-state injection   -> Env.ExecSQL escape hatch
 //	#182 mid-flush concurrency     -> PausingS3, RunFlushWith(FlushOverrides{S3})
-//	#185 circuit breaker           -> WithBreaker
+//	#185 degraded/breaker          -> WithBreaker, WithDuckMaxConnections, HaltS3, ReopenDuckDB, Query.AllowPartialDegradedMode
 //	#189 multi-schema isolation    -> schemas/e2e_simple + e2e_second, per-test DB
 //
 // Environment variables: KEEP_E2E_ENV, E2E_SEED, E2E_ARTIFACTS_DIR,

--- a/internal/e2e_harness/production/engine.go
+++ b/internal/e2e_harness/production/engine.go
@@ -19,16 +19,18 @@ func (e *Env) Engine() *fedengine.DBFederatedQueryEngine {
 	}
 
 	repo := internal.NewDBPersistentRecordRepository(e.Pool, e.Metadata)
-	var breaker *fedengine.CircuitBreaker
-	if e.opts.breakerFailures > 0 {
-		breaker = fedengine.NewCircuitBreaker(e.opts.breakerFailures, e.opts.breakerCooldown, e.opts.breakerCooldown)
+	if e.breaker == nil && e.opts.breakerFailures > 0 {
+		// Built once per Env, not per engine assembly: breaker state must
+		// survive ReopenDuckDB/RestartPostgres handle rebuilds so #185
+		// recovery scenarios can observe the open-to-closed transition.
+		e.breaker = fedengine.NewCircuitBreaker(e.opts.breakerFailures, e.opts.breakerCooldown, e.opts.breakerCooldown)
 	}
 
 	e.engine = fedengine.NewDBFederatedQueryEngine(
 		repo,
 		fedengine.NewPostgresDirtyIDFetcher(e.Pool),
 		fedengine.NewDuckDBClientQueryExecutor(e.Duck),
-		breaker,
+		e.breaker,
 		e.DuckCfg,
 		e.Metadata,
 		fedengine.DuckDBPostgresConnStringFromPool(e.Pool),

--- a/internal/e2e_harness/production/env.go
+++ b/internal/e2e_harness/production/env.go
@@ -327,7 +327,9 @@ func (e *Env) reconnectAfterRestart(ctx context.Context) error {
 // open-to-closed transition against a healthy DuckDB.
 func (e *Env) ReopenDuckDB() error {
 	if e.Duck != nil {
-		_ = e.Duck.Close()
+		if err := e.Duck.Close(); err != nil {
+			e.T.Logf("reopen duckdb: close old client: %v", err)
+		}
 	}
 	if err := e.startDuckDB(); err != nil {
 		return fmt.Errorf("reopen duckdb client: %w", err)

--- a/internal/e2e_harness/production/env.go
+++ b/internal/e2e_harness/production/env.go
@@ -47,6 +47,7 @@ type Env struct {
 
 	manager      forma.EntityManager
 	engine       *fedengine.DBFederatedQueryEngine
+	breaker      *fedengine.CircuitBreaker
 	events       []*Event
 	eventSeq     int
 	queryN       int
@@ -305,6 +306,23 @@ func (e *Env) reconnectAfterRestart(ctx context.Context) error {
 	e.CDC = e.buildCDCConfig()
 	e.manager = nil
 	e.engine = nil
+	return nil
+}
+
+// ReopenDuckDB replaces the Env's (possibly closed) DuckDB client with a
+// fresh one and drops the lazily built engine and manager so the next use
+// rebinds them. The cached circuit breaker deliberately survives: breaker
+// state must span client rebuilds so #185 recovery scenarios can observe the
+// open-to-closed transition against a healthy DuckDB.
+func (e *Env) ReopenDuckDB() error {
+	if e.Duck != nil {
+		_ = e.Duck.Close()
+	}
+	if err := e.startDuckDB(); err != nil {
+		return fmt.Errorf("reopen duckdb client: %w", err)
+	}
+	e.engine = nil
+	e.manager = nil
 	return nil
 }
 

--- a/internal/e2e_harness/production/env.go
+++ b/internal/e2e_harness/production/env.go
@@ -67,6 +67,7 @@ type envOptions struct {
 	minRecords      int
 	maxAgeMs        int64
 	duckMemoryMB    int
+	duckMaxConns    int
 	breakerFailures int
 	breakerCooldown time.Duration
 	routing         forma.RoutingStrategy
@@ -100,6 +101,16 @@ func WithDuckMemoryMB(mb int) EnvOption {
 	return func(o *envOptions) { o.duckMemoryMB = mb }
 }
 
+// WithDuckMaxConnections overrides the per-test DuckDB connection pool size
+// (default 2). NewDuckDBClient applies the session-scoped S3 SET statements
+// on a single pooled connection (duckdb_conn.go), so with :memory: a second
+// pooled connection opened under load lacks S3 config and fails S3 reads
+// with HTTP 404 / empty region. Tests that issue concurrent DuckDB queries
+// should pin this to 1 until that gap is fixed.
+func WithDuckMaxConnections(n int) EnvOption {
+	return func(o *envOptions) { o.duckMaxConns = n }
+}
+
 // WithBreaker enables a circuit breaker on the federated engine (for #185).
 func WithBreaker(maxFailures int, cooldown time.Duration) EnvOption {
 	return func(o *envOptions) {
@@ -127,7 +138,7 @@ func NewEnv(t *testing.T, c *Cluster, opts ...EnvOption) *Env {
 	t.Helper()
 	ctx := context.Background()
 
-	options := envOptions{minRecords: 1, maxAgeMs: 3600000, duckMemoryMB: 1024}
+	options := envOptions{minRecords: 1, maxAgeMs: 3600000, duckMemoryMB: 1024, duckMaxConns: 2}
 	for _, opt := range opts {
 		opt(&options)
 	}
@@ -224,7 +235,7 @@ func (e *Env) startDuckDB() error {
 		S3AccessKey:    c.S3AccessKey,
 		S3SecretKey:    c.S3SecretKey,
 		S3Region:       c.S3Region,
-		MaxConnections: 2,
+		MaxConnections: e.opts.duckMaxConns,
 		MaxParallelism: 2,
 		QueryTimeout:   60 * time.Second,
 	}

--- a/internal/e2e_harness/production/query.go
+++ b/internal/e2e_harness/production/query.go
@@ -55,11 +55,13 @@ type Query struct {
 // need: the translated federated query and the full execution plan
 // (SQL, parameters, routing, timings).
 type QueryResult struct {
-	Spec    Query
-	Records []*model.PersistentRecord
-	Total   int64
-	Plan    *model.ExecutionPlan
-	FQ      *model.FederatedAttributeQuery
+	Spec        Query
+	Records     []*model.PersistentRecord
+	Total       int64
+	TotalPages  int
+	CurrentPage int
+	Plan        *model.ExecutionPlan
+	FQ          *model.FederatedAttributeQuery
 }
 
 // ParquetGlob returns the production-layout parquet path template: one flat
@@ -75,7 +77,7 @@ func (e *Env) ParquetGlob() string {
 func (e *Env) Query(ctx context.Context, q Query) (*QueryResult, error) {
 	fq, err := e.buildFederatedQuery(q)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build federated query (schema=%s): %w", q.Schema.Name, err)
 	}
 
 	opts := &model.FederatedQueryOptions{
@@ -90,11 +92,13 @@ func (e *Env) Query(ctx context.Context, q Query) (*QueryResult, error) {
 	}
 
 	result := &QueryResult{
-		Spec:    q,
-		Records: page.Records,
-		Total:   page.TotalRecords,
-		Plan:    opts.ExecutionPlan,
-		FQ:      fq,
+		Spec:        q,
+		Records:     page.Records,
+		Total:       page.TotalRecords,
+		TotalPages:  page.TotalPages,
+		CurrentPage: page.CurrentPage,
+		Plan:        opts.ExecutionPlan,
+		FQ:          fq,
 	}
 	e.queryN++
 	e.queries = append(e.queries, result)

--- a/internal/e2e_harness/production/query.go
+++ b/internal/e2e_harness/production/query.go
@@ -37,6 +37,12 @@ type Query struct {
 	PreferredTiers []model.DataTier    `json:"preferred_tiers,omitempty"`
 	Keyset         *model.KeysetCursor `json:"keyset,omitempty"`
 
+	// AllowPartialDegradedMode forwards the public degraded-mode flag (#185):
+	// on a DuckDB-side failure the engine falls back to postgres-only instead
+	// of failing the query. Non-degradable errors (missing schema metadata)
+	// still surface.
+	AllowPartialDegradedMode bool `json:"allow_partial_degraded_mode,omitempty"`
+
 	// UseMainAsAnchor forwards the public anchor hint (#184 preference
 	// contract: the hint must surface in the execution plan).
 	UseMainAsAnchor bool `json:"use_main_as_anchor,omitempty"`
@@ -73,8 +79,9 @@ func (e *Env) Query(ctx context.Context, q Query) (*QueryResult, error) {
 	}
 
 	opts := &model.FederatedQueryOptions{
-		IncludeExecutionPlan: true,
-		ExecutionPlan:        &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
+		AllowPartialDegradedMode: q.AllowPartialDegradedMode,
+		IncludeExecutionPlan:     true,
+		ExecutionPlan:            &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
 	}
 
 	page, err := e.Engine().Query(ctx, e.Tables, fq, opts)

--- a/internal/federated/circuit_breaker_integration_test.go
+++ b/internal/federated/circuit_breaker_integration_test.go
@@ -1,0 +1,132 @@
+package federated
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/stretchr/testify/require"
+)
+
+// #185 breaker scenario 5: both failure classes — query execution errors and
+// row-stream errors — must increment the breaker through the production
+// StreamDuckDBFederatedQuery path, and a clean stream must reset it. The
+// engine-internal seams (fakeDuckDBExecutor / iterators) are the injection
+// surface; a deterministic mid-stream infrastructure failure cannot be
+// staged from real containers.
+
+// failingScanRows yields rows whose Scan always fails, driving the
+// streamDuckDBRows error path.
+type failingScanRows struct{}
+
+func (f *failingScanRows) Next() bool             { return true }
+func (f *failingScanRows) Scan(dest ...any) error { return fmt.Errorf("forced scan failure") }
+func (f *failingScanRows) Err() error             { return nil }
+func (f *failingScanRows) Close() error           { return nil }
+
+// scriptedDuckDBExecutor plays one prepared outcome per Query call and
+// repeats the last one when the script runs out.
+type scriptedDuckDBExecutor struct {
+	calls  int
+	script []func() (duckDBRowsIterator, error)
+}
+
+func (s *scriptedDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
+	idx := s.calls
+	s.calls++
+	if idx >= len(s.script) {
+		idx = len(s.script) - 1
+	}
+	return s.script[idx]()
+}
+
+func newBreakerTestEngine(t *testing.T, duck DuckDBQueryExecutor, breaker *CircuitBreaker) *DBFederatedQueryEngine {
+	t.Helper()
+	engine := NewDBFederatedQueryEngine(&fakePostgresFederatedSource{}, &fakeDirtyIDFetcher{}, duck, breaker,
+		forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}},
+		testMetadataCacheSchema7(t), "")
+	engine.buildDuckSQL = func(tpl *template.Template, params any, q *model.FederatedAttributeQuery, dirtyIDs []uuid.UUID, dual *sqlgen.DualClauses) (string, []any, error) {
+		return "SELECT fake", nil, nil
+	}
+	return engine
+}
+
+func breakerTestQuery() (*model.FederatedAttributeQuery, model.StorageTables) {
+	return &model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 2000},
+			PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
+		}, model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"}
+}
+
+func TestBreakerRecordsExecutionFailures(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	breaker := NewCircuitBreaker(2, time.Minute, time.Minute)
+	duck := &fakeDuckDBExecutor{err: fmt.Errorf("forced execution failure")}
+	engine := newBreakerTestEngine(t, duck, breaker)
+	fq, tables := breakerTestQuery()
+
+	for i := 0; i < 2; i++ {
+		require.False(t, breaker.IsOpen(), "breaker open before threshold at failure %d", i+1)
+		_, err := engine.Query(context.Background(), tables, fq, nil)
+		require.ErrorContains(t, err, "execute duckdb query")
+	}
+	require.True(t, breaker.IsOpen(), "two execution failures must open a threshold-2 breaker")
+
+	// The open breaker rejects before DuckDB: the executor is not reached.
+	calls := duck.calls
+	_, err := engine.Query(context.Background(), tables, fq, nil)
+	require.ErrorContains(t, err, "circuit breaker open")
+	require.Equal(t, calls, duck.calls, "open breaker must not reach the executor")
+}
+
+func TestBreakerRecordsStreamFailures(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	breaker := NewCircuitBreaker(2, time.Minute, time.Minute)
+	duck := &fakeDuckDBExecutor{rows: &failingScanRows{}}
+	engine := newBreakerTestEngine(t, duck, breaker)
+	fq, tables := breakerTestQuery()
+
+	for i := 0; i < 2; i++ {
+		require.False(t, breaker.IsOpen(), "breaker open before threshold at failure %d", i+1)
+		_, err := engine.Query(context.Background(), tables, fq, nil)
+		require.ErrorContains(t, err, "scan duckdb row")
+	}
+	require.True(t, breaker.IsOpen(), "two row-stream failures must open a threshold-2 breaker")
+}
+
+func TestBreakerSuccessResetsFailureHistory(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	breaker := NewCircuitBreaker(2, time.Minute, time.Minute)
+	duck := &scriptedDuckDBExecutor{script: []func() (duckDBRowsIterator, error){
+		func() (duckDBRowsIterator, error) { return nil, fmt.Errorf("forced execution failure") },
+		func() (duckDBRowsIterator, error) { return &singleDuckDBRow{rowID: uuid.New()}, nil },
+		func() (duckDBRowsIterator, error) { return nil, fmt.Errorf("forced execution failure") },
+	}}
+	engine := newBreakerTestEngine(t, duck, breaker)
+	fq, tables := breakerTestQuery()
+
+	_, err := engine.Query(context.Background(), tables, fq, nil)
+	require.Error(t, err)
+
+	_, err = engine.Query(context.Background(), tables, fq, nil)
+	require.NoError(t, err, "clean stream must succeed and reset the breaker")
+
+	// One failure after the reset stays below the threshold of 2: the
+	// success cleared the prior failure from the history.
+	_, err = engine.Query(context.Background(), tables, fq, nil)
+	require.Error(t, err)
+	require.False(t, breaker.IsOpen(), "success must have cleared the failure history")
+}

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -112,7 +112,7 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 	// boundary tie group (#183).
 	if fq.KeysetCursor != nil && len(fq.KeysetCursor.Columns) > 0 {
 		if err := validateKeysetTiebreak(fq.KeysetCursor); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("validate keyset cursor: %w", err)
 		}
 	}
 	// Only explicit hot-only requests short-circuit to Postgres. Empty
@@ -148,7 +148,12 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 		// even under AllowPartialDegradedMode.
 		if opts != nil && opts.AllowPartialDegradedMode && !errors.Is(err, ErrSchemaMetadataCacheRequired) {
 			recordDegradedFallbackPlan(opts, tables, err)
-			return e.queryPostgresOnly(ctx, tables, fq)
+			page, perr := e.queryPostgresOnly(ctx, tables, fq)
+			if perr != nil {
+				return nil, perr
+			}
+			attachExecutionPlan(page, opts)
+			return page, nil
 		}
 		return nil, fmt.Errorf("duckdb federated query: %w", err)
 	}
@@ -166,7 +171,12 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 			// the degraded mode contract promises to serve Postgres-only.
 			if opts != nil && opts.AllowPartialDegradedMode && !errors.Is(cerr, ErrSchemaMetadataCacheRequired) {
 				recordDegradedFallbackPlan(opts, tables, cerr)
-				return e.queryPostgresOnly(ctx, tables, fq)
+				page, perr := e.queryPostgresOnly(ctx, tables, fq)
+				if perr != nil {
+					return nil, perr
+				}
+				attachExecutionPlan(page, opts)
+				return page, nil
 			}
 			return nil, fmt.Errorf("compute empty-page federated count: %w", cerr)
 		}
@@ -247,6 +257,16 @@ func recordDegradedFallbackPlan(opts *model.FederatedQueryOptions, tables model.
 		SQL:    fmt.Sprintf("OLTP optimized query over %s", tables.EntityMain),
 		Reason: "degraded fallback (postgres-only)",
 	})
+}
+
+// attachExecutionPlan stitches the recorded plan onto the returned page so
+// engine callers that only see the page (not the options) still observe the
+// degraded fallback (#185 review finding).
+func attachExecutionPlan(page *model.PersistentRecordPage, opts *model.FederatedQueryOptions) {
+	if page == nil || opts == nil || !opts.IncludeExecutionPlan || opts.ExecutionPlan == nil {
+		return
+	}
+	page.ExecutionPlan = opts.ExecutionPlan
 }
 
 func (e *DBFederatedQueryEngine) queryPostgresOnly(ctx context.Context, tables model.StorageTables, fq *model.FederatedAttributeQuery) (*model.PersistentRecordPage, error) {

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -147,6 +147,7 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 		// would silently return a partial result and mask it (#151). Surface it
 		// even under AllowPartialDegradedMode.
 		if opts != nil && opts.AllowPartialDegradedMode && !errors.Is(err, ErrSchemaMetadataCacheRequired) {
+			recordDegradedFallbackPlan(opts, tables, err)
 			return e.queryPostgresOnly(ctx, tables, fq)
 		}
 		return nil, fmt.Errorf("duckdb federated query: %w", err)
@@ -164,6 +165,7 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 			// exception): a transient failure here must not fail a request
 			// the degraded mode contract promises to serve Postgres-only.
 			if opts != nil && opts.AllowPartialDegradedMode && !errors.Is(cerr, ErrSchemaMetadataCacheRequired) {
+				recordDegradedFallbackPlan(opts, tables, cerr)
 				return e.queryPostgresOnly(ctx, tables, fq)
 			}
 			return nil, fmt.Errorf("compute empty-page federated count: %w", cerr)
@@ -216,6 +218,34 @@ func recordHotOnlyGatePlan(opts *model.FederatedQueryOptions, tables model.Stora
 		Engine: "postgres",
 		SQL:    fmt.Sprintf("OLTP optimized query over %s", tables.EntityMain),
 		Reason: "hot-only gate (OLTP main)",
+	})
+}
+
+// recordDegradedFallbackPlan rewrites the execution plan when a DuckDB-side
+// failure degrades the query to Postgres-only (#185): without it the plan
+// keeps the pre-failure routing decision (UseDuckDB=true) and never mentions
+// the fallback, so "the plan reflects actual access" would not hold for the
+// degraded-mode contract. Tiers states physical coverage — postgres serves
+// the hot storage regardless of the tiers the request asked for (#184).
+func recordDegradedFallbackPlan(opts *model.FederatedQueryOptions, tables model.StorageTables, cause error) {
+	if opts == nil || !opts.IncludeExecutionPlan {
+		return
+	}
+	if opts.ExecutionPlan == nil {
+		opts.ExecutionPlan = &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}}
+	}
+	opts.ExecutionPlan.Routing = model.RoutingDecision{
+		Tiers:     []model.DataTier{model.DataTierHot},
+		UseDuckDB: false,
+		Reason:    "degraded fallback (AllowPartialDegradedMode)",
+	}
+	opts.ExecutionPlan.Notes = append(opts.ExecutionPlan.Notes,
+		fmt.Sprintf("degraded fallback to postgres-only: %v", cause))
+	opts.ExecutionPlan.Sources = append(opts.ExecutionPlan.Sources, model.DataSourcePlan{
+		Tier:   model.DataTierHot,
+		Engine: "postgres",
+		SQL:    fmt.Sprintf("OLTP optimized query over %s", tables.EntityMain),
+		Reason: "degraded fallback (postgres-only)",
 	})
 }
 

--- a/internal/federated/engine_empty_page_test.go
+++ b/internal/federated/engine_empty_page_test.go
@@ -224,4 +224,7 @@ func TestDBFederatedQueryEngine_RecountDegradedFallbackRecordsExecutionPlan(t *t
 		"plan must not claim DuckDB after recount degraded fallback: %+v", opts.ExecutionPlan.Routing)
 	require.Contains(t, opts.ExecutionPlan.Routing.Reason, "degraded fallback")
 	requirePlanHasNoteContaining(t, opts.ExecutionPlan, "forced recount failure")
+	// The plan must ride on the returned page, not just opts (#185).
+	require.NotNil(t, page.ExecutionPlan)
+	require.False(t, page.ExecutionPlan.Routing.UseDuckDB)
 }

--- a/internal/federated/engine_empty_page_test.go
+++ b/internal/federated/engine_empty_page_test.go
@@ -191,3 +191,37 @@ func TestDBFederatedQueryEngine_RecountFailureErrorsWithoutDegradedMode(t *testi
 	require.ErrorContains(t, err, "compute empty-page federated count")
 	require.Equal(t, 0, pg.queryCalls)
 }
+
+// TestDBFederatedQueryEngine_RecountDegradedFallbackRecordsExecutionPlan pins
+// #185 scenario 6 on the second fallback site: when the empty-page recount
+// fails and degraded mode absorbs it, the plan must also reflect the
+// postgres-only fallback.
+func TestDBFederatedQueryEngine_RecountDegradedFallbackRecordsExecutionPlan(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &sequencedDuckDBExecutor{
+		rows: []duckDBRowsIterator{&emptyDuckDBRows{}},
+		errs: []error{nil, fmt.Errorf("forced recount failure")},
+	}
+	var built []model.FederatedAttributeQuery
+	engine := newEmptyPageTestEngine(t, &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 7}}, duck, &built)
+
+	opts := &model.FederatedQueryOptions{
+		AllowPartialDegradedMode: true,
+		IncludeExecutionPlan:     true,
+	}
+	page, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		&model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10, Offset: 50},
+			PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
+		}, opts)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(7), page.TotalRecords)
+	require.False(t, opts.ExecutionPlan.Routing.UseDuckDB,
+		"plan must not claim DuckDB after recount degraded fallback: %+v", opts.ExecutionPlan.Routing)
+	require.Contains(t, opts.ExecutionPlan.Routing.Reason, "degraded fallback")
+	requirePlanHasNoteContaining(t, opts.ExecutionPlan, "forced recount failure")
+}

--- a/internal/federated/engine_test.go
+++ b/internal/federated/engine_test.go
@@ -3,6 +3,7 @@ package federated
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -432,4 +433,57 @@ func TestEngineCompiledPlanCache(t *testing.T) {
 	_, _, err = newEngine(duckC).ExecuteDuckDBFederatedQuery(context.Background(), tables, qC, qC.Limit, 0, nil, optsC)
 	require.NoError(t, err)
 	require.Contains(t, optsC.ExecutionPlan.Notes, "plan_cache=miss")
+}
+
+// requirePlanHasNoteContaining asserts one plan note contains substr.
+func requirePlanHasNoteContaining(t *testing.T, plan *model.ExecutionPlan, substr string) {
+	t.Helper()
+	require.NotNil(t, plan)
+	for _, n := range plan.Notes {
+		if strings.Contains(n, substr) {
+			return
+		}
+	}
+	t.Fatalf("no plan note contains %q; notes: %v", substr, plan.Notes)
+}
+
+// requirePlanHasPostgresSource asserts the plan records a postgres source
+// whose reason contains reasonSubstr.
+func requirePlanHasPostgresSource(t *testing.T, plan *model.ExecutionPlan, reasonSubstr string) {
+	t.Helper()
+	require.NotNil(t, plan)
+	for _, s := range plan.Sources {
+		if s.Engine == "postgres" && strings.Contains(s.Reason, reasonSubstr) {
+			return
+		}
+	}
+	t.Fatalf("no postgres source with reason containing %q; sources: %+v", reasonSubstr, plan.Sources)
+}
+
+// TestDBFederatedQueryEngine_DegradedFallbackRecordsExecutionPlan pins the
+// #185 scenario-6 contract: when AllowPartialDegradedMode absorbs a DuckDB
+// failure, the returned execution plan must reflect the postgres-only
+// fallback instead of keeping the stale pre-failure routing decision.
+func TestDBFederatedQueryEngine_DegradedFallbackRecordsExecutionPlan(t *testing.T) {
+	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 1}}
+	duck := &fakeDuckDBExecutor{err: fmt.Errorf("forced duck failure")}
+	engine := NewDBFederatedQueryEngine(pg, nil, duck, nil, forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}}, testMetadataCacheSchema7(t), "")
+
+	opts := &model.FederatedQueryOptions{
+		AllowPartialDegradedMode: true,
+		IncludeExecutionPlan:     true,
+	}
+	_, err := engine.Query(context.Background(), model.StorageTables{EntityMain: "main", EAVData: "eav"}, &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 2000},
+		PreferredTiers: []model.DataTier{model.DataTierHot, model.DataTierCold},
+	}, opts)
+
+	require.NoError(t, err)
+	require.NotNil(t, opts.ExecutionPlan)
+	require.False(t, opts.ExecutionPlan.Routing.UseDuckDB,
+		"plan must not claim DuckDB after degraded fallback: %+v", opts.ExecutionPlan.Routing)
+	require.Equal(t, []model.DataTier{model.DataTierHot}, opts.ExecutionPlan.Routing.Tiers)
+	require.Contains(t, opts.ExecutionPlan.Routing.Reason, "degraded fallback")
+	requirePlanHasNoteContaining(t, opts.ExecutionPlan, "forced duck failure")
+	requirePlanHasPostgresSource(t, opts.ExecutionPlan, "degraded fallback")
 }

--- a/internal/federated/engine_test.go
+++ b/internal/federated/engine_test.go
@@ -473,7 +473,7 @@ func TestDBFederatedQueryEngine_DegradedFallbackRecordsExecutionPlan(t *testing.
 		AllowPartialDegradedMode: true,
 		IncludeExecutionPlan:     true,
 	}
-	_, err := engine.Query(context.Background(), model.StorageTables{EntityMain: "main", EAVData: "eav"}, &model.FederatedAttributeQuery{
+	page, err := engine.Query(context.Background(), model.StorageTables{EntityMain: "main", EAVData: "eav"}, &model.FederatedAttributeQuery{
 		AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 2000},
 		PreferredTiers: []model.DataTier{model.DataTierHot, model.DataTierCold},
 	}, opts)
@@ -486,4 +486,8 @@ func TestDBFederatedQueryEngine_DegradedFallbackRecordsExecutionPlan(t *testing.
 	require.Contains(t, opts.ExecutionPlan.Routing.Reason, "degraded fallback")
 	requirePlanHasNoteContaining(t, opts.ExecutionPlan, "forced duck failure")
 	requirePlanHasPostgresSource(t, opts.ExecutionPlan, "degraded fallback")
+	// The plan must also ride on the returned page, not just opts: a caller
+	// that only sees the page must still observe the degraded fallback (#185).
+	require.NotNil(t, page.ExecutionPlan)
+	require.False(t, page.ExecutionPlan.Routing.UseDuckDB)
 }


### PR DESCRIPTION
Closes #185. Part of epic #172.

## What

- **Production fix**: degraded fallback now records the execution plan (`recordDegradedFallbackPlan`, both fallback sites) — previously the plan kept the stale `UseDuckDB=true` routing decision with no fallback marker (scenario 6 gap, counterpart of the #184 hot-only gate plan).
- **Degraded-mode e2e** (`degraded_mode_e2e_test.go`): real S3 outage via `Cluster.HaltS3` (docker stop; DuckDB httpfs cannot be faulted at the Go-client layer), closed embedded DuckDB client, renamed `change_log` (dirty-fetch), ghost schema outside the metadata snapshot (`ErrSchemaMetadataCacheRequired` non-degradable, degraded-on included).
- **Circuit breaker e2e** (`circuit_breaker_e2e_test.go`): threshold→open→reject-before-DuckDB, auto-recovery after openDuration, no-half-open characterization, concurrent open/close transitions.
- **Engine integration** (`circuit_breaker_integration_test.go`): execution failures AND row-stream failures both increment the breaker through the real query path; success resets history. Deterministic mid-stream infra failure cannot be staged from containers, hence the seam-level tests.
- Harness verbs: `HaltS3`, `ReopenDuckDB` (breaker state survives rebuilds), `WithDuckMaxConnections`, `Query.AllowPartialDegradedMode`.

## Adjudications for review

1. **Scenario 3 (half-open)**: the breaker has no half-open state by design (circuit_breaker.go design note) — open expiry releases all queries and the first success clears history. Tests characterize this; strict single-probe semantics would be a follow-up.
2. **Dirty-fetch outage is effectively non-degradable (characterized)**: the plan assumed a broken change_log degrades to a complete postgres-only result, masking the outage. Implementation showed otherwise: the PG optimized template UNIONs the change_log real-time buffer into its anchor CTE (`internal/advanced_query_template.go`), so the fallback query fails too — with degraded mode ON, a change_log outage surfaces as an error rather than being masked. The e2e characterizes this (deviation comment in `TestDegradedMode_DirtyFetchFailure`); no masking risk exists.

## Follow-ups

- DuckDB session-scoped S3 config lands on only one pooled connection (`duckdb_conn.go`); `MaxConnections>1` over `:memory:` yields S3-unconfigured connections that 404 under concurrency. Latent in production (default MaxConnections=1); surfaced by the concurrent breaker e2e, which pins `WithDuckMaxConnections(1)`. Filed as #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
