### PR TITLE
feat(federated): #246 guarded single-probe half-open circuit breaker recovery

### DIFF
--- a/internal/e2e_harness/production/circuit_breaker_e2e_test.go
+++ b/internal/e2e_harness/production/circuit_breaker_e2e_test.go
@@ -16,13 +16,14 @@ import (
 const breakerRejection = "circuit breaker open"
 
 // TestCircuitBreaker_OpensAtThresholdAndRecovers covers #185 breaker
-// scenarios 1-3 end to end: exactly N real DuckDB failures (a closed
-// database/sql client) open the breaker, an open breaker rejects queries
-// before reaching DuckDB (rejection persists across a DuckDB rebuild while
-// openDuration lasts), after openDuration the first success closes the
-// breaker immediately, and the cleared failure history means one fresh
-// failure does not reopen it — the documented immediate-forgiveness design
-// with no half-open state accumulation (circuit_breaker.go design note).
+// scenarios 1-3 plus the #246 single-probe semantics end to end: exactly N
+// real DuckDB failures (a closed database/sql client) open the breaker, an
+// open breaker rejects queries before reaching DuckDB (rejection persists
+// across a DuckDB rebuild while openDuration lasts), after openDuration the
+// single admitted probe succeeds and closes the breaker (failure history
+// cleared, so one fresh failure does not reopen it), and a FAILED probe
+// re-opens the breaker for a fresh openDuration with no threshold
+// re-accumulation (circuit_breaker.go type doc).
 func TestCircuitBreaker_OpensAtThresholdAndRecovers(t *testing.T) {
 	const threshold = 3
 	const cooldown = 5 * time.Second
@@ -66,8 +67,8 @@ func TestCircuitBreaker_OpensAtThresholdAndRecovers(t *testing.T) {
 		t.Fatalf("query while open with healthy duckdb: want breaker rejection, got: %v", err)
 	}
 
-	// Scenario 2: after openDuration the first query flows through, succeeds,
-	// and closes the breaker (oracle-checked result).
+	// Scenario 2: after openDuration the first query is admitted as the
+	// single probe, succeeds, and closes the breaker (oracle-checked result).
 	time.Sleep(cooldown + time.Second)
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
 
@@ -85,20 +86,57 @@ func TestCircuitBreaker_OpensAtThresholdAndRecovers(t *testing.T) {
 		t.Fatalf("reopen duckdb after single failure: %v", err)
 	}
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
+
+	// Scenario 4 (#246): a failed probe re-opens the breaker for a fresh
+	// openDuration without threshold re-accumulation.
+	if err := env.Duck.Close(); err != nil {
+		t.Fatalf("close duckdb client for probe-failure leg: %v", err)
+	}
+	for i := 0; i < threshold; i++ {
+		if _, err := env.Query(ctx, Query{Schema: wide, Limit: 20}); err == nil {
+			t.Fatalf("probe-failure leg failure %d/%d: expected error with duckdb closed, got success", i+1, threshold)
+		} else if strings.Contains(err.Error(), breakerRejection) {
+			t.Fatalf("probe-failure leg failure %d/%d: breaker opened before the threshold: %v", i+1, threshold, err)
+		}
+	}
+	// Breaker is open again; wait out the cooldown with DuckDB STILL closed.
+	time.Sleep(cooldown + time.Second)
+	// The single admitted probe reaches the dead client and fails for real...
+	if _, err := env.Query(ctx, Query{Schema: wide, Limit: 20}); err == nil {
+		t.Fatal("probe against closed duckdb: expected real failure, got success")
+	} else if strings.Contains(err.Error(), breakerRejection) {
+		t.Fatalf("probe against closed duckdb: want a real failure, got breaker rejection: %v", err)
+	}
+	// ...and that SINGLE failure re-opens the breaker immediately — no
+	// threshold re-accumulation while half-open.
+	if _, err := env.Query(ctx, Query{Schema: wide, Limit: 20}); err == nil || !strings.Contains(err.Error(), breakerRejection) {
+		t.Fatalf("query after failed probe: want breaker rejection, got: %v", err)
+	}
+	// Recovery: healthy client + a fresh expired openDuration → the next
+	// probe succeeds and closes the breaker.
+	if err := env.ReopenDuckDB(); err != nil {
+		t.Fatalf("reopen duckdb after failed probe: %v", err)
+	}
+	time.Sleep(cooldown + time.Second)
+	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 20})
 }
 
-// TestCircuitBreaker_ConcurrentTransitions is #185 breaker scenario 4:
-// goroutines hammer the engine while the breaker trips, and again after it
-// recovers. During the outage every outcome must be one of the two legal
-// failures — a real DuckDB error or a breaker rejection, never a success or
-// a panic — and after recovery every concurrent query must succeed. Engine
-// calls go through eng.Query directly: Env.Query records results without a
-// lock and is not safe for concurrent use.
+// TestCircuitBreaker_ConcurrentTransitions is #185 breaker scenario 4 under
+// the #246 single-probe semantics: goroutines hammer the engine while the
+// breaker trips, and again after it recovers. During the outage every
+// outcome must be one of the two legal failures — a real DuckDB error or a
+// breaker rejection, never a success or a panic. At recovery a concurrent
+// burst gets exactly one admitted probe: the only legal outcomes are
+// success (the probe, plus stragglers arriving after it closed the breaker)
+// or a breaker rejection; once the probe has closed the breaker a full
+// concurrent burst must succeed. Engine calls go through eng.Query
+// directly: Env.Query records results without a lock and is not safe for
+// concurrent use.
 //
-// Runs on the harness-default DuckDB pool (2 connections): this test is the
-// regression gate for #245 — per-connection init must configure every pooled
-// connection, or one of the concurrent recovery queries 404s with an empty
-// s3_region.
+// Runs on the harness-default DuckDB pool (2 connections): the final
+// all-succeed burst is the regression gate for #245 — per-connection init
+// must configure every pooled connection, or one of the concurrent queries
+// 404s with an empty s3_region.
 func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
 	const threshold = 3
 	const cooldown = 3 * time.Second
@@ -158,8 +196,10 @@ func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
 	}
 	t.Logf("open phase: %d real failures, %d breaker rejections", real, rejected)
 
-	// Recovery under concurrency: healthy client + expired openDuration must
-	// let every worker through. Engine is rebuilt single-threaded first.
+	// Recovery under single-probe (#246): after openDuration a concurrent
+	// burst yields exactly one admitted probe; the rest are rejected until
+	// the probe's success closes the breaker. With a healthy client the
+	// only legal outcomes are success or breaker rejection.
 	if err := env.ReopenDuckDB(); err != nil {
 		t.Fatalf("reopen duckdb: %v", err)
 	}
@@ -177,7 +217,37 @@ func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
 	}
 	wg2.Wait()
 	close(errs2)
+
+	var succeeded, probeRejected int
 	for err := range errs2 {
+		switch {
+		case err == nil:
+			succeeded++
+		case strings.Contains(err.Error(), breakerRejection):
+			probeRejected++
+		default:
+			t.Errorf("recovery burst: want success or breaker rejection, got: %v", err)
+		}
+	}
+	if succeeded == 0 {
+		t.Errorf("recovery burst: no worker succeeded (breaker rejections: %d)", probeRejected)
+	}
+	t.Logf("recovery burst: %d succeeded, %d rejected while the probe was in flight", succeeded, probeRejected)
+
+	// The probe has closed the breaker: a full concurrent burst must now
+	// succeed (this is the #245 pooled-connection regression gate).
+	errs3 := make(chan error, workers)
+	var wg3 sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg3.Add(1)
+		go func() {
+			defer wg3.Done()
+			errs3 <- runOne()
+		}()
+	}
+	wg3.Wait()
+	close(errs3)
+	for err := range errs3 {
 		if err != nil {
 			t.Errorf("post-recovery concurrent query failed: %v", err)
 		}

--- a/internal/e2e_harness/production/circuit_breaker_e2e_test.go
+++ b/internal/e2e_harness/production/circuit_breaker_e2e_test.go
@@ -166,6 +166,49 @@ func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
 		t.Fatalf("close duckdb client: %v", err)
 	}
 
+	// Outage phase: every outcome must be a real failure or a breaker
+	// rejection — never a success.
+	succeeded, rejected, real := classifyBurstOutcomes(runConcurrentBurst(workers, queriesPerWorker, runOne))
+	if succeeded > 0 {
+		t.Errorf("%d queries succeeded while duckdb was closed", succeeded)
+	}
+	if rejected == 0 {
+		t.Errorf("no breaker rejections across %d concurrent queries (real failures: %d)", workers*queriesPerWorker, len(real))
+	}
+	t.Logf("open phase: %d real failures, %d breaker rejections", len(real), rejected)
+
+	// Recovery under single-probe (#246): after openDuration a concurrent
+	// burst yields exactly one admitted probe; the rest are rejected until
+	// the probe's success closes the breaker. With a healthy client the
+	// only legal outcomes are success or breaker rejection.
+	if err := env.ReopenDuckDB(); err != nil {
+		t.Fatalf("reopen duckdb: %v", err)
+	}
+	eng = env.Engine()
+	time.Sleep(cooldown + time.Second)
+
+	succeeded, rejected, real = classifyBurstOutcomes(runConcurrentBurst(workers, 1, runOne))
+	for _, err := range real {
+		t.Errorf("recovery burst: want success or breaker rejection, got: %v", err)
+	}
+	if succeeded == 0 {
+		t.Errorf("recovery burst: no worker succeeded (breaker rejections: %d)", rejected)
+	}
+	t.Logf("recovery burst: %d succeeded, %d rejected while the probe was in flight", succeeded, rejected)
+
+	// The probe has closed the breaker: a full concurrent burst must now
+	// succeed (this is the #245 pooled-connection regression gate).
+	for _, err := range runConcurrentBurst(workers, 1, runOne) {
+		if err != nil {
+			t.Errorf("post-recovery concurrent query failed: %v", err)
+		}
+	}
+}
+
+// runConcurrentBurst fans runOne out over workers goroutines, each calling
+// it queriesPerWorker times, and returns every outcome after all goroutines
+// have terminated.
+func runConcurrentBurst(workers, queriesPerWorker int, runOne func() error) []error {
 	errCh := make(chan error, workers*queriesPerWorker)
 	var wg sync.WaitGroup
 	for w := 0; w < workers; w++ {
@@ -180,76 +223,25 @@ func TestCircuitBreaker_ConcurrentTransitions(t *testing.T) {
 	wg.Wait()
 	close(errCh)
 
-	var real, rejected int
+	outcomes := make([]error, 0, workers*queriesPerWorker)
 	for err := range errCh {
-		switch {
-		case err == nil:
-			t.Error("query succeeded while duckdb was closed")
-		case strings.Contains(err.Error(), breakerRejection):
-			rejected++
-		default:
-			real++
-		}
+		outcomes = append(outcomes, err)
 	}
-	if rejected == 0 {
-		t.Errorf("no breaker rejections across %d concurrent queries (real failures: %d)", workers*queriesPerWorker, real)
-	}
-	t.Logf("open phase: %d real failures, %d breaker rejections", real, rejected)
+	return outcomes
+}
 
-	// Recovery under single-probe (#246): after openDuration a concurrent
-	// burst yields exactly one admitted probe; the rest are rejected until
-	// the probe's success closes the breaker. With a healthy client the
-	// only legal outcomes are success or breaker rejection.
-	if err := env.ReopenDuckDB(); err != nil {
-		t.Fatalf("reopen duckdb: %v", err)
-	}
-	eng = env.Engine()
-	time.Sleep(cooldown + time.Second)
-
-	errs2 := make(chan error, workers)
-	var wg2 sync.WaitGroup
-	for w := 0; w < workers; w++ {
-		wg2.Add(1)
-		go func() {
-			defer wg2.Done()
-			errs2 <- runOne()
-		}()
-	}
-	wg2.Wait()
-	close(errs2)
-
-	var succeeded, probeRejected int
-	for err := range errs2 {
+// classifyBurstOutcomes splits burst outcomes into successes, breaker
+// rejections, and the remaining real errors.
+func classifyBurstOutcomes(outcomes []error) (succeeded, rejected int, real []error) {
+	for _, err := range outcomes {
 		switch {
 		case err == nil:
 			succeeded++
 		case strings.Contains(err.Error(), breakerRejection):
-			probeRejected++
+			rejected++
 		default:
-			t.Errorf("recovery burst: want success or breaker rejection, got: %v", err)
+			real = append(real, err)
 		}
 	}
-	if succeeded == 0 {
-		t.Errorf("recovery burst: no worker succeeded (breaker rejections: %d)", probeRejected)
-	}
-	t.Logf("recovery burst: %d succeeded, %d rejected while the probe was in flight", succeeded, probeRejected)
-
-	// The probe has closed the breaker: a full concurrent burst must now
-	// succeed (this is the #245 pooled-connection regression gate).
-	errs3 := make(chan error, workers)
-	var wg3 sync.WaitGroup
-	for w := 0; w < workers; w++ {
-		wg3.Add(1)
-		go func() {
-			defer wg3.Done()
-			errs3 <- runOne()
-		}()
-	}
-	wg3.Wait()
-	close(errs3)
-	for err := range errs3 {
-		if err != nil {
-			t.Errorf("post-recovery concurrent query failed: %v", err)
-		}
-	}
+	return succeeded, rejected, real
 }

--- a/internal/e2e_harness/production/doc.go
+++ b/internal/e2e_harness/production/doc.go
@@ -33,6 +33,7 @@
 //	#181 failure-state injection   -> Env.ExecSQL escape hatch
 //	#182 mid-flush concurrency     -> PausingS3, RunFlushWith(FlushOverrides{S3})
 //	#185 degraded/breaker          -> WithBreaker, HaltS3, ReopenDuckDB, Query.AllowPartialDegradedMode
+//	#246 breaker single-probe      -> WithBreaker, Duck.Close, ReopenDuckDB
 //	#186 multi-schema isolation    -> schemas/e2e_simple + e2e_second, per-test DB
 //	#260 nested dotted attributes  -> schemas/e2e_nested, nested_attrs_e2e_test.go
 //

--- a/internal/federated/circuit_breaker.go
+++ b/internal/federated/circuit_breaker.go
@@ -5,7 +5,28 @@ import (
 	"time"
 )
 
-// CircuitBreaker is a lightweight in-memory circuit breaker.
+// CircuitBreaker is a lightweight in-memory circuit breaker with strict
+// single-probe half-open recovery (#246, supersedes the #185
+// immediate-forgiveness design).
+//
+// States (all transitions guarded by mu):
+//   - closed: no open period recorded; every caller is admitted.
+//   - open (now < openUntil): every caller is rejected.
+//   - half-open (openUntil elapsed): Allow admits exactly one caller as the
+//     probe and rejects the rest until the probe resolves. RecordSuccess
+//     closes the breaker (failure history cleared); RecordFailure re-opens
+//     it for a fresh openDuration without threshold re-accumulation.
+//
+// Probe abandonment: a probe that never reports (its query was cancelled
+// between Allow and Record*) lapses openDuration after admission, and the
+// next Allow reclaims the slot. A lost probe therefore costs at most one
+// extra openDuration of rejections.
+//
+// Stale callers: RecordSuccess closes the breaker from any state — a query
+// admitted before the breaker opened that completes afterwards is real
+// evidence the dependency is healthy. A stale RecordFailure landing while a
+// probe is in flight re-opens the breaker: conservative, and
+// indistinguishable from a probe failure without per-caller tokens.
 type CircuitBreaker struct {
 	mu           sync.Mutex
 	failures     []time.Time
@@ -13,6 +34,8 @@ type CircuitBreaker struct {
 	window       time.Duration
 	openUntil    time.Time
 	openDuration time.Duration
+	probing      bool
+	probeStarted time.Time
 }
 
 // NewCircuitBreaker creates a configured circuit breaker.
@@ -25,7 +48,36 @@ func NewCircuitBreaker(threshold int, window, openDuration time.Duration) *Circu
 	}
 }
 
-// RecordFailure records a failure occurrence and opens the breaker if threshold exceeded.
+// Allow reports whether the caller may proceed. In half-open state it
+// atomically reserves the single probe slot: the one caller that receives
+// true while others are rejected MUST resolve the probe via RecordSuccess
+// or RecordFailure (or let the reservation lapse after openDuration).
+func (cb *CircuitBreaker) Allow() bool {
+	if cb == nil {
+		return true
+	}
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	now := time.Now()
+	if now.Before(cb.openUntil) {
+		return false
+	}
+	if cb.openUntil.IsZero() && !cb.probing {
+		return true // closed: nothing to recover from
+	}
+	if cb.probing && now.Sub(cb.probeStarted) < cb.openDuration {
+		return false // half-open with a live probe in flight
+	}
+	// Half-open with a free (or lapsed) probe slot: this caller is the probe.
+	cb.probing = true
+	cb.probeStarted = now
+	return true
+}
+
+// RecordFailure records a failure occurrence. A probe failure re-opens the
+// breaker directly; otherwise failures accumulate in the sliding window and
+// open the breaker at threshold.
 func (cb *CircuitBreaker) RecordFailure() {
 	if cb == nil {
 		return
@@ -34,6 +86,15 @@ func (cb *CircuitBreaker) RecordFailure() {
 	defer cb.mu.Unlock()
 
 	now := time.Now()
+	if cb.probing {
+		// Probe failure: re-open for a fresh openDuration. The failure
+		// window is not consulted — half-open never re-accumulates the
+		// threshold (#246).
+		cb.probing = false
+		cb.openUntil = now.Add(cb.openDuration)
+		return
+	}
+
 	// drop old failures outside the window
 	cutoff := now.Add(-cb.window)
 	i := 0
@@ -55,14 +116,9 @@ func (cb *CircuitBreaker) RecordFailure() {
 	}
 }
 
-// RecordSuccess resets failure history when operations succeed.
-//
-// Design note: this breaker forgives immediately on the first success after
-// the open period expires; it does not implement a half-open probe state.
-// That favors fast recovery when the downstream is healthy again, but it also
-// means a single success clears prior failures even if the dependency is still
-// unstable. If stricter half-open semantics are needed, extend this logic with
-// a probe counter guarded by mu.
+// RecordSuccess closes the breaker and clears the failure history. It
+// resolves an in-flight probe, and also closes from open state when a
+// pre-open in-flight query completes (see the type doc on stale callers).
 func (cb *CircuitBreaker) RecordSuccess() {
 	if cb == nil {
 		return
@@ -71,9 +127,12 @@ func (cb *CircuitBreaker) RecordSuccess() {
 	defer cb.mu.Unlock()
 	cb.failures = cb.failures[:0]
 	cb.openUntil = time.Time{}
+	cb.probing = false
 }
 
-// IsOpen returns true if the breaker is currently open.
+// IsOpen reports whether the timed open period is currently active.
+// Observation only (tests, telemetry): admission control — including the
+// half-open probe reservation — lives in Allow.
 func (cb *CircuitBreaker) IsOpen() bool {
 	if cb == nil {
 		return false

--- a/internal/federated/circuit_breaker.go
+++ b/internal/federated/circuit_breaker.go
@@ -20,7 +20,10 @@ import (
 // Probe abandonment: a probe that never reports (its query was cancelled
 // between Allow and Record*) lapses openDuration after admission, and the
 // next Allow reclaims the slot. A lost probe therefore costs at most one
-// extra openDuration of rejections.
+// extra openDuration of rejections. The flip side: a probe still legitimately
+// running past openDuration is indistinguishable from an abandoned one, so a
+// slow dependency can see more than one concurrent probe — "exactly one" holds
+// only for probes that resolve within openDuration.
 //
 // Stale callers: RecordSuccess closes the breaker from any state — a query
 // admitted before the breaker opened that completes afterwards is real

--- a/internal/federated/circuit_breaker_integration_test.go
+++ b/internal/federated/circuit_breaker_integration_test.go
@@ -61,9 +61,9 @@ func newBreakerTestEngine(t *testing.T, duck DuckDBQueryExecutor, breaker *Circu
 
 func breakerTestQuery() (*model.FederatedAttributeQuery, model.StorageTables) {
 	return &model.FederatedAttributeQuery{
-			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 2000},
-			PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
-		}, model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"}
+		AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 2000},
+		PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
+	}, model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"}
 }
 
 func TestBreakerRecordsExecutionFailures(t *testing.T) {
@@ -142,9 +142,17 @@ type blockingDuckDBExecutor struct {
 
 func (b *blockingDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
 	b.calls.Add(1)
-	b.entered <- struct{}{}
-	<-b.release
-	return &singleDuckDBRow{rowID: uuid.New()}, nil
+	select {
+	case b.entered <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-b.release:
+		return &singleDuckDBRow{rowID: uuid.New()}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // #246: through the real Query path, the half-open probe executes DuckDB
@@ -162,23 +170,37 @@ func TestBreakerHalfOpenSingleProbeThroughQueryPath(t *testing.T) {
 	breaker.RecordFailure() // threshold 1: breaker opens
 	time.Sleep(100 * time.Millisecond)
 
-	probeErr := make(chan error, 1)
+	// A cancellable context plus the ctx-aware executor guarantee the probe
+	// goroutine terminates even when an assertion below fails fatally.
+	ctx, cancel := context.WithCancel(context.Background())
+	var probeErr error
+	probeDone := make(chan struct{})
 	go func() {
-		_, err := engine.Query(context.Background(), tables, fq, nil)
-		probeErr <- err
+		defer close(probeDone)
+		_, probeErr = engine.Query(ctx, tables, fq, nil)
 	}()
-	<-duck.entered // probe admitted and inside the executor
+	t.Cleanup(func() {
+		cancel()
+		<-probeDone
+	})
+
+	select {
+	case <-duck.entered: // probe admitted and inside the executor
+	case <-probeDone:
+		t.Fatalf("probe exited before reaching the executor: %v", probeErr)
+	}
 
 	// A concurrent caller is rejected without reaching the executor.
-	_, err := engine.Query(context.Background(), tables, fq, nil)
+	_, err := engine.Query(ctx, tables, fq, nil)
 	require.ErrorContains(t, err, "circuit breaker open")
 	require.Equal(t, int32(1), duck.calls.Load(), "non-probe caller must not reach the executor")
 
 	close(duck.release)
-	require.NoError(t, <-probeErr, "probe must succeed and close the breaker")
+	<-probeDone
+	require.NoError(t, probeErr, "probe must succeed and close the breaker")
 
 	// Probe success closed the breaker: the next caller flows through.
-	_, err = engine.Query(context.Background(), tables, fq, nil)
+	_, err = engine.Query(ctx, tables, fq, nil)
 	require.NoError(t, err, "breaker must be closed after probe success")
 	require.Equal(t, int32(2), duck.calls.Load(), "post-probe caller must reach the executor")
 }

--- a/internal/federated/circuit_breaker_integration_test.go
+++ b/internal/federated/circuit_breaker_integration_test.go
@@ -3,6 +3,7 @@ package federated
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"text/template"
 	"time"
@@ -129,4 +130,55 @@ func TestBreakerSuccessResetsFailureHistory(t *testing.T) {
 	_, err = engine.Query(context.Background(), tables, fq, nil)
 	require.Error(t, err)
 	require.False(t, breaker.IsOpen(), "success must have cleared the failure history")
+}
+
+// blockingDuckDBExecutor blocks each Query until released, letting a test
+// hold the half-open probe in flight while other callers race the breaker.
+type blockingDuckDBExecutor struct {
+	entered chan struct{}
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+func (b *blockingDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
+	b.calls.Add(1)
+	b.entered <- struct{}{}
+	<-b.release
+	return &singleDuckDBRow{rowID: uuid.New()}, nil
+}
+
+// #246: through the real Query path, the half-open probe executes DuckDB
+// while a concurrent caller is rejected without reaching the executor —
+// mirroring the open-breaker short-circuit call-count assertion above.
+func TestBreakerHalfOpenSingleProbeThroughQueryPath(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	breaker := NewCircuitBreaker(1, time.Minute, 50*time.Millisecond)
+	duck := &blockingDuckDBExecutor{entered: make(chan struct{}, 1), release: make(chan struct{})}
+	engine := newBreakerTestEngine(t, duck, breaker)
+	fq, tables := breakerTestQuery()
+
+	breaker.RecordFailure() // threshold 1: breaker opens
+	time.Sleep(100 * time.Millisecond)
+
+	probeErr := make(chan error, 1)
+	go func() {
+		_, err := engine.Query(context.Background(), tables, fq, nil)
+		probeErr <- err
+	}()
+	<-duck.entered // probe admitted and inside the executor
+
+	// A concurrent caller is rejected without reaching the executor.
+	_, err := engine.Query(context.Background(), tables, fq, nil)
+	require.ErrorContains(t, err, "circuit breaker open")
+	require.Equal(t, int32(1), duck.calls.Load(), "non-probe caller must not reach the executor")
+
+	close(duck.release)
+	require.NoError(t, <-probeErr, "probe must succeed and close the breaker")
+
+	// Probe success closed the breaker: the next caller flows through.
+	_, err = engine.Query(context.Background(), tables, fq, nil)
+	require.NoError(t, err, "breaker must be closed after probe success")
+	require.Equal(t, int32(2), duck.calls.Load(), "post-probe caller must reach the executor")
 }

--- a/internal/federated/circuit_breaker_test.go
+++ b/internal/federated/circuit_breaker_test.go
@@ -2,6 +2,7 @@ package federated
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -84,6 +85,117 @@ func TestCircuitBreakerRecordSuccessClosesBreakerImmediately(t *testing.T) {
 	cb.RecordSuccess()
 	if cb.IsOpen() {
 		t.Fatal("RecordSuccess must close the breaker immediately")
+	}
+}
+
+func TestCircuitBreakerAllowClosedAdmitsAll(t *testing.T) {
+	cb := NewCircuitBreaker(2, 10*time.Second, 5*time.Second)
+	for i := 0; i < 2; i++ {
+		if !cb.Allow() {
+			t.Fatalf("closed breaker must admit caller %d without reserving a probe", i+1)
+		}
+	}
+	cb.RecordFailure() // below threshold: still closed
+	if !cb.Allow() {
+		t.Fatal("breaker below threshold must remain closed")
+	}
+}
+
+func TestCircuitBreakerAllowNilSafety(t *testing.T) {
+	var nilBreaker *CircuitBreaker
+	if !nilBreaker.Allow() {
+		t.Fatal("nil breaker must admit everything")
+	}
+}
+
+func TestCircuitBreakerAllowRejectsWhileOpen(t *testing.T) {
+	cb := NewCircuitBreaker(1, 10*time.Second, 10*time.Second)
+	cb.RecordFailure()
+	if cb.Allow() {
+		t.Fatal("open breaker must reject before openDuration elapses")
+	}
+}
+
+func TestCircuitBreakerHalfOpenAdmitsExactlyOneProbe(t *testing.T) {
+	cb := NewCircuitBreaker(1, 10*time.Second, 50*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(100 * time.Millisecond)
+
+	var admitted int32
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if cb.Allow() {
+				atomic.AddInt32(&admitted, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&admitted); got != 1 {
+		t.Fatalf("half-open breaker must admit exactly 1 probe, admitted %d", got)
+	}
+}
+
+func TestCircuitBreakerProbeSuccessCloses(t *testing.T) {
+	cb := NewCircuitBreaker(1, 10*time.Second, 50*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(100 * time.Millisecond)
+
+	if !cb.Allow() {
+		t.Fatal("first caller after openDuration must be admitted as the probe")
+	}
+	if cb.Allow() {
+		t.Fatal("second caller must be rejected while the probe is in flight")
+	}
+	cb.RecordSuccess()
+	for i := 0; i < 2; i++ {
+		if !cb.Allow() {
+			t.Fatalf("probe success must close the breaker for all callers, caller %d rejected", i+1)
+		}
+	}
+}
+
+func TestCircuitBreakerProbeFailureReopensWithoutThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(3, 10*time.Second, 50*time.Millisecond)
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.Allow() {
+		t.Fatal("breaker must be open at threshold")
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if !cb.Allow() {
+		t.Fatal("probe must be admitted after openDuration")
+	}
+	cb.RecordFailure() // ONE probe failure — far below the threshold of 3
+	if cb.Allow() {
+		t.Fatal("probe failure must re-open immediately, without threshold re-accumulation")
+	}
+	time.Sleep(100 * time.Millisecond)
+	if !cb.Allow() {
+		t.Fatal("a fresh probe must be admitted after the renewed openDuration")
+	}
+}
+
+func TestCircuitBreakerAbandonedProbeReclaimed(t *testing.T) {
+	cb := NewCircuitBreaker(1, 10*time.Second, 50*time.Millisecond)
+	cb.RecordFailure()
+	time.Sleep(100 * time.Millisecond)
+
+	if !cb.Allow() {
+		t.Fatal("probe must be admitted after openDuration")
+	}
+	if cb.Allow() {
+		t.Fatal("probe slot must be exclusive while in flight")
+	}
+	// The probe never reports (cancelled query). The reservation lapses
+	// openDuration after admission and the slot becomes reclaimable.
+	time.Sleep(100 * time.Millisecond)
+	if !cb.Allow() {
+		t.Fatal("abandoned probe must be reclaimable after openDuration")
 	}
 }
 

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -88,10 +88,13 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 		return 0, fmt.Errorf("duckdb client not available: %w", ErrDuckDBUnavailable)
 	}
 
-	// Reject-before-DuckDB (#185): an open breaker must short-circuit before
-	// ANY DuckDB or S3 work — including the #189 pre-read schema probes and
-	// path resolution, which reach storage.
-	if e.breaker != nil && e.breaker.IsOpen() {
+	// Reject-before-DuckDB (#185): a non-admitted caller must short-circuit
+	// before ANY DuckDB or S3 work — including the #189 pre-read schema
+	// probes and path resolution, which reach storage. Allow also reserves
+	// the half-open single probe (#246); early-error returns between here
+	// and duck.Query abandon the probe, whose reservation lapses after
+	// openDuration (see the CircuitBreaker type doc).
+	if !e.breaker.Allow() {
 		planCtx.recordClientUnavailable()
 		return 0, fmt.Errorf("duckdb circuit breaker open, query rejected: %w", ErrDuckDBUnavailable)
 	}


### PR DESCRIPTION
## Summary

Closes #246.

Replaces the federated circuit breaker's immediate-forgiveness recovery with **strict single-probe half-open** semantics, superseding the #185 design note (adjudicated in https://github.com/Lychee-Technology/forma/issues/185#issuecomment-4965109283 with #246 as the opt-in trigger).

- **Open → Half-open:** when `openDuration` elapses, `Allow()` atomically admits exactly ONE caller as the probe under the existing mutex; concurrent callers keep receiving the same rejection error until the probe resolves.
- **Probe success → Closed:** failure history cleared (as today).
- **Probe failure → Open again** for a fresh `openDuration` — no threshold re-accumulation while half-open.
- **Probe abandonment** (query cancelled between `Allow` and `Record*`, or engine early-error paths before `duck.Query`): the reservation lapses `openDuration` after admission and the next `Allow` reclaims the slot — a lost probe costs at most one extra `openDuration` of rejections. Documented caveat: a probe legitimately outliving `openDuration` is indistinguishable from an abandoned one, so a slow dependency can see more than one concurrent probe.
- **Nil-safety preserved:** `Allow()` returns true on nil, so the engine's `e.breaker != nil` guard is dropped.

## API shape

`Allow() bool` performs admission + probe reservation (per the issue's design note — `IsOpen()` cannot express "you are the probe"). `IsOpen()` is retained unchanged as an observation-only snapshot of the timed open period. The engine's single production call site (`duckdb_query.go`) swaps `IsOpen()` → `Allow()`; `RecordSuccess`/`RecordFailure` call sites are untouched. Rejection error text is byte-for-byte unchanged, so degraded-mode interplay under `AllowPartialDegradedMode` (pinned by #185 tests) is unaffected. No config changes; probe count is not configurable (YAGNI per issue).

## Deliberate semantics for stale callers

- `RecordSuccess` closes from any state: a query admitted before the breaker opened that completes afterwards is real evidence of health (preserves existing behavior + tests).
- A stale `RecordFailure` landing while a probe is in flight re-opens the breaker: conservative, indistinguishable from a probe failure without per-caller tokens.

## Test matrix (per issue)

- **Unit** (`circuit_breaker_test.go`): 32 goroutines racing `Allow()` after expiry → exactly 1 admitted; probe success closes; probe failure re-opens without threshold; abandoned probe reclaimed after `openDuration`; nil-safety; all pre-#246 window/threshold tests unchanged and green.
- **Integration** (`circuit_breaker_integration_test.go`): blocking-executor test through the real `Query → StreamDuckDBFederatedQuery` path — probe executes DuckDB while a concurrent caller is rejected **without reaching the executor** (call-count assertion, mirroring the existing open-breaker short-circuit test).
- **E2E** (`circuit_breaker_e2e_test.go`, updated deliberately per the issue — PR #244's characterization was the update surface):
  - `TestCircuitBreaker_OpensAtThresholdAndRecovers`: #185 scenarios 1–3 survive (the serial post-cooldown query IS the probe); new probe-failure leg — DuckDB still closed after cooldown → one real probe failure → immediate re-open, next query breaker-rejected with no threshold re-accumulation → recovery probe closes.
  - `TestCircuitBreaker_ConcurrentTransitions`: recovery phase re-staged — burst 1 outcomes must be success ∪ breaker-rejection with ≥1 success (observed: `1 succeeded, 7 rejected while the probe was in flight` — exactly single-probe); final all-succeed burst preserves the #245 pooled-connection regression gate.

Red-first evidence: before the e2e update, the new implementation left `OpensAtThresholdAndRecovers` green and failed `ConcurrentTransitions` exactly at the all-workers-succeed recovery assertion (7/8 rejected), matching the issue's prediction.

## Verification

- `make test` + `make lint` green.
- Full production harness (`make test-e2e-production`) green (124s).
- Targeted e2e `-run 'TestCircuitBreaker_'` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
