### PR TITLE
fix(sqlgen,transform): #205 bound bigint carries full int64 — typed EAV pivot + exact write-path sidecar

### DIFF
--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -400,7 +400,7 @@ func castDateMainValue(col string, meta forma.AttributeMetadata) string {
 // uuid live in value_text. The output types mirror the federated reader's
 // EAV pivot (sqlgen.BuildSchemaProjection): BOOLEAN for bool, epoch-ms
 // BIGINT for dates, native numeric types otherwise (#173).
-// 热端 pivot(sqlgen.eavPivotExpr)必须与本映射保持一致(#205)。
+// 热端 pivot(sqlgen.buildEAVPivotExpr)必须与本映射保持一致(#205)。
 func castEAVValue(meta forma.AttributeMetadata) string {
 	switch meta.ValueType {
 	case forma.ValueTypeBool:

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -400,6 +400,7 @@ func castDateMainValue(col string, meta forma.AttributeMetadata) string {
 // uuid live in value_text. The output types mirror the federated reader's
 // EAV pivot (sqlgen.BuildSchemaProjection): BOOLEAN for bool, epoch-ms
 // BIGINT for dates, native numeric types otherwise (#173).
+// 热端 pivot(sqlgen.eavPivotExpr)必须与本映射保持一致(#205)。
 func castEAVValue(meta forma.AttributeMetadata) string {
 	switch meta.ValueType {
 	case forma.ValueTypeBool:

--- a/internal/e2e_harness/production/boundary_roundtrip_e2e_test.go
+++ b/internal/e2e_harness/production/boundary_roundtrip_e2e_test.go
@@ -5,7 +5,6 @@ package production
 import (
 	"context"
 	"math"
-	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -116,25 +115,14 @@ func TestBoundBigintMaxInt64WriteCorrupts(t *testing.T) {
 	}
 }
 
-// TestFederatedReadRejectsStoredMaxInt64 pins the federated crash on a stored
-// math.MaxInt64 (#205). A stored MaxInt64 is a legal Postgres BIGINT state an
-// external writer can produce, but the forma write path cannot produce it
-// portably (float64(MaxInt64) is out of int64 range and the conversion is
-// implementation-dependent per the Go spec), so it is injected with ExecSQL —
-// the harness's documented escape hatch — rather than written through the API.
-//
-// The corruption is NOT in storage: the direct hot read returns MaxInt64
-// exactly, proving Postgres holds it losslessly. It is the federated DuckDB
-// projection that fails, because duckdb_schema_projection unifies the hot leg
-// and the parquet main column with
-// COALESCE(ANY_VALUE(hot_vals.amount), m.bigint_01) into DOUBLE
-// (internal/sqlgen/duckdb_schema_projection.go:197-198), and casting DOUBLE
-// 2^63 back to INT64 overflows.
-//
-// When #205 fixes the projection to preserve int64 the federated read will
-// succeed and the guard below fails the test on purpose: flip it to assert the
-// exact round-trip and raise maxBoundBigint to math.MaxInt64.
-func TestFederatedReadRejectsStoredMaxInt64(t *testing.T) {
+// TestFederatedReadReturnsStoredMaxInt64 proves the #205 Hop-2 fix: a stored
+// math.MaxInt64 — a legal Postgres BIGINT state an external writer can produce,
+// injected via ExecSQL because the pre-#205 write path could not produce it
+// portably — now survives the federated DuckDB projection exactly. Pre-#205
+// the COALESCE(DOUBLE pivot, m.bigint_01) unification made CAST-back overflow
+// ("Conversion Error ... out of range for INT64") on every federated read of
+// the schema.
+func TestFederatedReadReturnsStoredMaxInt64(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
 	ctx := context.Background()
@@ -144,18 +132,16 @@ func TestFederatedReadRejectsStoredMaxInt64(t *testing.T) {
 	if err := env.ApplyEvents(ctx, ev); err != nil {
 		t.Fatalf("apply create: %v", err)
 	}
-
 	// Base file so the federated query routes to DuckDB; the row stays
-	// unflushed in change_log, so it is still served from the hot pg_source leg.
+	// unflushed in change_log, so it is served from the hot pg_source leg.
 	if _, err := env.RunInit(ctx, wide); err != nil {
 		t.Fatalf("run init: %v", err)
 	}
-	// Inject a legal-but-API-unreachable stored MaxInt64.
 	env.ExecSQL(ctx,
 		"UPDATE entity_main SET bigint_01 = $1 WHERE ltbase_schema_id = $2",
 		int64(math.MaxInt64), wide.ID)
 
-	// Direct path is exact: Postgres holds MaxInt64 losslessly.
+	// Direct hot path: storage holds MaxInt64 losslessly (unchanged pre/post fix).
 	hot, err := env.Query(ctx, Query{Schema: wide, PreferHot: true, Limit: 10})
 	if err != nil {
 		t.Fatalf("hot query: %v", err)
@@ -164,20 +150,23 @@ func TestFederatedReadRejectsStoredMaxInt64(t *testing.T) {
 		t.Fatal("hot query returned no records")
 	}
 	if got := hot.Records[0].Int64Items["bigint_01"]; got != math.MaxInt64 {
-		t.Fatalf("stored bound bigint via hot read = %d, want %d — storage must hold MaxInt64 exactly",
-			got, int64(math.MaxInt64))
+		t.Fatalf("stored bound bigint via hot read = %d, want %d", got, int64(math.MaxInt64))
 	}
 
-	// Federated path crashes: the DOUBLE 2^63 → INT64 cast overflows.
-	_, ferr := env.Query(ctx, Query{Schema: wide, Limit: 10})
-	if ferr == nil {
-		t.Fatalf("federated read of a stored MaxInt64 succeeded — #205 appears fixed; " +
-			"flip this test to assert the exact round-trip and raise maxBoundBigint to math.MaxInt64")
+	// Federated path: must succeed and be exact (#205).
+	fed, ferr := env.Query(ctx, Query{Schema: wide, Limit: 10})
+	if ferr != nil {
+		t.Fatalf("federated read of stored MaxInt64 must succeed post-#205: %v", ferr)
 	}
-	if !strings.Contains(ferr.Error(), "out of range") {
-		t.Fatalf("federated error = %q, want the DOUBLE→INT64 out-of-range cast failure (#205)", ferr.Error())
+	if !fed.Plan.Routing.UseDuckDB {
+		t.Errorf("federated query did not route to duckdb: %+v", fed.Plan.Routing)
 	}
-	t.Logf("OBSERVED federated read failure on stored MaxInt64: %v", ferr)
+	if len(fed.Records) == 0 {
+		t.Fatal("federated query returned no records")
+	}
+	if got := fed.Records[0].Int64Items["bigint_01"]; got != math.MaxInt64 {
+		t.Fatalf("federated bound bigint = %d, want %d (exact MaxInt64)", got, int64(math.MaxInt64))
+	}
 }
 
 const zeroUUID = "00000000-0000-0000-0000-000000000000"

--- a/internal/e2e_harness/production/boundary_roundtrip_e2e_test.go
+++ b/internal/e2e_harness/production/boundary_roundtrip_e2e_test.go
@@ -196,9 +196,10 @@ func buildBoundaryEvents(wide SchemaRef) (nullRow, zeroRow, maxRow, minRow *Even
 // TestNullAndBoundaryRoundTripAcrossTiers proves that NULL, empty-string,
 // zero, and extreme boundary values survive write → CDC export → parquet →
 // federated merge-on-read intact across all three tiers. Null+max land
-// cold-only, zero+min stay warm, and fresh null+max copies stay hot. The
-// physical layer reuses Task 4's per-file value assertion; the logical layer
-// adds float64-proof exact typed assertions the oracle cannot make.
+// cold-only, zero+min plus a fresh warm max stay warm, and fresh null+max
+// copies stay hot — so +MaxInt64 is proven on all three tiers. The physical
+// layer reuses Task 4's per-file value assertion; the logical layer adds
+// float64-proof exact typed assertions the oracle cannot make.
 func TestNullAndBoundaryRoundTripAcrossTiers(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
@@ -222,6 +223,15 @@ func TestNullAndBoundaryRoundTripAcrossTiers(t *testing.T) {
 	env.ExecSQL(ctx,
 		"DELETE FROM change_log WHERE schema_id = $1 AND row_id = ANY($2)",
 		wide.ID, rowIDs([]*Event{nullRow, maxRow}))
+
+	// Warm tier: a fresh max-shape row applied after init and flushed to
+	// delta, so +MaxInt64 is proven on warm too (PR #284 review, AC4) —
+	// the original maxRow is cold-only and hotMax stays hot.
+	_, _, warmMax, _ := buildBoundaryEvents(wide)
+	if err := env.ApplyEvents(ctx, warmMax); err != nil {
+		t.Fatalf("apply warm max boundary create: %v", err)
+	}
+
 	if _, err := env.RunFlush(ctx); err != nil {
 		t.Fatalf("flush: %v", err)
 	}
@@ -234,7 +244,7 @@ func TestNullAndBoundaryRoundTripAcrossTiers(t *testing.T) {
 
 	// Physical layer: reuse Task 4's per-file value assertion (NULL columns
 	// included), then the NULL-vs-zero distinction per boundary row.
-	truth := buildWideTruth(ctx, t, env, wide.ID, append(batch, hotNull, hotMax))
+	truth := buildWideTruth(ctx, t, env, wide.ID, append(batch, hotNull, hotMax, warmMax))
 	manifests, err := env.loadManifests(ctx)
 	if err != nil {
 		t.Fatalf("load manifests: %v", err)
@@ -252,7 +262,7 @@ func TestNullAndBoundaryRoundTripAcrossTiers(t *testing.T) {
 	if fed == nil {
 		return
 	}
-	assertBoundaryRecords(t, "federated", fed, nullRow, zeroRow, maxRow, minRow, hotNull, hotMax)
+	assertBoundaryRecords(t, "federated", fed, nullRow, zeroRow, maxRow, minRow, hotNull, hotMax, warmMax)
 }
 
 // assertBoundaryRecords asserts exact typed values that the oracle's float64

--- a/internal/e2e_harness/production/boundary_roundtrip_e2e_test.go
+++ b/internal/e2e_harness/production/boundary_roundtrip_e2e_test.go
@@ -13,36 +13,19 @@ import (
 
 // maxBoundBigint is the boundary asserted for the bound bigint column.
 //
-// FINDING (#174): math.MaxInt64 is NOT faithfully representable end to end,
-// even though bigint_01 is a true BIGINT at rest. The write path (forma
-// EntityManager) marshals numeric payloads through float64 — exactly as any
-// production JSON API does — so a bound bigint cannot carry every int64:
-//
-//   - +math.MaxInt64 (2^63-1) marshals to float64 2^63, which SATURATES back
-//     to MaxInt64 on the way into the Postgres int8 column: a false positive
-//     that hides the precision loss (the naive probe below would have passed).
-//   - -math.MaxInt64 marshals to float64 -2^63 and lands as math.MinInt64, an
-//     off-by-one that DOES surface; and a stored MaxInt64 even breaks the
-//     federated DuckDB read (CAST of DOUBLE 2^63 → INT64 overflows).
-//
-// The largest power of two below 2^63 — 2^62 — is exactly representable in
-// float64 and round-trips faithfully through every tier, so it is the value
-// the boundary matrix asserts. This answers issue #174's "max int64" bullet:
-// the ceiling for a bound bigint under float64 marshaling is 2^62, not 2^63-1.
-//
-// Both failure modes are not merely documented here — they are pinned by
-// TestBoundBigintMaxInt64WriteCorrupts (the write-path off-by-one, deterministic
-// on every platform) and TestFederatedReadRejectsStoredMaxInt64 (the federated
-// DOUBLE→INT64 cast overflow). Both are #205 regression tripwires: when #205
-// lifts the float64 hop they must fail, and their doc comments say how to flip
-// them and raise maxBoundBigint to math.MaxInt64.
-var maxBoundBigint = int64(1) << 62
+// #205 lifted both float64 hops (write path: exact int64 sidecar through the
+// transform chain; read path: typed EAV pivot so the federated projection
+// keeps BIGINT through COALESCE/UNION unification), so a bound bigint now
+// carries the full int64 range end to end. Pre-#205 the empirical ceiling was
+// 1<<62 (the largest float64-exact power of two below 2^63) — see the #174
+// finding preserved in git history.
+var maxBoundBigint = int64(math.MaxInt64)
 
 // TestBoundBigintAcceptsInt64Probe pins the bigint contract described on
 // maxBoundBigint: the write path ACCEPTS an int64 payload without error, and
-// the chosen float64-exact boundary (2^62) round-trips through hot storage
-// intact. math.MaxInt64 is deliberately not asserted here — see the finding
-// above for why it is unrepresentable by design.
+// the boundary value round-trips through hot storage intact. Post-#205 the
+// contract is the full int64 range, so maxBoundBigint is math.MaxInt64 and the
+// assertion auto-tightens to it (the exact int64 sidecar carries every int64).
 func TestBoundBigintAcceptsInt64Probe(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
@@ -65,32 +48,22 @@ func TestBoundBigintAcceptsInt64Probe(t *testing.T) {
 	}
 	got, ok := hot.Records[0].Int64Items["bigint_01"]
 	if !ok || got != maxBoundBigint {
-		t.Fatalf("bound bigint stored %d (present=%t), want %d (2^62)", got, ok, maxBoundBigint)
+		t.Fatalf("bound bigint stored %d (present=%t), want %d (MaxInt64)", got, ok, maxBoundBigint)
 	}
 }
 
-// TestBoundBigintMaxInt64WriteCorrupts pins the float64 write-path hop (#205):
-// the forma EntityManager marshals numeric payloads through float64, so a bound
-// bigint payload of -math.MaxInt64 (-2^63+1) is silently corrupted on the way
-// into Postgres. Unlike +math.MaxInt64 — whose out-of-range float64→int64
-// conversion is implementation-dependent per the Go spec, so its stored value
-// is NOT portable and must not be asserted — this case is fully defined on
-// EVERY platform: float64(-math.MaxInt64) rounds to exactly -2^63, and
-// int64(-2^63) IS in range, so the conversion is deterministic. The stored
-// value is therefore always math.MinInt64: the caller wrote
-// -9223372036854775807 but storage holds -9223372036854775808.
-//
-// When #205 fixes the write path (numeric payloads no longer routed through
-// float64) this test MUST fail — got will equal -math.MaxInt64 — at which point
-// flip the assertion to want == int64(-math.MaxInt64).
-func TestBoundBigintMaxInt64WriteCorrupts(t *testing.T) {
+// TestBoundBigintPreservesNegMaxInt64 pins the #205 Hop-1 fix: pre-#205 the
+// float64 write hop deterministically corrupted a -math.MaxInt64 payload to
+// math.MinInt64 (float64(-MaxInt64) rounds to -2^63). Post-#205 the exact
+// int64 sidecar must deliver the caller's value unchanged.
+func TestBoundBigintPreservesNegMaxInt64(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
 	ctx := context.Background()
 	wide := DefaultSchemaFixtures()[1]
 
 	ev := CreateEvent(wide, map[string]any{
-		"title":  "bigint-min-corruption",
+		"title":  "bigint-neg-max",
 		"amount": int64(-math.MaxInt64),
 	})
 	if err := env.ApplyEvents(ctx, ev); err != nil {
@@ -107,11 +80,9 @@ func TestBoundBigintMaxInt64WriteCorrupts(t *testing.T) {
 	if !ok {
 		t.Fatal("bound bigint absent from hot record")
 	}
-	// #205: caller wrote -math.MaxInt64, storage holds math.MinInt64 (the
-	// off-by-one the float64 write path introduces). Flip when #205 lands.
-	if got != math.MinInt64 {
-		t.Fatalf("bound bigint stored %d, want %d (math.MinInt64) — the -MaxInt64 write "+
-			"corrupted via the float64 hop; if got == -MaxInt64, #205 is fixed", got, int64(math.MinInt64))
+	if got != -math.MaxInt64 {
+		t.Fatalf("bound bigint stored %d, want %d — the write path must not round through float64 (#205)",
+			got, int64(-math.MaxInt64))
 	}
 }
 
@@ -175,6 +146,8 @@ const maxUUID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 // float64-exact EAV bigint bound: EAV values travel as float64 through the
 // Go model (transform.extractValueFromEAVRecord), so 2^53 is the largest
 // exactly-representable EAV integer. Bound bigints don't share this limit.
+// As of #205 a bound bigint carries the full int64 range, so it no longer
+// shares this 2^53 EAV ceiling.
 const maxEAVInt = float64(1 << 53)
 
 // preEpochJoinedMS is 1900-01-01T00:00:00Z in epoch milliseconds — the

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -79,7 +79,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	zap.S().Infow("create request received", "schema", schemaName)
 
 	var rawBody any
-	if err := readJSONBody(r, &rawBody); err != nil {
+	if err := readEntityJSONBody(r, &rawBody); err != nil {
 		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid json body: %v", err))
 		return
 	}
@@ -267,7 +267,7 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body map[string]any
-	if err := readJSONBody(r, &body); err != nil {
+	if err := readEntityJSONBody(r, &body); err != nil {
 		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid json body: %v", err))
 		return
 	}
@@ -617,6 +617,17 @@ func parseUUID(s string) (uuid.UUID, error) {
 func readJSONBody(r *http.Request, v any) error {
 	defer r.Body.Close()
 	return json.NewDecoder(r.Body).Decode(v)
+}
+
+// readEntityJSONBody decodes an entity data payload with json.Number for
+// numeric literals, so integer attribute values above 2^53 reach the
+// transform chain undamaged (#205). Non-entity payloads (row-id arrays,
+// typed query requests) keep readJSONBody's plain decoding.
+func readEntityJSONBody(r *http.Request, v any) error {
+	defer r.Body.Close()
+	dec := json.NewDecoder(r.Body)
+	dec.UseNumber()
+	return dec.Decode(v)
 }
 
 // parseCreateObjects parses create payloads that can be either a single object or an object array.

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,9 @@ type mockEntityManager struct {
 	batchCreateResult *forma.BatchResult
 	batchCreateErr    error
 	batchCreateReq    *forma.BatchOperation
+	updateResult      *forma.DataRecord
+	updateErr         error
+	updateReq         *forma.EntityOperation
 	crossSchemaResult *forma.QueryResult
 	crossSchemaErr    error
 	crossSchemaReq    *forma.CrossSchemaRequest
@@ -39,6 +43,10 @@ func (m *mockEntityManager) Get(ctx context.Context, req *forma.QueryRequest) (*
 }
 
 func (m *mockEntityManager) Update(ctx context.Context, req *forma.EntityOperation) (*forma.DataRecord, error) {
+	m.updateReq = req
+	if m.updateResult != nil || m.updateErr != nil {
+		return m.updateResult, m.updateErr
+	}
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -249,6 +257,60 @@ func TestHandleCreateRejectsNonObjectArrayElements(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+}
+
+// TestCreateAndUpdateDecodeEntityNumbersExactly guards #205: HTTP entity
+// bodies must decode integer literals with json.Number so values above 2^53
+// (including the full ±int64 range) reach the manager boundary undamaged,
+// rather than being pre-rounded through float64 by the default decoder.
+func TestCreateAndUpdateDecodeEntityNumbersExactly(t *testing.T) {
+	signs := []string{"9223372036854775807", "-9223372036854775807"}
+
+	for _, lit := range signs {
+		t.Run("create/"+lit, func(t *testing.T) {
+			manager := &mockEntityManager{batchCreateResult: &forma.BatchResult{}}
+			server := &Server{manager: manager}
+
+			body := fmt.Sprintf(`{"amount": %s}`, lit)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/visit", bytes.NewReader([]byte(body)))
+			rec := httptest.NewRecorder()
+			server.handleCreate(rec, req)
+
+			if manager.batchCreateReq == nil {
+				t.Fatalf("expected BatchCreate request to be captured")
+			}
+			if len(manager.batchCreateReq.Operations) != 1 {
+				t.Fatalf("expected 1 operation, got %d", len(manager.batchCreateReq.Operations))
+			}
+			got := manager.batchCreateReq.Operations[0].Data["amount"]
+			if want := json.Number(lit); got != want {
+				t.Fatalf("Data[amount] = %#v (%T), want %#v", got, got, want)
+			}
+		})
+
+		t.Run("update/"+lit, func(t *testing.T) {
+			manager := &mockEntityManager{updateResult: &forma.DataRecord{}}
+			server := &Server{manager: manager}
+
+			rowID := uuid.New()
+			body := fmt.Sprintf(`{"amount": %s}`, lit)
+			url := fmt.Sprintf("/api/v1/visit/%s", rowID.String())
+			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader([]byte(body)))
+			rec := httptest.NewRecorder()
+			server.handleUpdate(rec, req)
+
+			if manager.updateReq == nil {
+				t.Fatalf("expected Update request to be captured")
+			}
+			want := json.Number(lit)
+			if got := manager.updateReq.Data["amount"]; got != want {
+				t.Fatalf("Data[amount] = %#v (%T), want %#v", got, got, want)
+			}
+			if got := manager.updateReq.Updates["amount"]; got != want {
+				t.Fatalf("Updates[amount] = %#v (%T), want %#v", got, got, want)
+			}
+		})
 	}
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -32,6 +32,13 @@ type EAVRecord struct {
 	ArrayIndices string
 	ValueText    *string
 	ValueNumeric *float64
+	// ValueInt64 is an exact int64 sidecar for bigint and epoch-ms date
+	// values. It is in-memory only: eav_data persistence and the EAV read
+	// paths keep the float64 ValueNumeric contract (2^53 ceiling), while
+	// main-column routing (storeInMainColumn) and read-back prefer
+	// ValueInt64 so column-bound bigint/unix_ms values carry the full
+	// int64 range without a float64 hop (#205).
+	ValueInt64 *int64
 }
 
 // AttributeOrder specifies how to sort by a particular attribute.

--- a/internal/numutil/convert.go
+++ b/internal/numutil/convert.go
@@ -3,8 +3,42 @@ package numutil
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 )
+
+// Int64Exact extracts an exact int64 from value without a float64 hop.
+// It reports ok=false when the value is not integral, overflows int64, or
+// has a type it cannot losslessly interpret; callers then fall back to the
+// float64 path (which keeps today's semantics).
+func Int64Exact(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case int16:
+		return int64(v), true
+	case json.Number:
+		i, err := v.Int64()
+		return i, err == nil
+	case string:
+		i, err := strconv.ParseInt(v, 10, 64)
+		return i, err == nil
+	case float64:
+		// 只接受整值且在 int64 可表示区间内的 float64;此时 int64(v) 对
+		// 该 float64 值本身是精确转换。2^63 及以上(含 float64(MaxInt64))
+		// 越界,交回 float64 回退路径维持旧语义。
+		if v != math.Trunc(v) || v < -9223372036854775808.0 || v >= 9223372036854775808.0 {
+			return 0, false
+		}
+		return int64(v), true
+	default:
+		return 0, false
+	}
+}
 
 func ToFloat64(value any) (float64, bool) {
 	val, err := Float64(value)

--- a/internal/numutil/convert_test.go
+++ b/internal/numutil/convert_test.go
@@ -1,9 +1,12 @@
 package numutil
 
 import (
+	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTryParseNumber(t *testing.T) {
@@ -37,6 +40,38 @@ func TestTryParseNumber(t *testing.T) {
 				assert.Equal(t, exp, val)
 			default:
 				t.Fatalf("unsupported expected type %T", exp)
+			}
+		})
+	}
+}
+
+func TestInt64Exact(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want int64
+		ok   bool
+	}{
+		{"int64_max", int64(math.MaxInt64), math.MaxInt64, true},
+		{"int64_neg_max", int64(-math.MaxInt64), -math.MaxInt64, true},
+		{"int", int(7), 7, true},
+		{"int32", int32(-5), -5, true},
+		{"int16", int16(3), 3, true},
+		{"json_number_int", json.Number("9223372036854775807"), math.MaxInt64, true},
+		{"json_number_frac", json.Number("1.5"), 0, false},
+		{"string_int", "-9223372036854775807", -math.MaxInt64, true},
+		{"string_junk", "abc", 0, false},
+		{"float64_integral", float64(1 << 62), 1 << 62, true},
+		{"float64_frac", float64(1.5), 0, false},
+		{"float64_2_63", math.Ldexp(1, 63), 0, false}, // 2^63 越界 int64
+		{"nil", nil, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Int64Exact(tc.in)
+			require.Equal(t, tc.ok, ok)
+			if tc.ok {
+				require.Equal(t, tc.want, got)
 			}
 		})
 	}

--- a/internal/sqlgen/duckdb_bigint_pivot_test.go
+++ b/internal/sqlgen/duckdb_bigint_pivot_test.go
@@ -1,0 +1,93 @@
+package sqlgen
+
+import (
+	"database/sql"
+	"math"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildEAVPivotEmitsTypedCasts pins the #205 Hop-2 fix: the EAV pivot must
+// emit per-type TRY_CASTs mirroring the CDC export side (cdc.castEAVValue), so
+// COALESCE(pivot, m.<col>) and the UNION ALL with parquet legs type-unify to
+// the attribute's native type instead of DOUBLE.
+func TestBuildEAVPivotEmitsTypedCasts(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"amount": {AttributeID: 5, ValueType: forma.ValueTypeBigInt,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint01}},
+		"joined": {AttributeID: 6, ValueType: forma.ValueTypeDateTime,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnBigint02, Encoding: forma.MainColumnEncodingUnixMs}},
+		"total": {AttributeID: 15, ValueType: forma.ValueTypeBigInt},
+		"qty":   {AttributeID: 16, ValueType: forma.ValueTypeInteger},
+		"level": {AttributeID: 17, ValueType: forma.ValueTypeSmallInt},
+		"ratio": {AttributeID: 18, ValueType: forma.ValueTypeNumeric},
+	}
+	sp, err := BuildSchemaProjection(7, cache)
+	require.NoError(t, err)
+
+	// bigint / date pivot 出 BIGINT;integer/smallint 出各自原生类型
+	require.Contains(t, sp.EAVPivotSelect,
+		"TRY_CAST(MAX(CASE WHEN attr_id = 5 THEN value_numeric END) AS BIGINT) AS amount")
+	require.Contains(t, sp.EAVPivotSelect,
+		"TRY_CAST(MAX(CASE WHEN attr_id = 6 THEN value_numeric END) AS BIGINT) AS joined")
+	require.Contains(t, sp.EAVPivotSelect,
+		"TRY_CAST(MAX(CASE WHEN attr_id = 15 THEN value_numeric END) AS BIGINT) AS total")
+	require.Contains(t, sp.EAVPivotSelect,
+		"TRY_CAST(MAX(CASE WHEN attr_id = 16 THEN value_numeric END) AS INTEGER) AS qty")
+	require.Contains(t, sp.EAVPivotSelect,
+		"TRY_CAST(MAX(CASE WHEN attr_id = 17 THEN value_numeric END) AS SMALLINT) AS level")
+	// numeric 保持 DOUBLE 语义:不 cast
+	require.Contains(t, sp.EAVPivotSelect,
+		"MAX(CASE WHEN attr_id = 18 THEN value_numeric END) AS ratio")
+	require.NotContains(t, sp.EAVPivotSelect, "attr_id = 18 THEN value_numeric END) AS ratio)")
+
+	// COALESCE 形态本身不变(修复靠 pivot 侧类型)
+	require.True(t, strings.Contains(sp.PGSourceSelect,
+		"COALESCE(ANY_VALUE(hot_vals.amount), m.bigint_01) AS amount"))
+}
+
+// TestDuckDBBigintTypeUnification pins the DuckDB engine facts #205 rests on:
+// the old DOUBLE-pivot shape crashes CAST-back at MaxInt64, the typed-pivot
+// shape is exact, and UNION ALL unification is what drags BIGINT to DOUBLE.
+func TestDuckDBBigintTypeUnification(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	// (1) 旧形态崩溃机制:COALESCE(DOUBLE, BIGINT) → DOUBLE,CAST 回 BIGINT 溢出。
+	var v int64
+	err = db.QueryRow(`SELECT CAST(COALESCE(CAST(NULL AS DOUBLE), 9223372036854775807::BIGINT) AS BIGINT)`).Scan(&v)
+	require.Error(t, err, "DOUBLE pivot 形态必须复现生产崩溃")
+	require.Contains(t, err.Error(), "out of range")
+
+	// (2) 新形态:BIGINT pivot → COALESCE 保 BIGINT,MaxInt64 精确。
+	require.NoError(t, db.QueryRow(`SELECT CAST(COALESCE(TRY_CAST(NULL AS BIGINT), 9223372036854775807::BIGINT) AS BIGINT)`).Scan(&v))
+	require.Equal(t, int64(math.MaxInt64), v)
+
+	// (3) UNION ALL 统一:BIGINT+DOUBLE→DOUBLE(污染路径),BIGINT+BIGINT→BIGINT。
+	var typ string
+	require.NoError(t, db.QueryRow(`SELECT typeof(x) FROM (SELECT 1::BIGINT AS x UNION ALL SELECT 1::DOUBLE) LIMIT 1`).Scan(&typ))
+	require.Equal(t, "DOUBLE", typ)
+	require.NoError(t, db.QueryRow(`SELECT typeof(x) FROM (SELECT 9223372036854775807::BIGINT AS x UNION ALL SELECT 0::BIGINT) LIMIT 1`).Scan(&typ))
+	require.Equal(t, "BIGINT", typ)
+
+	// (4) iso8601 护栏:date 属性 pivot 从 DOUBLE 改 BIGINT 后,与 VARCHAR 主列
+	// (iso8601 编码绑定 text 列)的 COALESCE 行为必须不变——两种 NULL 类型下
+	// 行为逐位一致(同成功同值,或同失败)。
+	q := func(sql string) (string, error) {
+		var s string
+		e := db.QueryRow(sql).Scan(&s)
+		return s, e
+	}
+	s1, e1 := q(`SELECT COALESCE(CAST(NULL AS DOUBLE), '2024-01-02T03:04:05Z'::VARCHAR)`)
+	s2, e2 := q(`SELECT COALESCE(TRY_CAST(NULL AS BIGINT), '2024-01-02T03:04:05Z'::VARCHAR)`)
+	require.Equal(t, e1 == nil, e2 == nil, "iso8601 热腿 COALESCE 行为不得因 pivot 类型改变")
+	if e1 == nil {
+		require.Equal(t, s1, s2)
+	}
+}

--- a/internal/sqlgen/duckdb_schema_projection.go
+++ b/internal/sqlgen/duckdb_schema_projection.go
@@ -213,7 +213,7 @@ func (sp *SchemaProjection) buildEAVPivot(attrs []attrProjectionInfo) {
 	for _, a := range attrs {
 		attrIDParts = append(attrIDParts, fmt.Sprintf("%d", a.attrID))
 		pivotParts = append(pivotParts, fmt.Sprintf("\t\t\t\t%s AS %s",
-			eavPivotExpr(a), ParquetAttrColumn(a.name)))
+			buildEAVPivotExpr(a), ParquetAttrColumn(a.name)))
 	}
 
 	if len(pivotParts) > 0 {
@@ -224,14 +224,14 @@ func (sp *SchemaProjection) buildEAVPivot(attrs []attrProjectionInfo) {
 	}
 }
 
-// eavPivotExpr renders the hot-tier EAV pivot expression for one attribute.
+// buildEAVPivotExpr renders the hot-tier EAV pivot expression for one attribute.
 // The output type must mirror the CDC export side (cdc.castEAVValue) so the
 // pg_source leg type-unifies with the parquet legs through COALESCE and
 // UNION ALL instead of widening to DOUBLE — which silently rounded bound
 // bigint values above 2^53 and crashed CAST-back at a stored MaxInt64 (#205).
 // TRY_CAST (not CAST) matches export semantics: an out-of-range NUMERIC in
 // eav_data becomes NULL on every tier alike instead of a read-path crash.
-func eavPivotExpr(a attrProjectionInfo) string {
+func buildEAVPivotExpr(a attrProjectionInfo) string {
 	if a.meta.ValueType == forma.ValueTypeBool {
 		// Wrap in <> 0 so the pivot column is BOOLEAN, not DOUBLE (#182).
 		return fmt.Sprintf("(MAX(CASE WHEN attr_id = %d THEN value_numeric END) <> 0)", a.attrID)

--- a/internal/sqlgen/duckdb_schema_projection.go
+++ b/internal/sqlgen/duckdb_schema_projection.go
@@ -212,19 +212,8 @@ func (sp *SchemaProjection) buildEAVPivot(attrs []attrProjectionInfo) {
 	sort.Slice(attrs, func(i, j int) bool { return attrs[i].name < attrs[j].name })
 	for _, a := range attrs {
 		attrIDParts = append(attrIDParts, fmt.Sprintf("%d", a.attrID))
-		var pivotExpr string
-		if a.meta.ValueType == forma.ValueTypeBool {
-			// Wrap in <> 0 so the pivot column is BOOLEAN, not DOUBLE.
-			// DuckDB WHERE uses CAST(? AS BOOLEAN); the pivot output must match.
-			pivotExpr = fmt.Sprintf(
-				"(MAX(CASE WHEN attr_id = %d THEN value_numeric END) <> 0)",
-				a.attrID)
-		} else {
-			pivotExpr = fmt.Sprintf(
-				"MAX(CASE WHEN attr_id = %d THEN %s END)",
-				a.attrID, eavValueColumn(a.meta.ValueType))
-		}
-		pivotParts = append(pivotParts, fmt.Sprintf("\t\t\t\t%s AS %s", pivotExpr, ParquetAttrColumn(a.name)))
+		pivotParts = append(pivotParts, fmt.Sprintf("\t\t\t\t%s AS %s",
+			eavPivotExpr(a), ParquetAttrColumn(a.name)))
 	}
 
 	if len(pivotParts) > 0 {
@@ -232,6 +221,33 @@ func (sp *SchemaProjection) buildEAVPivot(attrs []attrProjectionInfo) {
 	}
 	if len(attrIDParts) > 0 {
 		sp.EAVPivotAttrs = strings.Join(attrIDParts, ", ")
+	}
+}
+
+// eavPivotExpr renders the hot-tier EAV pivot expression for one attribute.
+// The output type must mirror the CDC export side (cdc.castEAVValue) so the
+// pg_source leg type-unifies with the parquet legs through COALESCE and
+// UNION ALL instead of widening to DOUBLE — which silently rounded bound
+// bigint values above 2^53 and crashed CAST-back at a stored MaxInt64 (#205).
+// TRY_CAST (not CAST) matches export semantics: an out-of-range NUMERIC in
+// eav_data becomes NULL on every tier alike instead of a read-path crash.
+func eavPivotExpr(a attrProjectionInfo) string {
+	if a.meta.ValueType == forma.ValueTypeBool {
+		// Wrap in <> 0 so the pivot column is BOOLEAN, not DOUBLE (#182).
+		return fmt.Sprintf("(MAX(CASE WHEN attr_id = %d THEN value_numeric END) <> 0)", a.attrID)
+	}
+	base := fmt.Sprintf("MAX(CASE WHEN attr_id = %d THEN %s END)",
+		a.attrID, eavValueColumn(a.meta.ValueType))
+	switch a.meta.ValueType {
+	case forma.ValueTypeBigInt, forma.ValueTypeDate, forma.ValueTypeDateTime:
+		return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", base)
+	case forma.ValueTypeInteger:
+		return fmt.Sprintf("TRY_CAST(%s AS INTEGER)", base)
+	case forma.ValueTypeSmallInt:
+		return fmt.Sprintf("TRY_CAST(%s AS SMALLINT)", base)
+	default:
+		// numeric 保持 DOUBLE;text/uuid 走 value_text,无 cast
+		return base
 	}
 }
 

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -55,7 +55,7 @@ func (c *AttributeConverter) ToEAVRecord(attr model.EntityAttribute, rowID uuid.
 		}
 		record.ValueNumeric = &numVal
 		if attr.ValueType == forma.ValueTypeBigInt {
-			if exact, ok := int64ExactForEAV(attr.Value); ok {
+			if exact, ok := toInt64ExactForEAV(attr.Value); ok {
 				record.ValueInt64 = &exact
 			}
 		}
@@ -186,18 +186,6 @@ func (c *AttributeConverter) FromEAVRecords(records []model.EAVRecord) ([]model.
 }
 
 // Helper functions for conversion
-
-// int64ExactForEAV mirrors numutil.Int64Exact but also accepts the pointer
-// shapes ToEAVRecord tolerates for numeric values.
-func int64ExactForEAV(value any) (int64, bool) {
-	if p, ok := value.(*int64); ok {
-		if p == nil {
-			return 0, false
-		}
-		return *p, true
-	}
-	return numutil.Int64Exact(value)
-}
 
 func toFloat64ForEAV(value any) (float64, error) {
 	switch v := value.(type) {

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -54,6 +54,11 @@ func (c *AttributeConverter) ToEAVRecord(attr model.EntityAttribute, rowID uuid.
 			return record, fmt.Errorf("convert to numeric: %w", err)
 		}
 		record.ValueNumeric = &numVal
+		if attr.ValueType == forma.ValueTypeBigInt {
+			if exact, ok := int64ExactForEAV(attr.Value); ok {
+				record.ValueInt64 = &exact
+			}
+		}
 
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
 		timeVal, err := toTimeForEAV(attr.Value)
@@ -62,6 +67,8 @@ func (c *AttributeConverter) ToEAVRecord(attr model.EntityAttribute, rowID uuid.
 		}
 		unixMillis := timeToUnixMillisFloat64(timeVal)
 		record.ValueNumeric = &unixMillis
+		exactMs := timeVal.UnixMilli()
+		record.ValueInt64 = &exactMs
 
 	case forma.ValueTypeUUID:
 		if uuidVal, ok := attr.Value.(uuid.UUID); ok {
@@ -179,6 +186,18 @@ func (c *AttributeConverter) FromEAVRecords(records []model.EAVRecord) ([]model.
 }
 
 // Helper functions for conversion
+
+// int64ExactForEAV mirrors numutil.Int64Exact but also accepts the pointer
+// shapes ToEAVRecord tolerates for numeric values.
+func int64ExactForEAV(value any) (int64, bool) {
+	if p, ok := value.(*int64); ok {
+		if p == nil {
+			return 0, false
+		}
+		return *p, true
+	}
+	return numutil.Int64Exact(value)
+}
 
 func toFloat64ForEAV(value any) (float64, error) {
 	switch v := value.(type) {
@@ -490,6 +509,9 @@ func extractValueFromEAVRecord(record model.EAVRecord, valueType forma.ValueType
 		if record.ValueText != nil {
 			return nil, storageTypeMismatchError(valueType, "value_text", "value_numeric")
 		}
+		if record.ValueInt64 != nil {
+			return *record.ValueInt64, nil
+		}
 		if record.ValueNumeric == nil {
 			return nil, nil
 		}
@@ -507,6 +529,9 @@ func extractValueFromEAVRecord(record model.EAVRecord, valueType forma.ValueType
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
 		if record.ValueText != nil {
 			return nil, storageTypeMismatchError(valueType, "value_text", "value_numeric")
+		}
+		if record.ValueInt64 != nil {
+			return time.UnixMilli(*record.ValueInt64).UTC(), nil
 		}
 		if record.ValueNumeric == nil {
 			return nil, nil

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -453,6 +454,12 @@ func toBool(value any) (bool, error) {
 		return v != 0, nil
 	case float64:
 		return v != 0, nil
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return false, fmt.Errorf("cannot convert json.Number %q to bool: %w", v.String(), err)
+		}
+		return f != 0, nil
 	default:
 		return false, fmt.Errorf("cannot convert %T to bool", value)
 	}

--- a/internal/transform/bigint_precision_test.go
+++ b/internal/transform/bigint_precision_test.go
@@ -1,0 +1,81 @@
+package transform
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func newBigintPrecisionRegistry() *stubSchemaRegistry {
+	return &stubSchemaRegistry{
+		schemaID:   202,
+		schemaName: "bigint_precision_test",
+		cache: forma.SchemaAttributeCache{
+			"amount": {
+				AttributeID: 1,
+				ValueType:   forma.ValueTypeBigInt,
+				ColumnBinding: &forma.MainColumnBinding{
+					ColumnName: forma.MainColumnBigint01,
+					Encoding:   forma.MainColumnEncodingDefault,
+				},
+			},
+		},
+	}
+}
+
+// TestToPersistentRecordPreservesBoundBigintExactly pins the #205 Hop-1 fix:
+// an int64-carrying payload must reach the bound BIGINT main column without a
+// float64 hop. Pre-#205, -MaxInt64 landed as MinInt64 (deterministic
+// off-by-one) and +MaxInt64 survived only by platform-dependent saturation.
+func TestToPersistentRecordPreservesBoundBigintExactly(t *testing.T) {
+	tr := NewPersistentRecordTransformer(newBigintPrecisionRegistry())
+	cases := []struct {
+		name string
+		in   any
+		want int64
+	}{
+		{"max_int64", int64(math.MaxInt64), math.MaxInt64},
+		{"neg_max_int64", int64(-math.MaxInt64), -math.MaxInt64},
+		{"above_2_53", int64(1<<53 + 1), 1<<53 + 1},
+		{"json_number", json.Number("9223372036854775807"), math.MaxInt64},
+		{"string", "9223372036854775807", math.MaxInt64},
+		{"float64_fallback", float64(42), 42},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, err := tr.ToPersistentRecord(context.Background(), 202, uuid.New(),
+				map[string]any{"amount": tc.in})
+			require.NoError(t, err)
+			got, ok := rec.Int64Items["bigint_01"]
+			require.True(t, ok, "bound bigint column absent")
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestFromPersistentRecordReturnsBoundBigintExactly pins the read-back leg: a
+// stored MaxInt64 (legal Postgres BIGINT, e.g. written by external tooling)
+// must surface exactly through the JSON transform, not via int64→float64→int64.
+func TestFromPersistentRecordReturnsBoundBigintExactly(t *testing.T) {
+	tr := NewPersistentRecordTransformer(newBigintPrecisionRegistry())
+	rec := &model.PersistentRecord{
+		SchemaID:     202,
+		RowID:        uuid.New(),
+		TextItems:    map[string]string{},
+		Int16Items:   map[string]int16{},
+		Int32Items:   map[string]int32{},
+		Int64Items:   map[string]int64{"bigint_01": math.MaxInt64},
+		Float64Items: map[string]float64{},
+		UUIDItems:    map[string]uuid.UUID{},
+	}
+	out, err := tr.FromPersistentRecord(context.Background(), rec)
+	require.NoError(t, err)
+	require.EqualValues(t, int64(math.MaxInt64), out["amount"],
+		"read-back must not round through float64")
+}

--- a/internal/transform/bigint_precision_test.go
+++ b/internal/transform/bigint_precision_test.go
@@ -95,3 +95,30 @@ func TestFromPersistentRecordReturnsBoundBigintExactly(t *testing.T) {
 		})
 	}
 }
+
+// TestToPersistentRecordClearsSidecarForEAVOnlyBigint pins the EAV-tier
+// contract: an unbound bigint attribute keeps the float64 ValueNumeric
+// contract (2^53 ceiling), so the exact sidecar must be cleared before the
+// record lands in OtherAttributes — otherwise the create-response echo
+// (which prefers ValueInt64) would diverge from what eav_data persists.
+func TestToPersistentRecordClearsSidecarForEAVOnlyBigint(t *testing.T) {
+	registry := &stubSchemaRegistry{
+		schemaID:   203,
+		schemaName: "bigint_eav_only_test",
+		cache: forma.SchemaAttributeCache{
+			"total": {
+				AttributeID: 1,
+				ValueType:   forma.ValueTypeBigInt,
+				// no ColumnBinding: EAV-only attribute
+			},
+		},
+	}
+	tr := NewPersistentRecordTransformer(registry)
+	rec, err := tr.ToPersistentRecord(context.Background(), 203, uuid.New(),
+		map[string]any{"total": int64(1<<53 + 3)})
+	require.NoError(t, err)
+	require.Len(t, rec.OtherAttributes, 1)
+	require.Nil(t, rec.OtherAttributes[0].ValueInt64,
+		"EAV-only bigint must not carry the exact sidecar")
+	require.NotNil(t, rec.OtherAttributes[0].ValueNumeric)
+}

--- a/internal/transform/bigint_precision_test.go
+++ b/internal/transform/bigint_precision_test.go
@@ -60,22 +60,38 @@ func TestToPersistentRecordPreservesBoundBigintExactly(t *testing.T) {
 }
 
 // TestFromPersistentRecordReturnsBoundBigintExactly pins the read-back leg: a
-// stored MaxInt64 (legal Postgres BIGINT, e.g. written by external tooling)
+// stored bigint (legal Postgres BIGINT, e.g. written by external tooling)
 // must surface exactly through the JSON transform, not via int64→float64→int64.
+// Pre-#205, the read path contains a float64 hop (persistent_record.go:402
+// `f := float64(val)` + attribute_converter.go:496 `int64(*record.ValueNumeric)`).
+// MaxInt64 case: saturation on arm64 (implementation-defined); kept for symmetry.
+// NegMaxInt64 and Above2_53: deterministic on all platforms pre-fix. They must red.
 func TestFromPersistentRecordReturnsBoundBigintExactly(t *testing.T) {
 	tr := NewPersistentRecordTransformer(newBigintPrecisionRegistry())
-	rec := &model.PersistentRecord{
-		SchemaID:     202,
-		RowID:        uuid.New(),
-		TextItems:    map[string]string{},
-		Int16Items:   map[string]int16{},
-		Int32Items:   map[string]int32{},
-		Int64Items:   map[string]int64{"bigint_01": math.MaxInt64},
-		Float64Items: map[string]float64{},
-		UUIDItems:    map[string]uuid.UUID{},
+	cases := []struct {
+		name string
+		val  int64
+	}{
+		{"max_int64", math.MaxInt64},
+		{"neg_max_int64", -math.MaxInt64},
+		{"above_2_53", 1<<53 + 1},
 	}
-	out, err := tr.FromPersistentRecord(context.Background(), rec)
-	require.NoError(t, err)
-	require.EqualValues(t, int64(math.MaxInt64), out["amount"],
-		"read-back must not round through float64")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &model.PersistentRecord{
+				SchemaID:     202,
+				RowID:        uuid.New(),
+				TextItems:    map[string]string{},
+				Int16Items:   map[string]int16{},
+				Int32Items:   map[string]int32{},
+				Int64Items:   map[string]int64{"bigint_01": tc.val},
+				Float64Items: map[string]float64{},
+				UUIDItems:    map[string]uuid.UUID{},
+			}
+			out, err := tr.FromPersistentRecord(context.Background(), rec)
+			require.NoError(t, err)
+			require.EqualValues(t, tc.val, out["amount"],
+				"read-back must not round through float64")
+		})
+	}
 }

--- a/internal/transform/persistent_record.go
+++ b/internal/transform/persistent_record.go
@@ -88,6 +88,10 @@ func (t *persistentRecordTransformer) ToPersistentRecord(ctx context.Context, sc
 				return nil, fmt.Errorf("failed to store attribute %s in main column: %w", attrName, err)
 			}
 		} else {
+			// EAV storage keeps the float64 ValueNumeric contract (2^53
+			// ceiling); clear the exact sidecar so the create-response echo
+			// matches what eav_data actually persists (#205).
+			eavRecord.ValueInt64 = nil
 			record.OtherAttributes = append(record.OtherAttributes, eavRecord)
 		}
 	}

--- a/internal/transform/persistent_record.go
+++ b/internal/transform/persistent_record.go
@@ -156,7 +156,9 @@ func (t *persistentRecordTransformer) storeInMainColumn(record *model.Persistent
 	switch binding.Encoding {
 	case forma.MainColumnEncodingUnixMs:
 		// Date stored as Unix milliseconds in bigint column
-		if attr.ValueNumeric != nil {
+		if attr.ValueInt64 != nil {
+			record.Int64Items[columnName] = *attr.ValueInt64
+		} else if attr.ValueNumeric != nil {
 			record.Int64Items[columnName] = int64(*attr.ValueNumeric)
 		}
 
@@ -207,7 +209,9 @@ func (t *persistentRecordTransformer) storeInMainColumn(record *model.Persistent
 			}
 
 		case forma.MainColumnTypeBigint:
-			if attr.ValueNumeric != nil {
+			if attr.ValueInt64 != nil {
+				record.Int64Items[columnName] = *attr.ValueInt64
+			} else if attr.ValueNumeric != nil {
 				record.Int64Items[columnName] = int64(*attr.ValueNumeric)
 			}
 
@@ -322,7 +326,9 @@ func (t *persistentRecordTransformer) readWithEncoding(record *model.PersistentR
 		// Read Unix milliseconds from bigint column and convert to time
 		if val, ok := record.Int64Items[columnName]; ok {
 			f := float64(val)
+			exact := val
 			attr.ValueNumeric = &f
+			attr.ValueInt64 = &exact
 			return attr, true, nil
 		}
 
@@ -400,7 +406,9 @@ func (t *persistentRecordTransformer) readWithDefaultEncoding(record *model.Pers
 	case forma.MainColumnTypeBigint:
 		if val, ok := record.Int64Items[columnName]; ok {
 			f := float64(val)
+			exact := val
 			attr.ValueNumeric = &f
+			attr.ValueInt64 = &exact
 			return attr, true, nil
 		}
 

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -354,6 +354,11 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 			return handleConversionError(err)
 		}
 		attr.ValueNumeric = &numVal
+		if meta.ValueType == forma.ValueTypeBigInt {
+			if exact, ok := numutil.Int64Exact(value); ok {
+				attr.ValueInt64 = &exact
+			}
+		}
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
 		timeVal, err := toTime(value)
 		if err != nil {
@@ -361,6 +366,8 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 		}
 		unixMillis := timeToUnixMillisFloat64(timeVal)
 		attr.ValueNumeric = &unixMillis
+		exactMs := timeVal.UnixMilli()
+		attr.ValueInt64 = &exactMs
 	case forma.ValueTypeBool:
 		boolVal, err := toBool(value)
 		if err != nil {

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/lychee-technology/forma/internal/model"
 
-	"github.com/lychee-technology/forma/internal/numutil"
-
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
@@ -322,77 +320,6 @@ func (t *transformer) flattenToAttributes(
 		}
 	}
 	return nil
-}
-
-func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta forma.AttributeMetadata) (bool, error) {
-	handleConversionError := func(err error) (bool, error) {
-		return false, fmt.Errorf(
-			"invalid value for attribute '%s' (attrID=%d): %w",
-			attrName,
-			meta.AttributeID,
-			fmt.Errorf("%w: %v", forma.ErrInvalidInput, err),
-		)
-	}
-
-	switch meta.ValueType {
-	case forma.ValueTypeUUID:
-		uuidVal, isUUID := toUUID(value)
-		if !isUUID {
-			return handleConversionError(fmt.Errorf("invalid UUID value: %v", value))
-		}
-		strVal := uuidVal.String()
-		attr.ValueText = &strVal
-	case forma.ValueTypeText:
-		strVal, err := toString(value)
-		if err != nil {
-			return handleConversionError(err)
-		}
-		attr.ValueText = &strVal
-	case forma.ValueTypeNumeric, forma.ValueTypeBigInt, forma.ValueTypeInteger, forma.ValueTypeSmallInt:
-		numVal, err := numutil.Float64(value)
-		if err != nil {
-			return handleConversionError(err)
-		}
-		attr.ValueNumeric = &numVal
-		if meta.ValueType == forma.ValueTypeBigInt {
-			if exact, ok := numutil.Int64Exact(value); ok {
-				attr.ValueInt64 = &exact
-			}
-		}
-	case forma.ValueTypeDate, forma.ValueTypeDateTime:
-		timeVal, err := toTime(value)
-		if err != nil {
-			return handleConversionError(err)
-		}
-		unixMillis := timeToUnixMillisFloat64(timeVal)
-		attr.ValueNumeric = &unixMillis
-		exactMs := timeVal.UnixMilli()
-		attr.ValueInt64 = &exactMs
-	case forma.ValueTypeBool:
-		boolVal, err := toBool(value)
-		if err != nil {
-			return handleConversionError(err)
-		}
-		floatBool := boolToFloat64(boolVal)
-		attr.ValueNumeric = &floatBool
-	default:
-		return handleConversionError(fmt.Errorf("unsupported value type '%s'", meta.ValueType))
-	}
-
-	return true, nil
-}
-
-func toString(value any) (string, error) {
-	switch v := value.(type) {
-	case string:
-		return v, nil
-	case []byte:
-		return string(v), nil
-	case fmt.Stringer:
-		return v.String(), nil
-	default:
-		return fmt.Sprintf("%v", value), nil
-	}
 }
 
 func validateRequiredAttributesFromInput(data map[string]any, cache forma.SchemaAttributeCache) error {

--- a/internal/transform/typed_value.go
+++ b/internal/transform/typed_value.go
@@ -78,3 +78,15 @@ func toString(value any) (string, error) {
 		return fmt.Sprintf("%v", value), nil
 	}
 }
+
+// toInt64ExactForEAV mirrors numutil.Int64Exact but also accepts the pointer
+// shapes ToEAVRecord tolerates for numeric values.
+func toInt64ExactForEAV(value any) (int64, bool) {
+	if p, ok := value.(*int64); ok {
+		if p == nil {
+			return 0, false
+		}
+		return *p, true
+	}
+	return numutil.Int64Exact(value)
+}

--- a/internal/transform/typed_value.go
+++ b/internal/transform/typed_value.go
@@ -1,0 +1,80 @@
+package transform
+
+import (
+	"fmt"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/numutil"
+)
+
+func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta forma.AttributeMetadata) (bool, error) {
+	handleConversionError := func(err error) (bool, error) {
+		return false, fmt.Errorf(
+			"invalid value for attribute '%s' (attrID=%d): %w",
+			attrName,
+			meta.AttributeID,
+			fmt.Errorf("%w: %v", forma.ErrInvalidInput, err),
+		)
+	}
+
+	switch meta.ValueType {
+	case forma.ValueTypeUUID:
+		uuidVal, isUUID := toUUID(value)
+		if !isUUID {
+			return handleConversionError(fmt.Errorf("invalid UUID value: %v", value))
+		}
+		strVal := uuidVal.String()
+		attr.ValueText = &strVal
+	case forma.ValueTypeText:
+		strVal, err := toString(value)
+		if err != nil {
+			return handleConversionError(err)
+		}
+		attr.ValueText = &strVal
+	case forma.ValueTypeNumeric, forma.ValueTypeBigInt, forma.ValueTypeInteger, forma.ValueTypeSmallInt:
+		numVal, err := numutil.Float64(value)
+		if err != nil {
+			return handleConversionError(err)
+		}
+		attr.ValueNumeric = &numVal
+		if meta.ValueType == forma.ValueTypeBigInt {
+			if exact, ok := numutil.Int64Exact(value); ok {
+				attr.ValueInt64 = &exact
+			}
+		}
+	case forma.ValueTypeDate, forma.ValueTypeDateTime:
+		timeVal, err := toTime(value)
+		if err != nil {
+			return handleConversionError(err)
+		}
+		unixMillis := timeToUnixMillisFloat64(timeVal)
+		attr.ValueNumeric = &unixMillis
+		exactMs := timeVal.UnixMilli()
+		attr.ValueInt64 = &exactMs
+	case forma.ValueTypeBool:
+		boolVal, err := toBool(value)
+		if err != nil {
+			return handleConversionError(err)
+		}
+		floatBool := boolToFloat64(boolVal)
+		attr.ValueNumeric = &floatBool
+	default:
+		return handleConversionError(fmt.Errorf("unsupported value type '%s'", meta.ValueType))
+	}
+
+	return true, nil
+}
+
+func toString(value any) (string, error) {
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case []byte:
+		return string(v), nil
+	case fmt.Stringer:
+		return v.String(), nil
+	default:
+		return fmt.Sprintf("%v", value), nil
+	}
+}


### PR DESCRIPTION
Closes #205.

## Root cause (two independent float64 hops)

- **Read (Hop 2)**: the hot-tier EAV pivot emitted bare `MAX(CASE WHEN attr_id = N THEN value_numeric END)` — DOUBLE via postgres_scan — so `COALESCE(pivot, m.bigint_01)` type-unified to DOUBLE and the `UNION ALL` dragged the parquet legs' exact BIGINT with it. The outer `CAST(attr AS BIGINT)` then crashed on a stored `MaxInt64` (`Conversion Error … out of range for INT64`) and silently rounded everything in (2^53, 2^63) on **all three tiers**.
- **Write (Hop 1)**: the transform chain bounces JSON → EAVRecord → EntityAttribute → EAVRecord → main columns, riding `float64` twice — `-MaxInt64` deterministically landed as `MinInt64`; `+MaxInt64` "survived" only by platform-dependent saturation.

## Fix

**Read side — typed EAV pivot** (`sqlgen.eavPivotExpr`): per-type `TRY_CAST` (BIGINT for bigint/date/datetime, INTEGER/SMALLINT for the smaller ints; numeric stays DOUBLE, bool keeps its `<> 0` wrap), mirroring the CDC export side `cdc.castEAVValue` — this is tier-parity restoration, not a new convention; the two sides now cross-reference each other. `TRY_CAST` (not `CAST`) matches export semantics: an out-of-range NUMERIC in eav_data becomes NULL on every tier alike instead of a read-path crash (acceptance criterion 3). SELECT-fragment change only — placeholders, bindings, GROUP BY, dirty-set barrier all untouched.

**Write side — exact int64 sidecar** (`model.EAVRecord.ValueInt64 *int64` + `numutil.Int64Exact`): set at every chain entry for bigint and unix-ms dates, preferred by `storeInMainColumn`/`extractValueFromEAVRecord`, with `ValueNumeric` always still set as the fallback and the **unchanged eav_data persistence contract** (EAV-only attributes deliberately keep the documented 2^53 float64 ceiling; the sidecar is cleared before records land in `OtherAttributes` so the create echo matches what eav_data persists — final-review finding I-1). Non-integral / out-of-range inputs fall back to byte-identical pre-#205 behavior.

## Tripwires flipped (as their own doc comments prescribed)

- `TestFederatedReadRejectsStoredMaxInt64` → `TestFederatedReadReturnsStoredMaxInt64` (exact round-trip + `Plan.Routing.UseDuckDB` proof)
- `TestBoundBigintMaxInt64WriteCorrupts` → `TestBoundBigintPreservesNegMaxInt64` (deterministic on every platform)
- `maxBoundBigint`: `1<<62` → `math.MaxInt64` — the boundary matrix now writes ±MaxInt64 through the API across hot/warm/cold

## New tests

- `internal/sqlgen/duckdb_bigint_pivot_test.go`: pivot-shape pins + real-DuckDB engine semantics (old shape's crash mechanism, typed shape's exactness, UNION unification rules, iso8601 COALESCE parity guard)
- `internal/transform/bigint_precision_test.go`: write + read-back exactness, table-driven with deterministic all-platform red cases (the MaxInt64-only legs saturate on arm64 — implementation-defined — so ±MaxInt64 and 2^53+1 legs carry the portable pin), plus the EAV-only sidecar-clearing regression
- `numutil.Int64Exact`: 13-case table

## Evidence

- Full production harness e2e green (100.5s, includes the boundary matrix at ±MaxInt64 across all tiers, oracle parity intact); federated `-short` suite green; `make test` + `make lint` (pinned v1.64.8) clean; no #276 flake observed.
- Every task went through spec+quality review; final whole-branch review (adversarial pass over the 9 commits) verdict: Ready to merge, with I-1 fixed in `e679324` and re-verified (BatchCreate flows through the same cleared site).

## Review notes / accepted observations

- `design_doc_sql_test.go` byte-pins only the `s3_source` projection, not the `pg_source` pivot; §5's example schema has no numeric EAV attr today so there is nothing to pin — but a future numeric-EAV line in §5 would not be text-guarded (pre-existing, informational).
- `TestFederatedReadReturnsStoredMaxInt64` keeps its ExecSQL injection deliberately: it proves the read-path fix independently of the write-path fix, matching the issue's external-writer framing.

## Follow-ups filed

- #282 — HTTP JSON decoding rides float64 (`UseNumber` decision; HTTP clients still see the 2^53 ceiling at the door — #205 AC1's "document as public contract" branch)
- #281 — bigint predicate + keyset-cursor binding exactness above 2^53 (comparison side, out of #205's projection scope)
- #283 — split `attribute_converter.go` (583 lines, pre-existing over-cap +25 here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)