### PR TITLE
docs(e2e): #262 document the intentional RustFS pin/tracking split

### DIFF
--- a/internal/e2e_harness/harness.go
+++ b/internal/e2e_harness/harness.go
@@ -202,11 +202,13 @@ const (
 	RustFSSecretKey = "minioadmin"
 )
 
-// StartS3 starts an S3-compatible object store container (RustFS, the same
-// image as deploy/docker-compose.yml) and returns its endpoint. RustFS replaced
-// the archived MinIO image, which no longer receives updates. The image is
-// pinned by digest so CI and review results stay reproducible across upstream
-// RustFS releases. Caller is responsible for calling StopS3.
+// StartS3 starts an S3-compatible object store container (RustFS) and returns
+// its endpoint. RustFS replaced the archived MinIO image, which no longer
+// receives updates. The image is pinned by digest so CI and review results
+// stay reproducible across upstream RustFS releases; deploy/docker-compose.yml
+// deliberately tracks rustfs:latest instead, so the dev stack picks up
+// upstream fixes without a manual digest bump (#262). Caller is responsible
+// for calling StopS3.
 func (h *TestHarness) StartS3(ctx context.Context) (string, error) {
 	req := testcontainers.ContainerRequest{
 		Image:        "rustfs/rustfs@sha256:fa19210ac4697c79d7ccca1ec9b0eb91aebacc6691991ffb14014bb3c67e6cc3",


### PR DESCRIPTION
Closes #262.

## Decision (adjudicated)

Option 2 from the issue: **keep `rustfs:latest` in `deploy/docker-compose.yml`** (the dev stack deliberately tracks upstream RustFS, preserving the #198 adjudication) and fix the harness doc comment instead.

## Change

One comment: `internal/e2e_harness/harness.go` `StartS3` no longer claims the harness uses "the same image as deploy/docker-compose.yml" (untrue since #198 pinned the harness to a digest). It now states the intentional split — harness pinned by digest for reproducible CI/review results; dev compose tracks `:latest` so local stacks pick up upstream fixes without manual digest bumps.

`deploy/docker-compose.yml` is untouched.

## Verification

- `go build ./...` green, `make lint` clean (pinned v1.64.8), `gofmt -l` clean.
- Comment-only change; no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)