### PR TITLE
perf(relations): batch parent enrichment lookup via set-based ANY anchor (#268, closes #263)

### DIFF
--- a/internal/entity_manager_test.go
+++ b/internal/entity_manager_test.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -515,13 +514,6 @@ type mockPersistentRecordRepository struct {
 	atomicDeleteFailAt int
 }
 
-type mockByAttrValuesCall struct {
-	schemaID int16
-	attr     string
-	values   []string
-	limit    int
-}
-
 type mockFederatedQueryEngine struct {
 	lastTables model.StorageTables
 	lastQuery  *model.FederatedAttributeQuery
@@ -643,62 +635,6 @@ func cloneRecordStore(src map[int16]map[uuid.UUID]*model.PersistentRecord) map[i
 		cloned[schemaID] = inner
 	}
 	return cloned
-}
-
-func (m *mockPersistentRecordRepository) QueryPersistentRecordsByAttrValues(ctx context.Context, tables model.StorageTables, schemaID int16, attr string, values []string, limit int) (*model.PersistentRecordPage, error) {
-	m.byAttrValuesCalls = append(m.byAttrValuesCalls, mockByAttrValuesCall{
-		schemaID: schemaID,
-		attr:     attr,
-		values:   append([]string(nil), values...),
-		limit:    limit,
-	})
-
-	valueSet := make(map[string]struct{}, len(values))
-	for _, v := range values {
-		valueSet[v] = struct{}{}
-	}
-
-	schemaRecords := m.records[schemaID]
-	rowIDs := make([]uuid.UUID, 0, len(schemaRecords))
-	for id := range schemaRecords {
-		rowIDs = append(rowIDs, id)
-	}
-	sort.Slice(rowIDs, func(i, j int) bool {
-		return rowIDs[i].String() < rowIDs[j].String()
-	})
-
-	selected := make([]*model.PersistentRecord, 0, len(values))
-	for _, id := range rowIDs {
-		record := schemaRecords[id]
-		matched := false
-		for _, text := range record.TextItems {
-			if _, ok := valueSet[text]; ok {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			for _, eav := range record.OtherAttributes {
-				if eav.ValueText == nil {
-					continue
-				}
-				if _, ok := valueSet[*eav.ValueText]; ok {
-					matched = true
-					break
-				}
-			}
-		}
-		if matched {
-			selected = append(selected, record)
-		}
-	}
-
-	return &model.PersistentRecordPage{
-		Records:      selected,
-		TotalRecords: int64(len(selected)),
-		TotalPages:   1,
-		CurrentPage:  1,
-	}, nil
 }
 
 func (m *mockPersistentRecordRepository) BatchInsertPersistentRecords(ctx context.Context, tables model.StorageTables, records []*model.PersistentRecord) error {
@@ -1202,114 +1138,6 @@ func TestEntityManager_QueryWithNilConfigUsesDefaults(t *testing.T) {
 }
 
 // Helper function to create test config
-// TestEntityManager_QueryEnrichesRelationsWithSingleBatchedParentLookup pins
-// the #268 fix: enriching a page of child records must issue exactly one
-// set-based parent lookup carrying every distinct foreign key, never one
-// OR-of-N condition query through QueryPersistentRecords.
-func TestEntityManager_QueryEnrichesRelationsWithSingleBatchedParentLookup(t *testing.T) {
-	ctx := context.Background()
-	config := createTestConfig()
-	registry, err := newFileSchemaRegistryFromDir("../cmd/server/schemas")
-	if err != nil {
-		t.Fatalf("failed to create schema registry: %v", err)
-	}
-	transformer := transform.NewPersistentRecordTransformer(registry)
-	mockRepo := newMockPersistentRecordRepository()
-
-	leadSchemaID, _, err := registry.GetSchemaByName("lead")
-	if err != nil {
-		t.Fatalf("failed to get lead schema: %v", err)
-	}
-	visitSchemaID, _, err := registry.GetSchemaByName("visit")
-	if err != nil {
-		t.Fatalf("failed to get visit schema: %v", err)
-	}
-
-	leadIDs := []string{uuid.New().String(), uuid.New().String()}
-	for i, leadID := range leadIDs {
-		mockRepo.storeRecord(buildPersistentRecord(t, transformer, leadSchemaID, uuid.New(), map[string]any{
-			"id":          leadID,
-			"tenantId":    "tenant-1",
-			"ownerUserId": "owner-1",
-			"pipeline":    "buy",
-			"stage":       "new",
-			"status":      "open",
-			"contact": map[string]any{
-				"isAnonymous":  false,
-				"name":         fmt.Sprintf("Parent %d", i),
-				"primaryPhone": fmt.Sprintf("555-000%d", i),
-			},
-			"createdAt": "2024-01-01T00:00:00Z",
-			"updatedAt": "2024-01-02T00:00:00Z",
-		}))
-	}
-
-	visitLeads := map[string]string{
-		"visit-batch-1": leadIDs[0],
-		"visit-batch-2": leadIDs[0],
-		"visit-batch-3": leadIDs[1],
-	}
-	for visitID, leadID := range visitLeads {
-		mockRepo.storeRecord(buildPersistentRecord(t, transformer, visitSchemaID, uuid.New(), map[string]any{
-			"id":               visitID,
-			"leadId":           leadID,
-			"userId":           "user-1",
-			"propertyId":       "prop-1",
-			"scheduledStartAt": "2024-02-01T00:00:00Z",
-			"status":           "scheduled",
-		}))
-	}
-
-	em := NewEntityManager(transformer, mockRepo, nil, registry, config)
-
-	result, err := em.Query(ctx, &forma.QueryRequest{SchemaName: "visit", Page: 1, ItemsPerPage: 10})
-	if err != nil {
-		t.Fatalf("Query failed: %v", err)
-	}
-	if len(result.Data) != len(visitLeads) {
-		t.Fatalf("expected %d visit records, got %d", len(visitLeads), len(result.Data))
-	}
-
-	parentNames := map[string]string{
-		leadIDs[0]: "Parent 0",
-		leadIDs[1]: "Parent 1",
-	}
-	for _, record := range result.Data {
-		leadID, _ := record.Attributes["leadId"].(string)
-		snapshot, ok := record.Attributes["contactSnapshot"].(map[string]any)
-		if !ok {
-			t.Fatalf("expected contactSnapshot populated for visit %v", record.Attributes["id"])
-		}
-		if snapshot["name"] != parentNames[leadID] {
-			t.Fatalf("expected contactSnapshot.name %q for lead %s, got %v", parentNames[leadID], leadID, snapshot["name"])
-		}
-	}
-
-	if len(mockRepo.byAttrValuesCalls) != 1 {
-		t.Fatalf("expected exactly 1 batched parent lookup, got %d", len(mockRepo.byAttrValuesCalls))
-	}
-	call := mockRepo.byAttrValuesCalls[0]
-	if call.schemaID != leadSchemaID {
-		t.Fatalf("expected parent lookup against lead schema %d, got %d", leadSchemaID, call.schemaID)
-	}
-	if call.attr != "id" {
-		t.Fatalf("expected parent lookup by attribute 'id', got %q", call.attr)
-	}
-	gotValues := append([]string(nil), call.values...)
-	wantValues := append([]string(nil), leadIDs...)
-	sort.Strings(gotValues)
-	sort.Strings(wantValues)
-	if !reflect.DeepEqual(gotValues, wantValues) {
-		t.Fatalf("expected batched values %v, got %v", wantValues, gotValues)
-	}
-
-	for _, q := range mockRepo.queries {
-		if q.SchemaID == leadSchemaID {
-			t.Fatalf("expected no condition-based parent query against lead schema, got condition %#v", q.Condition)
-		}
-	}
-}
-
 func createTestConfig() *forma.Config {
 	return &forma.Config{
 		Query: forma.QueryConfig{

--- a/internal/entity_manager_test.go
+++ b/internal/entity_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -508,9 +509,17 @@ type mockPersistentRecordRepository struct {
 	lastQuery          *model.PersistentRecordQuery
 	queries            []*model.PersistentRecordQuery
 	queryFunc          func(ctx context.Context, query *model.PersistentRecordQuery) (*model.PersistentRecordPage, error)
+	byAttrValuesCalls  []mockByAttrValuesCall
 	atomicInsertFailAt int
 	atomicUpdateFailAt int
 	atomicDeleteFailAt int
+}
+
+type mockByAttrValuesCall struct {
+	schemaID int16
+	attr     string
+	values   []string
+	limit    int
 }
 
 type mockFederatedQueryEngine struct {
@@ -634,6 +643,62 @@ func cloneRecordStore(src map[int16]map[uuid.UUID]*model.PersistentRecord) map[i
 		cloned[schemaID] = inner
 	}
 	return cloned
+}
+
+func (m *mockPersistentRecordRepository) QueryPersistentRecordsByAttrValues(ctx context.Context, tables model.StorageTables, schemaID int16, attr string, values []string, limit int) (*model.PersistentRecordPage, error) {
+	m.byAttrValuesCalls = append(m.byAttrValuesCalls, mockByAttrValuesCall{
+		schemaID: schemaID,
+		attr:     attr,
+		values:   append([]string(nil), values...),
+		limit:    limit,
+	})
+
+	valueSet := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		valueSet[v] = struct{}{}
+	}
+
+	schemaRecords := m.records[schemaID]
+	rowIDs := make([]uuid.UUID, 0, len(schemaRecords))
+	for id := range schemaRecords {
+		rowIDs = append(rowIDs, id)
+	}
+	sort.Slice(rowIDs, func(i, j int) bool {
+		return rowIDs[i].String() < rowIDs[j].String()
+	})
+
+	selected := make([]*model.PersistentRecord, 0, len(values))
+	for _, id := range rowIDs {
+		record := schemaRecords[id]
+		matched := false
+		for _, text := range record.TextItems {
+			if _, ok := valueSet[text]; ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			for _, eav := range record.OtherAttributes {
+				if eav.ValueText == nil {
+					continue
+				}
+				if _, ok := valueSet[*eav.ValueText]; ok {
+					matched = true
+					break
+				}
+			}
+		}
+		if matched {
+			selected = append(selected, record)
+		}
+	}
+
+	return &model.PersistentRecordPage{
+		Records:      selected,
+		TotalRecords: int64(len(selected)),
+		TotalPages:   1,
+		CurrentPage:  1,
+	}, nil
 }
 
 func (m *mockPersistentRecordRepository) BatchInsertPersistentRecords(ctx context.Context, tables model.StorageTables, records []*model.PersistentRecord) error {
@@ -1137,6 +1202,114 @@ func TestEntityManager_QueryWithNilConfigUsesDefaults(t *testing.T) {
 }
 
 // Helper function to create test config
+// TestEntityManager_QueryEnrichesRelationsWithSingleBatchedParentLookup pins
+// the #268 fix: enriching a page of child records must issue exactly one
+// set-based parent lookup carrying every distinct foreign key, never one
+// OR-of-N condition query through QueryPersistentRecords.
+func TestEntityManager_QueryEnrichesRelationsWithSingleBatchedParentLookup(t *testing.T) {
+	ctx := context.Background()
+	config := createTestConfig()
+	registry, err := newFileSchemaRegistryFromDir("../cmd/server/schemas")
+	if err != nil {
+		t.Fatalf("failed to create schema registry: %v", err)
+	}
+	transformer := transform.NewPersistentRecordTransformer(registry)
+	mockRepo := newMockPersistentRecordRepository()
+
+	leadSchemaID, _, err := registry.GetSchemaByName("lead")
+	if err != nil {
+		t.Fatalf("failed to get lead schema: %v", err)
+	}
+	visitSchemaID, _, err := registry.GetSchemaByName("visit")
+	if err != nil {
+		t.Fatalf("failed to get visit schema: %v", err)
+	}
+
+	leadIDs := []string{uuid.New().String(), uuid.New().String()}
+	for i, leadID := range leadIDs {
+		mockRepo.storeRecord(buildPersistentRecord(t, transformer, leadSchemaID, uuid.New(), map[string]any{
+			"id":          leadID,
+			"tenantId":    "tenant-1",
+			"ownerUserId": "owner-1",
+			"pipeline":    "buy",
+			"stage":       "new",
+			"status":      "open",
+			"contact": map[string]any{
+				"isAnonymous":  false,
+				"name":         fmt.Sprintf("Parent %d", i),
+				"primaryPhone": fmt.Sprintf("555-000%d", i),
+			},
+			"createdAt": "2024-01-01T00:00:00Z",
+			"updatedAt": "2024-01-02T00:00:00Z",
+		}))
+	}
+
+	visitLeads := map[string]string{
+		"visit-batch-1": leadIDs[0],
+		"visit-batch-2": leadIDs[0],
+		"visit-batch-3": leadIDs[1],
+	}
+	for visitID, leadID := range visitLeads {
+		mockRepo.storeRecord(buildPersistentRecord(t, transformer, visitSchemaID, uuid.New(), map[string]any{
+			"id":               visitID,
+			"leadId":           leadID,
+			"userId":           "user-1",
+			"propertyId":       "prop-1",
+			"scheduledStartAt": "2024-02-01T00:00:00Z",
+			"status":           "scheduled",
+		}))
+	}
+
+	em := NewEntityManager(transformer, mockRepo, nil, registry, config)
+
+	result, err := em.Query(ctx, &forma.QueryRequest{SchemaName: "visit", Page: 1, ItemsPerPage: 10})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result.Data) != len(visitLeads) {
+		t.Fatalf("expected %d visit records, got %d", len(visitLeads), len(result.Data))
+	}
+
+	parentNames := map[string]string{
+		leadIDs[0]: "Parent 0",
+		leadIDs[1]: "Parent 1",
+	}
+	for _, record := range result.Data {
+		leadID, _ := record.Attributes["leadId"].(string)
+		snapshot, ok := record.Attributes["contactSnapshot"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected contactSnapshot populated for visit %v", record.Attributes["id"])
+		}
+		if snapshot["name"] != parentNames[leadID] {
+			t.Fatalf("expected contactSnapshot.name %q for lead %s, got %v", parentNames[leadID], leadID, snapshot["name"])
+		}
+	}
+
+	if len(mockRepo.byAttrValuesCalls) != 1 {
+		t.Fatalf("expected exactly 1 batched parent lookup, got %d", len(mockRepo.byAttrValuesCalls))
+	}
+	call := mockRepo.byAttrValuesCalls[0]
+	if call.schemaID != leadSchemaID {
+		t.Fatalf("expected parent lookup against lead schema %d, got %d", leadSchemaID, call.schemaID)
+	}
+	if call.attr != "id" {
+		t.Fatalf("expected parent lookup by attribute 'id', got %q", call.attr)
+	}
+	gotValues := append([]string(nil), call.values...)
+	wantValues := append([]string(nil), leadIDs...)
+	sort.Strings(gotValues)
+	sort.Strings(wantValues)
+	if !reflect.DeepEqual(gotValues, wantValues) {
+		t.Fatalf("expected batched values %v, got %v", wantValues, gotValues)
+	}
+
+	for _, q := range mockRepo.queries {
+		if q.SchemaID == leadSchemaID {
+			t.Fatalf("expected no condition-based parent query against lead schema, got condition %#v", q.Condition)
+		}
+	}
+}
+
 func createTestConfig() *forma.Config {
 	return &forma.Config{
 		Query: forma.QueryConfig{

--- a/internal/entity_relation_service.go
+++ b/internal/entity_relation_service.go
@@ -120,24 +120,11 @@ func (s *entityRelationService) fetchParents(ctx context.Context, rel RelationDe
 		return nil, fmt.Errorf("get parent schema %s: %w", rel.ParentSchema, err)
 	}
 
-	var cond forma.Condition
-	if len(ids) == 1 {
-		cond = &forma.KvCondition{Attr: rel.ParentIDAttr, Value: ids[0]}
-	} else {
-		conditions := make([]forma.Condition, 0, len(ids))
-		for _, id := range ids {
-			conditions = append(conditions, &forma.KvCondition{Attr: rel.ParentIDAttr, Value: id})
-		}
-		cond = &forma.CompositeCondition{Logic: forma.LogicOr, Conditions: conditions}
-	}
-
-	page, err := s.repository.QueryPersistentRecords(ctx, &model.PersistentRecordQuery{
-		Tables:    s.resolveTables(),
-		SchemaID:  parentSchemaID,
-		Condition: cond,
-		Limit:     len(ids),
-		Offset:    0,
-	})
+	// One set-based lookup for the whole page (#268): expanding per-id
+	// equality conditions into an OR composite degenerated into N correlated
+	// EXISTS subqueries against the EAV table.
+	page, err := s.repository.QueryPersistentRecordsByAttrValues(
+		ctx, s.resolveTables(), parentSchemaID, rel.ParentIDAttr, ids, len(ids))
 	if err != nil {
 		return nil, fmt.Errorf("query parent records for schema %s: %w", rel.ParentSchema, err)
 	}

--- a/internal/entity_relation_service_test.go
+++ b/internal/entity_relation_service_test.go
@@ -1,0 +1,197 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/transform"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+)
+
+// mockByAttrValuesCall records one QueryPersistentRecordsByAttrValues
+// invocation on mockPersistentRecordRepository (declared in
+// entity_manager_test.go) for batching assertions.
+type mockByAttrValuesCall struct {
+	schemaID int16
+	attr     string
+	values   []string
+	limit    int
+}
+
+func (m *mockPersistentRecordRepository) QueryPersistentRecordsByAttrValues(ctx context.Context, tables model.StorageTables, schemaID int16, attr string, values []string, limit int) (*model.PersistentRecordPage, error) {
+	m.byAttrValuesCalls = append(m.byAttrValuesCalls, mockByAttrValuesCall{
+		schemaID: schemaID,
+		attr:     attr,
+		values:   append([]string(nil), values...),
+		limit:    limit,
+	})
+
+	valueSet := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		valueSet[v] = struct{}{}
+	}
+
+	schemaRecords := m.records[schemaID]
+	rowIDs := make([]uuid.UUID, 0, len(schemaRecords))
+	for id := range schemaRecords {
+		rowIDs = append(rowIDs, id)
+	}
+	sort.Slice(rowIDs, func(i, j int) bool {
+		return rowIDs[i].String() < rowIDs[j].String()
+	})
+
+	selected := make([]*model.PersistentRecord, 0, len(values))
+	for _, id := range rowIDs {
+		if mockRecordMatchesAnyTextValue(schemaRecords[id], valueSet) {
+			selected = append(selected, schemaRecords[id])
+		}
+	}
+
+	return &model.PersistentRecordPage{
+		Records:      selected,
+		TotalRecords: int64(len(selected)),
+		TotalPages:   1,
+		CurrentPage:  1,
+	}, nil
+}
+
+func mockRecordMatchesAnyTextValue(record *model.PersistentRecord, valueSet map[string]struct{}) bool {
+	for _, text := range record.TextItems {
+		if _, ok := valueSet[text]; ok {
+			return true
+		}
+	}
+	for _, eav := range record.OtherAttributes {
+		if eav.ValueText == nil {
+			continue
+		}
+		if _, ok := valueSet[*eav.ValueText]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// seedVisitEnrichmentFixture stores two parent leads (contact names
+// "Parent 0"/"Parent 1") and three visits referencing them; it returns the
+// lead schema id, the lead ids, and the visit->lead assignment.
+func seedVisitEnrichmentFixture(t *testing.T, transformer model.PersistentRecordTransformer, mockRepo *mockPersistentRecordRepository, registry forma.SchemaRegistry) (int16, []string, map[string]string) {
+	t.Helper()
+
+	leadSchemaID, _, err := registry.GetSchemaByName("lead")
+	if err != nil {
+		t.Fatalf("failed to get lead schema: %v", err)
+	}
+	visitSchemaID, _, err := registry.GetSchemaByName("visit")
+	if err != nil {
+		t.Fatalf("failed to get visit schema: %v", err)
+	}
+
+	leadIDs := []string{uuid.New().String(), uuid.New().String()}
+	for i, leadID := range leadIDs {
+		mockRepo.storeRecord(buildPersistentRecord(t, transformer, leadSchemaID, uuid.New(), map[string]any{
+			"id":          leadID,
+			"tenantId":    "tenant-1",
+			"ownerUserId": "owner-1",
+			"pipeline":    "buy",
+			"stage":       "new",
+			"status":      "open",
+			"contact": map[string]any{
+				"isAnonymous":  false,
+				"name":         fmt.Sprintf("Parent %d", i),
+				"primaryPhone": fmt.Sprintf("555-000%d", i),
+			},
+			"createdAt": "2024-01-01T00:00:00Z",
+			"updatedAt": "2024-01-02T00:00:00Z",
+		}))
+	}
+
+	visitLeads := map[string]string{
+		"visit-batch-1": leadIDs[0],
+		"visit-batch-2": leadIDs[0],
+		"visit-batch-3": leadIDs[1],
+	}
+	for visitID, leadID := range visitLeads {
+		mockRepo.storeRecord(buildPersistentRecord(t, transformer, visitSchemaID, uuid.New(), map[string]any{
+			"id":               visitID,
+			"leadId":           leadID,
+			"userId":           "user-1",
+			"propertyId":       "prop-1",
+			"scheduledStartAt": "2024-02-01T00:00:00Z",
+			"status":           "scheduled",
+		}))
+	}
+
+	return leadSchemaID, leadIDs, visitLeads
+}
+
+// TestEntityManager_QueryEnrichesRelationsWithSingleBatchedParentLookup pins
+// the #268 fix: enriching a page of child records must issue exactly one
+// set-based parent lookup carrying every distinct foreign key, never one
+// OR-of-N condition query through QueryPersistentRecords.
+func TestEntityManager_QueryEnrichesRelationsWithSingleBatchedParentLookup(t *testing.T) {
+	ctx := context.Background()
+	config := createTestConfig()
+	registry, err := newFileSchemaRegistryFromDir("../cmd/server/schemas")
+	if err != nil {
+		t.Fatalf("failed to create schema registry: %v", err)
+	}
+	transformer := transform.NewPersistentRecordTransformer(registry)
+	mockRepo := newMockPersistentRecordRepository()
+	leadSchemaID, leadIDs, visitLeads := seedVisitEnrichmentFixture(t, transformer, mockRepo, registry)
+
+	em := NewEntityManager(transformer, mockRepo, nil, registry, config)
+
+	result, err := em.Query(ctx, &forma.QueryRequest{SchemaName: "visit", Page: 1, ItemsPerPage: 10})
+	if err != nil {
+		t.Fatalf("Query failed: %v", err)
+	}
+	if len(result.Data) != len(visitLeads) {
+		t.Fatalf("expected %d visit records, got %d", len(visitLeads), len(result.Data))
+	}
+
+	parentNames := map[string]string{
+		leadIDs[0]: "Parent 0",
+		leadIDs[1]: "Parent 1",
+	}
+	for _, record := range result.Data {
+		leadID, _ := record.Attributes["leadId"].(string)
+		snapshot, ok := record.Attributes["contactSnapshot"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected contactSnapshot populated for visit %v", record.Attributes["id"])
+		}
+		if snapshot["name"] != parentNames[leadID] {
+			t.Fatalf("expected contactSnapshot.name %q for lead %s, got %v", parentNames[leadID], leadID, snapshot["name"])
+		}
+	}
+
+	if len(mockRepo.byAttrValuesCalls) != 1 {
+		t.Fatalf("expected exactly 1 batched parent lookup, got %d", len(mockRepo.byAttrValuesCalls))
+	}
+	call := mockRepo.byAttrValuesCalls[0]
+	if call.schemaID != leadSchemaID {
+		t.Fatalf("expected parent lookup against lead schema %d, got %d", leadSchemaID, call.schemaID)
+	}
+	if call.attr != "id" {
+		t.Fatalf("expected parent lookup by attribute 'id', got %q", call.attr)
+	}
+	gotValues := append([]string(nil), call.values...)
+	wantValues := append([]string(nil), leadIDs...)
+	sort.Strings(gotValues)
+	sort.Strings(wantValues)
+	if !reflect.DeepEqual(gotValues, wantValues) {
+		t.Fatalf("expected batched values %v, got %v", wantValues, gotValues)
+	}
+
+	for _, q := range mockRepo.queries {
+		if q.SchemaID == leadSchemaID {
+			t.Fatalf("expected no condition-based parent query against lead schema, got condition %#v", q.Condition)
+		}
+	}
+}

--- a/internal/model/interfaces.go
+++ b/internal/model/interfaces.go
@@ -50,6 +50,11 @@ type PersistentRecordWriter interface {
 type PersistentRecordReader interface {
 	GetPersistentRecord(ctx context.Context, tables StorageTables, schemaID int16, rowID uuid.UUID) (*PersistentRecord, error)
 	QueryPersistentRecords(ctx context.Context, query *PersistentRecordQuery) (*PersistentRecordPage, error)
+	// QueryPersistentRecordsByAttrValues fetches full records whose attribute
+	// equals any of the given values via one set-based lookup (#268). It exists
+	// for internal batch lookups (relation enrichment); it must never expand to
+	// an OR-of-N condition per value.
+	QueryPersistentRecordsByAttrValues(ctx context.Context, tables StorageTables, schemaID int16, attr string, values []string, limit int) (*PersistentRecordPage, error)
 }
 
 type FederatedQueryEngine interface {

--- a/internal/postgres_persistent_repository_by_attr_values.go
+++ b/internal/postgres_persistent_repository_by_attr_values.go
@@ -1,0 +1,106 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// QueryPersistentRecordsByAttrValues fetches full records whose attribute
+// equals any of the given values through a single set-based anchor scan
+// (#268). Relation enrichment previously expanded one equality condition per
+// value into OR-of-N correlated EXISTS subqueries, which degenerated into a
+// full EAV scan with N subplans per row.
+func (r *DBPersistentRecordRepository) QueryPersistentRecordsByAttrValues(
+	ctx context.Context,
+	tables model.StorageTables,
+	schemaID int16,
+	attr string,
+	values []string,
+	limit int,
+) (*model.PersistentRecordPage, error) {
+	if schemaID <= 0 {
+		return nil, fmt.Errorf("failed to query records by attr values: schema id %d must be positive", schemaID)
+	}
+	if len(values) == 0 {
+		return &model.PersistentRecordPage{CurrentPage: 1}, nil
+	}
+	if r.metadataCache == nil {
+		return nil, fmt.Errorf("failed to query records by attr %q: schema metadata cache not available for schema_id %d", attr, schemaID)
+	}
+	cache, ok := r.metadataCache.GetSchemaCacheByID(schemaID)
+	if !ok {
+		return nil, fmt.Errorf("failed to query records by attr %q: no schema metadata for schema_id %d", attr, schemaID)
+	}
+	meta, ok := cache[attr]
+	if !ok {
+		return nil, fmt.Errorf("failed to query records by attr %q: attribute not found in schema_id %d", attr, schemaID)
+	}
+
+	clause, args, useMainTableAsAnchor, err := buildAttrValuesAnchor(attr, meta, values)
+	if err != nil {
+		return nil, err
+	}
+
+	if limit <= 0 {
+		limit = len(values)
+	}
+
+	records, totalRecords, err := r.runOptimizedQuery(
+		ctx, tables, schemaID, clause, args, limit, 0, nil, useMainTableAsAnchor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query records by attr %q for schema_id %d: %w", attr, schemaID, err)
+	}
+
+	return &model.PersistentRecordPage{
+		Records:      records,
+		TotalRecords: totalRecords,
+		TotalPages:   model.ComputeTotalPages(totalRecords, limit),
+		CurrentPage:  1,
+	}, nil
+}
+
+// buildAttrValuesAnchor renders the set-based anchor clause for one attribute
+// against a value list. Placeholders start at $2: StreamOptimizedQuery binds
+// $1 to the schema id.
+func buildAttrValuesAnchor(attr string, meta forma.AttributeMetadata, values []string) (string, []any, bool, error) {
+	if meta.ColumnBinding != nil {
+		// Encoded bindings (unix-ms, bool-int, ...) need per-value transforms
+		// this batch path does not perform; plain text columns bind directly.
+		if meta.ColumnBinding.Encoding != "" || !isTextLikeValueType(meta.ValueType) {
+			return "", nil, false, fmt.Errorf(
+				"failed to build attr-values anchor for %q: unsupported main-column binding (column %s, encoding %q, value_type %s)",
+				attr, meta.ColumnBinding.ColumnName, meta.ColumnBinding.Encoding, meta.ValueType)
+		}
+		clause := fmt.Sprintf("m.%s = ANY($2)", sanitizeIdentifier(string(meta.ColumnBinding.ColumnName)))
+		return clause, []any{values}, true, nil
+	}
+
+	if isTextLikeValueType(meta.ValueType) {
+		return "t.attr_id = $2 AND t.value_text = ANY($3)", []any{meta.AttributeID, values}, false, nil
+	}
+
+	switch meta.ValueType {
+	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
+		numeric := make([]float64, 0, len(values))
+		for _, v := range values {
+			parsed, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return "", nil, false, fmt.Errorf(
+					"failed to build attr-values anchor for %q: invalid numeric value %q", attr, v)
+			}
+			numeric = append(numeric, parsed)
+		}
+		return "t.attr_id = $2 AND t.value_numeric = ANY($3)", []any{meta.AttributeID, numeric}, false, nil
+	default:
+		return "", nil, false, fmt.Errorf(
+			"failed to build attr-values anchor for %q: unsupported value_type %s", attr, meta.ValueType)
+	}
+}
+
+func isTextLikeValueType(vt forma.ValueType) bool {
+	return vt == forma.ValueTypeText || vt == forma.ValueTypeUUID
+}

--- a/internal/postgres_persistent_repository_by_attr_values.go
+++ b/internal/postgres_persistent_repository_by_attr_values.go
@@ -29,20 +29,20 @@ func (r *DBPersistentRecordRepository) QueryPersistentRecordsByAttrValues(
 		return &model.PersistentRecordPage{CurrentPage: 1}, nil
 	}
 	if r.metadataCache == nil {
-		return nil, fmt.Errorf("failed to query records by attr %q: schema metadata cache not available for schema_id %d", attr, schemaID)
+		return nil, fmt.Errorf("failed to query records by attr %q for schema %d: metadata cache is nil (expected a loaded schema metadata cache)", attr, schemaID)
 	}
 	cache, ok := r.metadataCache.GetSchemaCacheByID(schemaID)
 	if !ok {
-		return nil, fmt.Errorf("failed to query records by attr %q: no schema metadata for schema_id %d", attr, schemaID)
+		return nil, fmt.Errorf("failed to query records by attr %q: schema %d not in metadata cache (expected a registered schema)", attr, schemaID)
 	}
 	meta, ok := cache[attr]
 	if !ok {
-		return nil, fmt.Errorf("failed to query records by attr %q: attribute not found in schema_id %d", attr, schemaID)
+		return nil, fmt.Errorf("failed to query records by attr %q: attribute not in metadata cache for schema %d (expected a registered attribute with a value type)", attr, schemaID)
 	}
 
 	clause, args, useMainTableAsAnchor, err := buildAttrValuesAnchor(attr, meta, values)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to query records by attr %q for schema %d: %w", attr, schemaID, err)
 	}
 
 	if limit <= 0 {
@@ -72,8 +72,8 @@ func buildAttrValuesAnchor(attr string, meta forma.AttributeMetadata, values []s
 		// this batch path does not perform; plain text columns bind directly.
 		if meta.ColumnBinding.Encoding != "" || !isTextLikeValueType(meta.ValueType) {
 			return "", nil, false, fmt.Errorf(
-				"failed to build attr-values anchor for %q: unsupported main-column binding (column %s, encoding %q, value_type %s)",
-				attr, meta.ColumnBinding.ColumnName, meta.ColumnBinding.Encoding, meta.ValueType)
+				"unsupported main-column binding for %s attribute %q: column %s with encoding %q (expected an unencoded text/uuid column for batch value lookup)",
+				meta.ValueType, attr, meta.ColumnBinding.ColumnName, meta.ColumnBinding.Encoding)
 		}
 		clause := fmt.Sprintf("m.%s = ANY($2)", sanitizeIdentifier(string(meta.ColumnBinding.ColumnName)))
 		return clause, []any{values}, true, nil
@@ -90,14 +90,16 @@ func buildAttrValuesAnchor(attr string, meta forma.AttributeMetadata, values []s
 			parsed, err := strconv.ParseFloat(v, 64)
 			if err != nil {
 				return "", nil, false, fmt.Errorf(
-					"failed to build attr-values anchor for %q: invalid numeric value %q", attr, v)
+					"invalid value %q for %s attribute %q: not parseable as float64 (expected a decimal value_numeric operand): %w",
+					v, meta.ValueType, attr, err)
 			}
 			numeric = append(numeric, parsed)
 		}
 		return "t.attr_id = $2 AND t.value_numeric = ANY($3)", []any{meta.AttributeID, numeric}, false, nil
 	default:
 		return "", nil, false, fmt.Errorf(
-			"failed to build attr-values anchor for %q: unsupported value_type %s", attr, meta.ValueType)
+			"unsupported value_type %s for attribute %q: no batch value column (expected text, uuid, or a numeric family type)",
+			meta.ValueType, attr)
 	}
 }
 

--- a/internal/postgres_persistent_repository_by_attr_values_test.go
+++ b/internal/postgres_persistent_repository_by_attr_values_test.go
@@ -1,0 +1,155 @@
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/schemameta"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newByAttrValuesTestCache(t *testing.T) *schemameta.MetadataCache {
+	t.Helper()
+	cache := schemameta.NewMetadataCache()
+	require.NoError(t, cache.RegisterSchema("parent", 1, forma.SchemaAttributeCache{
+		"id": {
+			AttributeID: 26,
+			ValueType:   forma.ValueTypeText,
+		},
+		"code": {
+			AttributeID:   30,
+			ValueType:     forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_01")},
+		},
+		"rank": {
+			AttributeID: 31,
+			ValueType:   forma.ValueTypeInteger,
+		},
+	}))
+	return cache
+}
+
+// TestQueryPersistentRecordsByAttrValuesUsesAnyArray pins the #268 fix: the
+// parent lookup must be one set-based anchor over the EAV text index
+// (attr_id = $2 AND value_text = ANY($3)), never OR-of-N correlated EXISTS.
+func TestQueryPersistentRecordsByAttrValuesUsesAnyArray(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	rowID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(2))
+
+	ids := []string{"parent-a", "parent-b"}
+	mock.ExpectQuery(`t\.attr_id = \$2 AND t\.value_text = ANY\(\$3\)`).
+		WithArgs(int16(1), int16(26), ids, 2, 0).
+		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
+
+	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "id", ids, len(ids))
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+	assert.Equal(t, rowID, page.Records[0].RowID)
+	assert.Equal(t, int64(2), page.TotalRecords)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryPersistentRecordsByAttrValuesEmptyValuesSkipsQuery asserts the
+// degenerate ANY('{}') query is never issued.
+func TestQueryPersistentRecordsByAttrValuesEmptyValuesSkipsQuery(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "id", nil, 0)
+	require.NoError(t, err)
+	assert.Empty(t, page.Records)
+	assert.Equal(t, int64(0), page.TotalRecords)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryPersistentRecordsByAttrValuesHotColumnUsesMainAnchor asserts a
+// main-table-bound attribute anchors on the hot column instead of the EAV
+// table.
+func TestQueryPersistentRecordsByAttrValuesHotColumnUsesMainAnchor(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	rowID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(1))
+
+	codes := []string{"c-1", "c-2"}
+	mock.ExpectQuery(`m\."text_01" = ANY\(\$2\)`).
+		WithArgs(int16(1), codes, 2, 0).
+		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
+
+	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "code", codes, len(codes))
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+	assert.Equal(t, int64(1), page.TotalRecords)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryPersistentRecordsByAttrValuesNumericValues asserts numeric EAV
+// attributes bind a float64 array against value_numeric.
+func TestQueryPersistentRecordsByAttrValuesNumericValues(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	rowID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(1))
+
+	mock.ExpectQuery(`t\.attr_id = \$2 AND t\.value_numeric = ANY\(\$3\)`).
+		WithArgs(int16(1), int16(31), []float64{7, 9}, 2, 0).
+		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
+
+	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "rank", []string{"7", "9"}, 2)
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryPersistentRecordsByAttrValuesUnknownAttr asserts the error names
+// the offending attribute instead of scanning a wrong column.
+func TestQueryPersistentRecordsByAttrValuesUnknownAttr(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	_, err = repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "missing", []string{"x"}, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -195,7 +195,7 @@ bun run build-k6
 ### Run Scenarios
 
 ```bash
-# Smoke test (5 VUs, 30s)
+# Smoke test (3 VUs, 30s steady)
 bun run k6-smoke
 
 # Full test (30 VUs, 2m)
@@ -212,17 +212,16 @@ The `k6-*` scripts prefer a local `k6` binary. If `k6` is not installed, they au
 
 ### k6 Thresholds
 
-Metrics are split by the route the engine actually reports in `execution_plan.routing` (only the `advanced_query` path carries one), not by which test function ran.
+Since #190/#243 the k6 smoke is a **functional concurrency gate, not a latency SLA**: precise latency numbers are owned by `benchmark-smoke` on dedicated hardware. All requests run the OLTP path (`federated.enabled` is never set); the DuckDB/S3 route is proven separately by `federated-check --require-duckdb` in CI.
 
-| Metric | Threshold | Description |
-|--------|-----------|-------------|
-| `forma_federated_query_duration` | p95 < 200ms | Advanced queries the engine routed to DuckDB |
-| `forma_pg_routed_query_duration` | p95 < 100ms | Advanced queries the engine served Postgres-only |
-| `forma_query_duration` | p95 < 100ms | General (OLTP GET) query latency |
-| `forma_query_success` | rate > 99% | Query success rate |
-| `http_req_failed` | rate < 1% | HTTP error rate |
+| Metric | Threshold | Role |
+|--------|-----------|------|
+| `forma_query_success` | rate > 97% | Functional gate (the real signal) |
+| `http_req_failed` | rate < 3% | Functional gate (the real signal) |
+| `forma_query_duration` | p95 < 8000ms | Hung/broken-server ceiling, not an SLA |
+| `http_req_duration` | p95 < 8000ms | Hung/broken-server ceiling, not an SLA |
 
-`forma_route_duckdb` / `forma_route_postgres` counters show the routing split. Note: with `items_per_page` ≤ 100 and shallow offsets the hybrid router often serves advanced queries Postgres-only, so `forma_federated_query_duration` may have few samples in the smoke scenario — that reflects real routing, not a bug.
+Every request is tagged with `qtype` (`simple_list`, `sorted_list`, `advanced_query`, `search`, `get_by_id`, `get_by_id_prefetch`) and `schema`, so a tail blowup can be attributed from `http_req_duration{qtype:…}` / `forma_query_duration{schema:…}` submetrics without re-analyzing the raw report (#263/#268 required exactly that attribution).
 
 ## Environment Variables
 

--- a/tests/e2e/k6/scenarios.ts
+++ b/tests/e2e/k6/scenarios.ts
@@ -146,13 +146,17 @@ function testSimpleQuery(schema: string): void {
   const itemsPerPage = randomElement([10, 20, 50, 100]);
   
   const url = `${BASE_URL}/api/v1/${schema}?page=${page}&items_per_page=${itemsPerPage}`;
+  // qtype/schema tags make http_req_duration submetrics attributable: the #263
+  // tail turned out to be one schema's requests (#268), which the untagged
+  // aggregate could not show without downloading the raw report.
+  const tags = { qtype: 'simple_list', schema };
   const start = Date.now();
-  
-  const res = http.get(url, { headers: getHeaders() });
+
+  const res = http.get(url, { headers: getHeaders(), tags });
   const duration = Date.now() - start;
-  
-  queryDuration.add(duration);
-  
+
+  queryDuration.add(duration, tags);
+
   const success = check(res, {
     'status is 200': (r) => r.status === 200,
     'response has data': (r) => {
@@ -185,13 +189,14 @@ function testSortedQuery(schema: string): void {
   const itemsPerPage = randomElement([20, 50]);
   
   const url = `${BASE_URL}/api/v1/${schema}?page=1&items_per_page=${itemsPerPage}&sort_by=${sortBy}&sort_order=${sortOrder}`;
+  const tags = { qtype: 'sorted_list', schema };
   const start = Date.now();
-  
-  const res = http.get(url, { headers: getHeaders() });
+
+  const res = http.get(url, { headers: getHeaders(), tags });
   const duration = Date.now() - start;
-  
+
   // Sorted list is an OLTP GET (no execution plan); it is not a federated route.
-  queryDuration.add(duration);
+  queryDuration.add(duration, tags);
 
   const success = check(res, {
     'sorted query status 200': (r) => r.status === 200,
@@ -243,12 +248,13 @@ function testAdvancedQuery(schema: string): void {
   };
 
   const url = `${BASE_URL}/api/v1/advanced_query`;
+  const tags = { qtype: 'advanced_query', schema };
   const start = Date.now();
 
-  const res = http.post(url, JSON.stringify(payload), { headers: getHeaders() });
+  const res = http.post(url, JSON.stringify(payload), { headers: getHeaders(), tags });
   const duration = Date.now() - start;
 
-  queryDuration.add(duration);
+  queryDuration.add(duration, tags);
 
   const success = check(res, {
     'advanced query status 200': (r) => r.status === 200,
@@ -276,13 +282,14 @@ function testCrossSchemaSearch(): void {
   
   // The search endpoint requires a `schemas` CSV param (else 400).
   const url = `${BASE_URL}/api/v1/search?q=${encodeURIComponent(searchTerm)}&schemas=${encodeURIComponent(SCHEMAS.join(','))}&page=1&items_per_page=20`;
+  const tags = { qtype: 'search', schema: 'multi' };
   const start = Date.now();
-  
-  const res = http.get(url, { headers: getHeaders() });
+
+  const res = http.get(url, { headers: getHeaders(), tags });
   const duration = Date.now() - start;
-  
+
   // Cross-schema search is its own endpoint (no execution plan); not a federated route.
-  queryDuration.add(duration);
+  queryDuration.add(duration, tags);
 
   const success = check(res, {
     'search status 200': (r) => r.status === 200,
@@ -300,7 +307,10 @@ function testCrossSchemaSearch(): void {
 function testGetSingleRecord(schema: string): void {
   // First, get a page of records to extract an ID
   const listUrl = `${BASE_URL}/api/v1/${schema}?page=1&items_per_page=10`;
-  const listRes = http.get(listUrl, { headers: getHeaders() });
+  const listRes = http.get(listUrl, {
+    headers: getHeaders(),
+    tags: { qtype: 'get_by_id_prefetch', schema },
+  });
   
   if (listRes.status !== 200) {
     queryErrors.add(1);
@@ -327,12 +337,13 @@ function testGetSingleRecord(schema: string): void {
   
   // Get single record
   const url = `${BASE_URL}/api/v1/${schema}/${rowId}`;
+  const tags = { qtype: 'get_by_id', schema };
   const start = Date.now();
-  
-  const res = http.get(url, { headers: getHeaders() });
+
+  const res = http.get(url, { headers: getHeaders(), tags });
   const duration = Date.now() - start;
-  
-  queryDuration.add(duration);
+
+  queryDuration.add(duration, tags);
   
   const success = check(res, {
     'get single status 200': (r) => r.status === 200,

--- a/tests/e2e/k6/scenarios.ts
+++ b/tests/e2e/k6/scenarios.ts
@@ -408,6 +408,7 @@ export function setup(): Record<string, unknown> {
   // seed first (run-k6.sh seeds before invoking k6).
   const healthRes = http.get(`${BASE_URL}/api/v1/lead?page=1&items_per_page=1`, {
     headers: getHeaders(),
+    tags: { qtype: 'setup_health_check', schema: 'lead' },
   });
 
   if (healthRes.status !== 200) {


### PR DESCRIPTION
## Summary

Fixes the root cause behind the k6 Smoke latency-ceiling "flake" (#263): it was never shared-runner noise but a deterministic relation-enrichment performance bug (#268). None of #263's three threshold options are taken — **thresholds are unchanged**; the `p95<8s` ceiling is precisely what caught this bug and now returns to its intended hung-server-guard role with ~100× headroom.

## Root cause (#268)

`visit` is the only e2e schema with an `x-relation` (`contactSnapshot` → `lead` via `leadId`). Every list/query page enriches relations; `fetchParents` expanded one `KvCondition{id=X}` per distinct FK into an OR-of-N composite. Each leaf renders as a correlated `EXISTS` against the EAV table, and the composite renders unparenthesized (#269), so the `schema_id` constraint only guards the first branch — the anchor became a full EAV scan (110k rows, all schemas) with up to N=items_per_page hashed subplans per row, once per page.

Measured attribution (both a failing and a "green" CI run): `visit` lists med 3.4s / max 13.5s while `lead`/`log` served in 10-60ms at the same timestamps. The "flake" was sampling luck over which schemas landed in the 62-sample p95 window. Evidence: https://github.com/Lychee-Technology/forma/issues/263#issuecomment-4989862190

## Fix

`fetchParents` now makes one set-based lookup through a new internal repository method:

- `QueryPersistentRecordsByAttrValues(ctx, tables, schemaID, attr, values, limit)` (`internal/model/interfaces.go`, impl `internal/postgres_persistent_repository_by_attr_values.go`) injects a constant-shape anchor clause — EAV text/uuid: `t.attr_id = $2 AND t.value_text = ANY($3)`; plain-text hot column: `m.<col> = ANY($2)`; numeric EAV: `value_numeric = ANY($3)`; anything else errors — and reuses `runOptimizedQuery` hydration unchanged.
- Public Condition DSL and the DuckDB/federated dual path are untouched. Enrichment semantics (enrich-all-when-unspecified) unchanged.
- Bonus: constant clause shape ends the per-page-size OLTP plan-cache misses the variable OR arity caused (`optimizedQueryShapeKey` includes arg count).

## Verification

**Anchor EXPLAIN ANALYZE** (seeded CI dataset, 2000 records/schema, 110k EAV rows, 50 ids):

| | plan | time |
|---|---|---|
| before | Seq Scan 110,400 rows × 50 hashed SubPlans (schema_id guard lost to #269) | **2189ms** |
| after | Index Only Scan on `(schema_id, attr_id, value_text, row_id)`, 36 buffers | **0.42ms** |

Identical result sets (50 row_ids both sides).

**End-to-end** (local M-series, same DB/data, before → after):

| query | before | after |
|---|---|---|
| `GET /visit?items_per_page=20` | 91.0s (cold) | 9.8ms |
| `GET /visit?items_per_page=50` | 11.95s | 14.8ms |
| `GET /visit?items_per_page=100` | 10.45s | 23.4ms |
| `GET /visit?...sort_by=createdAt` | 5-7s | 20ms |
| `GET /lead?items_per_page=50` (unchanged path) | 98.7ms | 11.8ms* |

\* lead also improves because the polluted OR branches previously scanned other schemas' EAV rows too (see #269) — cross-traffic contention is gone.

**Correctness**: `contactSnapshot` cross-checked against parent `lead.contact` for sampled pages — 5/5 match; existing `TestEntityManager_Get` enrichment + projection-exclusion tests stay green.

**Local k6 smoke** (fixed server): p95 **60ms** / max 82ms (was p95 11.5s / max 14.45s), 976/976 checks, 520 iterations vs ~62 (throughput recovered 8×). Per-tag breakdown confirms visit ≈ lead ≈ log across every qtype.

**Tests**: TDD red-first — repository tests pin the `ANY($n)` clause/args (incl. empty-values skip, hot-column anchor, numeric array, unknown-attr error); an entity-manager test pins exactly one batched parent lookup carrying all distinct FKs and zero condition-based lead queries. `make test` and `make lint` (golangci-lint v1.64.8) green.

## Observability (#263 follow-through)

k6 requests now carry `qtype` + `schema` tags, so `http_req_duration{qtype:…}`/`{schema:…}` submetrics attribute any future tail without downloading the raw report. Thresholds untouched. `tests/e2e/README.md` threshold table updated from the pre-#190 route-split model to the current functional-gate model.

## Related

- #269 (filed during this work): top-level OR composites render unparenthesized on the PG optimized-query path — correctness (total_records pollution, pagination drift) + perf for user-supplied OR conditions. Kept out of scope here; enrichment no longer emits OR composites at all.

Closes #268
Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)
