### PR TITLE
fix(cdc): #210 stamp base export ver_ts from ltbase_updated_at, not created_at

### DIFF
--- a/internal/cdc/export_sql_shared_test.go
+++ b/internal/cdc/export_sql_shared_test.go
@@ -87,7 +87,7 @@ func TestBuildExportSQL_CommonSemanticsAcrossModes(t *testing.T) {
 			},
 			expectedMemoryLimit:  "6GB",
 			expectedModeTable:    "",
-			expectedTimeSlotExpr: "m.ltbase_created_at AS changed_at",
+			expectedTimeSlotExpr: "m.ltbase_updated_at AS changed_at",
 			expectActiveOnly:     true,
 		},
 	}

--- a/internal/cdc/init_exporter.go
+++ b/internal/cdc/init_exporter.go
@@ -22,7 +22,11 @@ func (e *DuckExporter) ExportBaseFileToTmp(ctx context.Context, cfg CDCConfig, p
 // buildBaseExportSQL constructs the DuckDB SQL for exporting base files.
 // Key differences from delta export:
 // 1. No change_log table involved
-// 2. Uses ltbase_created_at as changed_at (the reader's version timestamp)
+// 2. Uses ltbase_updated_at as changed_at (the reader's version timestamp):
+//    the base row IS the state as of its last update, and every write path
+//    stamps ltbase_updated_at and change_log.changed_at from the same clock
+//    read, so the base copy ranks exactly at its newest flushed delta — never
+//    below a previously flushed older version (#210)
 // 3. Queries entity_main directly for row metadata
 func buildBaseExportSQL(pgConnStr string, s3TmpPath string, cfg CDCConfig, schemaID int16, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) (string, string, string, error) {
 	plan, err := buildExportSQLPlan(exportModeSpec{
@@ -31,7 +35,7 @@ func buildBaseExportSQL(pgConnStr string, s3TmpPath string, cfg CDCConfig, schem
 		useChangeLog:       false,
 		schemaIDSelect:     "m.ltbase_schema_id AS schema_id",
 		rowIDSelect:        "m.ltbase_row_id AS row_id",
-		timeSlotSelect:     "m.ltbase_created_at AS changed_at",
+		timeSlotSelect:     "m.ltbase_updated_at AS changed_at",
 		deletedAtSelect:    "COALESCE(m.ltbase_deleted_at, 0) AS deleted_at",
 	}, pgConnStr, s3TmpPath, cfg, schemaID, 0, rowIDs, attrCache)
 	if err != nil {

--- a/internal/cdc/init_exporter.go
+++ b/internal/cdc/init_exporter.go
@@ -2,6 +2,7 @@ package cdc
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
@@ -21,13 +22,13 @@ func (e *DuckExporter) ExportBaseFileToTmp(ctx context.Context, cfg CDCConfig, p
 
 // buildBaseExportSQL constructs the DuckDB SQL for exporting base files.
 // Key differences from delta export:
-// 1. No change_log table involved
-// 2. Uses ltbase_updated_at as changed_at (the reader's version timestamp):
-//    the base row IS the state as of its last update, and every write path
-//    stamps ltbase_updated_at and change_log.changed_at from the same clock
-//    read, so the base copy ranks exactly at its newest flushed delta — never
-//    below a previously flushed older version (#210)
-// 3. Queries entity_main directly for row metadata
+//  1. No change_log table involved
+//  2. Uses ltbase_updated_at as changed_at (the reader's version timestamp):
+//     the base row IS the state as of its last update, and every write path
+//     stamps ltbase_updated_at and change_log.changed_at from the same clock
+//     read, so the base copy ranks exactly at its newest flushed delta — never
+//     below a previously flushed older version (#210)
+//  3. Queries entity_main directly for row metadata
 func buildBaseExportSQL(pgConnStr string, s3TmpPath string, cfg CDCConfig, schemaID int16, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) (string, string, string, error) {
 	plan, err := buildExportSQLPlan(exportModeSpec{
 		defaultMemoryLimit: "8GB",
@@ -39,7 +40,7 @@ func buildBaseExportSQL(pgConnStr string, s3TmpPath string, cfg CDCConfig, schem
 		deletedAtSelect:    "COALESCE(m.ltbase_deleted_at, 0) AS deleted_at",
 	}, pgConnStr, s3TmpPath, cfg, schemaID, 0, rowIDs, attrCache)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", fmt.Errorf("failed to build base export SQL plan for schema %d: %w", schemaID, err)
 	}
 
 	return plan.sql, plan.mainQuery, plan.eavQuery, nil

--- a/internal/e2e_harness/production/filter_lww_e2e_test.go
+++ b/internal/e2e_harness/production/filter_lww_e2e_test.go
@@ -80,12 +80,13 @@ func testStaleFilterDeltaGenerations(ctx context.Context, t *testing.T, env *Env
 
 // testStaleFilterBaseVsDelta is issue #178 scenario 1 in the base-vs-delta
 // layout: v1 (matching) in base via init + onboarding cleanup, v2
-// (non-matching) in a delta flushed afterwards. Deterministic under #210:
-// base ver_ts = create time < delta ver_ts = update time.
+// (non-matching) in a delta flushed afterwards. Deterministic ordering: base
+// ver_ts = v1's ltbase_updated_at (#210), equal to its create time since the
+// row was never updated before init, < delta ver_ts = v2's update time.
 func testStaleFilterBaseVsDelta(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
 	creates := buildOpenCreates(wide, 5)
 	mustApplyEvents(ctx, t, env, "apply creates", creates...)
-	report, err := env.RunInit(ctx, wide) // base = v1 @ create-time ver_ts
+	report, err := env.RunInit(ctx, wide) // base = v1 @ its update-time ver_ts (= create time here)
 	if err != nil {
 		t.Fatalf("run init: %v", err)
 	}

--- a/internal/e2e_harness/production/filter_lww_helpers_test.go
+++ b/internal/e2e_harness/production/filter_lww_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 )
 
 // Shared fixture for the filter-LWW production suites (#178, #215).
@@ -56,6 +57,20 @@ func assertRowCount(ctx context.Context, t *testing.T, env *Env, name string, q 
 	t.Helper()
 	if res := env.AssertQueryMatches(ctx, q); res != nil && len(res.Records) != want {
 		t.Fatalf("%s returned %d rows, want %d", name, len(res.Records), want)
+	}
+}
+
+// waitClockPast blocks until the process wall clock is strictly past every
+// given event's ChangedAt. The repository stamps changed_at from this same
+// process clock (nowMillis, postgres_persistent_repository.go), so a write
+// issued after this returns lands on a strictly later millisecond — making a
+// subsequent assertStrictlyNewer deterministic instead of racing the clock.
+func waitClockPast(t *testing.T, evs ...*Event) {
+	t.Helper()
+	for _, ev := range evs {
+		for time.Now().UnixMilli() <= ev.ChangedAt {
+			time.Sleep(time.Millisecond)
+		}
 	}
 }
 

--- a/internal/e2e_harness/production/filter_lww_helpers_test.go
+++ b/internal/e2e_harness/production/filter_lww_helpers_test.go
@@ -61,7 +61,8 @@ func assertRowCount(ctx context.Context, t *testing.T, env *Env, name string, q 
 
 // assertStrictlyNewer fails fast when any new version's changed_at is not
 // strictly after its predecessor's at millisecond resolution — otherwise an
-// LWW probe degrades into the undefined equal-ver_ts tie tracked by #210.
+// LWW probe degrades into an undefined equal-ver_ts tie (#210 fixed the init
+// stamp; equal-timestamp DIVERGENT versions of a row remain unranked).
 func assertStrictlyNewer(t *testing.T, olds, news []*Event) {
 	t.Helper()
 	for i := range olds {

--- a/internal/e2e_harness/production/full_type_parquet_e2e_test.go
+++ b/internal/e2e_harness/production/full_type_parquet_e2e_test.go
@@ -348,12 +348,13 @@ type systemCols struct {
 // picking the producer-specific expectation per tier. Observed emissions
 // (2026-07): schema_id == fixture ID (both tiers); ltbase_created_at /
 // ltbase_updated_at == the entity_main source stamps (both tiers). changed_at:
-// BASE exporter emits m.ltbase_created_at AS changed_at
-// (internal/cdc/init_exporter.go:35); DELTA emits cl.changed_at
-// (internal/cdc/duckdb_exporter.go:153) == Event.ChangedAt. deleted_at: BASE
-// COALESCEs to 0 (init_exporter.go:36); DELTA emits raw cl.deleted_at, NULL for
-// a live create (duckdb_exporter.go:154). ltbase_deleted_at is the raw
-// entity_main main column, NULL for every non-deleted row on both tiers.
+// BASE exporter emits m.ltbase_updated_at AS changed_at — the row's true
+// latest-version timestamp (#210; internal/cdc/init_exporter.go); DELTA emits
+// cl.changed_at (internal/cdc/duckdb_exporter.go) == Event.ChangedAt.
+// deleted_at: BASE COALESCEs to 0 (init_exporter.go); DELTA emits raw
+// cl.deleted_at, NULL for a live create (duckdb_exporter.go).
+// ltbase_deleted_at is the raw entity_main main column, NULL for every
+// non-deleted row on both tiers.
 func checkSystemColumns(t *testing.T, tier string, rowID uuid.UUID, schemaID int16, want *wideVals, got systemCols) {
 	t.Helper()
 	if !got.schema.Valid || got.schema.Int16 != schemaID {
@@ -369,7 +370,7 @@ func checkSystemColumns(t *testing.T, tier string, rowID uuid.UUID, schemaID int
 	wantChangedAt := want.changedAt      // delta: cl.changed_at
 	var wantDeletedAt *int64             // delta: raw cl.deleted_at, NULL for a create
 	if tier == "base" {
-		wantChangedAt = want.ltbaseCreatedAt // base: m.ltbase_created_at AS changed_at
+		wantChangedAt = want.ltbaseUpdatedAt // base: m.ltbase_updated_at AS changed_at (#210)
 		zero := int64(0)                     // base: COALESCE(ltbase_deleted_at, 0)
 		wantDeletedAt = &zero
 	}

--- a/internal/e2e_harness/production/init_ver_ts_lww_e2e_test.go
+++ b/internal/e2e_harness/production/init_ver_ts_lww_e2e_test.go
@@ -1,0 +1,89 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+)
+
+// TestInitVerTsLWW (#210) pins the cdc-init version-timestamp contract on the
+// federated LWW path: init must stamp base rows with the row's true
+// latest-version timestamp (ltbase_updated_at AS changed_at), not its
+// creation time. Under the pre-#210 contract (ltbase_created_at) any row
+// updated after creation left init with a base copy whose ver_ts predated
+// every previously flushed delta version — so a stale delta deterministically
+// beat the fresh base under
+//
+//	ORDER BY ver_ts DESC, source_tier_priority DESC, deleted_ts DESC, row_id ASC
+//	(advanced_query_template_duckdb.go)
+//
+// and the federated path served superseded attributes until the row's next
+// mutation. The sequence below is reachable straight through the documented
+// onboarding steps (#176): backfill with cdc-init after some updates were
+// already flushed, then clear change_log.
+func TestInitVerTsLWW(t *testing.T) {
+	cluster := SharedCluster(t)
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	scenarios := []struct {
+		name string
+		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
+	}{
+		{"fresh_base_beats_stale_delta", testFreshBaseBeatsStaleDelta},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			sc.run(context.Background(), t, NewEnv(t, cluster), wide)
+		})
+	}
+}
+
+// testFreshBaseBeatsStaleDelta is #210's failure-mode-1 construction, built
+// entirely from production verbs: create v1 (T1) -> update v2 (T2) -> flush
+// (delta: v2 attrs @ ver_ts = T2) -> update v3 (T3) -> RunInit (base: v3
+// attrs) -> onboarding change_log cleanup. The base copy holds the newest
+// attribute state, so LWW must surface v3. With init stamping create-time the
+// base carried ver_ts = T1 < T2 and the stale delta v2 won every read; with
+// init stamping ltbase_updated_at the base carries T3 and wins by strict
+// recency. The oracle folds the event log to v3, so AssertQueryMatches is the
+// full assertion — there is no ver_ts tie here for its Seq tiebreak to paper
+// over.
+func testFreshBaseBeatsStaleDelta(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+	target := CreateEvent(wide, map[string]any{"title": "v1", "count": float64(100)})
+	bystander := CreateEvent(wide, map[string]any{"title": "bystander", "count": float64(999)})
+	mustApplyEvents(ctx, t, env, "fm1 creates", target, bystander)
+
+	v2 := UpdateEvent(wide, target.RowID, map[string]any{"title": "stale-v2", "count": float64(400000)})
+	mustApplyEvents(ctx, t, env, "fm1 update v2", v2)
+	assertStrictlyNewer(t, []*Event{target}, []*Event{v2})
+	mustFlush(ctx, t, env) // delta: v2 attrs @ ver_ts = T2
+
+	v3 := UpdateEvent(wide, target.RowID, map[string]any{"title": "fresh-v3", "count": float64(500000)})
+	mustApplyEvents(ctx, t, env, "fm1 update v3", v3)
+	assertStrictlyNewer(t, []*Event{v2}, []*Event{v3})
+
+	if _, err := env.RunInit(ctx, wide); err != nil { // base: v3 attrs @ init's ver_ts stamp
+		t.Fatalf("run init: %v", err)
+	}
+	env.ExecSQL(ctx, "DELETE FROM change_log") // onboarding cleanup (#176) ⇒ cold-only, DuckDB routing
+
+	q := Query{Schema: wide, Sorts: []Sort{{Attr: "count"}}, Limit: 10}
+	res := env.AssertQueryMatches(ctx, q) // oracle expects v3 attributes
+	if res == nil {
+		return
+	}
+	if !res.Plan.Routing.UseDuckDB {
+		t.Fatalf("expected DuckDB routing, got OLTP: %+v", res.Plan.Routing)
+	}
+	seen := 0
+	for _, rec := range res.Records {
+		if rec.RowID == target.RowID {
+			seen++
+		}
+	}
+	if seen != 1 { // hard invariant: rn = 1 must yield exactly one surviving copy
+		t.Fatalf("target row_id surfaced %d times, want exactly 1 (rn = 1 broke)", seen)
+	}
+}

--- a/internal/e2e_harness/production/init_ver_ts_lww_e2e_test.go
+++ b/internal/e2e_harness/production/init_ver_ts_lww_e2e_test.go
@@ -55,11 +55,13 @@ func testFreshBaseBeatsStaleDelta(ctx context.Context, t *testing.T, env *Env, w
 	bystander := CreateEvent(wide, map[string]any{"title": "bystander", "count": float64(999)})
 	mustApplyEvents(ctx, t, env, "fm1 creates", target, bystander)
 
+	waitClockPast(t, target)
 	v2 := UpdateEvent(wide, target.RowID, map[string]any{"title": "stale-v2", "count": float64(400000)})
 	mustApplyEvents(ctx, t, env, "fm1 update v2", v2)
 	assertStrictlyNewer(t, []*Event{target}, []*Event{v2})
 	mustFlush(ctx, t, env) // delta: v2 attrs @ ver_ts = T2
 
+	waitClockPast(t, v2)
 	v3 := UpdateEvent(wide, target.RowID, map[string]any{"title": "fresh-v3", "count": float64(500000)})
 	mustApplyEvents(ctx, t, env, "fm1 update v3", v3)
 	assertStrictlyNewer(t, []*Event{v2}, []*Event{v3})

--- a/internal/e2e_harness/production/three_tier_merge_e2e_test.go
+++ b/internal/e2e_harness/production/three_tier_merge_e2e_test.go
@@ -213,16 +213,13 @@ func testDirtyHotShadowsCold(ctx context.Context, t *testing.T, env *Env, wide S
 }
 
 // testChangedAtBeatsTierLayout supersedes the ConflictingCreatedAndUpdatedAt
-// stub. The init export contract makes created_at and updated_at orderings
-// genuinely conflict across tiers: cdc-init stamps base rows with
-// ltbase_created_at as the version timestamp (internal/cdc/init_exporter.go),
-// so the base copy written LAST carries the OLDEST ver_ts while the freshest
-// version lives in a delta written earlier. LWW must pick the strictly newest
-// changed_at (the update time) — not created_at, tier tags, or file write
-// order. The equal-ver_ts tie between CONFLICTING parquet versions (base
-// state newer than the last flush) is undefined by the ranking and
-// deliberately not exercised here; the init ver_ts contract is tracked by
-// #210.
+// stub. Three physical copies of every row coexist across the cold tier: v1
+// and v2 in two delta generations plus the base duplicate of v2 written by
+// cdc-init (which since #210 stamps ltbase_updated_at as the version
+// timestamp, so the base copy ranks exactly at v2's delta). LWW must pick the
+// strictly newest changed_at (the update time) — not created_at, tier tags,
+// or file write order: a ranking keyed on created_at would see all three
+// copies tie and could surface v1.
 func testChangedAtBeatsTierLayout(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
 	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 5})
 	if err := env.ApplyEvents(ctx, creates...); err != nil {
@@ -254,7 +251,7 @@ func testChangedAtBeatsTierLayout(ctx context.Context, t *testing.T, env *Env, w
 		t.Fatalf("manifest holds %d delta files, want 2 (v1 and v2 generations)", got)
 	}
 
-	report, err := env.RunInit(ctx, wide) // base = v2 attrs @ create-time ver_ts
+	report, err := env.RunInit(ctx, wide) // base = v2 attrs @ update-time ver_ts (#210)
 	if err != nil {
 		t.Fatalf("run init: %v", err)
 	}

--- a/internal/e2e_harness/production/tiebreak_lww_e2e_test.go
+++ b/internal/e2e_harness/production/tiebreak_lww_e2e_test.go
@@ -9,21 +9,22 @@ import (
 
 // TestWarmColdTiebreak (#183, epic #172 Phase 3) probes the federated LWW
 // tiebreak when a live BASE (cold init) copy and a live DELTA (cold flush)
-// copy of the same row_id carry an EQUAL ver_ts — the tie #210 calls
-// "undefined". The dedup ranks
+// copy of the same row_id meet in one glob scan. The dedup ranks
 //
 //	ORDER BY ver_ts DESC, source_tier_priority DESC, deleted_ts DESC, row_id ASC
 //	(advanced_query_template_duckdb.go:76-83)
 //
 // All parquet rows share tier priority 1; live BASE rows carry deleted_ts = 0
-// (init COALESCEs ltbase_deleted_at, init_exporter.go:36) while live DELTA
-// rows carry deleted_ts = NULL. Under DuckDB's default NULLS LAST, 0 sorts
-// before NULL in a DESC key, so on an equal-ver_ts tie the BASE copy wins
-// deterministically. cdc-init stamps base ver_ts from ltbase_created_at
-// (init_exporter.go:35) and delta from changed_at, so create->flush->init with
-// no intervening update yields identical ver_ts (scenario 1) while
-// create->flush->update->init yields equal-ver_ts DIVERGENT values (scenario
-// 2). Scenario 3 pins the same asymmetry from the deleted-row side.
+// (init COALESCEs ltbase_deleted_at, init_exporter.go) while live DELTA rows
+// carry deleted_ts = NULL — under DuckDB's default NULLS LAST, 0 sorts before
+// NULL in a DESC key, so on an equal-ver_ts tie the BASE copy wins. Since
+// #210, cdc-init stamps base ver_ts from ltbase_updated_at (the same clock
+// read as change_log.changed_at), so an equal-ver_ts base/delta tie only
+// arises between copies encoding the SAME version: create->flush->init with
+// no intervening update (scenario 1, identical values) or a restamped
+// tombstone (scenario 3). Scenario 2 pins the #210 fix itself: an intervening
+// update no longer yields the pre-#210 divergent equal-ver_ts tie — the base
+// copy carries the update's timestamp and wins by strict recency.
 func TestWarmColdTiebreak(t *testing.T) {
 	cluster := SharedCluster(t)
 	wide := DefaultSchemaFixtures()[1] // e2e_wide
@@ -33,7 +34,7 @@ func TestWarmColdTiebreak(t *testing.T) {
 		run  func(ctx context.Context, t *testing.T, env *Env, schema SchemaRef)
 	}{
 		{"equal_verts_identical_copies", testEqualVertsIdenticalCopies},
-		{"equal_verts_divergent_values_probe", testEqualVertsDivergentProbe},
+		{"init_restamp_beats_stale_delta", testInitRestampBeatsStaleDelta},
 		{"equal_verts_tombstone_wins", testEqualVertsTombstoneWins},
 	}
 	for _, sc := range scenarios {
@@ -45,9 +46,9 @@ func TestWarmColdTiebreak(t *testing.T) {
 }
 
 // testEqualVertsIdenticalCopies pins the hard invariant of the identical-copy
-// tie: create -> flush (delta @ create-ts) -> RunInit (base @ ltbase_created_at
-// = the same ts) leaves each row with two cold copies sharing ver_ts AND
-// attribute values. Whichever copy wins rn = 1, the row set must be exactly the
+// tie: create -> flush (delta @ create-ts) -> RunInit (base @
+// ltbase_updated_at, which equals the create ts for a never-updated row)
+// leaves each row with two cold copies sharing ver_ts AND attribute values. Whichever copy wins rn = 1, the row set must be exactly the
 // three v1 rows — no duplication (both copies surfacing) and no drop. The
 // winner identity is irrelevant here (copies are identical), so this is a
 // multiplicity invariant, not a scan-order pin.
@@ -87,65 +88,49 @@ func testEqualVertsIdenticalCopies(ctx context.Context, t *testing.T, env *Env, 
 	}
 }
 
-// testEqualVertsDivergentProbe is #210's failure-mode-2 construction, built
-// entirely from production verbs: create stale-v1 + a bystander -> flush (delta
-// v1 @ T1, deleted_ts NULL) -> update to fresh-v2 -> RunInit (base carries the
-// v2 attrs but ver_ts = ltbase_created_at = T1, deleted_ts 0). After clearing
-// change_log the row is cold-only with two live copies at an EQUAL ver_ts and
-// DIVERGENT values. The probe settles empirically whether the tie is
-// deterministic; it deliberately does NOT route through AssertQueryMatches
-// because the oracle's Seq tiebreak would declare v2 the truth and beg the
-// question. The only hard invariant is exactly-once (rn = 1).
-func testEqualVertsDivergentProbe(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
+// testInitRestampBeatsStaleDelta pins the #210 fix from the read side. The
+// construction is the former failure-mode-2 probe, unchanged: create stale-v1
+// + a bystander -> flush (delta v1 @ T1, deleted_ts NULL) -> update to
+// fresh-v2 @ T2 -> RunInit -> clear change_log. Pre-#210 the base copy
+// carried the v2 attrs at ver_ts = ltbase_created_at = T1, producing an
+// equal-ver_ts DIVERGENT tie that base only won through the deleted_ts
+// 0-vs-NULL accident (the retired adjudication A3, arm A). Since #210,
+// cdc-init stamps ver_ts from ltbase_updated_at, so the base copy carries T2
+// and beats the stale delta by strict recency — no tie exists. The oracle now
+// agrees for the same reason (its Seq tiebreak has no equal-ChangedAt pair to
+// break), so AssertQueryMatches carries the value assertion; exactly-once
+// (rn = 1) stays as the hard invariant.
+func testInitRestampBeatsStaleDelta(ctx context.Context, t *testing.T, env *Env, wide SchemaRef) {
 	target := CreateEvent(wide, map[string]any{"title": "stale-v1", "count": float64(111)})
 	bystander := CreateEvent(wide, map[string]any{"title": "bystander", "count": float64(999)})
-	mustApplyEvents(ctx, t, env, "divergent create + bystander", target, bystander)
+	mustApplyEvents(ctx, t, env, "restamp create + bystander", target, bystander)
 	mustFlush(ctx, t, env) // delta v1 @ T1
 
 	upd := UpdateEvent(wide, target.RowID, map[string]any{"title": "fresh-v2", "count": float64(222)})
-	mustApplyEvents(ctx, t, env, "divergent update", upd)
+	mustApplyEvents(ctx, t, env, "restamp update", upd)
 	assertStrictlyNewer(t, []*Event{target}, []*Event{upd}) // v2 is a genuinely later write
 
-	if _, err := env.RunInit(ctx, wide); err != nil { // base v2 attrs @ ver_ts = create T1
+	if _, err := env.RunInit(ctx, wide); err != nil { // base v2 attrs @ ver_ts = update T2 (#210)
 		t.Fatalf("run init: %v", err)
 	}
 	env.ExecSQL(ctx, "DELETE FROM change_log") // cold-only ⇒ DuckDB routing
 
 	q := Query{Schema: wide, Sorts: []Sort{{Attr: "count"}}, Limit: 10}
-	winners := make(map[string]int)
-	for i := 0; i < 20; i++ {
-		res, err := env.Query(ctx, q)
-		if err != nil {
-			t.Fatalf("probe run %d: %v", i, err)
-		}
-		if i == 0 && !res.Plan.Routing.UseDuckDB {
-			t.Fatalf("expected DuckDB routing, got OLTP: %+v", res.Plan.Routing)
-		}
-		seen := 0
-		title := ""
-		for _, rec := range res.Records {
-			if rec.RowID == target.RowID {
-				seen++
-				title = rec.TextItems["text_01"]
-			}
-		}
-		if seen != 1 { // hard invariant: rn = 1 must yield exactly one surviving copy
-			t.Fatalf("probe run %d: target row_id appeared %d times, want exactly 1 (rn = 1 broke)", i, seen)
-		}
-		winners[title]++
+	res := env.AssertQueryMatches(ctx, q) // oracle expects fresh-v2 by strict recency
+	if res == nil {
+		return
 	}
-
-	// Adjudication A3 — arm A (finalized from the 20-run probe: fresh-v2 won
-	// 20/20). The base copy (fresh-v2, deleted_ts 0) beats the live delta
-	// (stale-v1, deleted_ts NULL) on every run: 0 sorts before NULL under
-	// deleted_ts DESC + DuckDB's default NULLS LAST, so on an equal ver_ts the
-	// base wins deterministically. This is a CHARACTERIZATION of the
-	// #174-pinned init/flush export asymmetry, NOT a designed contract — #210
-	// still calls this tie undefined, so this assertion must be revisited when
-	// #210 lands a deliberate tie rule.
-	t.Logf("arm A: equal-ver_ts winner distribution %v", winners)
-	if winners["fresh-v2"] != 20 {
-		t.Fatalf("equal-ver_ts base/delta tie: fresh-v2 (base) won %d/20 runs, want 20 — the deterministic deleted_ts 0 < NULL tiebreak regressed (revisit against #210)", winners["fresh-v2"])
+	if !res.Plan.Routing.UseDuckDB {
+		t.Fatalf("expected DuckDB routing, got OLTP: %+v", res.Plan.Routing)
+	}
+	seen := 0
+	for _, rec := range res.Records {
+		if rec.RowID == target.RowID {
+			seen++
+		}
+	}
+	if seen != 1 { // hard invariant: rn = 1 must yield exactly one surviving copy
+		t.Fatalf("target row_id surfaced %d times, want exactly 1 (rn = 1 broke)", seen)
 	}
 }
 

--- a/internal/e2e_harness/production/tiebreak_lww_e2e_test.go
+++ b/internal/e2e_harness/production/tiebreak_lww_e2e_test.go
@@ -106,6 +106,7 @@ func testInitRestampBeatsStaleDelta(ctx context.Context, t *testing.T, env *Env,
 	mustApplyEvents(ctx, t, env, "restamp create + bystander", target, bystander)
 	mustFlush(ctx, t, env) // delta v1 @ T1
 
+	waitClockPast(t, target)
 	upd := UpdateEvent(wide, target.RowID, map[string]any{"title": "fresh-v2", "count": float64(222)})
 	mustApplyEvents(ctx, t, env, "restamp update", upd)
 	assertStrictlyNewer(t, []*Event{target}, []*Event{upd}) // v2 is a genuinely later write


### PR DESCRIPTION
Closes #210.

## Problem

`cdc-init` exported `m.ltbase_created_at AS changed_at`, so a base row carrying post-create attribute state ranked at its **creation** time in the federated LWW dedup (`ver_ts DESC, source_tier_priority DESC, deleted_ts DESC, row_id ASC`; all parquet rows share tier priority 1). Two failure modes, both probe-confirmed in the issue:

- **FM1 — deterministic stale read**: create(T1) → update v2(T2) → flush (delta v2@T2) → update v3(T3) → init (base v3@**T1**) → onboarding change_log cleanup (#176). The stale delta v2 outranks the fresh base v3 on every read until the row's next mutation.
- **FM2 — divergent equal-ver_ts tie**: create(T1) → flush (delta v1@T1) → update v2(T2) → init (base v2@**T1**). Both copies tie on ver_ts with different attributes; base won only through the `deleted_ts` 0-vs-NULL NULLS LAST accident (#183's A3 arm-A characterization, comment-pinned "revisit when #210 lands").

## Fix (adjudicated direction 1)

One production line: `init_exporter.go` now stamps `m.ltbase_updated_at AS changed_at`.

Why this is semantically exact, not just newer-is-better:
- Every write path (Insert/Update/BatchInsert/BatchUpdate, soft delete via the update statement) stamps `ltbase_updated_at` **and** `change_log.changed_at` from the **same clock read in the same transaction** (`postgres_persistent_repository.go:156/173`, `_batch.go:76/85`). The base copy therefore ranks exactly at its newest flushed delta — never below a previously flushed older version, never above a later hot write.
- `GREATEST(created, updated)` is unnecessary: `updated_at >= created_at` always holds (equal at insert).
- Hard deletes remove the row entirely and init exports `activeOnly`, so no path leaves `updated_at` stale.

Both failure modes vanish: FM1 because base now carries T3 > T2; FM2 because the intervening update lifts base to T2 — equal-ver_ts base/delta ties now only occur between copies encoding the **same version with identical attributes** (winner-indifferent).

## Commits (red-first)

1. `test(cdc)`: FM1 e2e `TestInitVerTsLWW/fresh_base_beats_stale_delta` through production verbs only — failed on main with the issue's exact diff (`expected fresh-v3/500000, actual stale-v2/400000`).
2. `fix(cdc)`: the one-line stamp change + flipped pinned expectation in `export_sql_shared_test.go` (verified red before the fix).
3. `test(e2e)`: ripple — see below.

## Test ripple

- `tiebreak_lww_e2e_test.go` (#183): `testEqualVertsDivergentProbe` **rewritten** as `testInitRestampBeatsStaleDelta` — same construction, but it now pins the fix (base wins by strict recency; A3 arm A retired). It routes through `AssertQueryMatches` since the oracle no longer has a tie to beg the question on; the rn=1 exactly-once invariant stays. `equal_verts_identical_copies` and `equal_verts_tombstone_wins` are untouched (still real ties, by same-version identity resp. restamp).
- `full_type_parquet_e2e_test.go`: base `changed_at` now pinned to `ltbase_updated_at`.
- `three_tier_merge_e2e_test.go` (#177): assertions unchanged (still green); the "base copy written LAST carries the OLDEST ver_ts" premise text updated.
- Comment sweep over remaining `#210` references: strictly-newer guards (`assertStrictlyNewer` etc.) kept — equal-timestamp **divergent** versions of a row remain unranked below `row_id ASC`; only comments stating the old init stamp as current fact were updated.
- Compaction needs **no change**: `merge_sql.go` passes `changed_at` through verbatim and its LWW fold now simply picks the correct version.

## Verification

- `make test` green, `make lint` clean (pinned v1.64.8).
- Targeted e2e: `TestInitVerTsLWW | TestWarmColdTiebreak | TestThreeTierMerge | TestNullAndBoundaryRoundTripAcrossTiers | TestCompactionRewrite* | TestFilterLWW*` — green.
- Full `make test-e2e-production` green (106s); `federated -tags=e2e -short` + benchmark green.

## Follow-up

- #274: the `deleted_ts` 0(base)-vs-NULL(delta) encoding asymmetry — post-fix ties are winner-indifferent, but the resolution still rests on a NULLS LAST accident rather than an explicit rule.

## Operational note

Existing pre-generated heavy-live datasets carry base files stamped under the old create-time contract. Rows updated-after-create before their init keep the old (losable) ver_ts until re-generated (same precedent as #200's dataset regeneration note). New inits are correct immediately; no migration of already-exported base files is performed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)