### PR TITLE
docs: reconcile rotted A-GI federated integration-test index (#265)

### DIFF
--- a/docs/integ-tests-cn.md
+++ b/docs/integ-tests-cn.md
@@ -43,8 +43,9 @@
 执行入口：
 
 - `go test ./internal -run TestIntegration_`
-- `go test ./internal -run TestInsertPersistentRecordIntegration|TestChangeLogWritesOnUpdateAndDeleteIntegration|TestRunOptimizedQueryIntegration`
-- `go test ./internal -run TestEvaluateRoutingPolicy_VariousStrategies|TestNewDuckDBClient_HealthCheck|TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion|TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation|TestBuildDuckDBQuery_TemplateRendering|TestExecuteDuckDBFederatedQuery_NilQuery|TestRenderDuckDBQuery_ParameterMerging`
+- `go test ./internal -run 'TestInsertPersistentRecordIntegration|TestChangeLogWritesOnUpdateAndDeleteIntegration|TestRunOptimizedQueryIntegration'`
+- `go test ./internal/federated -run 'TestEvaluateRoutingPolicy_VariousStrategies|TestNewDuckDBClient_HealthCheck|TestAppendDirtyExclusion|TestFinalizeDuckDBExecutionPlan_CaptureDisabled|TestBuildDuckDBQuery_AdvancedTemplate|TestExecuteDuckDBFederatedQuery_NilQuery'`
+- `go test ./internal/sqlgen -run 'TestBuildDuckDBQuery_PropagatesRenderError|TestBuildDuckDBQuery_KeysetArgsBindLast'`
 
 用例清单：
 
@@ -64,18 +65,18 @@
   验收条件：`hybrid`/`cost-first`/禁用配置下路由决策符合策略。
 - `A-GI-009` `TestNewDuckDBClient_HealthCheck`  
   验收条件：DuckDB client 初始化成功且健康检查通过。
-- `A-GI-011` `TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion`  
-  验收条件：脏 ID 排除子句构造正确（包含 `NOT IN` 且参数正确）。
-- `A-GI-012` `TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation`  
-  验收条件：执行计划链路可初始化且不崩溃。
-- `A-GI-013` `TestBuildDuckDBQuery_TemplateRendering`  
-  验收条件：模板渲染出的 SQL 包含预期 `LIMIT/OFFSET` 语义。
+- `A-GI-011` `TestAppendDirtyExclusion`  
+  验收条件：脏 ID 排除子句构造正确（包含 `NOT IN`，参数数量与脏 ID 一一对应）。
+- `A-GI-012` `TestFinalizeDuckDBExecutionPlan_CaptureDisabled`  
+  验收条件：执行计划捕获关闭时，finalize 路径可安全执行且不崩溃。
+- `A-GI-013` `TestBuildDuckDBQuery_AdvancedTemplate`  
+  验收条件：高级查询模板携带 Limit/Offset 参数渲染成功，产出非空 SQL 与非 nil 参数。
 - `A-GI-014` `TestExecuteDuckDBFederatedQuery_NilQuery`  
   验收条件：空查询入参返回明确错误。
 - `A-GI-015` `TestBuildDuckDBQuery_PropagatesRenderError` (`internal/sqlgen`)  
   验收条件：模板渲染错误由 `BuildDuckDBQuery` 向上抛出（surfaced），不被吞掉。
-- `A-GI-016` `TestRenderDuckDBQuery_ParameterMerging`  
-  验收条件：where 参数合并顺序和内容正确。
+- `A-GI-016` `TestBuildDuckDBQuery_KeysetArgsBindLast` (`internal/sqlgen`)  
+  验收条件：keyset 查询参数合并顺序正确——keyset 值最后绑定，`?` 占位符数量与参数数一致，且不出现 `$n` 占位符。
 
 ## 3.2 Go E2E Harness 基础用例
 
@@ -364,7 +365,7 @@
 
 - Go 集成：`internal/integration_suite_test.go`  
 - Repo 集成：`internal/postgres_persistent_repository_integration_test.go`  
-- DuckDB/联邦集成：`internal/postgres_duckdb_federated_integration_test.go`  
+- DuckDB/联邦集成：`internal/federated/duckdb_federated_integration_test.go`  
 - E2E Harness：`internal/e2e_harness/e2e_test.go`  
 - Federated E2E：`internal/e2e_harness/federated/*_test.go`  
 - Bun E2E：`tests/e2e/scripts/*.ts`  

--- a/docs/integ-tests-en.md
+++ b/docs/integ-tests-en.md
@@ -43,8 +43,9 @@ Pure unit-test-level assertions are out of scope.
 Execution entry:
 
 - `go test ./internal -run TestIntegration_`
-- `go test ./internal -run TestInsertPersistentRecordIntegration|TestChangeLogWritesOnUpdateAndDeleteIntegration|TestRunOptimizedQueryIntegration`
-- `go test ./internal -run TestEvaluateRoutingPolicy_VariousStrategies|TestNewDuckDBClient_HealthCheck|TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion|TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation|TestBuildDuckDBQuery_TemplateRendering|TestExecuteDuckDBFederatedQuery_NilQuery|TestRenderDuckDBQuery_ParameterMerging`
+- `go test ./internal -run 'TestInsertPersistentRecordIntegration|TestChangeLogWritesOnUpdateAndDeleteIntegration|TestRunOptimizedQueryIntegration'`
+- `go test ./internal/federated -run 'TestEvaluateRoutingPolicy_VariousStrategies|TestNewDuckDBClient_HealthCheck|TestAppendDirtyExclusion|TestFinalizeDuckDBExecutionPlan_CaptureDisabled|TestBuildDuckDBQuery_AdvancedTemplate|TestExecuteDuckDBFederatedQuery_NilQuery'`
+- `go test ./internal/sqlgen -run 'TestBuildDuckDBQuery_PropagatesRenderError|TestBuildDuckDBQuery_KeysetArgsBindLast'`
 
 Test cases:
 
@@ -64,18 +65,18 @@ Test cases:
   Acceptance: routing decisions match strategy for `hybrid`, `cost-first`, and disabled config.
 - `A-GI-009` `TestNewDuckDBClient_HealthCheck`  
   Acceptance: DuckDB client initializes successfully and health check passes.
-- `A-GI-011` `TestStreamDuckDBFederatedQuery_WithDirtyIDsExclusion`  
-  Acceptance: dirty-ID exclusion clause is constructed correctly (`NOT IN` + correct args).
-- `A-GI-012` `TestStreamDuckDBFederatedQuery_ExecutionPlanInstrumentation`  
-  Acceptance: execution-plan instrumentation path initializes without crash.
-- `A-GI-013` `TestBuildDuckDBQuery_TemplateRendering`  
-  Acceptance: rendered SQL includes expected `LIMIT/OFFSET` semantics.
+- `A-GI-011` `TestAppendDirtyExclusion`  
+  Acceptance: dirty-ID exclusion clause is constructed correctly (`NOT IN` present; arg count matches the dirty IDs).
+- `A-GI-012` `TestFinalizeDuckDBExecutionPlan_CaptureDisabled`  
+  Acceptance: the execution-plan finalize path runs safely without crashing when capture is disabled.
+- `A-GI-013` `TestBuildDuckDBQuery_AdvancedTemplate`  
+  Acceptance: the advanced query template renders successfully with Limit/Offset params, producing non-empty SQL and non-nil args.
 - `A-GI-014` `TestExecuteDuckDBFederatedQuery_NilQuery`  
   Acceptance: nil query input returns explicit error.
 - `A-GI-015` `TestBuildDuckDBQuery_PropagatesRenderError` (`internal/sqlgen`)  
   Acceptance: a template render error is propagated (surfaced) by `BuildDuckDBQuery` rather than swallowed.
-- `A-GI-016` `TestRenderDuckDBQuery_ParameterMerging`  
-  Acceptance: merged where-args order and content are correct.
+- `A-GI-016` `TestBuildDuckDBQuery_KeysetArgsBindLast` (`internal/sqlgen`)  
+  Acceptance: merged arg order for keyset queries is correct — the keyset value binds last, `?` placeholder count equals arg count, and no `$n` placeholders appear.
 
 ## 3.2 Go E2E Harness Baseline Cases
 
@@ -364,7 +365,7 @@ Note: These manual cases close automation gaps and cover pre-production must-che
 
 - Go integration: `internal/integration_suite_test.go`  
 - Repository integration: `internal/postgres_persistent_repository_integration_test.go`  
-- DuckDB/federated integration: `internal/postgres_duckdb_federated_integration_test.go`  
+- DuckDB/federated integration: `internal/federated/duckdb_federated_integration_test.go`  
 - E2E harness: `internal/e2e_harness/e2e_test.go`  
 - Federated E2E: `internal/e2e_harness/federated/*_test.go`  
 - Bun E2E scripts: `tests/e2e/scripts/*.ts`  


### PR DESCRIPTION
Closes #265.

## What

Documentation-only. Reconciles the rotted A-GI federated integration-test index in `docs/integ-tests-{cn,en}.md` (deferred doc debt from the #196 audit / PR #264):

1. **Run command fixed** — the old line 47 `go test ./internal -run ...` was non-recursive (all 7 listed tests live in subpackages → matched nothing). Split into two per-package commands (`./internal/federated`, `./internal/sqlgen`) with the `-run` regex quoted (unquoted `|` is a shell pipe). Also quoted the line-46 regex for the same reason.
2. **Phantom entries retargeted** — 4 index entries referenced tests that exist nowhere in the tree; each is retargeted to the real successor covering the same concern, with the acceptance text rewritten to what the successor actually asserts:
   - A-GI-011 → `TestAppendDirtyExclusion` (internal/federated)
   - A-GI-012 → `TestFinalizeDuckDBExecutionPlan_CaptureDisabled` (internal/federated)
   - A-GI-013 → `TestBuildDuckDBQuery_AdvancedTemplate` (internal/federated)
   - A-GI-016 → `TestBuildDuckDBQuery_KeysetArgsBindLast` (internal/sqlgen)
3. **A-GI-015 reachability** — the new `./internal/sqlgen` run line reaches `TestBuildDuckDBQuery_PropagatesRenderError` (ported in PR #264).
4. **Extra audit finding (beyond #265's letter)** — Section 7 (line 367, both files) referenced the nonexistent `internal/postgres_duckdb_federated_integration_test.go`; corrected to `internal/federated/duckdb_federated_integration_test.go`.

## Verification

- Both documented run commands executed: 6 tests pass in `internal/federated`, 2 in `internal/sqlgen` (non-zero tests run; previously `no tests to run`).
- Every A-GI test name grep-verified to exist (`func <Name>(`).
- cn/en entry IDs, test names, and run commands diff-verified identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)