### PR TITLE
fix(query): parenthesize anchor condition injections on the PG optimized path (#269)

### DIFF
--- a/internal/advanced_query_template.go
+++ b/internal/advanced_query_template.go
@@ -6,14 +6,17 @@ var optimizedQuerySQLTemplate = template.Must(template.New("optimizedQuery").Fun
 	"add": func(a, b int) int { return a + b },
 }).Parse(`
 	        WITH anchor AS (
+	            {{- /* Every condition injection is parenthesized (#269): the
+	                 sites join it with AND, and a bare top-level OR would bind
+	                 tighter than the schema/correlation constraints. */}}
 	            {{- if .UseMainTableAsAnchor }}
 	            SELECT m.ltbase_row_id AS row_id
 	            FROM {{.MainTable}} m
-	            WHERE m.ltbase_schema_id = {{.SchemaID}} AND {{.Anchor.Condition}}
+	            WHERE m.ltbase_schema_id = {{.SchemaID}} AND ({{.Anchor.Condition}})
 	            {{- else }}
 	            SELECT DISTINCT t.row_id
 	            FROM {{.EAVTable}} t
-	            WHERE t.schema_id = {{.SchemaID}} AND {{.Anchor.Condition}}
+	            WHERE t.schema_id = {{.SchemaID}} AND ({{.Anchor.Condition}})
 	            {{- end }}
 	            {{- if .ChangeLogTable }}
 	            UNION
@@ -29,7 +32,7 @@ var optimizedQuerySQLTemplate = template.Must(template.New("optimizedQuery").Fun
 	                    FROM {{.MainTable}} m
 	                    WHERE m.ltbase_schema_id = {{.SchemaID}}
 	                        AND m.ltbase_row_id = cl.row_id
-	                        AND {{.Anchor.Condition}}
+	                        AND ({{.Anchor.Condition}})
 	                )
 	                {{- else }}
 	                AND EXISTS (
@@ -37,7 +40,7 @@ var optimizedQuerySQLTemplate = template.Must(template.New("optimizedQuery").Fun
 	                    FROM {{.EAVTable}} t
 	                    WHERE t.schema_id = {{.SchemaID}}
 	                        AND t.row_id = cl.row_id
-	                        AND {{.Anchor.Condition}}
+	                        AND ({{.Anchor.Condition}})
 	                )
 	                {{- end }}
 	            {{- end }}

--- a/internal/advanced_query_template_test.go
+++ b/internal/advanced_query_template_test.go
@@ -73,6 +73,61 @@ func TestOptimizedQueryTemplate_ChangeLogUsesExistsForEAVAnchor(t *testing.T) {
 	require.NotContains(t, anchor, "SELECT DISTINCT cl.row_id")
 }
 
+// TestOptimizedQueryTemplate_AnchorConditionParenthesized (#269): every
+// {{.Anchor.Condition}} injection site joins the schema_id constraint with
+// AND, so the injected condition must be wrapped in parentheses. Without
+// them a top-level multi-branch OR parses as
+// `(schema_id = $1 AND branch1) OR branch2 ...` by operator precedence, and
+// every branch after the first scans unconstrained by the requested schema
+// (polluted anchor: inflated total_records, pagination drift).
+func TestOptimizedQueryTemplate_AnchorConditionParenthesized(t *testing.T) {
+	cases := []struct {
+		name          string
+		useMainAnchor bool
+		condition     string
+	}{
+		{
+			name:          "main_anchor",
+			useMainAnchor: true,
+			condition:     `(m."integer_01" = $2) OR (m."integer_01" = $3)`,
+		},
+		{
+			name:          "eav_anchor",
+			useMainAnchor: false,
+			condition:     `(EXISTS (SELECT 1 FROM x)) OR (EXISTS (SELECT 1 FROM y))`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sql, err := renderTemplate(optimizedQuerySQLTemplate, map[string]any{
+				"EAVTable":             "eav_data",
+				"MainTable":            "entity_main",
+				"ChangeLogTable":       "change_log",
+				"MainProjection":       "m.ltbase_schema_id, m.ltbase_row_id",
+				"SchemaID":             "$1",
+				"UseMainTableAsAnchor": tc.useMainAnchor,
+				"Anchor": map[string]any{
+					"Condition": tc.condition,
+				},
+				"SortKeys": []model.AttributeOrder{},
+				"Limit":    "$4",
+				"Offset":   "$5",
+				"PageSize": "$4",
+			})
+			require.NoError(t, err)
+			anchor := anchorCTESegment(t, sql)
+
+			// Each anchor variant injects the condition twice: the anchor scan
+			// and the change_log EXISTS branch. Both must parenthesize it.
+			require.Equal(t, 2, strings.Count(anchor, "AND ("+tc.condition+")"),
+				"anchor CTE must wrap the injected condition in parens at both sites:\n%s", anchor)
+			require.NotContains(t, anchor, "AND "+tc.condition+"\n",
+				"anchor CTE must not inject the condition bare:\n%s", anchor)
+		})
+	}
+}
+
 func TestOptimizedQueryTemplate_WithoutChangeLogHasNoUnionBranch(t *testing.T) {
 	sql, err := renderTemplate(optimizedQuerySQLTemplate, map[string]any{
 		"EAVTable":             "eav_data",

--- a/internal/e2e_harness/production/or_composite_e2e_test.go
+++ b/internal/e2e_harness/production/or_composite_e2e_test.go
@@ -30,25 +30,7 @@ func TestORCompositeSchemaScoping(t *testing.T) {
 	fixtures := DefaultSchemaFixtures()
 	wide, second := fixtures[1], fixtures[2]
 
-	// Target schema: three rows, exactly one matching the first OR branch and
-	// none matching the second.
-	mustApplyEvents(ctx, t, env, "seed e2e_second",
-		CreateEvent(second, map[string]any{"label": "match", "code": 111}),
-		CreateEvent(second, map[string]any{"label": "other-a", "code": 222}),
-		CreateEvent(second, map[string]any{"label": "other-b", "code": 333}),
-	)
-
-	// Pollution source: five e2e_wide rows whose integer_01 (count) equals the
-	// second OR branch's value. Under the unparenthesized render these enter
-	// the anchor of the e2e_second query.
-	wideCreates := make([]*Event, 0, 5)
-	for i := 0; i < 5; i++ {
-		wideCreates = append(wideCreates, CreateEvent(wide, map[string]any{
-			"title": "pollution",
-			"count": 777,
-		}))
-	}
-	mustApplyEvents(ctx, t, env, "seed e2e_wide pollution rows", wideCreates...)
+	seedCrossSchemaIntegerCollision(ctx, t, env, wide, second)
 
 	// Positive control: the pollution rows are really present and matchable
 	// in their own schema — a broken seed cannot fake the probe green.
@@ -65,36 +47,7 @@ func TestORCompositeSchemaScoping(t *testing.T) {
 		t.Fatalf("positive control: e2e_wide count=777 total %d, want 5", control.Total)
 	}
 
-	// The probe: top-level OR on the target schema. The harness Query spec only
-	// builds AND composites, so construct the federated query directly (same
-	// shape Env.buildFederatedQuery emits). PreferHot pins the hot-only OLTP
-	// route through the optimized PG template.
-	fq := &model.FederatedAttributeQuery{
-		AttributeQuery: model.AttributeQuery{
-			SchemaID: second.ID,
-			Condition: &forma.CompositeCondition{
-				Logic: forma.LogicOr,
-				Conditions: []forma.Condition{
-					&forma.KvCondition{Attr: "code", Value: "equals:111"},
-					&forma.KvCondition{Attr: "code", Value: "equals:777"},
-				},
-			},
-			Limit: 10,
-		},
-		PreferredTiers: []model.DataTier{model.DataTierHot, model.DataTierWarm, model.DataTierCold},
-		PreferHot:      true,
-	}
-	opts := &model.FederatedQueryOptions{
-		IncludeExecutionPlan: true,
-		ExecutionPlan:        &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
-	}
-	page, err := env.Engine().Query(ctx, env.Tables, fq, opts)
-	if err != nil {
-		t.Fatalf("OR query on e2e_second: %v", err)
-	}
-	if opts.ExecutionPlan.Routing.UseDuckDB {
-		t.Fatalf("OR probe unexpectedly routed to DuckDB; the #269 surface is the PG optimized path: %+v", opts.ExecutionPlan.Routing)
-	}
+	page := queryHotTopLevelOR(ctx, t, env, second, "code", "111", "777")
 
 	// Exactly one e2e_second row matches (code=111, since 777 exists only in
 	// e2e_wide). A polluted anchor reports total_records=6 (1 + 5 foreign).
@@ -109,4 +62,66 @@ func TestORCompositeSchemaScoping(t *testing.T) {
 	if page.TotalRecords != 1 {
 		t.Errorf("OR query total_records = %d, want 1 (anchor polluted by foreign-schema rows, #269)", page.TotalRecords)
 	}
+}
+
+// seedCrossSchemaIntegerCollision seeds the #269 pollution geometry: three
+// target-schema rows (exactly one matching the probe's first OR branch, none
+// matching the second) plus five e2e_wide rows whose integer_01 (count)
+// equals the second branch's value — the rows an unscoped branch would admit
+// into the target schema's anchor.
+func seedCrossSchemaIntegerCollision(ctx context.Context, t *testing.T, env *Env, wide, second SchemaRef) {
+	t.Helper()
+
+	mustApplyEvents(ctx, t, env, "seed e2e_second",
+		CreateEvent(second, map[string]any{"label": "match", "code": 111}),
+		CreateEvent(second, map[string]any{"label": "other-a", "code": 222}),
+		CreateEvent(second, map[string]any{"label": "other-b", "code": 333}),
+	)
+
+	wideCreates := make([]*Event, 0, 5)
+	for i := 0; i < 5; i++ {
+		wideCreates = append(wideCreates, CreateEvent(wide, map[string]any{
+			"title": "pollution",
+			"count": 777,
+		}))
+	}
+	mustApplyEvents(ctx, t, env, "seed e2e_wide pollution rows", wideCreates...)
+}
+
+// queryHotTopLevelOR runs `attr = v1 OR attr = v2` as a top-level OR against
+// the real engine and returns the page. The harness Query spec only builds
+// AND composites, so the federated query is constructed directly (same shape
+// Env.buildFederatedQuery emits). PreferHot pins the hot-only OLTP route
+// through the optimized PG template; a DuckDB-routing guard keeps the probe
+// on the #269 surface.
+func queryHotTopLevelOR(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, attr, v1, v2 string) *model.PersistentRecordPage {
+	t.Helper()
+
+	fq := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{
+			SchemaID: schema.ID,
+			Condition: &forma.CompositeCondition{
+				Logic: forma.LogicOr,
+				Conditions: []forma.Condition{
+					&forma.KvCondition{Attr: attr, Value: "equals:" + v1},
+					&forma.KvCondition{Attr: attr, Value: "equals:" + v2},
+				},
+			},
+			Limit: 10,
+		},
+		PreferredTiers: []model.DataTier{model.DataTierHot, model.DataTierWarm, model.DataTierCold},
+		PreferHot:      true,
+	}
+	opts := &model.FederatedQueryOptions{
+		IncludeExecutionPlan: true,
+		ExecutionPlan:        &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
+	}
+	page, err := env.Engine().Query(ctx, env.Tables, fq, opts)
+	if err != nil {
+		t.Fatalf("top-level OR query on %s: %v", schema.Name, err)
+	}
+	if opts.ExecutionPlan.Routing.UseDuckDB {
+		t.Fatalf("OR probe unexpectedly routed to DuckDB; the #269 surface is the PG optimized path: %+v", opts.ExecutionPlan.Routing)
+	}
+	return page
 }

--- a/internal/e2e_harness/production/or_composite_e2e_test.go
+++ b/internal/e2e_harness/production/or_composite_e2e_test.go
@@ -1,0 +1,112 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+
+	forma "github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// TestORCompositeSchemaScoping (#269): a top-level multi-branch OR condition
+// on the PostgreSQL optimized-query path must stay scoped to the requested
+// schema. The template joins the anchor condition with
+// `schema_id = $1 AND <condition>`; if the OR renders unparenthesized, every
+// branch after the first admits rows from OTHER schemas into the anchor.
+// Final records survive (main_data re-filters by schema), but
+// `COUNT(*) OVER()` counts the polluted anchor — total_records inflates and
+// LIMIT/OFFSET paginates over foreign row_ids.
+//
+// Fixture geometry: e2e_second.code and e2e_wide.count are both bound to
+// entity_main.integer_01, so a wide row with count=777 is exactly the foreign
+// row an unscoped `integer_01 = 777` branch would admit.
+func TestORCompositeSchemaScoping(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+
+	fixtures := DefaultSchemaFixtures()
+	wide, second := fixtures[1], fixtures[2]
+
+	// Target schema: three rows, exactly one matching the first OR branch and
+	// none matching the second.
+	mustApplyEvents(ctx, t, env, "seed e2e_second",
+		CreateEvent(second, map[string]any{"label": "match", "code": 111}),
+		CreateEvent(second, map[string]any{"label": "other-a", "code": 222}),
+		CreateEvent(second, map[string]any{"label": "other-b", "code": 333}),
+	)
+
+	// Pollution source: five e2e_wide rows whose integer_01 (count) equals the
+	// second OR branch's value. Under the unparenthesized render these enter
+	// the anchor of the e2e_second query.
+	wideCreates := make([]*Event, 0, 5)
+	for i := 0; i < 5; i++ {
+		wideCreates = append(wideCreates, CreateEvent(wide, map[string]any{
+			"title": "pollution",
+			"count": 777,
+		}))
+	}
+	mustApplyEvents(ctx, t, env, "seed e2e_wide pollution rows", wideCreates...)
+
+	// Positive control: the pollution rows are really present and matchable
+	// in their own schema — a broken seed cannot fake the probe green.
+	control := env.AssertQueryMatches(ctx, Query{
+		Schema:    wide,
+		Filters:   []Filter{{Attr: "count", Value: "777"}},
+		Limit:     10,
+		PreferHot: true,
+	})
+	if control == nil {
+		return
+	}
+	if control.Total != 5 {
+		t.Fatalf("positive control: e2e_wide count=777 total %d, want 5", control.Total)
+	}
+
+	// The probe: top-level OR on the target schema. The harness Query spec only
+	// builds AND composites, so construct the federated query directly (same
+	// shape Env.buildFederatedQuery emits). PreferHot pins the hot-only OLTP
+	// route through the optimized PG template.
+	fq := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{
+			SchemaID: second.ID,
+			Condition: &forma.CompositeCondition{
+				Logic: forma.LogicOr,
+				Conditions: []forma.Condition{
+					&forma.KvCondition{Attr: "code", Value: "equals:111"},
+					&forma.KvCondition{Attr: "code", Value: "equals:777"},
+				},
+			},
+			Limit: 10,
+		},
+		PreferredTiers: []model.DataTier{model.DataTierHot, model.DataTierWarm, model.DataTierCold},
+		PreferHot:      true,
+	}
+	opts := &model.FederatedQueryOptions{
+		IncludeExecutionPlan: true,
+		ExecutionPlan:        &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
+	}
+	page, err := env.Engine().Query(ctx, env.Tables, fq, opts)
+	if err != nil {
+		t.Fatalf("OR query on e2e_second: %v", err)
+	}
+	if opts.ExecutionPlan.Routing.UseDuckDB {
+		t.Fatalf("OR probe unexpectedly routed to DuckDB; the #269 surface is the PG optimized path: %+v", opts.ExecutionPlan.Routing)
+	}
+
+	// Exactly one e2e_second row matches (code=111, since 777 exists only in
+	// e2e_wide). A polluted anchor reports total_records=6 (1 + 5 foreign).
+	if len(page.Records) != 1 {
+		t.Errorf("OR query returned %d records, want 1", len(page.Records))
+	}
+	for _, rec := range page.Records {
+		if rec.SchemaID != second.ID {
+			t.Errorf("OR query returned record from schema %d, want only %d", rec.SchemaID, second.ID)
+		}
+	}
+	if page.TotalRecords != 1 {
+		t.Errorf("OR query total_records = %d, want 1 (anchor polluted by foreign-schema rows, #269)", page.TotalRecords)
+	}
+}

--- a/internal/postgres_persistent_repository_query.go
+++ b/internal/postgres_persistent_repository_query.go
@@ -127,7 +127,7 @@ func (r *DBPersistentRecordRepository) StreamOptimizedQuery(
 func optimizedQueryShapeKey(tables model.StorageTables, useMainTableAsAnchor bool, clause string, argCount int, orders []model.AttributeOrder) uint64 {
 	parts := make([]string, 0, 6+6*len(orders))
 	parts = append(parts,
-		"pg-optimized-v1",
+		"pg-optimized-v2", // v2: anchor condition parenthesized (#269)
 		tables.EAVData,
 		tables.EntityMain,
 		tables.ChangeLog,

--- a/internal/sqlgen/condition_walker.go
+++ b/internal/sqlgen/condition_walker.go
@@ -85,8 +85,11 @@ var (
 		nilNode:            nilNodeTrue,
 	}
 	hybridStyle = compositeStyle{
-		emptyAnd:           "1=1",
-		emptyOr:            "1=0",
+		emptyAnd: "1=1",
+		emptyOr:  "1=0",
+		// Safe only because every consumer parenthesizes the injected clause
+		// at the template seam (optimizedQuerySQLTemplate anchor sites per
+		// #269; the DuckDB template has always wrapped its injections).
 		outerParensOnMulti: false,
 		allEmpty:           allEmptyOmit,
 		nilNode:            nilNodeError,


### PR DESCRIPTION
Closes #269.

## Problem

The PG optimized-query template joined the injected anchor condition bare — `WHERE t.schema_id = $1 AND {{.Anchor.Condition}}` — at all four injection sites. By operator precedence, a top-level multi-branch `OR` parsed as `(schema_id = $1 AND b1) OR b2 OR ...`:

1. **Anchor pollution**: every OR branch after the first scanned unconstrained by the requested schema, admitting foreign-schema `row_id`s into the anchor → inflated `total_records`/`total_pages`, `LIMIT/OFFSET` paginating over a polluted set.
2. **Performance**: the unconstrained branches degrade the anchor into a cross-schema EAV scan with correlated EXISTS subplans per row (a large contributor to the latency measured in #268/#263).
3. **Worse than the issue reported** (found red-first by the new e2e): inside the change_log hot-buffer `EXISTS`, the OR also escaped the *row correlation* (`m.ltbase_row_id = cl.row_id AND b1) OR b2`), making the EXISTS true for **every** buffered row of the schema whenever *any* row anywhere matched the second branch — so hot-path queries returned **wrong records**, not just a wrong count. The red run returned 3 records / total_records=8 where the truth is 1 / 1.

## Fix

Parenthesize all four `{{.Anchor.Condition}}` injection sites in `internal/advanced_query_template.go` — the issue's second fix direction, chosen over flipping `hybridStyle.outerParensOnMulti` because:

- it mirrors the established DuckDB-template convention (its injections have always been wrapped, which is what makes `duckStyle.outerParensOnMulti=false` safe), and
- the hybrid clause is also consumed by the federated template's already-parenthesized seams — flipping the walker style would churn that path's rendered SQL for no correctness gain.

The safety precondition is now documented on `hybridStyle` (`internal/sqlgen/condition_walker.go`). The plan-cache template tag is bumped `pg-optimized-v1` → `pg-optimized-v2` with the shape change.

## Regression coverage (both committed red first, then green after the fix)

- **Unit** `TestOptimizedQueryTemplate_AnchorConditionParenthesized`: renders both anchor variants (main / EAV) with a multi-branch OR clause and asserts both injection sites per variant wrap it in parens.
- **E2E** `TestORCompositeSchemaScoping` (production harness, real PG, hot-only OLTP route): exploits the fixture geometry — `e2e_second.code` and `e2e_wide.count` are both bound to `entity_main.integer_01` — so `code=111 OR code=777` on `e2e_second` would admit the five wide rows with `count=777` under the bug. Asserts record count, per-record schema, `total_records`, a non-DuckDB routing guard, and a positive control proving the pollution rows exist and match in their own schema.

## Verification

- `make test` — 26 packages ok, zero failures
- `make lint` — clean (golangci-lint v1.64.8)
- `make test-e2e-production` — full suite green (103s), including the new test
- Red states observed before the fix: unit (both subtests), e2e (3 records / total 8)

## Notes for review

- Rendered-SQL shape change is expected: characterization surfaces were audited (`advanced_query_template_test.go`, `postgres_persistent_repository_test.go` line 282 asserts hybrid-emitter output, not template joins; the render benchmark asserts no shape) — no existing assertion needed updating.
- Single-leaf and AND-composite conditions gain redundant-but-harmless parens; the walker already parenthesizes each child, so semantics are unchanged on those shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)