### PR TITLE
fix(cdc): #219 normalize non-unix_ms date main columns to epoch-ms on export

### DIFF
--- a/internal/cdc/cast_date_duckdb_test.go
+++ b/internal/cdc/cast_date_duckdb_test.go
@@ -1,0 +1,68 @@
+package cdc
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCastDateMainValue_ExecutesToEpochMs proves the #219 normalization end to
+// end against a real DuckDB engine: the expression castMainValue emits for each
+// date/datetime encoding evaluates to the SAME epoch-ms BIGINT, and that value
+// reads back unchanged through the federated reader's CAST(attr AS BIGINT)
+// projection. Pre-#219 the iso8601/default branches produced native
+// DATE/TIMESTAMP columns that CAST(... AS BIGINT) reinterpreted as
+// days/microseconds — a silent 10^3-10^8x scale error on the warm/cold tiers.
+func TestCastDateMainValue_ExecutesToEpochMs(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	// 2024-01-02T03:04:05Z == 1704164645000 ms since the epoch.
+	const wantEpochMs int64 = 1704164645000
+
+	cases := []struct {
+		name string
+		meta forma.AttributeMetadata
+		// source SQL column value expression matching how the write path stores
+		// this encoding: iso8601 -> RFC3339 text; unix_ms/default -> epoch-ms bigint.
+		sourceExpr string
+	}{
+		{
+			name:       "iso8601_text",
+			meta:       forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnText02, Encoding: forma.MainColumnEncodingISO8601}},
+			sourceExpr: "'2024-01-02T03:04:05Z'",
+		},
+		{
+			name:       "unix_ms_bigint",
+			meta:       forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02, Encoding: forma.MainColumnEncodingUnixMs}},
+			sourceExpr: "1704164645000::BIGINT",
+		},
+		{
+			name:       "default_bigint",
+			meta:       forma.AttributeMetadata{ValueType: forma.ValueTypeDate, ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02}},
+			sourceExpr: "1704164645000::BIGINT",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Export side: evaluate the exporter's cast over the stored value.
+			exportExpr := castMainValue("m", tc.meta)
+			var exported int64
+			require.NoError(t,
+				db.QueryRow("SELECT "+exportExpr+" FROM (SELECT "+tc.sourceExpr+" AS m) t").Scan(&exported),
+				"export expr %q must evaluate", exportExpr)
+			require.Equal(t, wantEpochMs, exported, "export must yield epoch-ms")
+
+			// Read side: the federated reader casts the parquet column with
+			// CAST(attr AS BIGINT); on an epoch-ms BIGINT column that is identity.
+			var readBack int64
+			require.NoError(t,
+				db.QueryRow("SELECT CAST(m AS BIGINT) FROM (SELECT ?::BIGINT AS m) t", exported).Scan(&readBack))
+			require.Equal(t, wantEpochMs, readBack, "reader CAST(attr AS BIGINT) must preserve epoch-ms")
+		})
+	}
+}

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -348,10 +348,9 @@ func duckTypeForValue(v forma.ValueType) string {
 // castMainValue projects a main-column-bound attribute into its parquet
 // column. The output type must match what the federated reader consumes:
 // its projection casts date/datetime attrs with CAST(attr AS BIGINT)
-// (sqlgen.duckDBAttrCast) and scans them as epoch-ms int64, mirroring the
-// write side (transform.storeInMainColumn), which stores unix_ms-encoded
-// dates as raw epoch millis in a bigint column. So unix_ms dates must stay
-// epoch-ms BIGINT here, matching castEAVValue's date handling (#194).
+// (sqlgen.duckDBAttrCast) and scans them as epoch-ms int64. So every
+// date/datetime encoding must export epoch-ms BIGINT here, matching
+// castEAVValue's date handling (#194, #219).
 func castMainValue(col string, meta forma.AttributeMetadata) string {
 	switch meta.ValueType {
 	case forma.ValueTypeBool:
@@ -363,16 +362,8 @@ func castMainValue(col string, meta forma.AttributeMetadata) string {
 		default:
 			return fmt.Sprintf("TRY_CAST(%s AS BOOLEAN)", col)
 		}
-	case forma.ValueTypeDate:
-		if meta.ColumnBinding != nil && meta.ColumnBinding.Encoding == forma.MainColumnEncodingUnixMs {
-			return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", col)
-		}
-		return fmt.Sprintf("TRY_CAST(%s AS DATE)", col)
-	case forma.ValueTypeDateTime:
-		if meta.ColumnBinding != nil && meta.ColumnBinding.Encoding == forma.MainColumnEncodingUnixMs {
-			return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", col)
-		}
-		return fmt.Sprintf("TRY_CAST(%s AS TIMESTAMP)", col)
+	case forma.ValueTypeDate, forma.ValueTypeDateTime:
+		return castDateMainValue(col, meta)
 	case forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeNumeric:
 		return fmt.Sprintf("TRY_CAST(%s AS %s)", col, duckTypeForValue(meta.ValueType))
 	case forma.ValueTypeUUID:
@@ -380,6 +371,26 @@ func castMainValue(col string, meta forma.AttributeMetadata) string {
 	default:
 		return fmt.Sprintf("CAST(%s AS VARCHAR)", col)
 	}
+}
+
+// castDateMainValue normalizes a date/datetime main column to epoch-ms BIGINT
+// regardless of its declared storage encoding, so the federated reader's
+// CAST(attr AS BIGINT) projection and epoch-ms BIGINT predicate binds (#200)
+// receive a consistent value on every tier (#219). The two storable shapes:
+//   - iso8601: an RFC3339 string in a text column -> parse to TIMESTAMP, then
+//     epoch_ms() yields BIGINT milliseconds.
+//   - unix_ms / default: epoch millis already in a bigint column -> pass
+//     through as BIGINT.
+//
+// Before #219 the non-unix_ms branch exported a native DATE/TIMESTAMP column,
+// which the reader's CAST(... AS BIGINT) reinterpreted as days- or
+// microseconds-since-epoch — silently off from the epoch-ms convention by a
+// factor of 10^3-10^8 on the warm/cold tiers.
+func castDateMainValue(col string, meta forma.AttributeMetadata) string {
+	if meta.ColumnBinding != nil && meta.ColumnBinding.Encoding == forma.MainColumnEncodingISO8601 {
+		return fmt.Sprintf("epoch_ms(TRY_CAST(%s AS TIMESTAMP))", col)
+	}
+	return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", col)
 }
 
 // castEAVValue projects an eav_data value into the parquet column for its

--- a/internal/cdc/export_sql_shared_test.go
+++ b/internal/cdc/export_sql_shared_test.go
@@ -328,40 +328,63 @@ func TestBuildSchemaDrivenProjection_BoundUnixMsDateAndDatetimeExportEpochMsBigi
 	}, projection.mainProjections)
 }
 
+// TestCastMainValue_DateAndDatetimeEncodings pins the #219 normalization: every
+// date/datetime encoding must export epoch-ms BIGINT so the federated reader's
+// CAST(attr AS BIGINT) projection and epoch-ms predicate binds line up on every
+// tier. iso8601 (RFC3339 text) is parsed to a TIMESTAMP then to epoch millis;
+// unix_ms and default (epoch millis already in a bigint column) pass through.
 func TestCastMainValue_DateAndDatetimeEncodings(t *testing.T) {
 	unixMs := &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02, Encoding: forma.MainColumnEncodingUnixMs}
-	unbound := &forma.MainColumnBinding{ColumnName: forma.MainColumnText01}
+	iso := &forma.MainColumnBinding{ColumnName: forma.MainColumnText02, Encoding: forma.MainColumnEncodingISO8601}
+	defaultBigint := &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02}
 
 	tests := []struct {
 		name     string
 		meta     forma.AttributeMetadata
+		col      string
 		expected string
 	}{
 		{
 			name:     "date unix_ms stays epoch-ms bigint",
 			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDate, ColumnBinding: unixMs},
+			col:      "m.bigint_02",
 			expected: "TRY_CAST(m.bigint_02 AS BIGINT)",
 		},
 		{
 			name:     "datetime unix_ms stays epoch-ms bigint",
 			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime, ColumnBinding: unixMs},
+			col:      "m.bigint_02",
 			expected: "TRY_CAST(m.bigint_02 AS BIGINT)",
 		},
 		{
-			name:     "date default encoding keeps native cast",
-			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDate, ColumnBinding: unbound},
-			expected: "TRY_CAST(m.bigint_02 AS DATE)",
+			name:     "date iso8601 parses text to epoch-ms bigint",
+			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDate, ColumnBinding: iso},
+			col:      "m.text_02",
+			expected: "epoch_ms(TRY_CAST(m.text_02 AS TIMESTAMP))",
 		},
 		{
-			name:     "datetime default encoding keeps native cast",
-			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime, ColumnBinding: unbound},
-			expected: "TRY_CAST(m.bigint_02 AS TIMESTAMP)",
+			name:     "datetime iso8601 parses text to epoch-ms bigint",
+			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime, ColumnBinding: iso},
+			col:      "m.text_02",
+			expected: "epoch_ms(TRY_CAST(m.text_02 AS TIMESTAMP))",
+		},
+		{
+			name:     "date default encoding (epoch-ms bigint) passes through",
+			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDate, ColumnBinding: defaultBigint},
+			col:      "m.bigint_02",
+			expected: "TRY_CAST(m.bigint_02 AS BIGINT)",
+		},
+		{
+			name:     "datetime default encoding (epoch-ms bigint) passes through",
+			meta:     forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime, ColumnBinding: defaultBigint},
+			col:      "m.bigint_02",
+			expected: "TRY_CAST(m.bigint_02 AS BIGINT)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, castMainValue("m.bigint_02", tt.meta))
+			require.Equal(t, tt.expected, castMainValue(tt.col, tt.meta))
 		})
 	}
 }


### PR DESCRIPTION
Closes #219. Refs #200, #194, #173.

## Direction changed after review: normalize, don't reject

The first cut rejected non-unix_ms date main-column bindings at registration. Review surfaced that this would also forbid **iso8601 date columns on the Postgres/OLTP path**, which are a legitimately-supported, tested capability (`parseDateValue` → RFC3339 text; `TestHybrid_DateTimeISO8601Encoding`). After tracing the corruption mechanism, the adjudicated direction is to **normalize the export** so the OLTP capability is preserved *and* the federated path serves it correctly.

## The corruption mechanism

An iso8601 datetime is stored as an RFC3339 **text** string (`transform.storeInMainColumn`). On the OLTP read path this is compared text-to-text — correct. But:

1. **CDC flush** (`castMainValue`): only `unix_ms` emitted epoch-ms `BIGINT`; iso8601/default fell to `TRY_CAST(col AS DATE/TIMESTAMP)` → a native DATE/TIMESTAMP parquet column.
2. **Federated read** (`duckDBAttrCast`): projects every date attr as `CAST(attr AS BIGINT)` → `CAST(DATE AS BIGINT)` = days-since-epoch, `CAST(TIMESTAMP AS BIGINT)` = micros-since-epoch.
3. **Predicate bind** (`ToDuckDBParam`, #200): epoch-**ms** int64.

So on the warm/cold tiers an iso8601 date came back off by 10³–10⁸× from the epoch-ms the filter compared against — silent wrong rows, no error. And since **CDC flushes every schema**, this hit any iso8601 (or default) date column once flushed, regardless of query routing.

## Fix

`castDateMainValue` normalizes every date/datetime encoding to epoch-ms `BIGINT`:
- **iso8601** (RFC3339 text): `epoch_ms(TRY_CAST(col AS TIMESTAMP))`
- **unix_ms / default** (epoch millis in a bigint column): `TRY_CAST(col AS BIGINT)`

The reader is unchanged — it now receives a consistent epoch-ms BIGINT from all encodings on every tier. No registration rejection; the OLTP iso8601 path and its tests are untouched.

## Tests

- `TestCastMainValue_DateAndDatetimeEncodings` extended: iso8601 and default now assert epoch-ms output (old expectations pinned the buggy native casts).
- **New `TestCastDateMainValue_ExecutesToEpochMs`** runs the emitted expressions against a real in-process DuckDB: iso8601 text `'2024-01-02T03:04:05Z'`, unix_ms bigint, and default bigint all evaluate to `1704164645000` and read back unchanged through `CAST(attr AS BIGINT)`.

## Verification

- `make test` — 26 packages ok, zero FAIL. `make lint` clean (pinned v1.64.8), `gofmt` clean.
- `go test -tags=e2e -short ./internal/e2e_harness/federated/...` green (116s + 50s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)