### PR TITLE
test(federated): retire skipped integration stubs superseded by the production E2E harness (#196)

### DIFF
--- a/docs/integ-tests-cn.md
+++ b/docs/integ-tests-cn.md
@@ -44,7 +44,7 @@
 
 - `go test ./internal -run TestIntegration_`
 - `go test ./internal -run TestInsertPersistentRecordIntegration|TestChangeLogWritesOnUpdateAndDeleteIntegration|TestRunOptimizedQueryIntegration`
-- `go test ./internal -run TestEvaluateRoutingPolicy_VariousStrategies|TestExecuteDuckDBFederatedQuery_ClientUnavailable|TestNewDuckDBClient_HealthCheck|TestStreamDuckDBFederatedQuery_BasicExecution|TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion|TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation|TestBuildDuckDBQuery_TemplateRendering|TestExecuteDuckDBFederatedQuery_NilQuery|TestBuildDuckDBQuery_InvalidTemplateSyntax|TestRenderDuckDBQuery_ParameterMerging`
+- `go test ./internal -run TestEvaluateRoutingPolicy_VariousStrategies|TestNewDuckDBClient_HealthCheck|TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion|TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation|TestBuildDuckDBQuery_TemplateRendering|TestExecuteDuckDBFederatedQuery_NilQuery|TestRenderDuckDBQuery_ParameterMerging`
 
 用例清单：
 
@@ -62,12 +62,8 @@
   验收条件：优化查询返回记录、总数及属性符合预期。
 - `A-GI-007` `TestEvaluateRoutingPolicy_VariousStrategies`  
   验收条件：`hybrid`/`cost-first`/禁用配置下路由决策符合策略。
-- `A-GI-008` `TestExecuteDuckDBFederatedQuery_ClientUnavailable`  
-  验收条件：DuckDB 客户端不可用时返回明确错误，不 silent fail。
 - `A-GI-009` `TestNewDuckDBClient_HealthCheck`  
   验收条件：DuckDB client 初始化成功且健康检查通过。
-- `A-GI-010` `TestStreamDuckDBFederatedQuery_BasicExecution`  
-  验收条件：模板 SQL 可执行并返回预期行数。
 - `A-GI-011` `TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion`  
   验收条件：脏 ID 排除子句构造正确（包含 `NOT IN` 且参数正确）。
 - `A-GI-012` `TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation`  
@@ -76,8 +72,8 @@
   验收条件：模板渲染出的 SQL 包含预期 `LIMIT/OFFSET` 语义。
 - `A-GI-014` `TestExecuteDuckDBFederatedQuery_NilQuery`  
   验收条件：空查询入参返回明确错误。
-- `A-GI-015` `TestBuildDuckDBQuery_InvalidTemplateSyntax`  
-  验收条件：异常模板不会导致进程崩溃（允许返回错误）。
+- `A-GI-015` `TestBuildDuckDBQuery_PropagatesRenderError` (`internal/sqlgen`)  
+  验收条件：模板渲染错误由 `BuildDuckDBQuery` 向上抛出（surfaced），不被吞掉。
 - `A-GI-016` `TestRenderDuckDBQuery_ParameterMerging`  
   验收条件：where 参数合并顺序和内容正确。
 

--- a/docs/integ-tests-en.md
+++ b/docs/integ-tests-en.md
@@ -44,7 +44,7 @@ Execution entry:
 
 - `go test ./internal -run TestIntegration_`
 - `go test ./internal -run TestInsertPersistentRecordIntegration|TestChangeLogWritesOnUpdateAndDeleteIntegration|TestRunOptimizedQueryIntegration`
-- `go test ./internal -run TestEvaluateRoutingPolicy_VariousStrategies|TestExecuteDuckDBFederatedQuery_ClientUnavailable|TestNewDuckDBClient_HealthCheck|TestStreamDuckDBFederatedQuery_BasicExecution|TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion|TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation|TestBuildDuckDBQuery_TemplateRendering|TestExecuteDuckDBFederatedQuery_NilQuery|TestBuildDuckDBQuery_InvalidTemplateSyntax|TestRenderDuckDBQuery_ParameterMerging`
+- `go test ./internal -run TestEvaluateRoutingPolicy_VariousStrategies|TestNewDuckDBClient_HealthCheck|TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion|TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation|TestBuildDuckDBQuery_TemplateRendering|TestExecuteDuckDBFederatedQuery_NilQuery|TestRenderDuckDBQuery_ParameterMerging`
 
 Test cases:
 
@@ -62,12 +62,8 @@ Test cases:
   Acceptance: optimized query returns expected records, total, and attributes.
 - `A-GI-007` `TestEvaluateRoutingPolicy_VariousStrategies`  
   Acceptance: routing decisions match strategy for `hybrid`, `cost-first`, and disabled config.
-- `A-GI-008` `TestExecuteDuckDBFederatedQuery_ClientUnavailable`  
-  Acceptance: explicit error returned when DuckDB client is unavailable; no silent failure.
 - `A-GI-009` `TestNewDuckDBClient_HealthCheck`  
   Acceptance: DuckDB client initializes successfully and health check passes.
-- `A-GI-010` `TestStreamDuckDBFederatedQuery_BasicExecution`  
-  Acceptance: template SQL executes and returns expected row count.
 - `A-GI-011` `TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion`  
   Acceptance: dirty-ID exclusion clause is constructed correctly (`NOT IN` + correct args).
 - `A-GI-012` `TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation`  
@@ -76,8 +72,8 @@ Test cases:
   Acceptance: rendered SQL includes expected `LIMIT/OFFSET` semantics.
 - `A-GI-014` `TestExecuteDuckDBFederatedQuery_NilQuery`  
   Acceptance: nil query input returns explicit error.
-- `A-GI-015` `TestBuildDuckDBQuery_InvalidTemplateSyntax`  
-  Acceptance: invalid template does not crash process (error is acceptable).
+- `A-GI-015` `TestBuildDuckDBQuery_PropagatesRenderError` (`internal/sqlgen`)  
+  Acceptance: a template render error is propagated (surfaced) by `BuildDuckDBQuery` rather than swallowed.
 - `A-GI-016` `TestRenderDuckDBQuery_ParameterMerging`  
   Acceptance: merged where-args order and content are correct.
 

--- a/internal/federated/duckdb_federated_integration_test.go
+++ b/internal/federated/duckdb_federated_integration_test.go
@@ -84,10 +84,6 @@ func TestEvaluateRoutingPolicy_QueryShapeAware(t *testing.T) {
 	require.False(t, dec.UseDuckDB)
 }
 
-func TestExecuteDuckDBFederatedQuery_ClientUnavailable(t *testing.T) {
-	t.Skip("requires root symbols (setupIntegrationEnv, NewDBPersistentRecordRepository); covered by root integration tests")
-}
-
 func TestNewDuckDBClient_HealthCheck(t *testing.T) {
 	skipIfNoDuckDB(t)
 	client, err := NewDuckDBClient(forma.DuckDBConfig{Enabled: true, DBPath: ":memory:"})
@@ -98,18 +94,10 @@ func TestNewDuckDBClient_HealthCheck(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestStreamDuckDBFederatedQuery_BasicExecution(t *testing.T) {
-	t.Skip("requires root symbols (setupIntegrationEnv, NewDBPersistentRecordRepository); covered by root integration tests")
-}
-
 func TestExecuteDuckDBFederatedQuery_NilQuery(t *testing.T) {
 	engine := &DBFederatedQueryEngine{}
 	_, _, err := engine.ExecuteDuckDBFederatedQuery(context.Background(), model.StorageTables{}, nil, 10, 0, nil, nil)
 	require.Error(t, err)
-}
-
-func TestBuildDuckDBQuery_InvalidTemplateSyntax(t *testing.T) {
-	t.Skip("requires root symbols (NewDBPersistentRecordRepository); covered by root integration tests")
 }
 
 func TestFinalizeDuckDBExecutionPlan_CaptureDisabled(t *testing.T) {

--- a/internal/sqlgen/duckdb_template_renderer_test.go
+++ b/internal/sqlgen/duckdb_template_renderer_test.go
@@ -2,6 +2,7 @@ package sqlgen
 
 import (
 	"testing"
+	"text/template"
 
 	"github.com/lychee-technology/forma/internal/model"
 
@@ -134,4 +135,29 @@ func TestBuildNonKeysetOrderBy_AlwaysAppendsRowIDTiebreak(t *testing.T) {
 		},
 	}
 	require.Equal(t, "qty ASC, row_id ASC", buildNonKeysetOrderBy(q))
+}
+
+// TestBuildDuckDBQuery_PropagatesRenderError verifies that a render-time
+// (template Execute) failure inside BuildDuckDBQuery is surfaced to the caller
+// rather than swallowed. It replaces the retired federated stub
+// TestBuildDuckDBQuery_InvalidTemplateSyntax (#196), whose premise was stale:
+// BuildDuckDBQuery receives an already-parsed *template.Template, so a *parse*
+// error cannot occur at that boundary — only an Execute error can. A template
+// calling ident on an invalid identifier forces exactly that Execute error,
+// because RenderSQLTemplate re-binds "ident" to the validating renderer.
+func TestBuildDuckDBQuery_PropagatesRenderError(t *testing.T) {
+	// A placeholder ident func is registered so the template parses; the real
+	// validating ident is injected by RenderSQLTemplate at render time.
+	tpl := template.Must(template.New("bad").Funcs(template.FuncMap{
+		"ident": func(name string) string { return name },
+	}).Parse(`SELECT * FROM {{ident .BadIdent}}`))
+
+	q := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0},
+	}
+
+	// dual == nil forces the generic render path through RenderSQLTemplate.
+	_, _, err := BuildDuckDBQuery(tpl, map[string]any{"BadIdent": "bad-name"}, q, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid SQL identifier")
 }


### PR DESCRIPTION
## What & why

Closes #196 (follow-up from PR #191, epic #172). Retires the three remaining permanently-skipped stubs in `internal/federated/duckdb_federated_integration_test.go`. Their skip reason claimed "covered by root integration tests" — but those root monolith tests no longer exist, so the stubs asserted nothing while still appearing in the integration-test index.

PR #209 already retired the seven three-tier stubs; this closes the remaining audit.

## Adjudication (per the issue's accept criteria: delete if superseded, port if genuinely uncovered)

| Stub | Verdict | Coverage / replacement |
|------|---------|------------------------|
| `TestExecuteDuckDBFederatedQuery_ClientUnavailable` | **Deleted** | `errors_test.go:TestSentinel_ClientUnavailable` (nil-client → `ErrDuckDBUnavailable`), `engine_test.go` (`"duckdb client unavailable"` plan note), `circuit_breaker_integration_test.go:TestBreakerRecordsExecutionFailures` (breaker-open sibling branch) |
| `TestStreamDuckDBFederatedQuery_BasicExecution` | **Deleted** | `circuit_breaker_integration_test.go` (real `engine.Query → StreamDuckDBFederatedQuery` via the `DuckDBQueryExecutor` seam) + production harness `TestThreeTierMerge/*`, `TestThreeTierIsolation`, `TestThreeTierSoftDelete`; nil-query guard = retained `TestExecuteDuckDBFederatedQuery_NilQuery` |
| `TestBuildDuckDBQuery_InvalidTemplateSyntax` | **Ported** | Premise was stale — `sqlgen.BuildDuckDBQuery` receives an already-parsed `*template.Template`, so a *parse* error is impossible there; only an `Execute`-time render error is reachable. Ported to `internal/sqlgen:TestBuildDuckDBQuery_PropagatesRenderError`, which forces a render error through the `BuildDuckDBQuery` boundary and asserts it propagates (`"invalid SQL identifier"`) instead of being swallowed |

## Changes

- `internal/sqlgen/duckdb_template_renderer_test.go` — new `TestBuildDuckDBQuery_PropagatesRenderError` (appended; existing #183 tests untouched).
- `internal/federated/duckdb_federated_integration_test.go` — three stubs removed (`skipIfNoDuckDB` helper and all retained tests kept).
- `docs/integ-tests-{cn,en}.md` — drop A-GI-008 / A-GI-010 entries (and their orphaned acceptance lines), retarget A-GI-015 to the ported test with an `(internal/sqlgen)` home marker, prune the three names from the `go test -run` command.

## Verification

- `grep -rn "t.Skip" internal/federated/` → empty (issue #196's core acceptance criterion).
- `go test ./internal/federated/... ./internal/sqlgen` → both `ok`.
- `make lint` → exit 0.

## Follow-up (out of scope)

The integ-tests A-GI index still lists other names (`TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion`, `TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation`, `TestBuildDuckDBQuery_TemplateRendering`, `TestRenderDuckDBQuery_ParameterMerging`) that may also be stale, and the doc's `go test ./internal -run …` line doesn't recurse into `./internal/sqlgen` where the ported test now lives — broader doc rot beyond this issue's three stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
