### PR TITLE
fix(federated): #245 run DuckDB session init on every pooled connection

### DIFF
--- a/internal/e2e_harness/production/README.md
+++ b/internal/e2e_harness/production/README.md
@@ -79,7 +79,7 @@ needs schema IDs beyond the fixtures can register its own via
 `RegisterSchemas` + `WithSchemaDir`.
 
 Options: `WithSeed`, `WithSchemaDir`, `WithFlushThresholds` (#179),
-`WithDuckMemoryMB`, `WithBreaker` (#185), `WithDuckMaxConnections` (#185),
+`WithDuckMemoryMB`, `WithBreaker` (#185), `WithDuckMaxConnections`,
 `WithRoutingStrategy`, `WithoutManifest`.
 
 ## Fixture schemas (`schemas/`)
@@ -182,10 +182,9 @@ where cdc-init bootstraps base files before federated reads. Use
   observe the open-to-closed transition against a healthy DuckDB.
 - `WithBreaker(maxFailures, cooldown)` (#185) enables the federated engine's
   circuit breaker; `WithDuckMaxConnections(n)` overrides the per-test DuckDB
-  pool size (default 2). Pin it to `1` for tests that issue **concurrent**
-  DuckDB queries: `NewDuckDBClient` applies the session-scoped S3 `SET`
-  statements on a single pooled connection (`duckdb_conn.go`), so over
-  `:memory:` a second connection opened under load lacks S3 config and 404s.
+  pool size (default 2). Since #245 every pooled connection self-configures
+  via the driver's per-connection init hook, so this is purely a pool-sizing
+  knob — concurrent DuckDB queries need no pinning.
   Set `Query.AllowPartialDegradedMode` to forward the public degraded-mode
   flag so a tier outage falls back to a postgres-only result (complete in
   today's PG-retains-all model) instead of erroring.
@@ -227,5 +226,5 @@ On failure (or `KEEP_E2E_ENV=1`) the Env writes
 | #179 flush failure matrix | `FaultInjectingS3` + `RunFlushWith` + `ExecSQL` |
 | #180 dry-run semantics | `RunFlushDry` |
 | #181 failure injection | `ExecSQL` |
-| #185 degraded mode & circuit breaker | `WithBreaker`, `Query.AllowPartialDegradedMode`, `Cluster.HaltS3`, `Env.ReopenDuckDB`, `WithDuckMaxConnections` |
+| #185 degraded mode & circuit breaker | `WithBreaker`, `Query.AllowPartialDegradedMode`, `Cluster.HaltS3`, `Env.ReopenDuckDB` |
 | #186 multi-schema isolation | `e2e_simple`/`e2e_second` + `FaultInjectingS3`/`PausingS3` (`multi_schema_isolation_e2e_test.go`, `concurrent_flush_multi_schema_e2e_test.go`) |

--- a/internal/e2e_harness/production/circuit_breaker_e2e_test.go
+++ b/internal/e2e_harness/production/circuit_breaker_e2e_test.go
@@ -95,11 +95,10 @@ func TestCircuitBreaker_OpensAtThresholdAndRecovers(t *testing.T) {
 // calls go through eng.Query directly: Env.Query records results without a
 // lock and is not safe for concurrent use.
 //
-// DuckDB MaxConnections is pinned to 1: NewDuckDBClient applies the
-// session-scoped S3 SET statements to a single pooled connection, so a
-// second :memory: connection opened under concurrency lacks S3 config and
-// 404s — a harness/client gap unrelated to breaker behavior (production
-// defaults to MaxConnections=1 and is unaffected; follow-up issue drafted).
+// Runs on the harness-default DuckDB pool (2 connections): this test is the
+// regression gate for #245 — per-connection init must configure every pooled
+// connection, or one of the concurrent recovery queries 404s with an empty
+// s3_region.
 func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
 	const threshold = 3
 	const cooldown = 3 * time.Second
@@ -107,7 +106,7 @@ func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
 	const queriesPerWorker = 5
 
 	ctx := context.Background()
-	env := NewEnv(t, SharedCluster(t), WithBreaker(threshold, cooldown), WithDuckMaxConnections(1))
+	env := NewEnv(t, SharedCluster(t), WithBreaker(threshold, cooldown))
 	wide := DefaultSchemaFixtures()[1]
 
 	seedTwoTiers(ctx, t, env, wide)

--- a/internal/e2e_harness/production/doc.go
+++ b/internal/e2e_harness/production/doc.go
@@ -32,7 +32,7 @@
 //	#180 dry-run semantics         -> RunFlushDry, RunInitWith(InitOverrides{DryRun})
 //	#181 failure-state injection   -> Env.ExecSQL escape hatch
 //	#182 mid-flush concurrency     -> PausingS3, RunFlushWith(FlushOverrides{S3})
-//	#185 degraded/breaker          -> WithBreaker, WithDuckMaxConnections, HaltS3, ReopenDuckDB, Query.AllowPartialDegradedMode
+//	#185 degraded/breaker          -> WithBreaker, HaltS3, ReopenDuckDB, Query.AllowPartialDegradedMode
 //	#186 multi-schema isolation    -> schemas/e2e_simple + e2e_second, per-test DB
 //	#260 nested dotted attributes  -> schemas/e2e_nested, nested_attrs_e2e_test.go
 //

--- a/internal/e2e_harness/production/env.go
+++ b/internal/e2e_harness/production/env.go
@@ -108,11 +108,9 @@ func WithDuckMemoryMB(mb int) EnvOption {
 }
 
 // WithDuckMaxConnections overrides the per-test DuckDB connection pool size
-// (default 2). NewDuckDBClient applies the session-scoped S3 SET statements
-// on a single pooled connection (duckdb_conn.go), so with :memory: a second
-// pooled connection opened under load lacks S3 config and fails S3 reads
-// with HTTP 404 / empty region. Tests that issue concurrent DuckDB queries
-// should pin this to 1 until that gap is fixed.
+// (default 2). Since #245 every pooled connection self-configures via the
+// driver's per-connection init hook, so this is purely a pool-sizing knob —
+// no pinning is needed for concurrent DuckDB queries.
 func WithDuckMaxConnections(n int) EnvOption {
 	return func(o *envOptions) { o.duckMaxConns = n }
 }

--- a/internal/e2e_harness/production/parquet_corruption_e2e_test.go
+++ b/internal/e2e_harness/production/parquet_corruption_e2e_test.go
@@ -36,7 +36,7 @@ func runParquetFaultScenario(t *testing.T, mutate func([]byte) []byte) {
 	t.Helper()
 	ctx := context.Background()
 	cluster := SharedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	seedTwoTiers(ctx, t, env, wide)
@@ -93,7 +93,7 @@ func runParquetFaultScenario(t *testing.T, mutate func([]byte) []byte) {
 func TestParquetCorruption_WrongSchemaFile(t *testing.T) {
 	ctx := context.Background()
 	cluster := SharedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	seedTwoTiers(ctx, t, env, wide)
@@ -136,7 +136,7 @@ func TestParquetCorruption_WrongSchemaFile(t *testing.T) {
 func TestParquetCorruption_WrongTypeFile(t *testing.T) {
 	ctx := context.Background()
 	cluster := SharedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	seedTwoTiers(ctx, t, env, wide)
@@ -185,7 +185,7 @@ func TestParquetCorruption_WrongTypeFile(t *testing.T) {
 func TestParquetCorruption_EmptyParquetFile(t *testing.T) {
 	ctx := context.Background()
 	cluster := SharedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	seedTwoTiers(ctx, t, env, wide)
@@ -217,7 +217,7 @@ func TestParquetCorruption_EmptyParquetFile(t *testing.T) {
 func TestParquetCorruption_WrongSchemaFile_GlobHint(t *testing.T) {
 	ctx := context.Background()
 	cluster := SharedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	seedTwoTiers(ctx, t, env, wide)

--- a/internal/e2e_harness/production/parquet_manifest_consistency_e2e_test.go
+++ b/internal/e2e_harness/production/parquet_manifest_consistency_e2e_test.go
@@ -21,7 +21,7 @@ import (
 func TestManifestConsistency_MissingListedParquet(t *testing.T) {
 	ctx := context.Background()
 	cluster := SharedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	keys := seedMultiParquet(ctx, t, env, wide)
@@ -86,7 +86,7 @@ func TestManifestConsistency_MissingListedParquet(t *testing.T) {
 func TestManifestConsistency_OneGoodOneBadFile(t *testing.T) {
 	ctx := context.Background()
 	cluster := SharedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	keys := seedMultiParquet(ctx, t, env, wide)

--- a/internal/e2e_harness/production/parquet_permission_e2e_test.go
+++ b/internal/e2e_harness/production/parquet_permission_e2e_test.go
@@ -22,7 +22,7 @@ import (
 func TestParquetPermission_BadCredentials(t *testing.T) {
 	ctx := context.Background()
 	cluster := SharedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	seedTwoTiers(ctx, t, env, wide)

--- a/internal/e2e_harness/production/postgres_halt_e2e_test.go
+++ b/internal/e2e_harness/production/postgres_halt_e2e_test.go
@@ -25,7 +25,7 @@ import (
 func TestPostgresHalt_ParquetTiersError(t *testing.T) {
 	ctx := context.Background()
 	cluster := DedicatedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	seedAllTiers(ctx, t, env, wide)

--- a/internal/e2e_harness/production/s3_recovery_e2e_test.go
+++ b/internal/e2e_harness/production/s3_recovery_e2e_test.go
@@ -25,7 +25,7 @@ import (
 func TestS3Restart_CleanRecovery(t *testing.T) {
 	ctx := context.Background()
 	cluster := DedicatedCluster(t)
-	env := NewEnv(t, cluster, WithDuckMaxConnections(1))
+	env := NewEnv(t, cluster)
 	wide := DefaultSchemaFixtures()[1]
 
 	seedAllTiers(ctx, t, env, wide)

--- a/internal/federated/duckdb_conn.go
+++ b/internal/federated/duckdb_conn.go
@@ -78,7 +78,7 @@ func NewDuckDBClientContext(ctx context.Context, cfg forma.DuckDBConfig) (*DuckD
 
 	// Pre-build the init statements; S3 credential validation fails fast here,
 	// before any connection is opened.
-	stmts, err := buildInitStatements(cfg)
+	steps, err := buildInitSteps(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("build duckdb init statements: %w", err)
 	}
@@ -87,7 +87,9 @@ func NewDuckDBClientContext(ctx context.Context, cfg forma.DuckDBConfig) (*DuckD
 	// connection — not once against the pool, which reaches a single arbitrary
 	// connection (issue #245). The connector init hook runs for each new physical
 	// connection; PingContext below opens and thereby initializes the first one.
-	connector, err := duckdb.NewConnector(dsn, makeConnInit(stmts))
+	// Failed init statements are logged and skipped, never blocking the
+	// connection — construction fails only on credential validation or ping.
+	connector, err := duckdb.NewConnector(dsn, makeConnInit(steps))
 	if err != nil {
 		return nil, fmt.Errorf("open duckdb connector: %w", err)
 	}
@@ -124,104 +126,115 @@ type initStmt struct {
 	label string
 }
 
-// buildInitStatements assembles the INSTALL/LOAD/SET/PRAGMA statements every pooled
-// connection must run on open: user extensions, httpfs (when S3 is enabled), parquet
-// (when parquet is enabled), S3 session settings, and resource pragmas.
-func buildInitStatements(cfg forma.DuckDBConfig) ([]initStmt, error) {
-	stmts := extensionStmts(cfg)
-	s3, err := s3Stmts(cfg)
+// initStep groups statements that depend on each other: when one fails, the
+// step's remaining statements are skipped (an extension whose INSTALL fails
+// must not be LOADed), while later steps still run.
+type initStep struct {
+	stmts []initStmt
+}
+
+func makeSingleStmtStep(sql, label string) initStep {
+	return initStep{stmts: []initStmt{{sql: sql, label: label}}}
+}
+
+// buildInitSteps assembles the INSTALL/LOAD/SET/PRAGMA steps every pooled
+// connection must run on open: user extensions, httpfs (when S3 is enabled),
+// parquet (when parquet is enabled), S3 session settings, and resource pragmas.
+func buildInitSteps(cfg forma.DuckDBConfig) ([]initStep, error) {
+	steps := buildExtensionSteps(cfg)
+	s3, err := buildS3Steps(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("build duckdb s3 statements: %w", err)
 	}
-	stmts = append(stmts, s3...)
-	stmts = append(stmts, pragmaStmts(cfg)...)
-	return stmts, nil
+	steps = append(steps, s3...)
+	steps = append(steps, buildPragmaSteps(cfg)...)
+	return steps, nil
 }
 
-func extensionStmts(cfg forma.DuckDBConfig) []initStmt {
-	var stmts []initStmt
+// buildExtensionSteps pairs each extension's INSTALL and LOAD into one step, so a
+// failed INSTALL skips that extension's LOAD.
+func buildExtensionSteps(cfg forma.DuckDBConfig) []initStep {
+	var steps []initStep
+	appendExt := func(ext string) {
+		steps = append(steps, initStep{stmts: []initStmt{
+			{sql: fmt.Sprintf("INSTALL %s;", ext), label: "install " + ext},
+			{sql: fmt.Sprintf("LOAD %s;", ext), label: "load " + ext},
+		}})
+	}
 	for _, ext := range cfg.Extensions {
-		stmts = append(stmts,
-			initStmt{sql: fmt.Sprintf("INSTALL %s;", ext), label: "install " + ext},
-			initStmt{sql: fmt.Sprintf("LOAD %s;", ext), label: "load " + ext},
-		)
+		appendExt(ext)
 	}
 	if cfg.EnableS3 {
-		stmts = append(stmts,
-			initStmt{sql: "INSTALL httpfs;", label: "install httpfs"},
-			initStmt{sql: "LOAD httpfs;", label: "load httpfs"},
-		)
+		appendExt("httpfs")
 	}
 	if cfg.EnableParquet {
-		stmts = append(stmts,
-			initStmt{sql: "INSTALL parquet;", label: "install parquet"},
-			initStmt{sql: "LOAD parquet;", label: "load parquet"},
-		)
+		appendExt("parquet")
 	}
-	return stmts
+	return steps
 }
 
-// s3Stmts builds the S3 session SET statements. Each credential passes the
-// character-denylist validation first, so invalid values fail construction.
-func s3Stmts(cfg forma.DuckDBConfig) ([]initStmt, error) {
+// buildS3Steps builds the S3 session SET statements. Each credential passes the
+// character-denylist validation first, so invalid values fail construction. The
+// SET statements are independent of each other, hence one step apiece.
+func buildS3Steps(cfg forma.DuckDBConfig) ([]initStep, error) {
 	if !cfg.EnableS3 {
 		return nil, nil
 	}
 
-	var stmts []initStmt
-	if cfg.S3AccessKey != "" {
-		if err := validateS3Credential("s3_access_key_id", cfg.S3AccessKey); err != nil {
-			return nil, fmt.Errorf("invalid duckdb s3 config: %w", err)
-		}
-		stmts = append(stmts, initStmt{sql: fmt.Sprintf("SET s3_access_key_id='%s';", cfg.S3AccessKey), label: "set s3_access_key_id"})
+	var steps []initStep
+	credentials := []struct{ name, value string }{
+		{"s3_access_key_id", cfg.S3AccessKey},
+		{"s3_secret_access_key", cfg.S3SecretKey},
+		{"s3_region", cfg.S3Region},
 	}
-	if cfg.S3SecretKey != "" {
-		if err := validateS3Credential("s3_secret_access_key", cfg.S3SecretKey); err != nil {
+	for _, c := range credentials {
+		if c.value == "" {
+			continue
+		}
+		if err := validateS3Credential(c.name, c.value); err != nil {
 			return nil, fmt.Errorf("invalid duckdb s3 config: %w", err)
 		}
-		stmts = append(stmts, initStmt{sql: fmt.Sprintf("SET s3_secret_access_key='%s';", cfg.S3SecretKey), label: "set s3_secret_access_key"})
-	}
-	if cfg.S3Region != "" {
-		if err := validateS3Credential("s3_region", cfg.S3Region); err != nil {
-			return nil, fmt.Errorf("invalid duckdb s3 config: %w", err)
-		}
-		stmts = append(stmts, initStmt{sql: fmt.Sprintf("SET s3_region='%s';", cfg.S3Region), label: "set s3_region"})
+		steps = append(steps, makeSingleStmtStep(fmt.Sprintf("SET %s='%s';", c.name, c.value), "set "+c.name))
 	}
 	if cfg.S3Endpoint != "" {
 		endpoint := strings.TrimPrefix(cfg.S3Endpoint, "http://")
 		if err := validateS3Credential("s3_endpoint", endpoint); err != nil {
 			return nil, fmt.Errorf("invalid duckdb s3 config: %w", err)
 		}
-		stmts = append(stmts,
-			initStmt{sql: fmt.Sprintf("SET s3_endpoint='%s';", endpoint), label: "set s3_endpoint"},
-			initStmt{sql: "SET s3_use_ssl=false;", label: "set s3_use_ssl"},
-			initStmt{sql: "SET s3_url_style='path';", label: "set s3_url_style"},
+		steps = append(steps,
+			makeSingleStmtStep(fmt.Sprintf("SET s3_endpoint='%s';", endpoint), "set s3_endpoint"),
+			makeSingleStmtStep("SET s3_use_ssl=false;", "set s3_use_ssl"),
+			makeSingleStmtStep("SET s3_url_style='path';", "set s3_url_style"),
 		)
 	}
-	return stmts, nil
+	return steps, nil
 }
 
-func pragmaStmts(cfg forma.DuckDBConfig) []initStmt {
-	var stmts []initStmt
+func buildPragmaSteps(cfg forma.DuckDBConfig) []initStep {
+	var steps []initStep
 	if cfg.MemoryLimitMB > 0 {
-		stmts = append(stmts, initStmt{sql: fmt.Sprintf("PRAGMA memory_limit='%dMB';", cfg.MemoryLimitMB), label: "set memory_limit"})
+		steps = append(steps, makeSingleStmtStep(fmt.Sprintf("PRAGMA memory_limit='%dMB';", cfg.MemoryLimitMB), "set memory_limit"))
 	}
 	if cfg.MaxParallelism > 0 {
-		stmts = append(stmts, initStmt{sql: fmt.Sprintf("PRAGMA threads=%d;", cfg.MaxParallelism), label: "set threads"})
+		steps = append(steps, makeSingleStmtStep(fmt.Sprintf("PRAGMA threads=%d;", cfg.MaxParallelism), "set threads"))
 	}
-	return stmts
+	return steps
 }
 
 // makeConnInit returns the connector init hook the driver runs for every new physical
 // connection. Failed statements are logged and skipped so a degraded init never blocks
 // the connection — the same policy the pool-level configuration used before.
-func makeConnInit(stmts []initStmt) func(driver.ExecerContext) error {
+func makeConnInit(steps []initStep) func(driver.ExecerContext) error {
 	return func(execer driver.ExecerContext) error {
-		for _, s := range stmts {
-			// The driver binds the Connect context to the connection while this hook
-			// runs; the statements are literal SQL, so no driver.NamedValue args.
-			if _, err := execer.ExecContext(context.Background(), s.sql, nil); err != nil {
-				zap.S().Warnw("duckdb: connection init step failed", "step", s.label, "err", err)
+		for _, step := range steps {
+			for _, s := range step.stmts {
+				// The driver binds the Connect context to the connection while this
+				// hook runs; the statements are literal SQL, so no driver.NamedValue
+				// args.
+				if _, err := execer.ExecContext(context.Background(), s.sql, nil); err != nil {
+					zap.S().Warnw("duckdb: connection init step failed", "step", s.label, "err", err)
+					break
+				}
 			}
 		}
 		return nil

--- a/internal/federated/duckdb_conn.go
+++ b/internal/federated/duckdb_conn.go
@@ -3,11 +3,12 @@ package federated
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"strings"
 	"time"
 
-	_ "github.com/duckdb/duckdb-go/v2"
+	duckdb "github.com/duckdb/duckdb-go/v2"
 	"github.com/lychee-technology/forma"
 	"go.uber.org/zap"
 )
@@ -75,10 +76,22 @@ func NewDuckDBClientContext(ctx context.Context, cfg forma.DuckDBConfig) (*DuckD
 		dsn = ":memory:"
 	}
 
-	db, err := sql.Open("duckdb", dsn)
+	// Pre-build the init statements; S3 credential validation fails fast here,
+	// before any connection is opened.
+	stmts, err := buildInitStatements(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("open duckdb: %w", err)
+		return nil, fmt.Errorf("build duckdb init statements: %w", err)
 	}
+
+	// LOAD/SET/PRAGMA are session-scoped, so they must run on every pooled
+	// connection — not once against the pool, which reaches a single arbitrary
+	// connection (issue #245). The connector init hook runs for each new physical
+	// connection; PingContext below opens and thereby initializes the first one.
+	connector, err := duckdb.NewConnector(dsn, makeConnInit(stmts))
+	if err != nil {
+		return nil, fmt.Errorf("open duckdb connector: %w", err)
+	}
+	db := sql.OpenDB(connector)
 
 	// Apply a small connection configuration.
 	// File-backed DuckDB in read/write mode is effectively single-writer; more
@@ -102,127 +115,117 @@ func NewDuckDBClientContext(ctx context.Context, cfg forma.DuckDBConfig) (*DuckD
 		return nil, fmt.Errorf("ping duckdb: %w", err)
 	}
 
-	if err := configureExtensions(ctx, db, cfg); err != nil {
-		db.Close()
-		return nil, err
-	}
-
-	if err := configureS3(ctx, db, cfg); err != nil {
-		db.Close()
-		return nil, err
-	}
-
-	if err := applyResourcePragmas(ctx, db, cfg); err != nil {
-		db.Close()
-		return nil, err
-	}
-
 	return &DuckDBClient{DB: db, cfg: cfg}, nil
 }
 
-// configureExtensions installs and loads user-specified extensions, plus httpfs (when S3
-// is enabled) and parquet (when parquet is enabled).
-func configureExtensions(ctx context.Context, db *sql.DB, cfg forma.DuckDBConfig) error {
-	// User-supplied extensions
-	for _, ext := range cfg.Extensions {
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("INSTALL %s;", ext)); err != nil {
-			zap.S().Warnw("duckdb: install extension failed", "extension", ext, "err", err)
-			continue
-		}
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("LOAD %s;", ext)); err != nil {
-			zap.S().Warnw("duckdb: load extension failed", "extension", ext, "err", err)
-		}
-	}
-
-	// httpfs — required for S3 access
-	if cfg.EnableS3 {
-		if _, err := db.ExecContext(ctx, "INSTALL httpfs;"); err == nil {
-			if _, err := db.ExecContext(ctx, "LOAD httpfs;"); err != nil {
-				zap.S().Warnw("duckdb: load httpfs failed", "err", err)
-			}
-		} else {
-			zap.S().Warnw("duckdb: install httpfs failed", "err", err)
-		}
-	}
-
-	// parquet extension
-	if cfg.EnableParquet {
-		if _, err := db.ExecContext(ctx, "INSTALL parquet;"); err == nil {
-			if _, err := db.ExecContext(ctx, "LOAD parquet;"); err != nil {
-				zap.S().Warnw("duckdb: load parquet failed", "err", err)
-			}
-		} else {
-			zap.S().Warnw("duckdb: install parquet failed", "err", err)
-		}
-	}
-
-	return nil
+// initStmt is a single statement executed on every new physical DuckDB connection.
+type initStmt struct {
+	sql   string
+	label string
 }
 
-// configureS3 sets DuckDB S3 PRAGMA values when S3 is enabled in the config.
-// Returns an error (and expects the caller to close the DB) if a credential fails
-// the character-denylist validation.
-func configureS3(ctx context.Context, db *sql.DB, cfg forma.DuckDBConfig) error {
+// buildInitStatements assembles the INSTALL/LOAD/SET/PRAGMA statements every pooled
+// connection must run on open: user extensions, httpfs (when S3 is enabled), parquet
+// (when parquet is enabled), S3 session settings, and resource pragmas.
+func buildInitStatements(cfg forma.DuckDBConfig) ([]initStmt, error) {
+	stmts := extensionStmts(cfg)
+	s3, err := s3Stmts(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build duckdb s3 statements: %w", err)
+	}
+	stmts = append(stmts, s3...)
+	stmts = append(stmts, pragmaStmts(cfg)...)
+	return stmts, nil
+}
+
+func extensionStmts(cfg forma.DuckDBConfig) []initStmt {
+	var stmts []initStmt
+	for _, ext := range cfg.Extensions {
+		stmts = append(stmts,
+			initStmt{sql: fmt.Sprintf("INSTALL %s;", ext), label: "install " + ext},
+			initStmt{sql: fmt.Sprintf("LOAD %s;", ext), label: "load " + ext},
+		)
+	}
+	if cfg.EnableS3 {
+		stmts = append(stmts,
+			initStmt{sql: "INSTALL httpfs;", label: "install httpfs"},
+			initStmt{sql: "LOAD httpfs;", label: "load httpfs"},
+		)
+	}
+	if cfg.EnableParquet {
+		stmts = append(stmts,
+			initStmt{sql: "INSTALL parquet;", label: "install parquet"},
+			initStmt{sql: "LOAD parquet;", label: "load parquet"},
+		)
+	}
+	return stmts
+}
+
+// s3Stmts builds the S3 session SET statements. Each credential passes the
+// character-denylist validation first, so invalid values fail construction.
+func s3Stmts(cfg forma.DuckDBConfig) ([]initStmt, error) {
 	if !cfg.EnableS3 {
-		return nil
+		return nil, nil
 	}
 
+	var stmts []initStmt
 	if cfg.S3AccessKey != "" {
 		if err := validateS3Credential("s3_access_key_id", cfg.S3AccessKey); err != nil {
-			return err
+			return nil, fmt.Errorf("invalid duckdb s3 config: %w", err)
 		}
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("SET s3_access_key_id='%s';", cfg.S3AccessKey)); err != nil {
-			zap.S().Warnw("duckdb: set s3_access_key_id failed", "err", err)
-		}
+		stmts = append(stmts, initStmt{sql: fmt.Sprintf("SET s3_access_key_id='%s';", cfg.S3AccessKey), label: "set s3_access_key_id"})
 	}
 	if cfg.S3SecretKey != "" {
 		if err := validateS3Credential("s3_secret_access_key", cfg.S3SecretKey); err != nil {
-			return err
+			return nil, fmt.Errorf("invalid duckdb s3 config: %w", err)
 		}
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("SET s3_secret_access_key='%s';", cfg.S3SecretKey)); err != nil {
-			zap.S().Warnw("duckdb: set s3_secret_access_key failed", "err", err)
-		}
+		stmts = append(stmts, initStmt{sql: fmt.Sprintf("SET s3_secret_access_key='%s';", cfg.S3SecretKey), label: "set s3_secret_access_key"})
 	}
 	if cfg.S3Region != "" {
 		if err := validateS3Credential("s3_region", cfg.S3Region); err != nil {
-			return err
+			return nil, fmt.Errorf("invalid duckdb s3 config: %w", err)
 		}
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("SET s3_region='%s';", cfg.S3Region)); err != nil {
-			zap.S().Warnw("duckdb: set s3_region failed", "err", err)
-		}
+		stmts = append(stmts, initStmt{sql: fmt.Sprintf("SET s3_region='%s';", cfg.S3Region), label: "set s3_region"})
 	}
 	if cfg.S3Endpoint != "" {
 		endpoint := strings.TrimPrefix(cfg.S3Endpoint, "http://")
 		if err := validateS3Credential("s3_endpoint", endpoint); err != nil {
-			return err
+			return nil, fmt.Errorf("invalid duckdb s3 config: %w", err)
 		}
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("SET s3_endpoint='%s';", endpoint)); err != nil {
-			zap.S().Warnw("duckdb: set s3_endpoint failed", "err", err)
-		}
-		if _, err := db.ExecContext(ctx, "SET s3_use_ssl=false;"); err != nil {
-			zap.S().Warnw("duckdb: set s3_use_ssl failed", "err", err)
-		}
-		if _, err := db.ExecContext(ctx, "SET s3_url_style='path';"); err != nil {
-			zap.S().Warnw("duckdb: set s3_url_style failed", "err", err)
-		}
+		stmts = append(stmts,
+			initStmt{sql: fmt.Sprintf("SET s3_endpoint='%s';", endpoint), label: "set s3_endpoint"},
+			initStmt{sql: "SET s3_use_ssl=false;", label: "set s3_use_ssl"},
+			initStmt{sql: "SET s3_url_style='path';", label: "set s3_url_style"},
+		)
 	}
-
-	return nil
+	return stmts, nil
 }
 
-// applyResourcePragmas sets memory_limit and thread-count pragmas when the config requests them.
-func applyResourcePragmas(ctx context.Context, db *sql.DB, cfg forma.DuckDBConfig) error {
+func pragmaStmts(cfg forma.DuckDBConfig) []initStmt {
+	var stmts []initStmt
 	if cfg.MemoryLimitMB > 0 {
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("PRAGMA memory_limit='%dMB';", cfg.MemoryLimitMB)); err != nil {
-			zap.S().Warnw("duckdb: set memory_limit failed", "err", err, "memoryLimitMB", cfg.MemoryLimitMB)
-		}
+		stmts = append(stmts, initStmt{sql: fmt.Sprintf("PRAGMA memory_limit='%dMB';", cfg.MemoryLimitMB), label: "set memory_limit"})
 	}
 	if cfg.MaxParallelism > 0 {
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("PRAGMA threads=%d;", cfg.MaxParallelism)); err != nil {
-			zap.S().Warnw("duckdb: set threads failed", "err", err, "maxParallelism", cfg.MaxParallelism)
-		}
+		stmts = append(stmts, initStmt{sql: fmt.Sprintf("PRAGMA threads=%d;", cfg.MaxParallelism), label: "set threads"})
 	}
-	return nil
+	return stmts
+}
+
+// makeConnInit returns the connector init hook the driver runs for every new physical
+// connection. Failed statements are logged and skipped so a degraded init never blocks
+// the connection — the same policy the pool-level configuration used before.
+func makeConnInit(stmts []initStmt) func(driver.ExecerContext) error {
+	return func(execer driver.ExecerContext) error {
+		for _, s := range stmts {
+			// The driver binds the Connect context to the connection while this hook
+			// runs; the statements are literal SQL, so no driver.NamedValue args.
+			if _, err := execer.ExecContext(context.Background(), s.sql, nil); err != nil {
+				zap.S().Warnw("duckdb: connection init step failed", "step", s.label, "err", err)
+			}
+		}
+		return nil
+	}
 }
 
 // Close closes the underlying DuckDB DB.

--- a/internal/federated/duckdb_conn_test.go
+++ b/internal/federated/duckdb_conn_test.go
@@ -3,6 +3,8 @@ package federated
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -124,7 +126,7 @@ func TestNewDuckDBClientContext_FirstConnectionConfigured(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	duck, err := NewDuckDBClientContext(ctx, s3ConfiguredDuckDBConfig())
+	duck, err := NewDuckDBClientContext(ctx, newS3ConfiguredDuckDBConfig())
 	require.NoError(t, err)
 	require.NotNil(t, duck)
 	defer duck.Close()
@@ -142,7 +144,7 @@ func TestNewDuckDBClientContext_FirstConnectionConfigured(t *testing.T) {
 // Invalid S3 credentials must fail construction (before any connection opens), not
 // surface as per-connection init warnings.
 func TestNewDuckDBClientContext_InvalidS3CredentialFailsFast(t *testing.T) {
-	cfg := s3ConfiguredDuckDBConfig()
+	cfg := newS3ConfiguredDuckDBConfig()
 	cfg.S3SecretKey = "bad'key"
 
 	_, err := NewDuckDBClient(cfg)
@@ -150,10 +152,10 @@ func TestNewDuckDBClientContext_InvalidS3CredentialFailsFast(t *testing.T) {
 	require.Contains(t, err.Error(), "forbidden character")
 }
 
-// s3ConfiguredDuckDBConfig returns a multi-connection S3-enabled config for the
+// newS3ConfiguredDuckDBConfig returns a multi-connection S3-enabled config for the
 // issue #245 tests. SET statements never touch the network, so no real S3
 // endpoint is required to observe per-connection session settings.
-func s3ConfiguredDuckDBConfig() forma.DuckDBConfig {
+func newS3ConfiguredDuckDBConfig() forma.DuckDBConfig {
 	return forma.DuckDBConfig{
 		Enabled:        true,
 		DBPath:         ":memory:",
@@ -173,7 +175,7 @@ func s3ConfiguredDuckDBConfig() forma.DuckDBConfig {
 // Issue #245: session-scoped SET statements (s3_region etc.) must reach every pooled
 // connection, not just the one that happened to serve the configuration calls.
 func TestNewDuckDBClientContext_AllConnectionsConfigured(t *testing.T) {
-	duck, err := NewDuckDBClient(s3ConfiguredDuckDBConfig())
+	duck, err := NewDuckDBClient(newS3ConfiguredDuckDBConfig())
 	require.NoError(t, err)
 	defer duck.Close()
 
@@ -205,7 +207,7 @@ func TestNewDuckDBClientContext_AllConnectionsConfigured(t *testing.T) {
 // Issue #245: mirrors the real failure shape — concurrent federated queries spread
 // across the pool must all see the configured S3 session settings.
 func TestNewDuckDBClientContext_ConcurrentConnectionsConfigured(t *testing.T) {
-	duck, err := NewDuckDBClient(s3ConfiguredDuckDBConfig())
+	duck, err := NewDuckDBClient(newS3ConfiguredDuckDBConfig())
 	require.NoError(t, err)
 	defer duck.Close()
 
@@ -234,6 +236,39 @@ func TestNewDuckDBClientContext_ConcurrentConnectionsConfigured(t *testing.T) {
 	for err := range errs {
 		t.Error(err)
 	}
+}
+
+// recordingExecer is a driver.ExecerContext fake that records every attempted
+// statement and fails the one matching failOn.
+type recordingExecer struct {
+	executed []string
+	failOn   string
+}
+
+func (r *recordingExecer) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	r.executed = append(r.executed, query)
+	if query == r.failOn {
+		return nil, errors.New("injected init failure")
+	}
+	return driver.RowsAffected(0), nil
+}
+
+// A failed INSTALL must skip that extension's LOAD (the pre-#245 log-and-skip
+// contract), while later init steps still run.
+func TestMakeConnInit_FailedInstallSkipsLoad(t *testing.T) {
+	cfg := newS3ConfiguredDuckDBConfig()
+	cfg.Extensions = []string{"bad_ext"}
+
+	steps, err := buildInitSteps(cfg)
+	require.NoError(t, err)
+
+	execer := &recordingExecer{failOn: "INSTALL bad_ext;"}
+	require.NoError(t, makeConnInit(steps)(execer))
+
+	require.Contains(t, execer.executed, "INSTALL bad_ext;")
+	require.NotContains(t, execer.executed, "LOAD bad_ext;")
+	require.Contains(t, execer.executed, "LOAD httpfs;", "later steps must still run after a failed step")
+	require.Contains(t, execer.executed, "SET s3_region='us-test-1';")
 }
 
 func TestNewDuckDBClient_DisabledConfig(t *testing.T) {

--- a/internal/federated/duckdb_conn_test.go
+++ b/internal/federated/duckdb_conn_test.go
@@ -117,23 +117,37 @@ func TestNewDuckDBClientContext_DeadlineExceeded(t *testing.T) {
 	require.Contains(t, err.Error(), "ping duckdb")
 }
 
-func TestNewDuckDBClientContext_ExtensionStepsUseCallerCtx(t *testing.T) {
-	cfg := forma.DuckDBConfig{
-		Enabled:        true,
-		DBPath:         ":memory:",
-		MemoryLimitMB:  256,
-		MaxParallelism: 1,
-		MaxConnections: 1,
-		QueryTimeout:   5 * time.Second,
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+// The ping issued during construction opens (and thereby initializes) the first
+// pooled connection, so a freshly constructed client must already expose the S3
+// session settings and extensions on that connection.
+func TestNewDuckDBClientContext_FirstConnectionConfigured(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	duck, err := NewDuckDBClientContext(ctx, cfg)
+	duck, err := NewDuckDBClientContext(ctx, s3ConfiguredDuckDBConfig())
 	require.NoError(t, err)
 	require.NotNil(t, duck)
 	defer duck.Close()
+
+	var region string
+	require.NoError(t, duck.DB.QueryRowContext(ctx, "SELECT current_setting('s3_region');").Scan(&region))
+	require.Equal(t, "us-test-1", region)
+
+	var loaded int
+	require.NoError(t, duck.DB.QueryRowContext(ctx,
+		"SELECT count(*) FROM duckdb_extensions() WHERE extension_name IN ('httpfs','parquet') AND loaded;").Scan(&loaded))
+	require.Equal(t, 2, loaded)
+}
+
+// Invalid S3 credentials must fail construction (before any connection opens), not
+// surface as per-connection init warnings.
+func TestNewDuckDBClientContext_InvalidS3CredentialFailsFast(t *testing.T) {
+	cfg := s3ConfiguredDuckDBConfig()
+	cfg.S3SecretKey = "bad'key"
+
+	_, err := NewDuckDBClient(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "forbidden character")
 }
 
 // s3ConfiguredDuckDBConfig returns a multi-connection S3-enabled config for the

--- a/internal/federated/duckdb_conn_test.go
+++ b/internal/federated/duckdb_conn_test.go
@@ -2,6 +2,9 @@ package federated
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -131,6 +134,92 @@ func TestNewDuckDBClientContext_ExtensionStepsUseCallerCtx(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, duck)
 	defer duck.Close()
+}
+
+// s3ConfiguredDuckDBConfig returns a multi-connection S3-enabled config for the
+// issue #245 tests. SET statements never touch the network, so no real S3
+// endpoint is required to observe per-connection session settings.
+func s3ConfiguredDuckDBConfig() forma.DuckDBConfig {
+	return forma.DuckDBConfig{
+		Enabled:        true,
+		DBPath:         ":memory:",
+		EnableS3:       true,
+		EnableParquet:  true,
+		S3Region:       "us-test-1",
+		S3Endpoint:     "127.0.0.1:9000",
+		S3AccessKey:    "test-access-key",
+		S3SecretKey:    "test-secret-key",
+		MemoryLimitMB:  256,
+		MaxParallelism: 2,
+		MaxConnections: 4,
+		QueryTimeout:   5 * time.Second,
+	}
+}
+
+// Issue #245: session-scoped SET statements (s3_region etc.) must reach every pooled
+// connection, not just the one that happened to serve the configuration calls.
+func TestNewDuckDBClientContext_AllConnectionsConfigured(t *testing.T) {
+	duck, err := NewDuckDBClient(s3ConfiguredDuckDBConfig())
+	require.NoError(t, err)
+	defer duck.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Hold the first physical connection while checking out a second, forcing the
+	// pool to open a fresh, lazily initialized connection.
+	conns := make([]*sql.Conn, 0, 2)
+	defer func() {
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+	}()
+	for i := 0; i < 2; i++ {
+		conn, err := duck.DB.Conn(ctx)
+		require.NoError(t, err, "checkout pooled connection %d", i)
+		conns = append(conns, conn)
+	}
+
+	for i, conn := range conns {
+		var region string
+		err := conn.QueryRowContext(ctx, "SELECT current_setting('s3_region');").Scan(&region)
+		require.NoError(t, err, "connection %d: query s3_region", i)
+		require.Equal(t, "us-test-1", region, "connection %d: s3_region not configured", i)
+	}
+}
+
+// Issue #245: mirrors the real failure shape — concurrent federated queries spread
+// across the pool must all see the configured S3 session settings.
+func TestNewDuckDBClientContext_ConcurrentConnectionsConfigured(t *testing.T) {
+	duck, err := NewDuckDBClient(s3ConfiguredDuckDBConfig())
+	require.NoError(t, err)
+	defer duck.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			var region string
+			if err := duck.DB.QueryRowContext(ctx, "SELECT current_setting('s3_region');").Scan(&region); err != nil {
+				errs <- fmt.Errorf("worker %d: query s3_region: %w", worker, err)
+				return
+			}
+			if region != "us-test-1" {
+				errs <- fmt.Errorf("worker %d: s3_region = %q, want %q", worker, region, "us-test-1")
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
 }
 
 func TestNewDuckDBClient_DisabledConfig(t *testing.T) {


### PR DESCRIPTION
Closes #245.

## Root cause

`NewDuckDBClientContext` issued `INSTALL`/`LOAD`/`SET`/`PRAGMA` through `db.ExecContext` after `sql.Open`, landing all session-scoped configuration on one arbitrary pooled connection. With `MaxConnections > 1`, lazily opened connections had no S3 settings, and concurrent federated queries failed with `in region ''` HTTP 404 (deterministically reproduced by `TestCircuitBreaker_ConcurrentTransitions` at pool size 2). Production default `MaxConnections: 1` made this latent; the e2e harness pinned 11 call sites to `WithDuckMaxConnections(1)` as a workaround.

One correction to the issue text, verified against driver source (`duckdb-go/v2 v2.5.6`): with `:memory:`, `NewConnector` opens the database once and all pooled connections share that instance — connections are not independent databases. The bug is purely that session-scoped statements reached a single connection, which also means fix direction 1 (per-connection init) is strictly better than direction 2 (`SET GLOBAL`): it covers `LOAD` and any future session-scoped statement as well.

## Fix

- Init statements are pre-built once per client (`buildInitStatements` — S3 credential denylist validation still fails fast at construction) and executed by a `duckdb.NewConnector` init hook (`makeConnInit`) that the driver invokes for **every** new physical connection; the pool is opened with `sql.OpenDB`.
- Failed init statements keep the previous log-and-skip policy, so init never blocks a connection — zero behavior change beyond the fix. `PingContext` still opens, initializes, and verifies the first connection at construction.
- Public signatures (`NewDuckDBClient`/`NewDuckDBClientContext`) unchanged; the `factory` seam is untouched. Both validators and the file-backed "database locked" warning are deliberately unchanged; no `:memory:` warning is needed since connections now self-configure.
- All 11 `WithDuckMaxConnections(1)` e2e pins removed — the production harness runs at its default pool of 2 again, making the whole suite a regression gate. The option itself stays as a plain pool-sizing knob.

## Commits (TDD)

1. `a7f748e` red — `TestNewDuckDBClientContext_AllConnectionsConfigured` holds one pooled connection while checking out a second and proves the lazily opened connection has a NULL `s3_region`; `_ConcurrentConnectionsConfigured` mirrors the real concurrent failure shape. Both failed before the fix (connection 1 NULL; 7/8 workers NULL).
2. `261df85` green — the connector refactor. `_ExtensionStepsUseCallerCtx` is superseded by `_FirstConnectionConfigured` (init no longer runs as construction-time pool calls); `_InvalidS3CredentialFailsFast` locks the fail-fast contract.
3. `f5f865f` — e2e pin removal + `env.go`/`doc.go`/README workaround-comment cleanup.

## Verification

- `go test ./internal/federated ./factory` — green (red tests confirmed failing first).
- `make lint`, `make test` — green.
- Focused e2e: `TestCircuitBreaker_ConcurrentTransitions` at default pool 2 — **PASS** (previously 5/5 failing per the #245 A/B evidence).
- Full `go test -v ./internal/e2e_harness/production/ -tags=e2e` — all green (122s), including every de-pinned scenario.

## Out of scope

`internal/cdc/duckdb_exporter.go` has the same pattern (worse: no `SetMaxOpenConns`, so an unbounded pool) — filed as #285 rather than widening this PR's blast radius into the CDC path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)