### PR TITLE
fix(sqlgen): #222 retire the toy-schema projection defaults in injectDuckDBTemplateParams

### DIFF
--- a/internal/federated/dotted_attrs_read_test.go
+++ b/internal/federated/dotted_attrs_read_test.go
@@ -147,3 +147,23 @@ func TestInjectSchemaProjectionsPropagatesCollision(t *testing.T) {
 	// propagated error must leave them untouched.
 	require.NotContains(t, sqlParams, "S3SourceSelect")
 }
+
+// TestApplySchemaProjection_NilProjectionFails pins the nil-projection guard
+// (#222/#280 review): a nil projection with no error must be refused, never
+// treated as success. The real schemaProjection seam never yields sp==nil
+// without an error, so the guard is exercised directly.
+func TestApplySchemaProjection_NilProjectionFails(t *testing.T) {
+	sqlParams := map[string]any{}
+	err := applySchemaProjection(sqlParams, 42, nil, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "42")
+	require.NotContains(t, sqlParams, "S3SourceSelect", "a refused projection must leave params unset")
+
+	// A non-nil projErr is still wrapped with schema context.
+	perr := applySchemaProjection(sqlParams, 42, nil, errTestProjection)
+	require.ErrorIs(t, perr, errTestProjection)
+	require.ErrorContains(t, perr, "42")
+	require.NotContains(t, sqlParams, "S3SourceSelect")
+}
+
+var errTestProjection = fmt.Errorf("boom")

--- a/internal/federated/duckdb_federated_integration_test.go
+++ b/internal/federated/duckdb_federated_integration_test.go
@@ -128,6 +128,24 @@ func TestBuildDuckDBQuery_AdvancedTemplate(t *testing.T) {
 		"Offset":               0,
 		"PageSize":             20,
 	}
+	// The advanced template refuses to render without schema projection params
+	// (#222 retired the toy defaults); derive them like injectSchemaProjections
+	// does, from the same fixture shape design_doc_sql_test.go pins.
+	sp, err := sqlgen.BuildSchemaProjection(1, forma.SchemaAttributeCache{
+		"name": {AttributeID: 1, ValueType: forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_01")}},
+		"age": {AttributeID: 2, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("integer_01")}},
+		"tag": {AttributeID: 205, ValueType: forma.ValueTypeText},
+	})
+	require.NoError(t, err)
+	params["S3SourceSelect"] = sp.S3SourceSelect
+	params["PGSourceSelect"] = sp.PGSourceSelect
+	params["PGGroupBy"] = sp.PGGroupBy
+	params["EAVPivotSelect"] = sp.EAVPivotSelect
+	params["EAVPivotAttrs"] = sp.EAVPivotAttrs
+	params["HasEAVPivot"] = sp.EAVPivotAttrs != ""
+	params["OuterSelect"] = sp.OuterSelect
 	sql, args, err := sqlgen.BuildDuckDBQuery(tmpl, params, q, []uuid.UUID{}, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, sql)

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -252,15 +252,24 @@ func (e *DBFederatedQueryEngine) injectSchemaProjections(sqlParams map[string]an
 
 	// Production schema: compute projections from the attribute cache
 	sp, hit, projErr := e.schemaProjection(schemaID, cache)
+	return hit, applySchemaProjection(sqlParams, schemaID, sp, projErr)
+}
+
+// applySchemaProjection writes the seven schema-projection params into sqlParams
+// from a computed projection, or refuses. Both a non-nil projErr and a nil
+// projection are hard failures: with the toy-schema defaults retired (#222)
+// there is nothing to fall through to, so an advanced-template render must fail
+// fast rather than emit unset projection params. Extracted so the nil-guard is
+// unit-testable (the real schemaProjection seam never yields sp==nil without an
+// error).
+func applySchemaProjection(sqlParams map[string]any, schemaID int16, sp *sqlgen.SchemaProjection, projErr error) error {
 	if projErr != nil {
 		// A non-nil projection error is a hard data-contract failure (e.g. the
-		// alias-collision guard in BuildSchemaProjection). Propagate it so the
-		// query fails fast instead of silently falling through to the retired
-		// toy-schema projection defaults (#222/#260).
-		return hit, fmt.Errorf("build schema projection for schema %d: %w", schemaID, projErr)
+		// alias-collision guard in BuildSchemaProjection). Propagate it.
+		return fmt.Errorf("build schema projection for schema %d: %w", schemaID, projErr)
 	}
 	if sp == nil {
-		return hit, nil
+		return fmt.Errorf("schema projection for schema %d is nil with no error; refusing to render with an undefined projection", schemaID)
 	}
 	sqlParams["S3SourceSelect"] = sp.S3SourceSelect
 	sqlParams["PGSourceSelect"] = sp.PGSourceSelect
@@ -269,7 +278,7 @@ func (e *DBFederatedQueryEngine) injectSchemaProjections(sqlParams map[string]an
 	sqlParams["EAVPivotAttrs"] = sp.EAVPivotAttrs
 	sqlParams["HasEAVPivot"] = len(sp.EAVPivotAttrs) > 0
 	sqlParams["OuterSelect"] = sp.OuterSelect
-	return hit, nil
+	return nil
 }
 
 func duckDBPostgresScanLocation(name string) (string, string) {

--- a/internal/health_and_renderer_test.go
+++ b/internal/health_and_renderer_test.go
@@ -110,6 +110,23 @@ func TestBuildDuckDBQuery_AdvancedTemplateUsesConfiguredTableNames(t *testing.T)
 		"EAVScanTable":       "eav_data",
 		"Anchor":             map[string]any{},
 	}
+	// The advanced template refuses to render without schema projection params
+	// (#222 retired the toy defaults); derive them like the engine's
+	// injectSchemaProjections does. The EAV attribute keeps the eav_data pivot
+	// scan in the rendered SQL, which this test asserts on.
+	sp, err := sqlgen.BuildSchemaProjection(42, forma.SchemaAttributeCache{
+		"name": {AttributeID: 1, ValueType: forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_01")}},
+		"tag": {AttributeID: 205, ValueType: forma.ValueTypeText},
+	})
+	require.NoError(t, err)
+	params["S3SourceSelect"] = sp.S3SourceSelect
+	params["PGSourceSelect"] = sp.PGSourceSelect
+	params["PGGroupBy"] = sp.PGGroupBy
+	params["EAVPivotSelect"] = sp.EAVPivotSelect
+	params["EAVPivotAttrs"] = sp.EAVPivotAttrs
+	params["HasEAVPivot"] = sp.EAVPivotAttrs != ""
+	params["OuterSelect"] = sp.OuterSelect
 
 	sql, _, err := sqlgen.BuildDuckDBQuery(sqlgen.AdvancedQueryTemplateDuckDB, params, q, nil, dual)
 	require.NoError(t, err)

--- a/internal/sqlgen/duckdb_compiled_query.go
+++ b/internal/sqlgen/duckdb_compiled_query.go
@@ -1,6 +1,7 @@
 package sqlgen
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -69,7 +70,7 @@ func CompileDuckDBQuery(tpl *template.Template, params map[string]any, q *model.
 
 	injectDuckDBTemplateParams(m, q, dual)
 	if err := requireProjectionParams(m); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("compile DuckDB query: %w", err)
 	}
 	// Compile-time keyset arg values are discarded; Bind re-derives them from
 	// the request cursor.

--- a/internal/sqlgen/duckdb_compiled_query.go
+++ b/internal/sqlgen/duckdb_compiled_query.go
@@ -68,6 +68,9 @@ func CompileDuckDBQuery(tpl *template.Template, params map[string]any, q *model.
 	m["HasHot"] = hasHot
 
 	injectDuckDBTemplateParams(m, q, dual)
+	if err := requireProjectionParams(m); err != nil {
+		return nil, err
+	}
 	// Compile-time keyset arg values are discarded; Bind re-derives them from
 	// the request cursor.
 	delete(m, "KEYSET_ARGS")

--- a/internal/sqlgen/duckdb_compiled_query_test.go
+++ b/internal/sqlgen/duckdb_compiled_query_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func compiledParityParams() map[string]any {
-	return map[string]any{
+func compiledParityParams(t *testing.T) map[string]any {
+	t.Helper()
+	return withTestProjection(t, map[string]any{
 		"EAVTable":       "eav_t",
 		"MainTable":      "main_t",
 		"ChangeLogTable": "cl_t",
@@ -20,7 +21,7 @@ func compiledParityParams() map[string]any {
 		"Limit":          25,
 		"Offset":         0,
 		"PageSize":       25,
-	}
+	}, 7)
 }
 
 // requireCompiledParity is the #142 phase-5 contract: Compile+Bind must
@@ -29,10 +30,10 @@ func compiledParityParams() map[string]any {
 func requireCompiledParity(t *testing.T, q *model.FederatedAttributeQuery, dual DualClauses, dirtyIDs []uuid.UUID) {
 	t.Helper()
 
-	wantSQL, wantArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), q, dirtyIDs, &dual)
+	wantSQL, wantArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), q, dirtyIDs, &dual)
 	require.NoError(t, err)
 
-	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), q, &dual, len(dirtyIDs) > 0)
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), q, &dual, len(dirtyIDs) > 0)
 	require.NoError(t, err)
 	require.NotNil(t, compiled)
 
@@ -105,7 +106,7 @@ func TestCompiledQueryColdOnlyParityOmitsPgSource(t *testing.T) {
 	require.NotEmpty(t, dual.PgMainArgs,
 		"precondition: the shape must carry pushdown args for the drop to be observable")
 
-	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), q, &dual, false)
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), q, &dual, false)
 	require.NoError(t, err)
 	require.NotNil(t, compiled)
 
@@ -134,7 +135,7 @@ func TestCompiledQueryReuseAcrossRequests(t *testing.T) {
 	dirtyB := []uuid.UUID{uuid.New()}
 
 	dualA := parityDual(t, qA.Condition, cache)
-	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), qA, &dualA, true)
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), qA, &dualA, true)
 	require.NoError(t, err)
 
 	// Bind request B through the plan compiled from request A's shape.
@@ -144,7 +145,7 @@ func TestCompiledQueryReuseAcrossRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	gotSQL, gotArgs := compiled.Bind(qB, dualB, dirtyB)
-	wantSQL, wantArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), qB, dirtyB, &dualB)
+	wantSQL, wantArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), qB, dirtyB, &dualB)
 	require.NoError(t, err)
 	require.Equal(t, wantSQL, gotSQL, "request B served from request A's skeleton must equal the direct build")
 	require.Equal(t, wantArgs, gotArgs)
@@ -154,13 +155,13 @@ func TestCompiledQueryReuseAcrossRequests(t *testing.T) {
 func TestCompileDuckDBQueryRejectsNonCacheablePaths(t *testing.T) {
 	q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7}}
 	empty := DualClauses{}
-	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), q, &empty, false)
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), q, &empty, false)
 	require.NoError(t, err)
 	require.Nil(t, compiled, "empty dual clause is not cacheable")
 
 	dual := DualClauses{DuckClause: "1=1"}
 	generic := template.Must(template.New("generic").Parse("SELECT 1 WHERE {{.Anchor.Condition}}"))
-	compiled, err = CompileDuckDBQuery(generic, compiledParityParams(), q, &dual, false)
+	compiled, err = CompileDuckDBQuery(generic, compiledParityParams(t), q, &dual, false)
 	require.NoError(t, err)
 	require.Nil(t, compiled, "non-advanced templates are not cacheable")
 }

--- a/internal/sqlgen/duckdb_compiled_query_test.go
+++ b/internal/sqlgen/duckdb_compiled_query_test.go
@@ -12,7 +12,7 @@ import (
 
 func compiledParityParams(t *testing.T) map[string]any {
 	t.Helper()
-	return withTestProjection(t, map[string]any{
+	return injectTestProjection(t, map[string]any{
 		"EAVTable":       "eav_t",
 		"MainTable":      "main_t",
 		"ChangeLogTable": "cl_t",

--- a/internal/sqlgen/duckdb_mixed_placeholder_regression_test.go
+++ b/internal/sqlgen/duckdb_mixed_placeholder_regression_test.go
@@ -33,7 +33,7 @@ func TestDuckDBMixedComposite_NoPlaceholderStyleMixing(t *testing.T) {
 	require.NotEmpty(t, dual.PgMainClause, "expected a main-column pushdown clause")
 	require.NotEmpty(t, dual.DuckClause, "expected a DuckDB logical clause")
 
-	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), q, nil, &dual)
+	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), q, nil, &dual)
 	require.NoError(t, err)
 
 	// Core guard: no "$n" numbered placeholders anywhere in the DuckDB statement.
@@ -75,7 +75,7 @@ func TestDuckDBMixedComposite_KeysetNoPlaceholderStyleMixing(t *testing.T) {
 	require.NotEmpty(t, dual.PgMainClause)
 	require.NotEmpty(t, dual.DuckClause)
 
-	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(), q, nil, &dual)
+	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), q, nil, &dual)
 	require.NoError(t, err)
 
 	require.NotContains(t, sql, "$", "keyset clause must obey the single-style invariant (#161/#212)")

--- a/internal/sqlgen/duckdb_namespace_render_test.go
+++ b/internal/sqlgen/duckdb_namespace_render_test.go
@@ -14,18 +14,7 @@ import (
 // the actual attribute-aliased CTE columns (`... AS age`, `... AS tag`).
 func nonBenchmarkNamespaceParams(t *testing.T, cache forma.SchemaAttributeCache) map[string]any {
 	t.Helper()
-	sp, err := BuildSchemaProjection(7, cache)
-	require.NoError(t, err)
-
-	p := compiledParityParams()
-	p["S3SourceSelect"] = sp.S3SourceSelect
-	p["PGSourceSelect"] = sp.PGSourceSelect
-	p["PGGroupBy"] = sp.PGGroupBy
-	p["EAVPivotSelect"] = sp.EAVPivotSelect
-	p["EAVPivotAttrs"] = sp.EAVPivotAttrs
-	p["HasEAVPivot"] = sp.EAVPivotAttrs != ""
-	p["OuterSelect"] = sp.OuterSelect
-	return p
+	return applyProjectionParams(t, compiledParityParams(t), 7, cache)
 }
 
 // TestDuckDBNamespace_RenderPaths_AttributeAliasedClause is the #167 render-path

--- a/internal/sqlgen/duckdb_query_edge_cases_test.go
+++ b/internal/sqlgen/duckdb_query_edge_cases_test.go
@@ -487,7 +487,7 @@ func TestBuildDuckDBQuery_NonKeysetSort_RespectsAttributeOrders(t *testing.T) {
 		DuckArgs:   nil,
 	}
 
-	params := map[string]any{}
+	params := withTestProjection(t, map[string]any{}, 1)
 	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
 	require.NoError(t, err)
 
@@ -514,7 +514,7 @@ func TestBuildDuckDBQuery_NonKeysetSort_FallbackWhenNoOrders(t *testing.T) {
 		DuckArgs:   nil,
 	}
 
-	params := map[string]any{}
+	params := withTestProjection(t, map[string]any{}, 1)
 	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
 	require.NoError(t, err)
 

--- a/internal/sqlgen/duckdb_query_edge_cases_test.go
+++ b/internal/sqlgen/duckdb_query_edge_cases_test.go
@@ -487,7 +487,7 @@ func TestBuildDuckDBQuery_NonKeysetSort_RespectsAttributeOrders(t *testing.T) {
 		DuckArgs:   nil,
 	}
 
-	params := withTestProjection(t, map[string]any{}, 1)
+	params := injectTestProjection(t, map[string]any{}, 1)
 	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
 	require.NoError(t, err)
 
@@ -514,7 +514,7 @@ func TestBuildDuckDBQuery_NonKeysetSort_FallbackWhenNoOrders(t *testing.T) {
 		DuckArgs:   nil,
 	}
 
-	params := withTestProjection(t, map[string]any{}, 1)
+	params := injectTestProjection(t, map[string]any{}, 1)
 	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
 	require.NoError(t, err)
 

--- a/internal/sqlgen/duckdb_render_and_dirtyids_test.go
+++ b/internal/sqlgen/duckdb_render_and_dirtyids_test.go
@@ -22,7 +22,7 @@ func TestAdvancedTemplate_NoResourcePragmas(t *testing.T) {
 	}
 	dual := &DualClauses{DuckClause: "1=1"}
 
-	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, nil, dual)
+	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, withTestProjection(t, map[string]any{}, 1), q, nil, dual)
 	require.NoError(t, err)
 	require.NotContains(t, sql, "PRAGMA")
 }
@@ -108,7 +108,7 @@ func TestBuildDuckDBQuery_KeysetArgsBindLast(t *testing.T) {
 		DuckArgs:   []any{int64(25), "Alice"},
 	}
 
-	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, nil, dual)
+	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, withTestProjection(t, map[string]any{}, 1), q, nil, dual)
 	require.NoError(t, err)
 
 	// [DuckArgs(2), PgMainArgs(0), DuckArgs(2), keyset(1)]

--- a/internal/sqlgen/duckdb_render_and_dirtyids_test.go
+++ b/internal/sqlgen/duckdb_render_and_dirtyids_test.go
@@ -22,7 +22,7 @@ func TestAdvancedTemplate_NoResourcePragmas(t *testing.T) {
 	}
 	dual := &DualClauses{DuckClause: "1=1"}
 
-	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, withTestProjection(t, map[string]any{}, 1), q, nil, dual)
+	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, injectTestProjection(t, map[string]any{}, 1), q, nil, dual)
 	require.NoError(t, err)
 	require.NotContains(t, sql, "PRAGMA")
 }
@@ -108,7 +108,7 @@ func TestBuildDuckDBQuery_KeysetArgsBindLast(t *testing.T) {
 		DuckArgs:   []any{int64(25), "Alice"},
 	}
 
-	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, withTestProjection(t, map[string]any{}, 1), q, nil, dual)
+	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, injectTestProjection(t, map[string]any{}, 1), q, nil, dual)
 	require.NoError(t, err)
 
 	// [DuckArgs(2), PgMainArgs(0), DuckArgs(2), keyset(1)]

--- a/internal/sqlgen/duckdb_scan_contract_test.go
+++ b/internal/sqlgen/duckdb_scan_contract_test.go
@@ -20,9 +20,10 @@ func TestAdvancedTemplate_PostgresScanContract(t *testing.T) {
 	}
 	dual := &DualClauses{DuckClause: "1=1"}
 	// Mirror the production params from buildDuckDBQueryWithPlan
-	// (internal/federated/duckdb_query.go); injectDuckDBTemplateParams fills
-	// the projection defaults, including HasEAVPivot = true.
-	params := map[string]any{
+	// (internal/federated/duckdb_query.go); the schema projection params come
+	// from the shared fixture (HasEAVPivot = true via the EAV tag attribute),
+	// mirroring the engine's injectSchemaProjections (#222).
+	params := withTestProjection(t, map[string]any{
 		"PG_CONN":              "dbname=forma host=localhost",
 		"ChangeLogSchema":      "public",
 		"ChangeLogScanTable":   "change_log",
@@ -32,7 +33,7 @@ func TestAdvancedTemplate_PostgresScanContract(t *testing.T) {
 		"EAVScanTable":         "eav_data_dev",
 		"S3_PATHS":             "['s3://bucket/base/*.parquet']",
 		"LOGICAL_WHERE_CLAUSE": "1=1",
-	}
+	}, 1)
 
 	sqlText, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
 	require.NoError(t, err)
@@ -72,7 +73,7 @@ func TestAdvancedTemplate_ColdOnlyOmitsPgSource(t *testing.T) {
 		DuckClause: "age > ?", DuckArgs: []any{int64(10)},
 		PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(10)},
 	}
-	params := map[string]any{
+	params := withTestProjection(t, map[string]any{
 		"PG_CONN":              "dbname=forma host=localhost",
 		"ChangeLogSchema":      "public",
 		"ChangeLogScanTable":   "change_log",
@@ -82,7 +83,7 @@ func TestAdvancedTemplate_ColdOnlyOmitsPgSource(t *testing.T) {
 		"EAVScanTable":         "eav_data_dev",
 		"S3_PATHS":             "['s3://bucket/base/*.parquet']",
 		"LOGICAL_WHERE_CLAUSE": "age > ?",
-	}
+	}, 1)
 
 	sqlText, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, nil, dual)
 	require.NoError(t, err)

--- a/internal/sqlgen/duckdb_scan_contract_test.go
+++ b/internal/sqlgen/duckdb_scan_contract_test.go
@@ -23,7 +23,7 @@ func TestAdvancedTemplate_PostgresScanContract(t *testing.T) {
 	// (internal/federated/duckdb_query.go); the schema projection params come
 	// from the shared fixture (HasEAVPivot = true via the EAV tag attribute),
 	// mirroring the engine's injectSchemaProjections (#222).
-	params := withTestProjection(t, map[string]any{
+	params := injectTestProjection(t, map[string]any{
 		"PG_CONN":              "dbname=forma host=localhost",
 		"ChangeLogSchema":      "public",
 		"ChangeLogScanTable":   "change_log",
@@ -73,7 +73,7 @@ func TestAdvancedTemplate_ColdOnlyOmitsPgSource(t *testing.T) {
 		DuckClause: "age > ?", DuckArgs: []any{int64(10)},
 		PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(10)},
 	}
-	params := withTestProjection(t, map[string]any{
+	params := injectTestProjection(t, map[string]any{
 		"PG_CONN":              "dbname=forma host=localhost",
 		"ChangeLogSchema":      "public",
 		"ChangeLogScanTable":   "change_log",

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -36,7 +36,6 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 	// Prepare where variables
 	var whereClause string
 	var whereArgs []any
-	var err error
 
 	// Ensure params is a map so we can inject Anchor.Condition, PgMainClause, and dirty helpers
 	m, ok := params.(map[string]any)
@@ -89,7 +88,7 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 		injectDuckDBTemplateParams(m, q, dual)
 		if isAdvancedTemplate {
 			if err := requireProjectionParams(m); err != nil {
-				return "", nil, err
+				return "", nil, fmt.Errorf("build DuckDB query: %w", err)
 			}
 		}
 		if !isAdvancedTemplate && len(dual.PgMainArgs) > 0 {
@@ -101,13 +100,18 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 		return RenderDuckDBQuery(tpl, merged, whereArgs)
 	}
 
-	// Legacy path (preserved for tests with dual=nil; production always uses dual path).
-	// A nil query must keep the old GenerateDuckDBWhereClause(nil) contract: "1=1".
+	return buildDuckDBQueryLegacy(tpl, m, anchor, q, dirtyIDs, isAdvancedTemplate)
+}
+
+// buildDuckDBQueryLegacy renders the dual==nil fallback path (preserved for
+// tests; production always takes the dual path). A nil query keeps the old
+// GenerateDuckDBWhereClause(nil) contract: "1=1".
+func buildDuckDBQueryLegacy(tpl *template.Template, m map[string]any, anchor map[string]any, q *model.FederatedAttributeQuery, dirtyIDs []uuid.UUID, isAdvancedTemplate bool) (string, []any, error) {
 	var fallbackCond forma.Condition
 	if q != nil {
 		fallbackCond = q.Condition
 	}
-	whereClause, whereArgs, err = buildDuckClause(fallbackCond, nil)
+	whereClause, whereArgs, err := buildDuckClause(fallbackCond, nil)
 	if err != nil {
 		return "", nil, err
 	}
@@ -127,7 +131,7 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 	injectDuckDBTemplateParams(m, q, nil)
 	if isAdvancedTemplate {
 		if err := requireProjectionParams(m); err != nil {
-			return "", nil, err
+			return "", nil, fmt.Errorf("build DuckDB query: %w", err)
 		}
 	}
 	whereArgs = appendKeysetArgs(m, whereArgs)

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -87,6 +87,11 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 			}
 		}
 		injectDuckDBTemplateParams(m, q, dual)
+		if isAdvancedTemplate {
+			if err := requireProjectionParams(m); err != nil {
+				return "", nil, err
+			}
+		}
 		if !isAdvancedTemplate && len(dual.PgMainArgs) > 0 {
 			whereArgs = append(whereArgs, dual.PgMainArgs...)
 		}
@@ -120,10 +125,49 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 		}
 	}
 	injectDuckDBTemplateParams(m, q, nil)
+	if isAdvancedTemplate {
+		if err := requireProjectionParams(m); err != nil {
+			return "", nil, err
+		}
+	}
 	whereArgs = appendKeysetArgs(m, whereArgs)
 
 	merged := MergeTemplateParamsWithDirtyIDs(m, dirtyIDs)
 	return RenderDuckDBQuery(tpl, merged, whereArgs)
+}
+
+// projectionParamKeys are the schema-derived projection params the advanced
+// template renders (sorted; keep sorted so the missing-param error is
+// deterministic). Production always sets all seven via the engine's
+// injectSchemaProjections — from BuildSchemaProjection (schema cache) or
+// BuildBenchmarkProjections (benchmark schemas). The renderer used to
+// substitute a retired toy-schema projection (name/age/tag, phantom ltbase_*
+// parquet aliases) for any missing key; that projection cannot be scanned by
+// duckDBScanBuffers under the #147 positional-scan contract, so a missing key
+// is now a hard error instead (#222).
+var projectionParamKeys = []string{
+	"EAVPivotAttrs",
+	"EAVPivotSelect",
+	"HasEAVPivot",
+	"OuterSelect",
+	"PGGroupBy",
+	"PGSourceSelect",
+	"S3SourceSelect",
+}
+
+// requireProjectionParams fails an advanced-template render whose params are
+// missing any schema-projection key, naming every absent key.
+func requireProjectionParams(params map[string]any) error {
+	var missing []string
+	for _, key := range projectionParamKeys {
+		if _, ok := params[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("advanced DuckDB template render is missing schema projection params [%s]; derive them via BuildSchemaProjection or BuildBenchmarkProjections — the toy-schema defaults were retired (#222)", strings.Join(missing, ", "))
 }
 
 func defaultIfEmpty(s, fallback string) string {
@@ -189,41 +233,6 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 		if paths, ok := params["DuckDBS3Paths"].([]string); ok && len(paths) > 0 {
 			params["S3_PATHS"] = formatDuckDBPathList(paths)
 		}
-	}
-
-	// Inject defaults for schema-driven projection parameters if not already set.
-	// These defaults match the pre-dynamic-template fixed schema layout.
-	if _, ok := params["S3SourceSelect"]; !ok {
-		params["S3SourceSelect"] = "row_id, ltbase_created_at AS created_at, ltbase_updated_at AS ver_ts, ltbase_deleted_at AS deleted_ts, name, age, tag"
-	}
-	if _, ok := params["PGSourceSelect"]; !ok {
-		params["PGSourceSelect"] = "m.ltbase_row_id AS row_id, m.ltbase_created_at AS created_at, cl.changed_at AS ver_ts, cl.deleted_at AS deleted_ts, CAST(m.text_01 AS VARCHAR) AS name, CAST(m.integer_01 AS INTEGER) AS age, MAX(CASE WHEN e.attr_id = 205 THEN CAST(e.value_text AS VARCHAR) END) AS tag"
-	}
-	if _, ok := params["PGGroupBy"]; !ok {
-		params["PGGroupBy"] = "m.ltbase_row_id, m.ltbase_created_at, cl.changed_at, cl.deleted_at, m.text_01, m.integer_01"
-	}
-	if _, ok := params["EAVPivotSelect"]; !ok {
-		params["EAVPivotSelect"] = "MAX(CASE WHEN attr_id = 205 THEN CAST(e.value_text AS VARCHAR) END) AS tag"
-	}
-	if _, ok := params["EAVPivotAttrs"]; !ok {
-		params["EAVPivotAttrs"] = "205"
-	}
-	if _, ok := params["HasEAVPivot"]; !ok {
-		params["HasEAVPivot"] = true
-	}
-	if _, ok := params["OuterSelect"]; !ok {
-		schemaID := int16(0)
-		if q != nil {
-			schemaID = q.SchemaID
-		}
-		params["OuterSelect"] = fmt.Sprintf(`%d::SMALLINT AS ltbase_schema_id,
-			CAST(row_id AS UUID) AS ltbase_row_id,
-			created_at AS ltbase_created_at,
-			ver_ts AS ltbase_updated_at,
-			deleted_ts AS ltbase_deleted_at,
-			name AS text_01,
-			age AS integer_01,
-			'[]'::TEXT AS attributes_json`, schemaID)
 	}
 
 	// Keyset pagination: inject cursor-derived WHERE clause and ORDER BY.

--- a/internal/sqlgen/keyset_placement_test.go
+++ b/internal/sqlgen/keyset_placement_test.go
@@ -24,7 +24,7 @@ func TestAdvancedTemplate_KeysetAppliedAfterDedup(t *testing.T) {
 	}
 	dual := &DualClauses{DuckClause: "1=1"}
 
-	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, withTestProjection(t, map[string]any{}, 1), q, nil, dual)
+	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, injectTestProjection(t, map[string]any{}, 1), q, nil, dual)
 	require.NoError(t, err)
 
 	rankedStart := strings.Index(sql, "ranked AS")

--- a/internal/sqlgen/keyset_placement_test.go
+++ b/internal/sqlgen/keyset_placement_test.go
@@ -24,7 +24,7 @@ func TestAdvancedTemplate_KeysetAppliedAfterDedup(t *testing.T) {
 	}
 	dual := &DualClauses{DuckClause: "1=1"}
 
-	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, nil, dual)
+	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, withTestProjection(t, map[string]any{}, 1), q, nil, dual)
 	require.NoError(t, err)
 
 	rankedStart := strings.Index(sql, "ranked AS")

--- a/internal/sqlgen/projection_params_test.go
+++ b/internal/sqlgen/projection_params_test.go
@@ -1,0 +1,95 @@
+package sqlgen
+
+import (
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// Shared projection fixtures for renderer/compiler tests (#222). The advanced
+// template refuses to render without the seven schema-projection params
+// (requireProjectionParams), so every test driving it must derive them from a
+// real BuildSchemaProjection call — never hand-written SQL, which is exactly
+// the drift the retired toy defaults caused.
+
+// testProjectionCache is the canonical name/age/tag fixture: a text main
+// column, an integer main column, and one EAV attribute (id 205) — the same
+// shape the design-doc §5 guard uses (internal/federated/design_doc_sql_test.go).
+func testProjectionCache() forma.SchemaAttributeCache {
+	return forma.SchemaAttributeCache{
+		"name": {AttributeID: 1, ValueType: forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_01")}},
+		"age": {AttributeID: 2, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("integer_01")}},
+		"tag": {AttributeID: 205, ValueType: forma.ValueTypeText},
+	}
+}
+
+// applyProjectionParams derives the seven projection params from the given
+// cache and copies them into params, returning it for chaining.
+func applyProjectionParams(t *testing.T, params map[string]any, schemaID int16, cache forma.SchemaAttributeCache) map[string]any {
+	t.Helper()
+	sp, err := BuildSchemaProjection(schemaID, cache)
+	require.NoError(t, err)
+	params["S3SourceSelect"] = sp.S3SourceSelect
+	params["PGSourceSelect"] = sp.PGSourceSelect
+	params["PGGroupBy"] = sp.PGGroupBy
+	params["EAVPivotSelect"] = sp.EAVPivotSelect
+	params["EAVPivotAttrs"] = sp.EAVPivotAttrs
+	params["HasEAVPivot"] = sp.EAVPivotAttrs != ""
+	params["OuterSelect"] = sp.OuterSelect
+	return params
+}
+
+// withTestProjection injects the canonical fixture projection into params.
+func withTestProjection(t *testing.T, params map[string]any, schemaID int16) map[string]any {
+	t.Helper()
+	return applyProjectionParams(t, params, schemaID, testProjectionCache())
+}
+
+// TestBuildDuckDBQuery_MissingProjectionParamsRejected pins the retirement of
+// the toy-schema defaults: an advanced-template render without the schema
+// projection params must fail naming every missing key — never silently
+// substitute a projection duckDBScanBuffers cannot scan.
+func TestBuildDuckDBQuery_MissingProjectionParamsRejected(t *testing.T) {
+	q := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10},
+	}
+	dual := &DualClauses{DuckClause: "1=1"}
+
+	_, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, nil, dual)
+	require.Error(t, err)
+	for _, key := range projectionParamKeys {
+		require.Contains(t, err.Error(), key)
+	}
+	require.Contains(t, err.Error(), "#222")
+
+	// One key present, six missing: only the absent keys are named.
+	_, _, err = BuildDuckDBQuery(AdvancedQueryTemplateDuckDB,
+		map[string]any{"S3SourceSelect": "row_id"}, q, nil, dual)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "[S3SourceSelect")
+	require.Contains(t, err.Error(), "OuterSelect")
+
+	// The legacy dual=nil path guards the advanced template the same way.
+	_, _, err = BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "S3SourceSelect")
+}
+
+// TestCompileDuckDBQuery_MissingProjectionParamsRejected mirrors the guard on
+// the compiled-plan entry point.
+func TestCompileDuckDBQuery_MissingProjectionParamsRejected(t *testing.T) {
+	q := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10},
+	}
+	dual := &DualClauses{DuckClause: "1=1"}
+
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, map[string]any{}, q, dual, false)
+	require.Error(t, err)
+	require.Nil(t, compiled)
+	require.Contains(t, err.Error(), "S3SourceSelect")
+}

--- a/internal/sqlgen/projection_params_test.go
+++ b/internal/sqlgen/projection_params_test.go
@@ -15,10 +15,10 @@ import (
 // real BuildSchemaProjection call — never hand-written SQL, which is exactly
 // the drift the retired toy defaults caused.
 
-// testProjectionCache is the canonical name/age/tag fixture: a text main
+// buildTestProjectionCache is the canonical name/age/tag fixture: a text main
 // column, an integer main column, and one EAV attribute (id 205) — the same
 // shape the design-doc §5 guard uses (internal/federated/design_doc_sql_test.go).
-func testProjectionCache() forma.SchemaAttributeCache {
+func buildTestProjectionCache() forma.SchemaAttributeCache {
 	return forma.SchemaAttributeCache{
 		"name": {AttributeID: 1, ValueType: forma.ValueTypeText,
 			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_01")}},
@@ -44,10 +44,10 @@ func applyProjectionParams(t *testing.T, params map[string]any, schemaID int16, 
 	return params
 }
 
-// withTestProjection injects the canonical fixture projection into params.
-func withTestProjection(t *testing.T, params map[string]any, schemaID int16) map[string]any {
+// injectTestProjection injects the canonical fixture projection into params.
+func injectTestProjection(t *testing.T, params map[string]any, schemaID int16) map[string]any {
 	t.Helper()
-	return applyProjectionParams(t, params, schemaID, testProjectionCache())
+	return applyProjectionParams(t, params, schemaID, buildTestProjectionCache())
 }
 
 // TestBuildDuckDBQuery_MissingProjectionParamsRejected pins the retirement of


### PR DESCRIPTION
Closes #222. Refs #214, #221, #260.

## Problem

`injectDuckDBTemplateParams` (`internal/sqlgen/duckdb_template_renderer.go`) substituted a retired toy-schema projection — `name/age/tag`, EAV attr 205, phantom `ltbase_created_at/updated_at/deleted_at` parquet aliases that don't exist in any CDC-produced parquet — for each of the seven schema-projection params a caller left unset. This was a second live copy of the exact fallback `injectSchemaProjections` (`internal/federated/duckdb_query.go`) already fails fast on: its column set can't be scanned by `duckDBScanBuffers` under the #147 positional-scan contract, so a missing param was "a hard error at best, misaligned rows at worst".

## Fix

Delete the seven defaults; add `requireProjectionParams` — an advanced-template render (`BuildDuckDBQuery` dual + legacy nil paths, and `CompileDuckDBQuery`) now fails fast naming every missing projection key. Production always sets all seven via the engine's `injectSchemaProjections` (`BuildSchemaProjection` for schema-cache queries, `BuildBenchmarkProjections` for benchmark schemas), so **no production path changes behavior** — the guard only bites callers that never had a valid projection.

### Issue item 3 already delivered by #260

The issue also asked that `injectSchemaProjections` propagate `projErr` instead of swallowing it. #260 (PR #273, `ec9add2`) already did this — `duckdb_query.go:253-272` propagates and hard-fails on an empty cache, pinned by `TestInjectSchemaProjectionsPropagatesCollision`. No further change there.

## Tests

The renderers now refuse an empty param map, so every test that drove the advanced template on the toy defaults derives real projection params from `BuildSchemaProjection`:

- New shared sqlgen helper `projection_params_test.go` (`testProjectionCache` / `applyProjectionParams` / `withTestProjection`); `compiledParityParams` now takes `t` and injects the fixture projection, which fixes the bulk of the sqlgen call sites in one place.
- `internal/health_and_renderer_test.go` and `internal/federated/duckdb_federated_integration_test.go` inline the same fixture (cross-package `_test` helpers aren't importable).
- New guard tests pin the missing-param rejection on both `BuildDuckDBQuery` and `CompileDuckDBQuery` (all keys named; partial-set names only the absent ones; legacy nil path guarded too).

## Acceptance (grep condition corrected)

The issue's original grep (`ltbase_updated_at\|ltbase_deleted_at` → no hits outside absence-asserting tests) was written before #221/#260 landed and is now stale. The real acceptance line: **`duckdb_template_renderer.go` has zero hits.** Remaining `internal/sqlgen` hits are all legitimate — the reserved-column set (`parquet_attr_column.go:60-61`) and the real runtime projections (`duckdb_schema_projection.go:270-271`, `duckdb_benchmark_projection.go:91-92`), which must stay.

## Verification

- `make test` — all 26 packages ok, zero FAIL. `make lint` clean (pinned v1.64.8).
- `go test -tags=e2e -short ./internal/e2e_harness/federated/...` green (render-path regression gate; 111s + 47s).
- `grep -n 'ltbase_updated_at\|ltbase_deleted_at' internal/sqlgen/duckdb_template_renderer.go` — no hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)