### PR TITLE
cdc: retire the no-attribute-cache generic export path (#193)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-cdc-193-retire-generic-export.md
+++ b/docs/superpowers/plans/2026-07-14-cdc-193-retire-generic-export.md
@@ -1,0 +1,660 @@
+# Retire the No-Attribute-Cache Generic CDC Export Path (#193) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CDC export (delta flush + base init) fail fast when a schema's attribute metadata cache is unresolvable, aborting the whole run before any side effect, and delete the dead `value_text`-only generic projection.
+
+**Architecture:** A shared `resolveRequiredAttrCache` helper (new `internal/cdc/errors.go`) treats a registry lookup error or an empty cache as a hard failure carrying the sentinel `ErrSchemaAttrCacheUnavailable`. Both schema loops (`processSchemas` for flush, `processInitSchemas` for init) run a **pre-flight pass** that resolves every schema's cache up front and aborts on the first failure — nothing flushes. The per-schema warn+fallback is removed and the export SQL builder hard-errors on an empty cache as defense in depth, letting the generic SQL code path be deleted.
+
+**Tech Stack:** Go, DuckDB (`postgres_query` export), testify (`require`), zap logging. Package `internal/cdc`.
+
+## Global Constraints
+
+- Source files ≤500 lines, functions ≤100 lines (`coding-standard.md`).
+- Always wrap errors with context: `fmt.Errorf("...: %w", err)` — never bare `return err`.
+- This is an operator/CDC path error, NOT HTTP write-path validation: the sentinel is a plain error, **NOT** wrapped in `forma.ErrInvalidInput` (`docs/error-handling.md`).
+- Error messages must name the logical value (attribute metadata cache), the `schema_id`, and the expected state / remedy.
+- Match errors with `errors.Is`/`errors.As`, never string comparison.
+- Test env for single-test runs (mirrors the Makefile): `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false`.
+- Module path: `github.com/lychee-technology/forma`. Type: `forma.SchemaAttributeCache map[string]forma.AttributeMetadata`.
+
+---
+
+### Task 1: Sentinel error + shared required-cache resolver
+
+**Files:**
+- Create: `internal/cdc/errors.go`
+- Create: `internal/cdc/errors_test.go`
+- Modify: `internal/cdc/mocks_test.go` (add `stubSchemaRegistry` test helper)
+
+**Interfaces:**
+- Produces: `var ErrSchemaAttrCacheUnavailable error` (sentinel) and
+  `func resolveRequiredAttrCache(reg forma.SchemaRegistry, schemaID int16) (forma.SchemaAttributeCache, error)`.
+  Returns `(nil, err)` wrapping the sentinel when `reg == nil`, when
+  `reg.GetSchemaAttributeCacheByID` errors, or when the returned cache is
+  empty (`len == 0`). Returns `(cache, nil)` when the cache is non-empty.
+- Produces (test helper): `type stubSchemaRegistry struct{ cache forma.SchemaAttributeCache }` implementing `forma.SchemaRegistry`, returning `cache` with no error.
+
+- [ ] **Step 1: Add the `stubSchemaRegistry` test helper to `mocks_test.go`**
+
+Append to `internal/cdc/mocks_test.go` (after the `errorSchemaRegistry` methods):
+
+```go
+// stubSchemaRegistry returns a fixed attribute cache with no error. A nil/empty
+// cache field models a schema whose lookup succeeds but carries no attributes.
+type stubSchemaRegistry struct{ cache forma.SchemaAttributeCache }
+
+func (r stubSchemaRegistry) GetSchemaAttributeCacheByName(string) (int16, forma.SchemaAttributeCache, error) {
+	return 0, r.cache, nil
+}
+
+func (r stubSchemaRegistry) GetSchemaAttributeCacheByID(int16) (string, forma.SchemaAttributeCache, error) {
+	return "", r.cache, nil
+}
+
+func (r stubSchemaRegistry) GetSchemaByName(string) (int16, forma.JSONSchema, error) {
+	return 0, forma.JSONSchema{}, nil
+}
+
+func (r stubSchemaRegistry) GetSchemaByID(int16) (string, forma.JSONSchema, error) {
+	return "", forma.JSONSchema{}, nil
+}
+
+func (r stubSchemaRegistry) ListSchemas() []string { return nil }
+
+// testAttrCache is a minimal populated cache (one column-bound text attr, one
+// EAV bool attr) shared by tests that need a resolvable schema.
+func testAttrCache() forma.SchemaAttributeCache {
+	return forma.SchemaAttributeCache{
+		"name": {
+			AttributeName: "name",
+			AttributeID:   10,
+			ValueType:     forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnText01},
+		},
+		"flag": {
+			AttributeName: "flag",
+			AttributeID:   11,
+			ValueType:     forma.ValueTypeBool,
+		},
+	}
+}
+```
+
+- [ ] **Step 2: Write the failing test for the resolver**
+
+Create `internal/cdc/errors_test.go`:
+
+```go
+package cdc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveRequiredAttrCache(t *testing.T) {
+	t.Run("registry lookup error", func(t *testing.T) {
+		_, err := resolveRequiredAttrCache(errorSchemaRegistry{err: errors.New("boom")}, 7)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+		require.Contains(t, err.Error(), "7")
+	})
+	t.Run("empty cache", func(t *testing.T) {
+		_, err := resolveRequiredAttrCache(stubSchemaRegistry{cache: forma.SchemaAttributeCache{}}, 9)
+		require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+		require.Contains(t, err.Error(), "9")
+	})
+	t.Run("nil registry", func(t *testing.T) {
+		_, err := resolveRequiredAttrCache(nil, 3)
+		require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	})
+	t.Run("populated cache", func(t *testing.T) {
+		cache, err := resolveRequiredAttrCache(stubSchemaRegistry{cache: testAttrCache()}, 1)
+		require.NoError(t, err)
+		require.NotEmpty(t, cache)
+	})
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run TestResolveRequiredAttrCache -v`
+Expected: FAIL — `undefined: resolveRequiredAttrCache` / `undefined: ErrSchemaAttrCacheUnavailable`.
+
+- [ ] **Step 4: Create `internal/cdc/errors.go`**
+
+```go
+package cdc
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/lychee-technology/forma"
+)
+
+// ErrSchemaAttrCacheUnavailable marks a CDC export that cannot proceed because a
+// schema's attribute metadata cache could not be resolved — the registry lookup
+// failed or the cache is empty. CDC export needs it to produce parquet the
+// federated reader can consume; without it the reader fails fast with
+// ErrSchemaMetadataCacheRequired (#193). This is an operator-visible
+// configuration error, not write-path validation, so it is NOT wrapped in
+// forma.ErrInvalidInput.
+var ErrSchemaAttrCacheUnavailable = errors.New("schema attribute metadata cache unavailable")
+
+// resolveRequiredAttrCache resolves schemaID's attribute cache, treating a nil
+// registry, a lookup error, or an empty cache as a hard failure. A real schema's
+// cache is never empty (it maps hot fields as well as EAV attributes), so an
+// empty cache means the schema is not registered — the same assumption the
+// federated reader makes (internal/federated/duckdb_query.go).
+func resolveRequiredAttrCache(reg forma.SchemaRegistry, schemaID int16) (forma.SchemaAttributeCache, error) {
+	if reg == nil {
+		return nil, fmt.Errorf("resolve attribute cache for schema %d: schema registry is nil: %w", schemaID, ErrSchemaAttrCacheUnavailable)
+	}
+	_, cache, err := reg.GetSchemaAttributeCacheByID(schemaID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve attribute cache for schema %d: %w: %w", schemaID, ErrSchemaAttrCacheUnavailable, err)
+	}
+	if len(cache) == 0 {
+		return nil, fmt.Errorf("schema %d has an empty attribute metadata cache: %w", schemaID, ErrSchemaAttrCacheUnavailable)
+	}
+	return cache, nil
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run TestResolveRequiredAttrCache -v`
+Expected: PASS (all four subtests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cdc/errors.go internal/cdc/errors_test.go internal/cdc/mocks_test.go
+git commit -m "feat(cdc): add ErrSchemaAttrCacheUnavailable + resolveRequiredAttrCache (#193)"
+```
+
+---
+
+### Task 2: Hard-error the export SQL builder on empty cache; delete generic path
+
+**Files:**
+- Modify: `internal/cdc/duckdb_exporter.go` (`buildExportSQLPlan` empty-cache branch → error; delete `buildGenericExportSQL`; delete `defaultMainColumns` field; fix dangling comment)
+- Modify: `internal/cdc/export_sql_builder.go` (delete `defaultDeltaMainColumns`, `defaultBaseMainColumns`)
+- Modify: `internal/cdc/init_exporter.go` (drop `defaultMainColumns` from the base `exportModeSpec` literal)
+- Modify: `internal/cdc/duckdb_exporter_sql_test.go` (migrate `nil`-cache tests to `testAttrCache()`; add error test)
+- Modify: `internal/cdc/init_exporter_sql_test.go` (migrate `nil`-cache tests to `testAttrCache()`; add error test)
+
+**Interfaces:**
+- Consumes: `ErrSchemaAttrCacheUnavailable` (Task 1), `testAttrCache()` (Task 1).
+- Produces: `buildExportSQLPlan` returns `(exportSQLPlan{}, error wrapping ErrSchemaAttrCacheUnavailable)` when `len(attrCache) == 0`. `buildExportSQL` and `buildBaseExportSQL` propagate that error. The `exportModeSpec.defaultMainColumns` field and the two `default*MainColumns` funcs no longer exist.
+
+- [ ] **Step 1: Write the failing error test (delta path)**
+
+Add to `internal/cdc/duckdb_exporter_sql_test.go`:
+
+```go
+func TestBuildExportSQL_ErrorsWithoutAttrCache(t *testing.T) {
+	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
+	_, _, _, _, err := buildExportSQL("host=pg", "s3://bucket/prefix/1/_tmp/tmp.parquet", CDCConfig{}, 1, 1700000000000, []uuid.UUID{rowID}, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	require.Contains(t, err.Error(), "1")
+}
+```
+
+Add the testify import to the file's import block if absent:
+
+```go
+	"github.com/stretchr/testify/require"
+```
+
+- [ ] **Step 2: Write the failing error test (base/init path)**
+
+Add to `internal/cdc/init_exporter_sql_test.go` (add the `require` import if absent):
+
+```go
+func TestBuildBaseExportSQL_ErrorsWithoutAttrCache(t *testing.T) {
+	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
+	_, _, _, err := buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", CDCConfig{}, 1, []uuid.UUID{rowID}, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	require.Contains(t, err.Error(), "1")
+}
+```
+
+- [ ] **Step 3: Run both new tests to verify they fail**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run 'ErrorsWithoutAttrCache' -v`
+Expected: FAIL — the builders currently return generic SQL and `err == nil`.
+
+- [ ] **Step 4: Convert the empty-cache branch to a hard error in `duckdb_exporter.go`**
+
+Replace the block at `internal/cdc/duckdb_exporter.go:226-233` (the `if len(attrCache) == 0 { ... return plan, nil }` generic branch):
+
+```go
+	if len(attrCache) == 0 {
+		mainColumns := spec.defaultMainColumns()
+		plan.mainQuery = buildMainEntityQuery(entityMain, schemaID, mainColumns, mFilter, spec.activeOnly)
+		plan.eavQuery = buildEAVQuery(eavData, schemaID, eFilter, nil)
+		mainSelectCols := append(spec.baseSelectColumns(), prefixColumns("m.", mainColumns[5:])...)
+		plan.sql = buildGenericExportSQL(spec, opts, copyOptions, pgEsc, s3Esc, plan.changeLogQuery, plan.mainQuery, plan.eavQuery, mainSelectCols)
+		return plan, nil
+	}
+```
+
+with:
+
+```go
+	if len(attrCache) == 0 {
+		// A resolvable attribute cache is mandatory: without it we cannot derive
+		// the numeric-family typing (bool as 1/0, dates as epoch ms) the
+		// federated reader expects, and the reader itself fails fast for no-cache
+		// schemas (ErrSchemaMetadataCacheRequired). Pre-flight validation in the
+		// flush/init loops should already have aborted; this is defense in depth
+		// for any caller that bypasses it (#193).
+		return exportSQLPlan{}, fmt.Errorf("build export SQL for schema %d: attribute metadata cache is required but empty: %w", schemaID, ErrSchemaAttrCacheUnavailable)
+	}
+```
+
+- [ ] **Step 5: Delete the now-dead `buildGenericExportSQL` function**
+
+Delete the entire `func buildGenericExportSQL(...)` (currently `internal/cdc/duckdb_exporter.go:257-302`).
+
+- [ ] **Step 6: Delete the dead `defaultMainColumns` field and fix the dangling comment**
+
+In `internal/cdc/duckdb_exporter.go`, remove the field from `exportModeSpec` (line 26):
+
+```go
+	defaultMainColumns func() []string
+```
+
+In `buildExportSQL` (line 163-172), remove the `defaultMainColumns: defaultDeltaMainColumns,` line from the `exportModeSpec{...}` literal.
+
+In `buildProjectedExportSQL`, update the comment that references the deleted function. Change:
+
+```go
+		// LEFT JOIN to entity_main so change_log tombstones of hard-deleted
+		// rows are exported instead of silently dropped (see
+		// buildGenericExportSQL, #173).
+```
+
+to:
+
+```go
+		// LEFT JOIN to entity_main so change_log tombstones of hard-deleted
+		// rows are exported instead of silently dropped (#173).
+```
+
+- [ ] **Step 7: Delete the two dead column-default funcs**
+
+In `internal/cdc/export_sql_builder.go`, delete `func defaultDeltaMainColumns() []string { ... }` (line 162) and `func defaultBaseMainColumns() []string { ... }` (line 179).
+
+In `internal/cdc/init_exporter.go` (line 27-37), remove the `defaultMainColumns: defaultBaseMainColumns,` line from the base `exportModeSpec{...}` literal.
+
+- [ ] **Step 8: Migrate the delta generic-SQL tests to a populated cache**
+
+In `internal/cdc/duckdb_exporter_sql_test.go`:
+
+In `TestBuildExportSQL_UsesRowIDsAndConfig`, change the `buildExportSQL(..., nil)` call (line 15) to pass `testAttrCache()` instead of the trailing `nil`. Then replace the projected-column assertion:
+
+```go
+	if !strings.Contains(sql, "changed_at") || !strings.Contains(sql, "attributes") {
+		t.Fatalf("sql missing projected columns (changed_at/attributes): %s", sql)
+	}
+```
+
+with (the schema-driven SQL projects the eav attribute by name, not the literal `attributes` list):
+
+```go
+	if !strings.Contains(sql, "changed_at") || !strings.Contains(sql, "flag") {
+		t.Fatalf("sql missing projected columns (changed_at/flag): %s", sql)
+	}
+```
+
+In `TestBuildExportSQL_UsesCustomTableNames`, change the `buildExportSQL(..., nil)` call (line 94) to pass `testAttrCache()`. Its assertions (custom `FROM` table names) are unchanged.
+
+Leave `TestBuildExportSQL_ErrorsOnEmptyRowIDs` as-is — it passes `nil` row ids, which errors in `buildExportSQLPlan` before the cache check, so it still asserts `err != nil` correctly.
+
+- [ ] **Step 9: Migrate the base/init generic-SQL tests to a populated cache**
+
+In `internal/cdc/init_exporter_sql_test.go`:
+
+In `TestBuildBaseExportSQL_UsesRowIDsAndConfig`, change the `buildBaseExportSQL(..., nil)` call (line 15) to pass `testAttrCache()`. Replace:
+
+```go
+	if !strings.Contains(sql, "changed_at") || !strings.Contains(sql, "attributes") {
+		t.Fatalf("sql missing projected columns (changed_at/attributes): %s", sql)
+	}
+```
+
+with:
+
+```go
+	if !strings.Contains(sql, "changed_at") || !strings.Contains(sql, "flag") {
+		t.Fatalf("sql missing projected columns (changed_at/flag): %s", sql)
+	}
+```
+
+In `TestBuildBaseExportSQL_UsesCustomTableNames`, change the `buildBaseExportSQL(..., nil)` call (line 90) to pass `testAttrCache()`. Its `FROM` assertions are unchanged.
+
+Leave `TestBuildBaseExportSQL_ErrorsOnEmptyRowIDs` as-is (nil row ids error first).
+
+- [ ] **Step 10: Run the full cdc package tests to verify green**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -v -run 'BuildExportSQL|BuildBaseExportSQL'`
+Expected: PASS, including the two new `ErrorsWithoutAttrCache` tests. No `undefined: buildGenericExportSQL` / `undefined: defaultDeltaMainColumns` compile errors.
+
+- [ ] **Step 11: Verify no dangling references to deleted symbols**
+
+Run: `grep -rn "buildGenericExportSQL\|defaultMainColumns\|defaultDeltaMainColumns\|defaultBaseMainColumns" internal/cdc/`
+Expected: no matches (empty output).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal/cdc/duckdb_exporter.go internal/cdc/export_sql_builder.go internal/cdc/init_exporter.go internal/cdc/duckdb_exporter_sql_test.go internal/cdc/init_exporter_sql_test.go
+git commit -m "feat(cdc): hard-error export SQL on empty attr cache; delete generic path (#193)"
+```
+
+---
+
+### Task 3: Flush pre-flight — abort the whole run on any unresolvable cache
+
+**Files:**
+- Modify: `internal/cdc/flusher.go` (`schemaFlushContext` gains `attrCaches`; `processSchemas` pre-flight; `executeFlush` reads pre-resolved cache)
+- Modify: `internal/cdc/flusher_test.go` (replace `TestExecuteFlush_FallsBackToGenericProjectionWhenSchemaLookupFails` with a pre-flight abort test + a positive pass-through test)
+
+**Interfaces:**
+- Consumes: `resolveRequiredAttrCache`, `ErrSchemaAttrCacheUnavailable` (Task 1); `stubSchemaRegistry`, `testAttrCache()` (Task 1).
+- Produces: `processSchemas` returns an error wrapping `ErrSchemaAttrCacheUnavailable` (and never invokes `processSchema`) when any schema's cache is unresolvable. On success it populates `c.attrCaches[schemaID]` for every schema before the per-schema loop. `executeFlush` reads `c.attrCaches[schemaID]` instead of consulting the registry.
+
+- [ ] **Step 1: Write the failing pre-flight abort test**
+
+In `internal/cdc/flusher_test.go`, delete `TestExecuteFlush_FallsBackToGenericProjectionWhenSchemaLookupFails` (lines 414-451) and add:
+
+```go
+func TestProcessSchemas_AbortsWhenSchemaCacheUnavailable(t *testing.T) {
+	processed := false
+	flushCtx := &schemaFlushContext{
+		logger:         zap.NewNop(),
+		schemaRegistry: errorSchemaRegistry{err: errors.New("schema unavailable")},
+		processSchemaFn: func(context.Context, int16) error {
+			processed = true
+			return nil
+		},
+	}
+
+	err := flushCtx.processSchemas(context.Background(), []int64{7})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	require.Contains(t, err.Error(), "7")
+	require.False(t, processed, "no schema must be flushed when pre-flight aborts")
+}
+
+func TestProcessSchemas_ResolvesCachesBeforeProcessing(t *testing.T) {
+	var processedIDs []int16
+	flushCtx := &schemaFlushContext{
+		logger:         zap.NewNop(),
+		schemaRegistry: stubSchemaRegistry{cache: testAttrCache()},
+		processSchemaFn: func(_ context.Context, id int16) error {
+			processedIDs = append(processedIDs, id)
+			return nil
+		},
+	}
+
+	err := flushCtx.processSchemas(context.Background(), []int64{7, 8})
+	require.NoError(t, err)
+	require.Equal(t, []int16{7, 8}, processedIDs)
+	require.NotEmpty(t, flushCtx.attrCaches[7])
+	require.NotEmpty(t, flushCtx.attrCaches[8])
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run TestProcessSchemas -v`
+Expected: FAIL — `flushCtx.attrCaches` undefined, and no pre-flight yet so the abort test either processes the schema or does not error with the sentinel.
+
+- [ ] **Step 3: Add the `attrCaches` field to `schemaFlushContext`**
+
+In `internal/cdc/flusher.go`, add the field to the `schemaFlushContext` struct (after `schemaRegistry`, line 248):
+
+```go
+	attrCaches       map[int16]forma.SchemaAttributeCache
+```
+
+- [ ] **Step 4: Add the pre-flight pass to `processSchemas`**
+
+In `internal/cdc/flusher.go`, in `processSchemas`, insert the pre-flight immediately after the `len(schemaIDs) == 0` early return (after line 261) and before `processSchema := c.processSchemaFn`:
+
+```go
+	caches := make(map[int16]forma.SchemaAttributeCache, len(schemaIDs))
+	for _, sid := range schemaIDs {
+		schemaID := int16(sid)
+		cache, err := resolveRequiredAttrCache(c.schemaRegistry, schemaID)
+		if err != nil {
+			return fmt.Errorf("cdc flush pre-flight: %w", err)
+		}
+		caches[schemaID] = cache
+	}
+	c.attrCaches = caches
+```
+
+- [ ] **Step 5: Make `executeFlush` read the pre-resolved cache**
+
+In `internal/cdc/flusher.go`, replace the registry-lookup block in `executeFlush` (lines 363-370):
+
+```go
+	var attrCache forma.SchemaAttributeCache
+	if c.schemaRegistry != nil {
+		if _, cache, err := c.schemaRegistry.GetSchemaAttributeCacheByID(schemaID); err != nil {
+			c.logger.Sugar().Warnw("schema registry lookup failed, using generic projection", "schema_id", schemaID, "err", err)
+		} else {
+			attrCache = cache
+		}
+	}
+```
+
+with:
+
+```go
+	// Cache was resolved and validated by the processSchemas pre-flight (#193).
+	attrCache := c.attrCaches[schemaID]
+```
+
+- [ ] **Step 6: Run the flush tests to verify green**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run 'TestProcessSchemas|TestExecuteFlush|TestExecuteBatch|TestRunOnce' -v`
+Expected: PASS. The two direct-`executeFlush` tests (`flush_batch_test.go`, the remaining `flusher_test.go` case) still pass — they set no registry, so `c.attrCaches[schemaID]` reads nil from a nil map (safe) and their mocked executor never invokes the exporter.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/cdc/flusher.go internal/cdc/flusher_test.go
+git commit -m "feat(cdc): pre-flight abort flush when any schema cache is unresolvable (#193)"
+```
+
+---
+
+### Task 4: Init pre-flight — abort base export on any unresolvable cache
+
+**Files:**
+- Modify: `internal/cdc/init.go` (`initRunContext` gains `attrCaches`; `processInitSchemas` pre-flight; `prepareSchemaInit` reads pre-resolved cache; delete `resolveSchemaAttrCache`)
+- Create: `internal/cdc/init_preflight_test.go`
+
+**Interfaces:**
+- Consumes: `resolveRequiredAttrCache`, `ErrSchemaAttrCacheUnavailable` (Task 1); `errorSchemaRegistry` (existing), `stubSchemaRegistry`, `testAttrCache()` (Task 1).
+- Produces: `processInitSchemas(ctx, runCtx, schemaIDs)` returns `(InitSummary{}, error wrapping ErrSchemaAttrCacheUnavailable)` without running any `initSchema` when a cache is unresolvable. On success it populates `runCtx.attrCaches[schemaID]` before the loop. `prepareSchemaInit` reads `runCtx.attrCaches[schemaID]`. `resolveSchemaAttrCache` is removed.
+
+- [ ] **Step 1: Write the failing init pre-flight abort test**
+
+Create `internal/cdc/init_preflight_test.go`:
+
+```go
+package cdc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestProcessInitSchemas_AbortsWhenSchemaCacheUnavailable(t *testing.T) {
+	runCtx := &initRunContext{
+		logger:         zap.NewNop(),
+		schemaRegistry: errorSchemaRegistry{err: errors.New("schema unavailable")},
+	}
+
+	summary, err := processInitSchemas(context.Background(), runCtx, []int64{7})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	require.Contains(t, err.Error(), "7")
+	require.Equal(t, InitSummary{}, summary)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run TestProcessInitSchemas_Aborts -v`
+Expected: FAIL — no pre-flight, so `processInitSchemas` proceeds into `initSchema` (nil `db` panic or a non-sentinel error), not a clean sentinel abort.
+
+- [ ] **Step 3: Add the `attrCaches` field to `initRunContext`**
+
+In `internal/cdc/init.go`, add to the `initRunContext` struct (after `schemaRegistry`, line 43):
+
+```go
+	attrCaches           map[int16]forma.SchemaAttributeCache
+```
+
+- [ ] **Step 4: Add the pre-flight pass to `processInitSchemas`**
+
+In `internal/cdc/init.go`, at the very top of `processInitSchemas` (before `summary := InitSummary{}`):
+
+```go
+	runCtx.attrCaches = make(map[int16]forma.SchemaAttributeCache, len(schemaIDs))
+	for _, sid := range schemaIDs {
+		schemaID := int16(sid)
+		cache, err := resolveRequiredAttrCache(runCtx.schemaRegistry, schemaID)
+		if err != nil {
+			return InitSummary{}, fmt.Errorf("cdc init pre-flight: %w", err)
+		}
+		runCtx.attrCaches[schemaID] = cache
+	}
+```
+
+- [ ] **Step 5: Make `prepareSchemaInit` read the pre-resolved cache and delete `resolveSchemaAttrCache`**
+
+In `internal/cdc/init.go`, in `prepareSchemaInit`, replace line 275:
+
+```go
+	state.attrCache = resolveSchemaAttrCache(runCtx, schemaID)
+```
+
+with:
+
+```go
+	// Cache was resolved and validated by the processInitSchemas pre-flight (#193).
+	state.attrCache = runCtx.attrCaches[schemaID]
+```
+
+Then delete the entire `func resolveSchemaAttrCache(runCtx *initRunContext, schemaID int16) forma.SchemaAttributeCache { ... }` (lines 280-290).
+
+- [ ] **Step 6: Run the init tests to verify green**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run 'TestProcessInitSchemas|TestResolveInit|TestRunInit|Init' -v`
+Expected: PASS. Confirm no `undefined: resolveSchemaAttrCache` reference remains:
+`grep -rn "resolveSchemaAttrCache" internal/cdc/` → empty.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/cdc/init.go internal/cdc/init_preflight_test.go
+git commit -m "feat(cdc): pre-flight abort base init when any schema cache is unresolvable (#193)"
+```
+
+---
+
+### Task 5: Update the e2e comment and verify the full suite + lint
+
+**Files:**
+- Modify: `internal/e2e_harness/production/multi_schema_isolation_e2e_test.go` (comment only)
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: no code change beyond the comment; a clean `make test` + `make lint`.
+
+- [ ] **Step 1: Update the stale comment in the isolation e2e**
+
+In `internal/e2e_harness/production/multi_schema_isolation_e2e_test.go`, replace the comment block (lines 29-31):
+
+```go
+// Missing schema metadata is deliberately NOT a vector: the flusher only
+// warns and falls back to the generic projection (internal/cdc/flusher.go),
+// a latent path owned by #193.
+```
+
+with:
+
+```go
+// Missing schema metadata is not exercised here: as of #193 the flusher and
+// init both pre-flight every schema's attribute cache and abort the whole run
+// (ErrSchemaAttrCacheUnavailable) before any side effect, rather than falling
+// back to a generic projection. That contract is pinned by unit tests in
+// internal/cdc (TestProcessSchemas_AbortsWhenSchemaCacheUnavailable,
+// TestProcessInitSchemas_AbortsWhenSchemaCacheUnavailable).
+```
+
+- [ ] **Step 2: Run the full cdc unit suite**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -count=1`
+Expected: `ok  github.com/lychee-technology/forma/internal/cdc`.
+
+- [ ] **Step 3: Build the e2e harness package (compile check for the comment file)**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go vet ./internal/e2e_harness/production/...`
+Expected: no errors (comment-only change compiles).
+
+- [ ] **Step 4: Run the project unit-test target**
+
+Run: `make test`
+Expected: PASS (wraps `go test . ./cdc ./cmd/... ./factory ./internal/...`).
+
+- [ ] **Step 5: Run lint**
+
+Run: `make lint`
+Expected: clean — in particular no `unused` findings for deleted symbols and no `errcheck`/`wrapcheck` regressions in the edited files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+git commit -m "docs(cdc): pin #193 pre-flight-abort contract in isolation e2e comment"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Retire, not align; fail fast" → Tasks 2, 3, 4 (hard error + pre-flight abort). ✓
+- "Abort whole run via pre-flight validation" → Task 3 (`processSchemas`), Task 4 (`processInitSchemas`). ✓
+- "Unresolvable = lookup error OR empty cache" → Task 1 `resolveRequiredAttrCache` (both branches) + test. ✓
+- "Top-level entrypoints already reject nil registry; close the per-schema gap" → pre-flight runs per-schema; helper also guards nil registry defensively. ✓
+- "Defense in depth: exporter hard-errors on empty cache" → Task 2 Step 4. ✓
+- "Delete dead generic code (`buildGenericExportSQL`, `defaultMainColumns` + `default*MainColumns`)" → Task 2 Steps 5-7 + grep gate Step 11. ✓
+- "Plain operator error, not `ErrInvalidInput`; names logical value + schema_id + remedy" → Task 1 `errors.go` (sentinel is plain `errors.New`; messages name schema id). ✓
+- "Regression tests pin behavior" → Task 2 (`*ErrorsWithoutAttrCache`), Task 3 (`TestProcessSchemas_Aborts...`), Task 4 (`TestProcessInitSchemas_Aborts...`). ✓
+- "Update multi_schema_isolation e2e comment" → Task 5 Step 1. ✓
+- "init_sizing.go `len==0` fallback: optional trim" → **intentionally left in place** as harmless defensive code; removing it would churn `resolveInitBatchSize`/`estimateRowSizeBytes` tests (`init_test.go:27,35` call it with `nil`) for no behavioral gain. Documented decision, not a gap.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to Task N" — every code step shows complete code. ✓
+
+**Type consistency:** `resolveRequiredAttrCache(reg, schemaID) (cache, error)` used identically in Tasks 3 and 4. `attrCaches map[int16]forma.SchemaAttributeCache` field name consistent on both `schemaFlushContext` and `initRunContext`. `ErrSchemaAttrCacheUnavailable` referenced consistently. `testAttrCache()`/`stubSchemaRegistry` defined in Task 1, consumed in Tasks 2-4. ✓

--- a/docs/superpowers/specs/2026-07-14-cdc-193-retire-generic-export-design.md
+++ b/docs/superpowers/specs/2026-07-14-cdc-193-retire-generic-export-design.md
@@ -1,0 +1,129 @@
+# Retire the no-attribute-cache generic CDC export path (#193)
+
+**Issue:** [#193](https://github.com/Lychee-Technology/forma/issues/193) — follow-up from PR #191 (#173, epic #172)
+**Date:** 2026-07-14
+**Scope:** `internal/cdc` only
+
+## Problem
+
+PR #191 fixed the schema-aware CDC export to read the numeric EAV family from
+`value_numeric` (bool as 1/0, dates as epoch ms), matching the mainline write
+path. The **generic** export path — taken when a schema's attribute cache can't
+be resolved (`resolveSchemaAttrCache` returns nil / `GetSchemaAttributeCacheByID`
+errors) — still emits a `value_text`-only `attributes` struct.
+
+This is latent today: the production federated reader already fails fast when no
+attribute cache is loaded (`ErrSchemaMetadataCacheRequired`,
+`internal/federated/duckdb_query.go:250`), so a no-cache schema can never be
+queried. But the write path silently produces Parquet the reader could never
+consume correctly, and it will bite whoever wires a schema without registry JSON.
+
+## Decision
+
+**Retire the generic path (fail fast), aborting the whole run via pre-flight
+validation.**
+
+Two decisions were settled during brainstorming:
+
+1. **Retire, not align.** Correct numeric-family typing (bool→1/0, date→epoch-ms)
+   cannot be derived without the attribute cache, so "align the output shape" is
+   infeasible. And even a shape-aligned output would have no consumer, because
+   the reader fails fast for no-cache schemas. Retiring makes the write path
+   symmetric with the read path.
+2. **Abort the whole run, all-or-nothing.** A single unresolvable schema aborts
+   the entire flush/init run **before any side effect** (no Parquet writes, no
+   `change_log` marking), rather than failing per-schema into the `errors.Join`
+   aggregate. Realized as a **pre-flight validation** pass ahead of both schema
+   loops.
+
+## Contract
+
+A CDC export — delta flush (`RunOnce`/`Runner.RunOnce`) or base init (`RunInit`) —
+**requires a resolvable attribute cache for every schema it will touch.** If any
+schema's cache is unresolvable, the run aborts before processing any schema.
+
+"Unresolvable" mirrors the reader exactly: **lookup error OR empty cache**
+(`len(cache) == 0`) both count. A real schema's attribute cache is never empty —
+it maps hot fields as well as EAV attributes — so an empty cache means "not
+found," the same assumption the reader already bakes in
+(`duckdb_query.go:242`).
+
+The top-level entrypoints already reject a nil registry
+(`flusher.go` `RunOnce`, `runner.go` `Runner.RunOnce`), so the only live gap this
+closes is the per-schema case: registry present, but one schema's lookup fails.
+
+## Behavior — pre-flight, all-or-nothing
+
+### Flush (`internal/cdc/flusher.go`)
+
+- Add a pre-flight pass in `processSchemas` (ahead of the per-schema loop): for
+  every `schemaID`, resolve its cache into a `map[int16]forma.SchemaAttributeCache`.
+  Any error or empty cache → return immediately, naming the offending schema; no
+  schema flushes.
+- Thread the resolved map down so `executeFlush` reads the pre-resolved cache
+  instead of re-resolving. The per-schema warn+fallback at `flusher.go:364-370`
+  is removed — `executeFlush` never sees a nil cache.
+
+### Init (`internal/cdc/init.go`)
+
+- Symmetric pre-flight in `processInitSchemas` (ahead of the loop).
+- `resolveSchemaAttrCache` changes from *warn → return nil* to *return
+  `(cache, error)`*; pre-flight aborts on the first unresolvable schema before any
+  `initSchema` runs.
+
+## Defense in depth + dead-code removal
+
+- `buildExportSQLPlan` (`duckdb_exporter.go:226`): convert the `len(attrCache)==0`
+  branch into a hard error instead of building generic SQL. The invariant then
+  holds even if a future caller bypasses pre-flight.
+- Cascade-delete the now-dead code, verified by compile + lint:
+  - `buildGenericExportSQL`
+  - `exportModeSpec.defaultMainColumns` field + its `defaultDeltaMainColumns` /
+    `defaultBaseMainColumns` assignments and the funcs
+  - the generic `mainSelectCols` construction (duckdb_exporter.go:227-231)
+- `init_sizing.go:36`'s `len(attrCache)==0` sizing fallback becomes dead too —
+  optional trim (leave only if it complicates the diff).
+
+## Error semantics
+
+This is the operator / CDC path, **not** HTTP write-path validation — so a plain
+operator-visible error, **not** wrapped in `forma.ErrInvalidInput`
+(see `docs/error-handling.md`). Introduce a sentinel in the `cdc` package (e.g.
+`ErrSchemaAttrCacheUnavailable`) for `errors.Is` matching in tests.
+
+The message names the logical value (attribute metadata cache), the `schema_id`,
+and the remedy (register the schema's JSON, or drop it from the flush set).
+
+## Testing (acceptance: a regression test pins the chosen behavior)
+
+- Invert `TestExecuteFlush_FallsBackToGenericProjectionWhenSchemaLookupFails` →
+  `TestRunFlush_AbortsWhenSchemaCacheUnavailable`: asserts `errors.Is(sentinel)`,
+  the error names the schema, and **no schema was flushed** (zero `executeSingle`
+  invocations) — pins all-or-nothing.
+- `TestRunInit_AbortsWhenSchemaCacheUnavailable` — symmetric for the init path.
+- `TestBuildExportSQLPlan_ErrorsWithoutAttrCache` — pins the defense-in-depth
+  hard error at the exporter boundary.
+- Update the `internal/e2e_harness/production/multi_schema_isolation_e2e_test.go`
+  comment: missing schema metadata is no longer a latent generic path; it is now
+  a hard pre-flight abort owned by this change.
+
+## Files touched
+
+- `internal/cdc/flusher.go` — pre-flight in `processSchemas`; remove per-schema
+  warn+fallback; thread resolved caches.
+- `internal/cdc/init.go` — pre-flight in `processInitSchemas`;
+  `resolveSchemaAttrCache` returns `(cache, error)`.
+- `internal/cdc/duckdb_exporter.go` — hard error on empty cache; delete dead
+  generic SQL builder + exclusive helpers.
+- `internal/cdc/` sentinel declaration (`ErrSchemaAttrCacheUnavailable`).
+- `internal/cdc/flusher_test.go` — invert existing test + new abort tests.
+- `internal/e2e_harness/production/multi_schema_isolation_e2e_test.go` — comment
+  update.
+- `internal/cdc/init_sizing.go` — optional dead-branch trim.
+
+## Out of scope
+
+- The reader side (already fails fast).
+- Any change to the schema-aware projection path (unaffected).
+- Adding a Docker-backed e2e vector for missing metadata — the unit-level abort
+  tests satisfy the acceptance criterion; an e2e vector is a possible follow-up.

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -23,7 +23,6 @@ type DuckExporter struct {
 
 type exportModeSpec struct {
 	defaultMemoryLimit string
-	defaultMainColumns func() []string
 	activeOnly         bool
 	useChangeLog       bool
 	schemaIDSelect     string
@@ -162,7 +161,6 @@ func escapeLiteral(s string) string {
 func buildExportSQL(pgConnStr string, s3TmpPath string, cfg CDCConfig, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) (string, string, string, string, error) {
 	plan, err := buildExportSQLPlan(exportModeSpec{
 		defaultMemoryLimit: "4GB",
-		defaultMainColumns: defaultDeltaMainColumns,
 		activeOnly:         false,
 		useChangeLog:       true,
 		schemaIDSelect:     "cl.schema_id",
@@ -224,12 +222,13 @@ func buildExportSQLPlan(spec exportModeSpec, pgConnStr string, s3TmpPath string,
 	copyOptions := buildParquetCopyOptions(opts)
 
 	if len(attrCache) == 0 {
-		mainColumns := spec.defaultMainColumns()
-		plan.mainQuery = buildMainEntityQuery(entityMain, schemaID, mainColumns, mFilter, spec.activeOnly)
-		plan.eavQuery = buildEAVQuery(eavData, schemaID, eFilter, nil)
-		mainSelectCols := append(spec.baseSelectColumns(), prefixColumns("m.", mainColumns[5:])...)
-		plan.sql = buildGenericExportSQL(spec, opts, copyOptions, pgEsc, s3Esc, plan.changeLogQuery, plan.mainQuery, plan.eavQuery, mainSelectCols)
-		return plan, nil
+		// A resolvable attribute cache is mandatory: without it we cannot derive
+		// the numeric-family typing (bool as 1/0, dates as epoch ms) the
+		// federated reader expects, and the reader itself fails fast for no-cache
+		// schemas (ErrSchemaMetadataCacheRequired). Pre-flight validation in the
+		// flush/init loops should already have aborted; this is defense in depth
+		// for any caller that bypasses it (#193).
+		return exportSQLPlan{}, fmt.Errorf("build export SQL for schema %d: attribute metadata cache is required but empty: %w", schemaID, ErrSchemaAttrCacheUnavailable)
 	}
 
 	projection := buildSchemaDrivenProjection(attrCache)
@@ -254,53 +253,6 @@ func (spec exportModeSpec) baseSelectColumns() []string {
 	}
 }
 
-func buildGenericExportSQL(spec exportModeSpec, opts exportSQLOptions, copyOptions, pgEsc, s3Esc, clQuery, mQuery, eQuery string, mainSelectCols []string) string {
-	mQueryEsc := escapeLiteral(mQuery)
-	eQueryEsc := escapeLiteral(eQuery)
-
-	if spec.useChangeLog {
-		// LEFT JOIN to entity_main: production deletes remove the entity row
-		// and leave only the change_log tombstone, which MUST still be
-		// exported (deleted_at set, attribute columns NULL) or the flush
-		// marks the tombstone flushed while dropping it from parquet and the
-		// cold tier resurrects the deleted row (#173).
-		clQueryEsc := escapeLiteral(clQuery)
-		return fmt.Sprintf(`PRAGMA memory_limit='%s';
-ATTACH IF NOT EXISTS '%s' AS pg_db (TYPE postgres, READ_ONLY);
-
-COPY (
-SELECT
-  %s,
-  e.attributes
-FROM postgres_query('pg_db', '%s') cl
-LEFT JOIN postgres_query('pg_db', '%s') m
-  ON cl.row_id = m.ltbase_row_id
-LEFT JOIN (
-  SELECT row_id, list(struct_pack(attr_id := attr_id, value_text := value_text)) AS attributes
-  FROM postgres_query('pg_db', '%s')
-  GROUP BY row_id
-) e ON cl.row_id = e.row_id
-) TO '%s' (%s);
-`, opts.memoryLimit, pgEsc, strings.Join(mainSelectCols, ",\n  "), clQueryEsc, mQueryEsc, eQueryEsc, s3Esc, copyOptions)
-	}
-
-	return fmt.Sprintf(`PRAGMA memory_limit='%s';
-ATTACH IF NOT EXISTS '%s' AS pg_db (TYPE postgres, READ_ONLY);
-
-COPY (
-SELECT
-  %s,
-  e.attributes
-FROM postgres_query('pg_db', '%s') m
-LEFT JOIN (
-  SELECT row_id, list(struct_pack(attr_id := attr_id, value_text := value_text)) AS attributes
-  FROM postgres_query('pg_db', '%s')
-  GROUP BY row_id
-) e ON m.ltbase_row_id = e.row_id
-) TO '%s' (%s);
-`, opts.memoryLimit, pgEsc, strings.Join(mainSelectCols, ",\n  "), mQueryEsc, eQueryEsc, s3Esc, copyOptions)
-}
-
 func buildProjectedExportSQL(spec exportModeSpec, opts exportSQLOptions, copyOptions, pgEsc, s3Esc, clQuery, mQuery, eQuery string, mainSelectCols, eavAgg []string) string {
 	mQueryEsc := escapeLiteral(mQuery)
 	eQueryEsc := escapeLiteral(eQuery)
@@ -308,8 +260,7 @@ func buildProjectedExportSQL(spec exportModeSpec, opts exportSQLOptions, copyOpt
 
 	if spec.useChangeLog {
 		// LEFT JOIN to entity_main so change_log tombstones of hard-deleted
-		// rows are exported instead of silently dropped (see
-		// buildGenericExportSQL, #173).
+		// rows are exported instead of silently dropped (#173).
 		clQueryEsc := escapeLiteral(clQuery)
 		return fmt.Sprintf(`PRAGMA memory_limit='%s';
 ATTACH IF NOT EXISTS '%s' AS pg_db (TYPE postgres, READ_ONLY);
@@ -347,14 +298,6 @@ func quoteUUIDList(ids []uuid.UUID) string {
 		parts = append(parts, fmt.Sprintf("UUID '%s'", id.String()))
 	}
 	return strings.Join(parts, ", ")
-}
-
-func prefixColumns(prefix string, cols []string) []string {
-	res := make([]string, 0, len(cols))
-	for _, c := range cols {
-		res = append(res, prefix+c)
-	}
-	return res
 }
 
 func sortedAttrKeys(cache forma.SchemaAttributeCache) []string {

--- a/internal/cdc/duckdb_exporter_sql_test.go
+++ b/internal/cdc/duckdb_exporter_sql_test.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildExportSQL_UsesRowIDsAndConfig(t *testing.T) {
 	cfg := CDCConfig{ChangeLogTable: "change_log_dev", DuckMemLimit: "2GB", ParquetCompression: "zstd", ParquetCompressionLevel: 5}
 	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
 
-	sql, clQuery, mQuery, eQuery, err := buildExportSQL("host=pg", "s3://bucket/prefix/1/_tmp/tmp.parquet", cfg, 1, 1700000000000, []uuid.UUID{rowID}, nil)
+	sql, clQuery, mQuery, eQuery, err := buildExportSQL("host=pg", "s3://bucket/prefix/1/_tmp/tmp.parquet", cfg, 1, 1700000000000, []uuid.UUID{rowID}, testAttrCache())
 	if err != nil {
 		t.Fatalf("buildExportSQL returned error: %v", err)
 	}
@@ -33,9 +34,17 @@ func TestBuildExportSQL_UsesRowIDsAndConfig(t *testing.T) {
 	if !strings.Contains(sql, "PARQUET_VERSION V2") {
 		t.Fatalf("sql missing parquet v2 export option: %s", sql)
 	}
-	if !strings.Contains(sql, "changed_at") || !strings.Contains(sql, "attributes") {
-		t.Fatalf("sql missing projected columns (changed_at/attributes): %s", sql)
+	if !strings.Contains(sql, "changed_at") || !strings.Contains(sql, "flag") {
+		t.Fatalf("sql missing projected columns (changed_at/flag): %s", sql)
 	}
+}
+
+func TestBuildExportSQL_ErrorsWithoutAttrCache(t *testing.T) {
+	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
+	_, _, _, _, err := buildExportSQL("host=pg", "s3://bucket/prefix/1/_tmp/tmp.parquet", CDCConfig{}, 1, 1700000000000, []uuid.UUID{rowID}, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	require.Contains(t, err.Error(), "1")
 }
 
 func TestBuildExportSQL_ErrorsOnEmptyRowIDs(t *testing.T) {
@@ -91,7 +100,7 @@ func TestBuildExportSQL_UsesCustomTableNames(t *testing.T) {
 	}
 	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
 
-	sql, clQuery, mQuery, eQuery, err := buildExportSQL("host=pg", "s3://bucket/prefix/1/_tmp/tmp.parquet", cfg, 1, 1700000000000, []uuid.UUID{rowID}, nil)
+	sql, clQuery, mQuery, eQuery, err := buildExportSQL("host=pg", "s3://bucket/prefix/1/_tmp/tmp.parquet", cfg, 1, 1700000000000, []uuid.UUID{rowID}, testAttrCache())
 	if err != nil {
 		t.Fatalf("buildExportSQL returned error: %v", err)
 	}

--- a/internal/cdc/errors.go
+++ b/internal/cdc/errors.go
@@ -1,0 +1,36 @@
+package cdc
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/lychee-technology/forma"
+)
+
+// ErrSchemaAttrCacheUnavailable marks a CDC export that cannot proceed because a
+// schema's attribute metadata cache could not be resolved — the registry lookup
+// failed or the cache is empty. CDC export needs it to produce parquet the
+// federated reader can consume; without it the reader fails fast with
+// ErrSchemaMetadataCacheRequired (#193). This is an operator-visible
+// configuration error, not write-path validation, so it is NOT wrapped in
+// forma.ErrInvalidInput.
+var ErrSchemaAttrCacheUnavailable = errors.New("schema attribute metadata cache unavailable")
+
+// resolveRequiredAttrCache resolves schemaID's attribute cache, treating a nil
+// registry, a lookup error, or an empty cache as a hard failure. A real schema's
+// cache is never empty (it maps hot fields as well as EAV attributes), so an
+// empty cache means the schema is not registered — the same assumption the
+// federated reader makes (internal/federated/duckdb_query.go).
+func resolveRequiredAttrCache(reg forma.SchemaRegistry, schemaID int16) (forma.SchemaAttributeCache, error) {
+	if reg == nil {
+		return nil, fmt.Errorf("resolve attribute cache for schema %d: schema registry is nil: %w", schemaID, ErrSchemaAttrCacheUnavailable)
+	}
+	_, cache, err := reg.GetSchemaAttributeCacheByID(schemaID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve attribute cache for schema %d: %w: %w", schemaID, ErrSchemaAttrCacheUnavailable, err)
+	}
+	if len(cache) == 0 {
+		return nil, fmt.Errorf("schema %d has an empty attribute metadata cache: %w", schemaID, ErrSchemaAttrCacheUnavailable)
+	}
+	return cache, nil
+}

--- a/internal/cdc/errors_test.go
+++ b/internal/cdc/errors_test.go
@@ -1,0 +1,32 @@
+package cdc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveRequiredAttrCache(t *testing.T) {
+	t.Run("registry lookup error", func(t *testing.T) {
+		_, err := resolveRequiredAttrCache(errorSchemaRegistry{err: errors.New("boom")}, 7)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+		require.Contains(t, err.Error(), "7")
+	})
+	t.Run("empty cache", func(t *testing.T) {
+		_, err := resolveRequiredAttrCache(stubSchemaRegistry{cache: forma.SchemaAttributeCache{}}, 9)
+		require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+		require.Contains(t, err.Error(), "9")
+	})
+	t.Run("nil registry", func(t *testing.T) {
+		_, err := resolveRequiredAttrCache(nil, 3)
+		require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	})
+	t.Run("populated cache", func(t *testing.T) {
+		cache, err := resolveRequiredAttrCache(stubSchemaRegistry{cache: testAttrCache()}, 1)
+		require.NoError(t, err)
+		require.NotEmpty(t, cache)
+	})
+}

--- a/internal/cdc/export_sql_builder.go
+++ b/internal/cdc/export_sql_builder.go
@@ -158,37 +158,3 @@ func buildEAVAggregationSQL(eQueryEsc string, eavAgg []string) string {
 		eQueryEsc,
 	)
 }
-
-func defaultDeltaMainColumns() []string {
-	return []string{
-		"ltbase_row_id",
-		"ltbase_schema_id",
-		"ltbase_created_at",
-		"ltbase_updated_at",
-		"ltbase_deleted_at",
-		"text_01", "text_02", "text_03", "text_04", "text_05",
-		"text_06", "text_07", "text_08", "text_09", "text_10",
-		"smallint_01", "smallint_02",
-		"integer_01", "integer_02", "integer_03",
-		"bigint_01", "bigint_02", "bigint_03", "bigint_04", "bigint_05",
-		"double_01", "double_02", "double_03", "double_04", "double_05",
-		"uuid_01", "uuid_02",
-	}
-}
-
-func defaultBaseMainColumns() []string {
-	return []string{
-		"ltbase_row_id",
-		"ltbase_schema_id",
-		"ltbase_created_at",
-		"ltbase_updated_at",
-		"ltbase_deleted_at",
-		"text_01", "text_02", "text_03", "text_04", "text_05",
-		"text_06", "text_07", "text_08", "text_09", "text_10",
-		"smallint_01", "smallint_02", "smallint_03",
-		"integer_01", "integer_02", "integer_03",
-		"bigint_01", "bigint_02", "bigint_03", "bigint_04", "bigint_05",
-		"double_01", "double_02", "double_03", "double_04", "double_05",
-		"uuid_01", "uuid_02",
-	}
-}

--- a/internal/cdc/export_sql_shared_test.go
+++ b/internal/cdc/export_sql_shared_test.go
@@ -93,8 +93,8 @@ func TestBuildExportSQL_CommonSemanticsAcrossModes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name+"/generic", func(t *testing.T) {
-			res, err := tt.build(nil)
+		t.Run(tt.name+"/mode-invariants", func(t *testing.T) {
+			res, err := tt.build(attrCache)
 			if err != nil {
 				t.Fatalf("build failed: %v", err)
 			}

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -246,6 +246,7 @@ type schemaFlushContext struct {
 	dryRun           bool
 	logger           *zap.Logger
 	schemaRegistry   forma.SchemaRegistry
+	attrCaches       map[int16]forma.SchemaAttributeCache
 	manifestStore    manifest.Store
 	manifestResolver manifest.PathResolver
 	acquireLock      func(context.Context, *sql.DB, int16) (bool, error)
@@ -259,6 +260,17 @@ func (c *schemaFlushContext) processSchemas(ctx context.Context, schemaIDs []int
 	if len(schemaIDs) == 0 {
 		return nil
 	}
+
+	caches := make(map[int16]forma.SchemaAttributeCache, len(schemaIDs))
+	for _, sid := range schemaIDs {
+		schemaID := int16(sid)
+		cache, err := resolveRequiredAttrCache(c.schemaRegistry, schemaID)
+		if err != nil {
+			return fmt.Errorf("cdc flush pre-flight: %w", err)
+		}
+		caches[schemaID] = cache
+	}
+	c.attrCaches = caches
 
 	processSchema := c.processSchemaFn
 	if processSchema == nil {
@@ -360,14 +372,8 @@ func (c *schemaFlushContext) executeFlush(ctx context.Context, schemaID int16) e
 		c.cfg.PGHost, c.cfg.PGPort, c.cfg.PGUser, c.cfg.PGDB, sslMode)
 	c.logger.Sugar().Infow("export snapshot", "schema_id", schemaID, "snapshot_ts", snapshot, "rows", len(ids), "pgConnForDuck", pgConnForDuckLoggable)
 
-	var attrCache forma.SchemaAttributeCache
-	if c.schemaRegistry != nil {
-		if _, cache, err := c.schemaRegistry.GetSchemaAttributeCacheByID(schemaID); err != nil {
-			c.logger.Sugar().Warnw("schema registry lookup failed, using generic projection", "schema_id", schemaID, "err", err)
-		} else {
-			attrCache = cache
-		}
-	}
+	// Cache was resolved and validated by the processSchemas pre-flight (#193).
+	attrCache := c.attrCaches[schemaID]
 
 	executor := &flushBatchExecutor{
 		db:               c.db,

--- a/internal/cdc/flusher_test.go
+++ b/internal/cdc/flusher_test.go
@@ -219,7 +219,8 @@ func TestGetUnflushedSchemaIDs_CanceledContext(t *testing.T) {
 func TestProcessSchemas_ContinuesAcrossFailuresAndJoinsErrors(t *testing.T) {
 	processed := make([]int16, 0, 3)
 	flushCtx := &schemaFlushContext{
-		logger: zap.NewNop(),
+		logger:         zap.NewNop(),
+		schemaRegistry: stubSchemaRegistry{cache: testAttrCache()},
 		processSchemaFn: func(_ context.Context, schemaID int16) error {
 			processed = append(processed, schemaID)
 			if schemaID == 2 {
@@ -411,41 +412,38 @@ func TestProcessSchema_SkipsWhenThresholdsAreNotMet(t *testing.T) {
 	require.Equal(t, 1, releaseCalls)
 }
 
-func TestExecuteFlush_FallsBackToGenericProjectionWhenSchemaLookupFails(t *testing.T) {
-	db, err := sql.Open("duckdb", ":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
-
-	ctx := context.Background()
-	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
-	require.NoError(t, err)
-	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
-	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, time.Now().UnixMilli())
-	require.NoError(t, err)
-
-	called := false
+func TestProcessSchemas_AbortsWhenSchemaCacheUnavailable(t *testing.T) {
+	processed := false
 	flushCtx := &schemaFlushContext{
-		db:             db,
-		cfg:            CDCConfig{BatchSize: 10, PGHost: "localhost", PGPort: 5432, PGUser: "pguser", PGDB: "forma"},
-		tableName:      "change_log",
-		pgPassword:     "secret",
 		logger:         zap.NewNop(),
 		schemaRegistry: errorSchemaRegistry{err: errors.New("schema unavailable")},
-		executeSingle: func(executor *flushBatchExecutor, batchIDs []uuid.UUID) error {
-			called = true
-			require.Len(t, batchIDs, 1)
-			require.Nil(t, executor.attrCache)
-			require.Equal(t, int16(7), executor.schemaID)
+		processSchemaFn: func(context.Context, int16) error {
+			processed = true
 			return nil
-		},
-		executeInChunks: func(*flushBatchExecutor, []uuid.UUID, int) error {
-			return errors.New("unexpected chunk execution")
 		},
 	}
 
-	err = flushCtx.executeFlush(ctx, 7)
+	err := flushCtx.processSchemas(context.Background(), []int64{7})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	require.Contains(t, err.Error(), "7")
+	require.False(t, processed, "no schema must be flushed when pre-flight aborts")
+}
+
+func TestProcessSchemas_ResolvesCachesBeforeProcessing(t *testing.T) {
+	var processedIDs []int16
+	flushCtx := &schemaFlushContext{
+		logger:         zap.NewNop(),
+		schemaRegistry: stubSchemaRegistry{cache: testAttrCache()},
+		processSchemaFn: func(_ context.Context, id int16) error {
+			processedIDs = append(processedIDs, id)
+			return nil
+		},
+	}
+
+	err := flushCtx.processSchemas(context.Background(), []int64{7, 8})
 	require.NoError(t, err)
-	require.True(t, called)
+	require.Equal(t, []int16{7, 8}, processedIDs)
+	require.NotEmpty(t, flushCtx.attrCaches[7])
+	require.NotEmpty(t, flushCtx.attrCaches[8])
 }

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -41,6 +41,7 @@ type initRunContext struct {
 	duck                 *DuckExporter
 	s3Client             S3ObjectClient
 	schemaRegistry       forma.SchemaRegistry
+	attrCaches           map[int16]forma.SchemaAttributeCache
 	manifestStore        manifest.Store
 	manifestResolver     manifest.PathResolver
 	logger               *zap.Logger
@@ -177,6 +178,16 @@ func RunInit(ctx context.Context, opts InitOptions) (InitSummary, error) {
 }
 
 func processInitSchemas(ctx context.Context, runCtx *initRunContext, schemaIDs []int64) (InitSummary, error) {
+	runCtx.attrCaches = make(map[int16]forma.SchemaAttributeCache, len(schemaIDs))
+	for _, sid := range schemaIDs {
+		schemaID := int16(sid)
+		cache, err := resolveRequiredAttrCache(runCtx.schemaRegistry, schemaID)
+		if err != nil {
+			return InitSummary{}, fmt.Errorf("cdc init pre-flight: %w", err)
+		}
+		runCtx.attrCaches[schemaID] = cache
+	}
+
 	summary := InitSummary{}
 	var schemaErrors []error
 
@@ -272,21 +283,10 @@ func prepareSchemaInit(ctx context.Context, runCtx *initRunContext, schemaID int
 	state := &schemaInitState{
 		schemaID: schemaID,
 	}
-	state.attrCache = resolveSchemaAttrCache(runCtx, schemaID)
+	// Cache was resolved and validated by the processInitSchemas pre-flight (#193).
+	state.attrCache = runCtx.attrCaches[schemaID]
 	state.batchSize = resolveInitBatchSize(runCtx, schemaID, state.attrCache)
 	return state, nil
-}
-
-func resolveSchemaAttrCache(runCtx *initRunContext, schemaID int16) forma.SchemaAttributeCache {
-	if runCtx.schemaRegistry == nil {
-		return nil
-	}
-	_, cache, err := runCtx.schemaRegistry.GetSchemaAttributeCacheByID(schemaID)
-	if err != nil {
-		runCtx.logger.Warn("schema registry lookup failed, using generic projection", zap.Int16("schema_id", schemaID), zap.Error(err))
-		return nil
-	}
-	return cache
 }
 
 func processSchemaBatches(ctx context.Context, runCtx *initRunContext, state *schemaInitState) error {

--- a/internal/cdc/init_exporter.go
+++ b/internal/cdc/init_exporter.go
@@ -27,7 +27,6 @@ func (e *DuckExporter) ExportBaseFileToTmp(ctx context.Context, cfg CDCConfig, p
 func buildBaseExportSQL(pgConnStr string, s3TmpPath string, cfg CDCConfig, schemaID int16, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) (string, string, string, error) {
 	plan, err := buildExportSQLPlan(exportModeSpec{
 		defaultMemoryLimit: "8GB",
-		defaultMainColumns: defaultBaseMainColumns,
 		activeOnly:         true,
 		useChangeLog:       false,
 		schemaIDSelect:     "m.ltbase_schema_id AS schema_id",

--- a/internal/cdc/init_exporter_sql_test.go
+++ b/internal/cdc/init_exporter_sql_test.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildBaseExportSQL_UsesRowIDsAndConfig(t *testing.T) {
 	cfg := CDCConfig{EntityMainTable: "entity_main_dev", DuckMemLimit: "6GB", ParquetCompression: "zstd", ParquetCompressionLevel: 5}
 	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
 
-	sql, mQuery, eQuery, err := buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", cfg, 1, []uuid.UUID{rowID}, nil)
+	sql, mQuery, eQuery, err := buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", cfg, 1, []uuid.UUID{rowID}, testAttrCache())
 	if err != nil {
 		t.Fatalf("buildBaseExportSQL returned error: %v", err)
 	}
@@ -33,9 +34,17 @@ func TestBuildBaseExportSQL_UsesRowIDsAndConfig(t *testing.T) {
 	if !strings.Contains(sql, "PARQUET_VERSION V2") {
 		t.Fatalf("sql missing parquet v2 export option: %s", sql)
 	}
-	if !strings.Contains(sql, "changed_at") || !strings.Contains(sql, "attributes") {
-		t.Fatalf("sql missing projected columns (changed_at/attributes): %s", sql)
+	if !strings.Contains(sql, "changed_at") || !strings.Contains(sql, "flag") {
+		t.Fatalf("sql missing projected columns (changed_at/flag): %s", sql)
 	}
+}
+
+func TestBuildBaseExportSQL_ErrorsWithoutAttrCache(t *testing.T) {
+	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
+	_, _, _, err := buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", CDCConfig{}, 1, []uuid.UUID{rowID}, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	require.Contains(t, err.Error(), "1")
 }
 
 func TestBuildBaseExportSQL_ErrorsOnEmptyRowIDs(t *testing.T) {
@@ -87,7 +96,7 @@ func TestBuildBaseExportSQL_UsesCustomTableNames(t *testing.T) {
 	}
 	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
 
-	_, mQuery, eQuery, err := buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", cfg, 1, []uuid.UUID{rowID}, nil)
+	_, mQuery, eQuery, err := buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", cfg, 1, []uuid.UUID{rowID}, testAttrCache())
 	if err != nil {
 		t.Fatalf("buildBaseExportSQL returned error: %v", err)
 	}

--- a/internal/cdc/init_preflight_test.go
+++ b/internal/cdc/init_preflight_test.go
@@ -1,0 +1,23 @@
+package cdc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestProcessInitSchemas_AbortsWhenSchemaCacheUnavailable(t *testing.T) {
+	runCtx := &initRunContext{
+		logger:         zap.NewNop(),
+		schemaRegistry: errorSchemaRegistry{err: errors.New("schema unavailable")},
+	}
+
+	summary, err := processInitSchemas(context.Background(), runCtx, []int64{7})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+	require.Contains(t, err.Error(), "7")
+	require.Equal(t, InitSummary{}, summary)
+}

--- a/internal/cdc/mocks_test.go
+++ b/internal/cdc/mocks_test.go
@@ -36,6 +36,46 @@ func (r errorSchemaRegistry) ListSchemas() []string {
 	return nil
 }
 
+// stubSchemaRegistry returns a fixed attribute cache with no error. A nil/empty
+// cache field models a schema whose lookup succeeds but carries no attributes.
+type stubSchemaRegistry struct{ cache forma.SchemaAttributeCache }
+
+func (r stubSchemaRegistry) GetSchemaAttributeCacheByName(string) (int16, forma.SchemaAttributeCache, error) {
+	return 0, r.cache, nil
+}
+
+func (r stubSchemaRegistry) GetSchemaAttributeCacheByID(int16) (string, forma.SchemaAttributeCache, error) {
+	return "", r.cache, nil
+}
+
+func (r stubSchemaRegistry) GetSchemaByName(string) (int16, forma.JSONSchema, error) {
+	return 0, forma.JSONSchema{}, nil
+}
+
+func (r stubSchemaRegistry) GetSchemaByID(int16) (string, forma.JSONSchema, error) {
+	return "", forma.JSONSchema{}, nil
+}
+
+func (r stubSchemaRegistry) ListSchemas() []string { return nil }
+
+// testAttrCache is a minimal populated cache (one column-bound text attr, one
+// EAV bool attr) shared by tests that need a resolvable schema.
+func testAttrCache() forma.SchemaAttributeCache {
+	return forma.SchemaAttributeCache{
+		"name": {
+			AttributeName: "name",
+			AttributeID:   10,
+			ValueType:     forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnText01},
+		},
+		"flag": {
+			AttributeName: "flag",
+			AttributeID:   11,
+			ValueType:     forma.ValueTypeBool,
+		},
+	}
+}
+
 type inMemoryManifestStore struct {
 	data    map[string][]byte
 	etags   map[string]string

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -173,18 +173,12 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 		manifestResolver: manifestResolver,
 	}
 
-	var schemaErrs []error
-	for _, sid := range schemaIDs {
-		schemaID := int16(sid)
-		if err := flushCtx.processSchema(ctx, schemaID); err != nil {
-			r.logger.Sugar().Errorw("process schema failed", "schema_id", schemaID, "err", err)
-			schemaErrs = append(schemaErrs, fmt.Errorf("schema %d: %w", schemaID, err))
-		}
-	}
-	if len(schemaErrs) > 0 {
-		return errors.Join(schemaErrs...)
-	}
-	return nil
+	// Delegate to processSchemas so the Runner path runs the same pre-flight
+	// (resolve every schema's attribute cache, abort the whole run before any
+	// side effect if one is unresolvable) that populates flushCtx.attrCaches for
+	// executeFlush. Duplicating the loop here silently skipped the pre-flight and
+	// left attrCaches nil, so the exporter hard-errored on every schema (#193).
+	return flushCtx.processSchemas(ctx, schemaIDs)
 }
 
 func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cachedS3Runtime, error) {

--- a/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+++ b/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
@@ -26,9 +26,12 @@ import (
 //     the #197 contract (error names the orphaned key, retry is a no-op, no
 //     self-repair) must hold per-schema without disturbing the sibling.
 //
-// Missing schema metadata is deliberately NOT a vector: the flusher only
-// warns and falls back to the generic projection (internal/cdc/flusher.go),
-// a latent path owned by #193.
+// Missing schema metadata is not exercised here: as of #193 the flusher and
+// init both pre-flight every schema's attribute cache and abort the whole run
+// (ErrSchemaAttrCacheUnavailable) before any side effect, rather than falling
+// back to a generic projection. That contract is pinned by unit tests in
+// internal/cdc (TestProcessSchemas_AbortsWhenSchemaCacheUnavailable,
+// TestProcessInitSchemas_AbortsWhenSchemaCacheUnavailable).
 func TestMultiSchemaFlushIsolation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
Closes #193.

## Problem

The CDC export had a **generic** projection path taken whenever a schema's attribute metadata cache couldn't be resolved (`resolveSchemaAttrCache` returned nil). It emitted `value_text`-only `attributes` structs — parquet the production federated reader could never consume correctly, since the reader already fails fast with `ErrSchemaMetadataCacheRequired` when no cache is loaded. Latent today, but it would bite whoever wired a schema without registry JSON.

## Decision (see design spec)

**Retire the generic path — fail fast, aborting the whole run via pre-flight validation.** Aligning the output was infeasible (numeric-family typing — bool→1/0, dates→epoch-ms — can't be derived without the cache) and pointless (no reader consumes a no-cache schema). This makes the write path symmetric with the read path.

## What changed (`internal/cdc` only)

- **Shared resolver + sentinel** (`errors.go`): `resolveRequiredAttrCache` treats a nil registry, a lookup error, or an empty cache (`len==0`, mirroring the reader) as unresolvable, carrying the plain operator sentinel `ErrSchemaAttrCacheUnavailable` (not `forma.ErrInvalidInput`).
- **Flush pre-flight** (`flusher.go`): `processSchemas` resolves every schema's cache up front and aborts before any side effect; `executeFlush` reads the pre-resolved cache instead of consulting the registry.
- **Init pre-flight** (`init.go`): symmetric in `processInitSchemas`; the old `resolveSchemaAttrCache` is deleted.
- **Defense in depth** (`duckdb_exporter.go`): `buildExportSQLPlan` hard-errors on an empty cache; the dead generic-projection code (`buildGenericExportSQL`, `defaultMainColumns` field, `defaultDeltaMainColumns`/`defaultBaseMainColumns`, orphaned `prefixColumns`) is removed. The schema-aware/projected path is unchanged.
- **Docs**: design spec + implementation plan under `docs/superpowers/`.

Pre-flight is all-or-nothing: an unresolvable schema aborts the entire flush/init run with zero parquet writes and zero `change_log` marks. Only schemas actually in the work set are validated, so a no-work schema never trips the abort.

## Tests

- `TestResolveRequiredAttrCache` — the four resolver cases.
- `TestBuildExportSQL_ErrorsWithoutAttrCache` / `TestBuildBaseExportSQL_ErrorsWithoutAttrCache` — exporter hard-error.
- `TestProcessSchemas_AbortsWhenSchemaCacheUnavailable` + `TestProcessInitSchemas_AbortsWhenSchemaCacheUnavailable` — pin the pre-flight abort (sentinel via `errors.Is`, schema named, zero side effects). These are cited in the `multi_schema_isolation` e2e comment.
- `make test` PASS across the module; `make lint` clean (golangci-lint v1.64.8).

## Review notes

Built via a per-task spec+quality review loop plus a broad whole-branch review (verdict: ready to merge). Two cosmetic Minors remain (non-blocking): a double-`%w` chain renders the sentinel text mid-message; the two `*ErrorsWithoutAttrCache` tests use `schemaID=1`, a weak witness that the message names the id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
