### PR TITLE
test(e2e): multi-schema isolation & backfill rerun safety (#186)

### DIFF
--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -60,7 +60,7 @@ is unavailable). Each `NewEnv`:
   `change_log.deleted_at`.
   CDC advisory locks are keyed `(schemaID, schemaID)` *per database OID*
   and `RunOnce` scans the whole `change_log`, so a private database gives
-  natural isolation and free multi-schema support (#189);
+  natural isolation and free multi-schema support (#186);
 - gets its own S3 prefix `e2e/<runID>/env<N>` and in-memory DuckDB client
   (1 GB default memory limit, `WithDuckMemoryMB` to override);
 - registers the fixture schemas (IDs 20-22; registration rejects the
@@ -88,7 +88,7 @@ Options: `WithSeed`, `WithSchemaDir`, `WithFlushThresholds` (#179),
 |---|---|---|
 | `e2e_simple` | 20 | minimal: bound text + EAV numeric |
 | `e2e_wide` | 21 | one attribute per scalar `forma.ValueType`, mixed main-column/EAV storage (#174) |
-| `e2e_second` | 22 | second schema for multi-schema isolation (#189) |
+| `e2e_second` | 22 | second schema for multi-schema isolation (#186) |
 
 Fixtures define only the attributes their tests use: the synthetic
 `name`/`version` injection in `sqlgen.BuildSchemaProjection` was removed in
@@ -228,4 +228,4 @@ On failure (or `KEEP_E2E_ENV=1`) the Env writes
 | #180 dry-run semantics | `RunFlushDry` |
 | #181 failure injection | `ExecSQL` |
 | #185 degraded mode & circuit breaker | `WithBreaker`, `Query.AllowPartialDegradedMode`, `Cluster.HaltS3`, `Env.ReopenDuckDB`, `WithDuckMaxConnections` |
-| #189 multi-schema | `e2e_simple`/`e2e_second` + per-test DB |
+| #186 multi-schema isolation | `e2e_simple`/`e2e_second` + `FaultInjectingS3`/`PausingS3` (`multi_schema_isolation_e2e_test.go`, `concurrent_flush_multi_schema_e2e_test.go`) |

--- a/internal/e2e_harness/production/cdc_fault_helpers_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_helpers_e2e_test.go
@@ -195,3 +195,68 @@ func assertSameRowIDs(t *testing.T, label string, got, want map[string]bool) {
 		}
 	}
 }
+
+// schemaKeyPrefix returns the Env-scoped S3 key prefix of one schema's
+// parquet partition (e.g. "e2e/<run>/env3/22/"). Matching on the full prefix
+// rather than a bare "/22/" substring keeps the filter unambiguous no matter
+// what the run ID or env sequence look like.
+func schemaKeyPrefix(env *Env, schema SchemaRef) string {
+	return fmt.Sprintf("%s/%d/", env.S3Prefix, schema.ID)
+}
+
+// finalsForSchema filters keys down to one schema's final parquet objects
+// (multi-schema passes legitimately mix partitions in one report, so the
+// global splitKeys alone cannot attribute objects to a schema).
+func finalsForSchema(env *Env, keys []string, schema SchemaRef) []string {
+	finals, _ := splitKeys(keys)
+	var got []string
+	for _, k := range finals {
+		if strings.HasPrefix(k, schemaKeyPrefix(env, schema)) {
+			got = append(got, k)
+		}
+	}
+	return got
+}
+
+// assertSchemaUntouchedByFault is the per-schema face of assertUntouched for
+// multi-schema passes (#186): the faulted schema promoted no final parquet,
+// every one of its rows stays dirty, and its manifest tracks nothing — while
+// sibling schemas may legitimately create objects in the same report. A
+// surviving /_tmp/ orphan under the schema is tolerated (cleanup is #226).
+func assertSchemaUntouchedByFault(ctx context.Context, t *testing.T, env *Env, report *FlushReport, schema SchemaRef, wantDirty int) {
+	t.Helper()
+	if finals := finalsForSchema(env, report.NewObjects, schema); len(finals) != 0 {
+		t.Errorf("schema %d must promote no final parquet after its fault, got %v", schema.ID, finals)
+	}
+	flushed, dirty := fetchChangeLogRowIDs(ctx, t, env, schema)
+	if len(flushed) != 0 || len(dirty) != wantDirty {
+		t.Errorf("schema %d rows must all stay dirty: flushed=%v dirty=%v, want %d dirty",
+			schema.ID, flushed, dirty, wantDirty)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, schema, nil)
+}
+
+// assertSchemaFullyFlushed asserts one schema committed completely inside a
+// multi-schema pass: all wantRows rows carry a flushed_at marker, exactly one
+// new final delta under the schema's partition holds exactly those rows, the
+// manifest tracks exactly that final, and no row was exported twice. newKeys
+// is the object set to attribute (a report diff or a fresh listing — under
+// concurrency a paused runner's report diff absorbs its sibling's writes, so
+// concurrent scenarios pass a fresh listS3Keys instead). Returns the finals.
+func assertSchemaFullyFlushed(ctx context.Context, t *testing.T, env *Env, newKeys []string, manifests map[int16]*manifest.Manifest, schema SchemaRef, wantRows int) []string {
+	t.Helper()
+	flushed, dirty := fetchChangeLogRowIDs(ctx, t, env, schema)
+	if len(flushed) != wantRows || len(dirty) != 0 {
+		t.Fatalf("schema %d must be fully flushed: flushed=%v dirty=%v, want %d flushed",
+			schema.ID, flushed, dirty, wantRows)
+	}
+	finals := finalsForSchema(env, newKeys, schema)
+	if len(finals) != 1 {
+		t.Fatalf("schema %d must promote exactly one final delta, got %v", schema.ID, finals)
+	}
+	assertSameRowIDs(t, fmt.Sprintf("schema %d parquet vs flushed set", schema.ID),
+		fetchParquetRowIDs(ctx, t, env, finals), flushed)
+	assertManifestDeltaPaths(t, manifests, schema, finals)
+	assertNoRowExportedTwice(ctx, t, env, schema)
+	return finals
+}

--- a/internal/e2e_harness/production/concurrent_flush_multi_schema_e2e_test.go
+++ b/internal/e2e_harness/production/concurrent_flush_multi_schema_e2e_test.go
@@ -1,0 +1,105 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+)
+
+// TestConcurrentFlushDifferentSchemas pins issue #186 scenario 3: the flush
+// advisory lock is scoped per schema — pg_try_advisory_lock(schemaID,
+// schemaID), internal/cdc/helpers.go — so a flush pass holding one schema's
+// lock neither blocks nor is blocked by a concurrent pass flushing a
+// different schema, and a locked schema is skipped (nil), not failed.
+//
+// Deterministic orchestration instead of a rerun-until-it-overlaps race:
+//
+//  1. Seed only schema A and start runner1, paused at its first CopyObject
+//     (PausingS3). At the pause runner1 has enumerated its dirty schemas —
+//     provably [A] alone, because B is not seeded yet — and sits inside A's
+//     processSchema holding A's advisory lock.
+//  2. Seed schema B and run runner2 to completion while runner1 is frozen.
+//     runner2 enumerates both schemas: A's lock is held, so A is skipped
+//     with no error and no side effects (same-schema exclusion on the real
+//     production path); B flushes fully (per-schema scope: A's in-flight
+//     flush is no contention for B).
+//  3. Resume runner1; A completes. Both schemas converge to exactly one
+//     final delta each, disjoint per-schema manifests, and oracle parity.
+func TestConcurrentFlushDifferentSchemas(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0] // e2e_simple (20)
+	second := DefaultSchemaFixtures()[2] // e2e_second (22)
+
+	// Seed ONLY schema A before runner1 starts; B is seeded strictly after
+	// the pause is reached, so runner1's enumeration cannot include it and
+	// the single CopyObject the pause intercepts is A's.
+	seedRows(ctx, t, env, simple, 3)
+
+	pauser := NewPausingS3(env.Cluster.S3, S3OpCopy)
+	runnerCtx, cancel := context.WithTimeout(ctx, pausedFlushTimeout)
+	// The flush goroutine must not touch t; it reports through done (buffered
+	// so it never leaks even when the test dies before reading it).
+	done := make(chan flushOutcome, 1)
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		report, err := env.RunFlushWith(runnerCtx, FlushOverrides{S3: pauser})
+		done <- flushOutcome{report: report, err: err}
+	}()
+	// Registered after NewEnv's cleanups, so this runs first: any early
+	// t.Fatal releases the paused flush and waits for it to exit while the
+	// Env's resources are still alive.
+	t.Cleanup(func() {
+		pauser.Resume()
+		cancel()
+		<-finished
+	})
+
+	select {
+	case <-pauser.Reached():
+	case out := <-done:
+		t.Fatalf("runner1 finished before reaching the CopyObject pause: err=%v", out.err)
+	}
+
+	seedRows(ctx, t, env, second, 3)
+	r2, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("runner2 must succeed while runner1 holds schema %d's lock: %v", simple.ID, err)
+	}
+	// runner2 committed B completely while A's flush was mid-flight...
+	assertSchemaFullyFlushed(ctx, t, env, r2.NewObjects, r2.Manifests, second, 3)
+	// ...and left the locked schema A entirely alone: every A row still
+	// dirty, no A final promoted.
+	flushedA, dirtyA := fetchChangeLogRowIDs(ctx, t, env, simple)
+	if len(flushedA) != 0 || len(dirtyA) != 3 {
+		t.Fatalf("runner2 must not touch the locked schema %d: flushed=%v dirty=%v",
+			simple.ID, flushedA, dirtyA)
+	}
+	if finals := finalsForSchema(env, r2.NewObjects, simple); len(finals) != 0 {
+		t.Errorf("runner2 must not promote finals for the locked schema %d, got %v", simple.ID, finals)
+	}
+
+	pauser.Resume()
+	out := <-done
+	if out.err != nil {
+		t.Fatalf("runner1 flush after resume: %v", out.err)
+	}
+
+	// Joint end state from a fresh listing and manifest load — runner1's
+	// report diff spans runner2's writes and cannot attribute objects.
+	keys, err := env.listS3Keys(ctx)
+	if err != nil {
+		t.Fatalf("list final s3 keys: %v", err)
+	}
+	manifests, err := env.loadManifests(ctx)
+	if err != nil {
+		t.Fatalf("load final manifests: %v", err)
+	}
+	assertSchemaFullyFlushed(ctx, t, env, keys, manifests, simple, 3)
+	assertSchemaFullyFlushed(ctx, t, env, keys, manifests, second, 3)
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
+	env.AssertQueryMatches(ctx, Query{Schema: second, Limit: 100})
+}

--- a/internal/e2e_harness/production/concurrent_flush_multi_schema_e2e_test.go
+++ b/internal/e2e_harness/production/concurrent_flush_multi_schema_e2e_test.go
@@ -26,6 +26,13 @@ import (
 //     flush is no contention for B).
 //  3. Resume runner1; A completes. Both schemas converge to exactly one
 //     final delta each, disjoint per-schema manifests, and oracle parity.
+//
+// The skip-while-locked proof depends on the runners using separate Postgres
+// sessions: pg_try_advisory_lock is reentrant within a session, and each
+// RunFlushWith builds its own Runner whose RunOnce opens its own sql.DB
+// (internal/cdc/flusher.go setupPostgresConnection). If the harness ever
+// shared one pool across runners, runner2 could re-acquire A's lock on the
+// holding connection and this test would stop proving exclusion.
 func TestConcurrentFlushDifferentSchemas(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/e2e_harness/production/doc.go
+++ b/internal/e2e_harness/production/doc.go
@@ -33,7 +33,7 @@
 //	#181 failure-state injection   -> Env.ExecSQL escape hatch
 //	#182 mid-flush concurrency     -> PausingS3, RunFlushWith(FlushOverrides{S3})
 //	#185 degraded/breaker          -> WithBreaker, WithDuckMaxConnections, HaltS3, ReopenDuckDB, Query.AllowPartialDegradedMode
-//	#189 multi-schema isolation    -> schemas/e2e_simple + e2e_second, per-test DB
+//	#186 multi-schema isolation    -> schemas/e2e_simple + e2e_second, per-test DB
 //
 // Environment variables: KEEP_E2E_ENV, E2E_SEED, E2E_ARTIFACTS_DIR,
 // E2E_VERBOSE, and PRODUCTION_E2E_EXTERNAL_* (see README.md).

--- a/internal/e2e_harness/production/generator.go
+++ b/internal/e2e_harness/production/generator.go
@@ -146,7 +146,7 @@ func MinimalProfile() AttrProfile {
 	}
 }
 
-// SecondProfile fits the e2e_second fixture (for #189).
+// SecondProfile fits the e2e_second fixture (for #186).
 func SecondProfile() AttrProfile {
 	return func(r *rand.Rand, ordinal int, partial bool) map[string]any {
 		return map[string]any{

--- a/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+++ b/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
@@ -1,0 +1,294 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestMultiSchemaFlushIsolation pins issue #186: a failure isolated to one
+// schema must not corrupt (or block) a sibling schema in the same CDC flush
+// pass. The production loop processes schemas sequentially and aggregates
+// per-schema errors via errors.Join (internal/cdc/runner.go), so the healthy
+// schema commits fully — rows marked, delta promoted, manifest updated —
+// while the faulted schema's rows stay dirty and the aggregate error names
+// only the faulted schema.
+//
+// Two failure vectors, one per pipeline side of mark-flushed:
+//
+//   - CopyFault (step 3, pre-mark): the faulted schema has zero side effects
+//     beyond a /_tmp/ orphan (#226) — all rows stay dirty for retry.
+//   - ManifestSaveFault (step 7, post-mark): the faulted schema's rows are
+//     already flushed and its final exists, but its manifest tracks nothing;
+//     the #197 contract (error names the orphaned key, retry is a no-op, no
+//     self-repair) must hold per-schema without disturbing the sibling.
+//
+// Missing schema metadata is deliberately NOT a vector: the flusher only
+// warns and falls back to the generic projection (internal/cdc/flusher.go),
+// a latent path owned by #193.
+func TestMultiSchemaFlushIsolation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	t.Run("CopyFault", func(t *testing.T) {
+		t.Parallel()
+		testMultiSchemaCopyFault(ctx, t)
+	})
+	t.Run("ManifestSaveFault", func(t *testing.T) {
+		t.Parallel()
+		testMultiSchemaManifestSaveFault(ctx, t)
+	})
+}
+
+// seedTwoSchemas seeds three creates in each isolation-pair schema and
+// baselines both on the hot tier (PreferHot: nothing has flushed yet, so a
+// federated read would hit an empty parquet glob).
+func seedTwoSchemas(ctx context.Context, t *testing.T, env *Env) (simple, second SchemaRef) {
+	t.Helper()
+	simple = DefaultSchemaFixtures()[0] // e2e_simple (20)
+	second = DefaultSchemaFixtures()[2] // e2e_second (22)
+	seedRows(ctx, t, env, simple, 3)
+	seedRows(ctx, t, env, second, 3)
+	env.AssertQueryMatches(ctx, Query{Schema: simple, PreferHot: true, Limit: 100})
+	env.AssertQueryMatches(ctx, Query{Schema: second, PreferHot: true, Limit: 100})
+	return simple, second
+}
+
+// assertErrorNamesOnlySchema asserts the aggregate flush error attributes the
+// failure to exactly the faulted schema (the errors.Join contract: per-schema
+// wrapping is "schema <id>: ...").
+func assertErrorNamesOnlySchema(t *testing.T, err error, faulted, healthy SchemaRef) {
+	t.Helper()
+	msg := err.Error()
+	if !strings.Contains(msg, fmt.Sprintf("schema %d:", faulted.ID)) {
+		t.Errorf("aggregate error must name schema %d, got: %v", faulted.ID, err)
+	}
+	if strings.Contains(msg, fmt.Sprintf("schema %d:", healthy.ID)) {
+		t.Errorf("aggregate error must not implicate healthy schema %d, got: %v", healthy.ID, err)
+	}
+}
+
+// testMultiSchemaCopyFault breaks the tmp->final promotion for one schema
+// only (the fault matches the schema's S3 partition) and asserts the sibling
+// schema's commit is complete and the failure is attributed correctly.
+func testMultiSchemaCopyFault(ctx context.Context, t *testing.T) {
+	env := NewEnv(t, SharedCluster(t))
+	simple, second := seedTwoSchemas(ctx, t, env)
+
+	faulty := &FaultInjectingS3{Inner: env.Cluster.S3,
+		Fault: S3Fault{Op: S3OpCopy, KeyContains: schemaKeyPrefix(env, second)}}
+	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty})
+	if err == nil {
+		t.Fatal("flush with one schema's CopyObject failing must fail")
+	}
+	if faulty.Injected() == 0 {
+		t.Fatal("fault never fired")
+	}
+	assertErrorNamesOnlySchema(t, err, second, simple)
+	if !strings.Contains(err.Error(), "copy tmp to final") {
+		t.Errorf("error must surface at the copy step, got: %v", err)
+	}
+
+	// The healthy schema commits fully; the faulted schema keeps every row
+	// dirty with no final and no manifest entry.
+	assertSchemaFullyFlushed(ctx, t, env, report.NewObjects, report.Manifests, simple, 3)
+	assertSchemaUntouchedByFault(ctx, t, env, report, second, 3)
+	if report.UnflushedAfter != 3 {
+		t.Errorf("only the faulted schema's rows may stay dirty, unflushed = %d, want 3", report.UnflushedAfter)
+	}
+
+	// Oracle parity on both sides: the flushed schema through the federated
+	// path, the faulted schema still hot-only (its glob has no finals).
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
+	env.AssertQueryMatches(ctx, Query{Schema: second, PreferHot: true, Limit: 100})
+}
+
+// testMultiSchemaManifestSaveFault breaks the manifest PutObject for one
+// schema only. The faulted schema lands in the #197 partial-commit state
+// (rows flushed, final promoted, manifest missing, no self-repair on retry)
+// while the sibling schema's manifest and data are untouched by the failure.
+func testMultiSchemaManifestSaveFault(ctx context.Context, t *testing.T) {
+	env := NewEnv(t, SharedCluster(t))
+	simple, second := seedTwoSchemas(ctx, t, env)
+
+	manifestKey := fmt.Sprintf("%s/manifest/%d.json", env.S3Prefix, second.ID)
+	faulty := &FaultInjectingS3{Inner: env.Cluster.S3,
+		Fault: S3Fault{Op: S3OpPut, KeyContains: manifestKey}}
+	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty})
+	if err == nil {
+		t.Fatal("flush with one schema's manifest save failing must fail")
+	}
+	if faulty.Injected() == 0 {
+		t.Fatal("fault never fired")
+	}
+	assertErrorNamesOnlySchema(t, err, second, simple)
+
+	// Healthy schema: complete commit including its manifest entry.
+	assertSchemaFullyFlushed(ctx, t, env, report.NewObjects, report.Manifests, simple, 3)
+
+	// Faulted schema: the #197 partial commit, scoped to this schema. Rows
+	// are marked flushed and the final exists, so the error must point the
+	// operator at the orphaned key; the manifest tracks nothing.
+	flushed, dirty := fetchChangeLogRowIDs(ctx, t, env, second)
+	if len(flushed) != 3 || len(dirty) != 0 {
+		t.Fatalf("schema %d rows must be marked flushed before the manifest step: flushed=%v dirty=%v",
+			second.ID, flushed, dirty)
+	}
+	finals := finalsForSchema(env, report.NewObjects, second)
+	if len(finals) != 1 {
+		t.Fatalf("schema %d final must exist when its manifest save fails, got %v", second.ID, finals)
+	}
+	if !strings.Contains(err.Error(), "manifest update") || !strings.Contains(err.Error(), finals[0]) {
+		t.Errorf("error must point at the orphaned final key %q, got: %v", finals[0], err)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, second, nil)
+
+	// Retry is a strict no-op for BOTH schemas: nothing dirty anywhere, no
+	// re-export, and no manifest self-repair for the faulted schema (#197).
+	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("clean retry flush: %v", err)
+	}
+	if retry.UnflushedBefore != 0 || len(retry.NewObjects) != 0 {
+		t.Errorf("retry must be a no-op: unflushed %d, new objects %v", retry.UnflushedBefore, retry.NewObjects)
+	}
+	assertManifestDeltaPaths(t, retry.Manifests, second, nil)
+
+	// Reads never consult the manifest: both schemas stay fully visible.
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
+	env.AssertQueryMatches(ctx, Query{Schema: second, Limit: 100})
+}
+
+// TestMultiSchemaRetryRepairsOnlyFailed pins issue #186 scenario 2: after a
+// pass where one schema failed at the copy step, a healed retry re-exports
+// only the failed schema. The healthy schema has nothing dirty, so it is not
+// re-exported, gains no new objects, and its manifest keeps exactly the
+// first pass's entry.
+func TestMultiSchemaRetryRepairsOnlyFailed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple, second := seedTwoSchemas(ctx, t, env)
+
+	faulty := &FaultInjectingS3{Inner: env.Cluster.S3,
+		Fault: S3Fault{Op: S3OpCopy, KeyContains: schemaKeyPrefix(env, second)}}
+	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty})
+	if err == nil {
+		t.Fatal("flush with one schema's CopyObject failing must fail")
+	}
+	if faulty.Injected() == 0 {
+		t.Fatal("fault never fired")
+	}
+	// First pass: the healthy schema's single final (isolation details are
+	// pinned by TestMultiSchemaFlushIsolation; here it anchors the retry).
+	firstFinals := assertSchemaFullyFlushed(ctx, t, env, report.NewObjects, report.Manifests, simple, 3)
+
+	// Healed retry: only the failed schema flushes.
+	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("healed retry flush: %v", err)
+	}
+	if retry.UnflushedBefore != 3 || retry.UnflushedAfter != 0 {
+		t.Errorf("retry unflushed %d -> %d, want 3 -> 0", retry.UnflushedBefore, retry.UnflushedAfter)
+	}
+	if healthyNew := finalsForSchema(env, retry.NewObjects, simple); len(healthyNew) != 0 {
+		t.Errorf("retry must not re-export the healthy schema, got new finals %v", healthyNew)
+	}
+	assertSchemaFullyFlushed(ctx, t, env, retry.NewObjects, retry.Manifests, second, 3)
+
+	// The healthy schema's manifest still tracks exactly the first pass's
+	// final — no duplicate entries, no re-export (its parquet inventory is
+	// re-checked for duplicates too).
+	assertManifestDeltaPaths(t, retry.Manifests, simple, firstFinals)
+	assertNoRowExportedTwice(ctx, t, env, simple)
+
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
+	env.AssertQueryMatches(ctx, Query{Schema: second, Limit: 100})
+}
+
+// TestInitSchemaScopedIsolation pins the backfill side of issue #186's
+// multi-schema story: cdc-init runs (and reruns) scoped to one schema via
+// SchemaIDFilter touch nothing of a sibling schema — no objects under its
+// partition, no manifest writes. Isolation is structural (per-schema key
+// partitions and per-schema manifest files); this test documents the
+// contract symmetrically with the flush-side isolation above. The rerun
+// half of the backfill story is owned by #176 (TestInitRerunIdempotency,
+// TestInitRerunAfterChangesReconcilesManifest, TestInitUnderConcurrentMutation).
+func TestInitSchemaScopedIsolation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	simple := DefaultSchemaFixtures()[0]
+	second := DefaultSchemaFixtures()[2]
+	seedRows(ctx, t, env, simple, 5)
+	seedRows(ctx, t, env, second, 5)
+
+	assertInitTouchesOnly := func(report *InitReport, target, sibling SchemaRef) {
+		t.Helper()
+		siblingManifestKey := fmt.Sprintf("%s/manifest/%d.json", env.S3Prefix, sibling.ID)
+		for _, k := range report.NewObjects {
+			if strings.HasPrefix(k, schemaKeyPrefix(env, sibling)) || k == siblingManifestKey {
+				t.Errorf("init of schema %d touched sibling schema %d: %s", target.ID, sibling.ID, k)
+			}
+		}
+	}
+
+	first, err := env.RunInit(ctx, simple)
+	if err != nil {
+		t.Fatalf("init schema %d: %v", simple.ID, err)
+	}
+	assertInitTouchesOnly(first, simple, second)
+	manifests, err := env.loadManifests(ctx)
+	if err != nil {
+		t.Fatalf("load manifests: %v", err)
+	}
+	if manifests[second.ID] != nil {
+		t.Fatalf("schema %d must have no manifest before its own init, got %+v", second.ID, manifests[second.ID])
+	}
+
+	secondInit, err := env.RunInit(ctx, second)
+	if err != nil {
+		t.Fatalf("init schema %d: %v", second.ID, err)
+	}
+	assertInitTouchesOnly(secondInit, second, simple)
+	siblingPaths := buildBasePaths(secondInit.Manifest)
+	if len(siblingPaths) == 0 {
+		t.Fatal("schema 22 init must produce base entries (positive control)")
+	}
+
+	// Rerun schema 20's init: the sibling's manifest and objects must be
+	// byte-for-byte uninvolved (deterministic keys make the rerun itself a
+	// pure overwrite, so any sibling-partition key here is a leak).
+	rerun, err := env.RunInit(ctx, simple)
+	if err != nil {
+		t.Fatalf("rerun init schema %d: %v", simple.ID, err)
+	}
+	assertInitTouchesOnly(rerun, simple, second)
+	manifests, err = env.loadManifests(ctx)
+	if err != nil {
+		t.Fatalf("reload manifests: %v", err)
+	}
+	rerunSibling := buildBasePaths(manifests[second.ID])
+	if len(rerunSibling) != len(siblingPaths) {
+		t.Fatalf("sibling base entries changed across the rerun: %v -> %v", siblingPaths, rerunSibling)
+	}
+	for p := range siblingPaths {
+		if !rerunSibling[p] {
+			t.Errorf("sibling base path %s lost across the rerun", p)
+		}
+	}
+
+	// Onboarding contract: init does not clear change_log; clear it so the
+	// base tier alone must answer, then oracle-check both schemas.
+	for _, ref := range []SchemaRef{simple, second} {
+		env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", ref.ID)
+	}
+	for _, ref := range []SchemaRef{simple, second} {
+		result := env.AssertQueryMatches(ctx, Query{Schema: ref, Limit: 100})
+		if result != nil && len(result.Records) != 5 {
+			t.Errorf("schema %d federated result has %d rows, want 5", ref.ID, len(result.Records))
+		}
+	}
+}

--- a/internal/e2e_harness/production/schema.go
+++ b/internal/e2e_harness/production/schema.go
@@ -30,7 +30,7 @@ type SchemaRef struct {
 //   - e2e_simple: two attributes (one column-bound text, one EAV numeric)
 //   - e2e_wide:   one attribute per scalar forma.ValueType, mixing
 //     main-column bindings and EAV-only storage (for #174)
-//   - e2e_second: a second schema for multi-schema isolation (for #189)
+//   - e2e_second: a second schema for multi-schema isolation (for #186)
 func DefaultSchemaFixtures() []SchemaRef {
 	return []SchemaRef{
 		{ID: SchemaIDSimple, Name: "e2e_simple"},


### PR DESCRIPTION
Closes #186 (epic #172, Phase 3 — final item).

## What

The multi-schema isolation half of #186, as four production-harness E2E tests; the backfill rerun-safety half is already covered by #176/PR #208 (adjudication with the scenario→test mapping is [on the issue](https://github.com/Lychee-Technology/forma/issues/186#issuecomment-4966244421)).

- **`TestMultiSchemaFlushIsolation`** — both schemas dirty in one pass, a fault scoped to one schema via its S3 key partition / manifest key:
  - *CopyFault* (pre-mark): the healthy schema commits fully (row-level flushed set == parquet row-ids == manifest entry) while the faulted schema keeps every row dirty with no final and no manifest entry (a `/_tmp/` orphan is tolerated, #226); the `errors.Join` aggregate names `schema 22` and the copy step, and does not implicate `schema 20`.
  - *ManifestSaveFault* (post-mark): the faulted schema lands in the #197 partial commit per-schema (rows flushed, final promoted, error names the orphaned key, retry is a strict no-op with no manifest self-repair) without disturbing the sibling.
- **`TestMultiSchemaRetryRepairsOnlyFailed`** — healed retry re-exports only the failed schema: no new finals under the healthy partition, its manifest keeps exactly the first pass's entry, and no row of either schema is exported twice.
- **`TestConcurrentFlushDifferentSchemas`** — deterministic per-schema advisory-lock scope proof on the real `cdc.Runner` path: runner1 pauses at schema A's CopyObject (holding A's `pg_try_advisory_lock(schemaID, schemaID)`), schema B is seeded only after the pause is reached (so runner1's enumeration provably contains A alone), and a concurrent full pass skips locked A with **no error and no side effects** while flushing B to completion; after resume both schemas converge to exactly one final each with disjoint manifests and oracle parity. This also gives same-schema exclusion its first production-path proof (the federated-harness version is hand-rolled).
- **`TestInitSchemaScopedIsolation`** — `cdc-init` runs/reruns scoped by `SchemaIDFilter` never touch a sibling schema's partition or manifest (symmetric documentation of the structurally-per-schema layout; the rerun contracts themselves are #176's tests).

All four are characterization tests and went green on first run — the believed-correct contracts (sequential per-schema loop + `errors.Join`, per-schema advisory lock, per-schema S3/manifest paths) held.

## Harness

- New per-schema helpers in `cdc_fault_helpers_e2e_test.go`: `finalsForSchema` / `assertSchemaUntouchedByFault` / `assertSchemaFullyFlushed` attribute objects by the full `{prefix}/{schemaID}/` key prefix (a bare `/22/` substring would be ambiguous against env sequence numbers), and take an explicit key set because a paused runner's report diff absorbs its sibling's writes — concurrent scenarios attribute from a fresh listing instead.
- First consumer of the `e2e_second` fixture + `SecondProfile` generator; their `#189` labels (and the README/doc.go consumer-map rows) were pre-renumber leftovers and now point at #186.

## Verification

- New tests: 3 runs (1 fresh + `-count=2`), all green, no flakes.
- `make lint` clean (golangci-lint v1.64.8), `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)