### PR TITLE
feat(cdc): #203 manifest-reconcile tool — report/repair/GC for S3 parquet vs manifest drift

### DIFF
--- a/cmd/tools/README.md
+++ b/cmd/tools/README.md
@@ -7,6 +7,9 @@ Forma Tools CLI
 --------
 - `generate-attributes`：从 JSON Schema 生成 `<schema>_attributes.json`。
 - `init-db`：创建 schema registry、entity main、EAV 数据表及索引。
+- `manifest-reconcile`：比对 S3 parquet 对象与 manifest 条目，报告孤儿/dangling，
+  `--repair` 补录 #197 flush 孤儿，`--gc` 清理 #188 compaction 遗留。
+  详见 `docs/manifest-reconcile.md`。退出码：0 一致 / 2 有差异 / 1 失败。
 
 generate-attributes
 -------------------

--- a/cmd/tools/main.go
+++ b/cmd/tools/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -37,6 +38,13 @@ func runToolMain(ctx context.Context, args []string, out io.Writer) int {
 	}
 
 	if err := cmd.run(ctx, args[1:]); err != nil {
+		// Commands report semantic outcomes (e.g. manifest-reconcile's
+		// "discrepancies found" = 2) via an ExitCode; those already rendered
+		// their output, so no error line is printed for them.
+		var ec exitCoder
+		if errors.As(err, &ec) {
+			return ec.ExitCode()
+		}
 		fmt.Fprintf(out, "%s: %v\n", cmd.name, err)
 		if cmd.exitOnError {
 			return 1
@@ -44,6 +52,11 @@ func runToolMain(ctx context.Context, args []string, out io.Writer) int {
 	}
 
 	return 0
+}
+
+// exitCoder lets a command error carry its own process exit code.
+type exitCoder interface {
+	ExitCode() int
 }
 
 func lookupToolCommand(name string) (toolCommand, bool) {
@@ -64,6 +77,7 @@ func toolCommands() []toolCommand {
 		{name: "cdc-flush", run: runCDCFlush, exitOnError: true},
 		{name: "cdc-init", run: runCDCInit, exitOnError: true},
 		{name: "compactor", run: runCompactor, exitOnError: true},
+		{name: "manifest-reconcile", run: runManifestReconcileFn, exitOnError: true},
 	}
 }
 
@@ -78,4 +92,5 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cdc-flush             Run CDC change_log flush to S3 parquet files")
 	fmt.Fprintln(out, "  cdc-init              Initialize S3 parquet base files from existing data")
 	fmt.Fprintln(out, "  compactor             Run compaction on parquet files for a schema")
+	fmt.Fprintln(out, "  manifest-reconcile    Diff S3 parquet objects against manifests; report, --repair orphaned deltas, --gc compaction leftovers")
 }

--- a/cmd/tools/manifest_reconcile.go
+++ b/cmd/tools/manifest_reconcile.go
@@ -131,7 +131,7 @@ var runManifestReconcileFn = runManifestReconcile
 func runManifestReconcile(ctx context.Context, args []string) error {
 	opts, err := parseReconcileFlags(args)
 	if err != nil {
-		return err
+		return fmt.Errorf("parse manifest-reconcile flags: %w", err)
 	}
 	if opts == nil { // help requested
 		return nil
@@ -155,10 +155,13 @@ func runManifestReconcile(ctx context.Context, args []string) error {
 	}
 
 	objectStore := &reconcile.S3ObjectStore{Client: s3Client, Bucket: opts.s3.bucket}
+	manifestStore := &manifest.S3Store{Client: s3Client, Bucket: opts.manifest.Bucket}
+	resolver := manifest.PathResolver{Prefix: opts.manifest.Prefix, PathTemplate: opts.manifest.PathTemplate}
 	r := &reconcile.Reconciler{
 		Lister:     objectStore,
 		Deleter:    objectStore,
-		Manifests:  buildReconcileManifestStore(opts, s3Client),
+		Manifests:  &reconcile.ResolverManifestStore{Store: manifestStore, Resolver: resolver},
+		GCStates:   &reconcile.ManifestGCStateStore{Store: manifestStore, Resolver: resolver},
 		Locker:     &reconcile.PGAdvisoryLocker{DB: db},
 		Schemas:    &reconcile.RegistrySchemaEnumerator{DB: db, Table: opts.registryTable, SchemaIDFilter: opts.schemaID},
 		Now:        time.Now,
@@ -220,15 +223,6 @@ func reconcileExitError(report reconcile.Report) error {
 		return &discrepancyError{count: residual}
 	}
 	return nil
-}
-
-// buildReconcileManifestStore wires the etag-aware S3 manifest store behind
-// the reconcile LoadOrCreate adapter.
-func buildReconcileManifestStore(opts *reconcileOptions, s3Client manifest.S3Client) *reconcile.ResolverManifestStore {
-	return &reconcile.ResolverManifestStore{
-		Store:    &manifest.S3Store{Client: s3Client, Bucket: opts.manifest.Bucket},
-		Resolver: manifest.PathResolver{Prefix: opts.manifest.Prefix, PathTemplate: opts.manifest.PathTemplate},
-	}
 }
 
 // openReconcileStatsEngine builds the CDC DuckDB exporter the repair path

--- a/cmd/tools/manifest_reconcile.go
+++ b/cmd/tools/manifest_reconcile.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -32,17 +33,18 @@ func (e *discrepancyError) ExitCode() int { return 2 }
 
 // reconcileOptions carries the parsed manifest-reconcile flag values.
 type reconcileOptions struct {
-	s3            s3Flags
-	pg            postgresFlags
-	manifest      cdc.ManifestConfig
-	dataPrefix    string
-	registryTable string
-	schemaID      int
-	repair        bool
-	gc            bool
-	gcGrace       time.Duration
-	etagRetries   int
-	duck          duckExportFlags
+	s3              s3Flags
+	pg              postgresFlags
+	manifest        cdc.ManifestConfig
+	dataPrefix      string
+	entityMainTable string
+	registryTable   string
+	schemaID        int
+	repair          bool
+	gc              bool
+	gcGrace         time.Duration
+	etagRetries     int
+	duck            duckExportFlags
 }
 
 // parseReconcileFlags parses and validates the subcommand flags. A nil
@@ -80,6 +82,7 @@ func parseReconcileFlags(args []string) (*reconcileOptions, error) {
 	// --s3-prefix / compactor --data-prefix): listing a different prefix
 	// reports every real file as dangling and every listed key as orphaned.
 	dataPrefix := fs.String("data-prefix", "data", "Data prefix for parquet files (must match the flusher's prefix)")
+	entityMainTable := fs.String("entity-main-table", "entity_main", "Entity main table (repair guard's liveness check)")
 	manifestPrefix := fs.String("manifest-prefix", "", "Manifest prefix in S3")
 	manifestTemplate := fs.String("manifest-template", "manifest/{{.SchemaID}}.json", "Manifest path template")
 	registryTable := fs.String("schema-registry-table", "", "Schema registry table for schema enumeration (required)")
@@ -103,12 +106,17 @@ func parseReconcileFlags(args []string) (*reconcileOptions, error) {
 		return nil, fmt.Errorf("--schema-registry-table is required")
 	}
 
+	if *gc && *gcGrace <= 0 {
+		return nil, fmt.Errorf("--gc-grace must be positive; a zero grace would delete a live compaction's staging objects")
+	}
+
 	opts.manifest = cdc.ManifestConfig{
 		Bucket:       opts.s3.bucket,
 		Prefix:       *manifestPrefix,
 		PathTemplate: *manifestTemplate,
 	}
 	opts.dataPrefix = *dataPrefix
+	opts.entityMainTable = *entityMainTable
 	opts.registryTable = *registryTable
 	opts.schemaID = *schemaID
 	opts.repair = *repair
@@ -146,9 +154,10 @@ func runManifestReconcile(ctx context.Context, args []string) error {
 		return fmt.Errorf("load AWS config: %w", err)
 	}
 
+	objectStore := &reconcile.S3ObjectStore{Client: s3Client, Bucket: opts.s3.bucket}
 	r := &reconcile.Reconciler{
-		Lister:     &reconcile.S3ObjectStore{Client: s3Client, Bucket: opts.s3.bucket},
-		Deleter:    &reconcile.S3ObjectStore{Client: s3Client, Bucket: opts.s3.bucket},
+		Lister:     objectStore,
+		Deleter:    objectStore,
 		Manifests:  buildReconcileManifestStore(opts, s3Client),
 		Locker:     &reconcile.PGAdvisoryLocker{DB: db},
 		Schemas:    &reconcile.RegistrySchemaEnumerator{DB: db, Table: opts.registryTable, SchemaIDFilter: opts.schemaID},
@@ -171,6 +180,7 @@ func runManifestReconcile(ctx context.Context, args []string) error {
 		}
 		defer func() { _ = exporter.DB.Close() }()
 		r.Stats = &reconcile.DuckStatsReader{DB: exporter.DB, Bucket: opts.s3.bucket}
+		r.LiveRows = &reconcile.PGLiveRows{DB: db, Table: opts.entityMainTable}
 	}
 
 	logger.Info("starting manifest reconcile",
@@ -184,15 +194,30 @@ func runManifestReconcile(ctx context.Context, args []string) error {
 		return fmt.Errorf("reconcile failed: %w", err)
 	}
 	report.Render(os.Stdout)
+	return reconcileExitError(report)
+}
 
-	if report.HasResidualDiscrepancies() {
-		count := 0
-		for _, s := range report.Schemas {
-			if s.Residual() {
-				count++
-			}
+// reconcileExitError maps a rendered report to the process outcome:
+// per-schema tool failures are a plain error (exit 1) — monitoring must not
+// mistake an S3 outage for data inconsistency — while pure residual
+// discrepancies exit 2 via discrepancyError, and a clean run exits 0.
+func reconcileExitError(report reconcile.Report) error {
+	var failed []string
+	residual := 0
+	for _, s := range report.Schemas {
+		if s.Err != nil {
+			failed = append(failed, fmt.Sprintf("schema %d: %v", s.SchemaID, s.Err))
+			continue
 		}
-		return &discrepancyError{count: count}
+		if s.Residual() {
+			residual++
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("reconcile failed for %d schema(s): %s", len(failed), strings.Join(failed, "; "))
+	}
+	if residual > 0 {
+		return &discrepancyError{count: residual}
 	}
 	return nil
 }
@@ -237,13 +262,26 @@ func openReconcileStatsEngine(ctx context.Context, opts *reconcileOptions, logge
 
 // buildToolSQLDB opens a database/sql handle (pgx driver) for tools that
 // need session-scoped Postgres features — the reconcile advisory lock pins
-// a single connection, which pgxpool does not expose.
+// a single connection, which pgxpool does not expose. Values are quoted so
+// passwords with spaces or quotes survive DSN parsing (the sibling copies
+// in internal/cdc/flusher.go and init.go still interpolate raw — follow-up:
+// extract one shared DSN builder).
 func buildToolSQLDB(pg postgresFlags) (*sql.DB, error) {
 	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		pg.host, pg.port, pg.user, pg.resolvedPassword("PGPASSWORD"), pg.database, pg.sslMode)
+		quotePGConnValue(pg.host), pg.port, quotePGConnValue(pg.user),
+		quotePGConnValue(pg.resolvedPassword("PGPASSWORD")),
+		quotePGConnValue(pg.database), quotePGConnValue(pg.sslMode))
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
 		return nil, fmt.Errorf("open pg: %w", err)
 	}
 	return db, nil
+}
+
+// quotePGConnValue quotes one keyword/value DSN value per libpq rules:
+// wrapped in single quotes with backslash and single-quote escaped.
+func quotePGConnValue(v string) string {
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, `'`, `\'`)
+	return "'" + v + "'"
 }

--- a/cmd/tools/manifest_reconcile.go
+++ b/cmd/tools/manifest_reconcile.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"go.uber.org/zap"
+
+	"github.com/lychee-technology/forma/internal/cdc"
+	"github.com/lychee-technology/forma/internal/manifest"
+	"github.com/lychee-technology/forma/internal/reconcile"
+)
+
+// discrepancyError signals that the reconcile run itself succeeded but left
+// residual discrepancies; runToolMain maps it to exit code 2 so periodic
+// checks can distinguish "inconsistent" (2) from "tool failed" (1).
+type discrepancyError struct {
+	count int
+}
+
+func (e *discrepancyError) Error() string {
+	return fmt.Sprintf("%d schema(s) with residual discrepancies", e.count)
+}
+
+func (e *discrepancyError) ExitCode() int { return 2 }
+
+// reconcileOptions carries the parsed manifest-reconcile flag values.
+type reconcileOptions struct {
+	s3            s3Flags
+	pg            postgresFlags
+	manifest      cdc.ManifestConfig
+	dataPrefix    string
+	registryTable string
+	schemaID      int
+	repair        bool
+	gc            bool
+	gcGrace       time.Duration
+	etagRetries   int
+	duck          duckExportFlags
+}
+
+// parseReconcileFlags parses and validates the subcommand flags. A nil
+// options value with a nil error means help was requested.
+func parseReconcileFlags(args []string) (*reconcileOptions, error) {
+	fs := flag.NewFlagSet("manifest-reconcile", flag.ContinueOnError)
+	fs.SetOutput(flag.CommandLine.Output())
+
+	opts := &reconcileOptions{}
+	opts.s3.register(fs, s3FlagOptions{
+		bucketUsage:    "S3 bucket for parquet/manifest files (required)",
+		bucketRequired: true,
+	})
+	opts.pg.register(fs, postgresFlagOptions{
+		hostFlag:        "pg-host",
+		portFlag:        "pg-port",
+		userFlag:        "pg-user",
+		passwordFlag:    "pg-password",
+		databaseFlag:    "pg-db",
+		sslModeFlag:     "pg-ssl-mode",
+		hostDefault:     "localhost",
+		portDefault:     5432,
+		userDefault:     "postgres",
+		databaseDefault: "forma",
+		sslModeDefault:  "require",
+		hostUsage:       "PostgreSQL host",
+		portUsage:       "PostgreSQL port",
+		userUsage:       "PostgreSQL user",
+		passwordUsage:   "PostgreSQL password (or set PGPASSWORD env)",
+		databaseUsage:   "PostgreSQL database",
+		sslModeUsage:    "PostgreSQL sslmode",
+	})
+
+	// Must match the prefix the flusher/init exported under (cdc-flush
+	// --s3-prefix / compactor --data-prefix): listing a different prefix
+	// reports every real file as dangling and every listed key as orphaned.
+	dataPrefix := fs.String("data-prefix", "data", "Data prefix for parquet files (must match the flusher's prefix)")
+	manifestPrefix := fs.String("manifest-prefix", "", "Manifest prefix in S3")
+	manifestTemplate := fs.String("manifest-template", "manifest/{{.SchemaID}}.json", "Manifest path template")
+	registryTable := fs.String("schema-registry-table", "", "Schema registry table for schema enumeration (required)")
+	schemaID := fs.Int("schema-id", 0, "Reconcile only this schema (0 = all registered schemas)")
+	repair := fs.Bool("repair", false, "Append manifest entries for delta-shaped orphans (metadata recomputed from parquet contents)")
+	gc := fs.Bool("gc", false, "Delete base-shaped and _tmp orphans older than the grace period")
+	gcGrace := fs.Duration("gc-grace", 15*time.Minute, "Minimum object age before --gc may delete it")
+	etagRetries := fs.Int("etag-retries", 3, "Manifest save retries on optimistic-concurrency conflict")
+	opts.duck.register(fs, duckExportFlagOptions{memLimitDefault: "4GB", queryTimeout: 5 * time.Minute})
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if err := opts.s3.validate(true); err != nil {
+		return nil, fmt.Errorf("validate s3 flags: %w", err)
+	}
+	if *registryTable == "" {
+		return nil, fmt.Errorf("--schema-registry-table is required")
+	}
+
+	opts.manifest = cdc.ManifestConfig{
+		Bucket:       opts.s3.bucket,
+		Prefix:       *manifestPrefix,
+		PathTemplate: *manifestTemplate,
+	}
+	opts.dataPrefix = *dataPrefix
+	opts.registryTable = *registryTable
+	opts.schemaID = *schemaID
+	opts.repair = *repair
+	opts.gc = *gc
+	opts.gcGrace = *gcGrace
+	opts.etagRetries = *etagRetries
+	return opts, nil
+}
+
+var runManifestReconcileFn = runManifestReconcile
+
+func runManifestReconcile(ctx context.Context, args []string) error {
+	opts, err := parseReconcileFlags(args)
+	if err != nil {
+		return err
+	}
+	if opts == nil { // help requested
+		return nil
+	}
+
+	logger, err := buildToolLogger(false)
+	if err != nil {
+		return fmt.Errorf("create logger: %w", err)
+	}
+	defer func() { _ = logger.Sync() }()
+
+	db, err := buildToolSQLDB(opts.pg)
+	if err != nil {
+		return fmt.Errorf("open postgres: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	s3Client, err := buildToolS3Client(ctx, opts.s3.region, opts.s3.endpoint, opts.s3.usePath)
+	if err != nil {
+		return fmt.Errorf("load AWS config: %w", err)
+	}
+
+	r := &reconcile.Reconciler{
+		Lister:     &reconcile.S3ObjectStore{Client: s3Client, Bucket: opts.s3.bucket},
+		Deleter:    &reconcile.S3ObjectStore{Client: s3Client, Bucket: opts.s3.bucket},
+		Manifests:  buildReconcileManifestStore(opts, s3Client),
+		Locker:     &reconcile.PGAdvisoryLocker{DB: db},
+		Schemas:    &reconcile.RegistrySchemaEnumerator{DB: db, Table: opts.registryTable, SchemaIDFilter: opts.schemaID},
+		Now:        time.Now,
+		Bucket:     opts.s3.bucket,
+		DataPrefix: opts.dataPrefix,
+		Logger:     logger,
+		Opts: reconcile.Options{
+			Repair:         opts.repair,
+			GC:             opts.gc,
+			GCGrace:        opts.gcGrace,
+			MaxETagRetries: opts.etagRetries,
+		},
+	}
+
+	if opts.repair {
+		exporter, err := openReconcileStatsEngine(ctx, opts, logger)
+		if err != nil {
+			return fmt.Errorf("build stats engine: %w", err)
+		}
+		defer func() { _ = exporter.DB.Close() }()
+		r.Stats = &reconcile.DuckStatsReader{DB: exporter.DB, Bucket: opts.s3.bucket}
+	}
+
+	logger.Info("starting manifest reconcile",
+		zap.String("bucket", opts.s3.bucket),
+		zap.String("data_prefix", opts.dataPrefix),
+		zap.Bool("repair", opts.repair),
+		zap.Bool("gc", opts.gc))
+
+	report, err := r.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("reconcile failed: %w", err)
+	}
+	report.Render(os.Stdout)
+
+	if report.HasResidualDiscrepancies() {
+		count := 0
+		for _, s := range report.Schemas {
+			if s.Residual() {
+				count++
+			}
+		}
+		return &discrepancyError{count: count}
+	}
+	return nil
+}
+
+// buildReconcileManifestStore wires the etag-aware S3 manifest store behind
+// the reconcile LoadOrCreate adapter.
+func buildReconcileManifestStore(opts *reconcileOptions, s3Client manifest.S3Client) *reconcile.ResolverManifestStore {
+	return &reconcile.ResolverManifestStore{
+		Store:    &manifest.S3Store{Client: s3Client, Bucket: opts.manifest.Bucket},
+		Resolver: manifest.PathResolver{Prefix: opts.manifest.Prefix, PathTemplate: opts.manifest.PathTemplate},
+	}
+}
+
+// openReconcileStatsEngine builds the CDC DuckDB exporter the repair path
+// reads parquet stats through — the same httpfs+credentials wiring the
+// compactor's merge engine uses. The pool is pinned to one connection: the
+// exporter's S3 session settings apply per connection, and a second pooled
+// connection would read s3:// without credentials (#285).
+func openReconcileStatsEngine(ctx context.Context, opts *reconcileOptions, logger *zap.Logger) (*cdc.DuckExporter, error) {
+	key, secret, token := resolveMergeCredentials(ctx, opts.s3.region, logger)
+	duckCfg := cdc.CDCConfig{
+		DuckDBPath:              opts.duck.duckDBPath,
+		DuckThreads:             opts.duck.duckThreads,
+		DuckMemLimit:            opts.duck.duckMemLimit,
+		QueryTimeout:            opts.duck.queryTimeout,
+		ParquetCompression:      opts.duck.parquetCompression,
+		ParquetCompressionLevel: opts.duck.parquetCompressionLevel,
+		S3Bucket:                opts.s3.bucket,
+		S3Endpoint:              opts.s3.endpoint,
+		S3Region:                opts.s3.region,
+		S3UseSSL:                opts.s3.useSSL,
+		S3UsePath:               opts.s3.usePath,
+		S3SessionToken:          token,
+	}
+	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, logger)
+	if err != nil {
+		return nil, fmt.Errorf("open stats duckdb: %w", err)
+	}
+	exporter.DB.SetMaxOpenConns(1)
+	return exporter, nil
+}
+
+// buildToolSQLDB opens a database/sql handle (pgx driver) for tools that
+// need session-scoped Postgres features — the reconcile advisory lock pins
+// a single connection, which pgxpool does not expose.
+func buildToolSQLDB(pg postgresFlags) (*sql.DB, error) {
+	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		pg.host, pg.port, pg.user, pg.resolvedPassword("PGPASSWORD"), pg.database, pg.sslMode)
+	db, err := sql.Open("pgx", connStr)
+	if err != nil {
+		return nil, fmt.Errorf("open pg: %w", err)
+	}
+	return db, nil
+}

--- a/cmd/tools/manifest_reconcile_test.go
+++ b/cmd/tools/manifest_reconcile_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/lychee-technology/forma/internal/reconcile"
 )
 
 func TestRunToolMain_ManifestReconcileExitCodes(t *testing.T) {
@@ -50,6 +52,52 @@ func TestRunToolMain_DiscrepancyExitPrintsNoErrorLine(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "manifest-reconcile:") {
 		t.Fatalf("discrepancy exit must not print an error line (report already rendered), got %q", out.String())
+	}
+}
+
+func TestReconcileExitError_ToolFailureBeatsDiscrepancy(t *testing.T) {
+	// Per-schema tool failures (S3 outage, lock error) must exit 1, not be
+	// folded into the exit-2 "discrepancies found" signal monitoring treats
+	// as data inconsistency.
+	failed := reconcile.Report{Schemas: []reconcile.SchemaReport{
+		{SchemaID: 1, Err: errors.New("s3 unavailable")},
+		{SchemaID: 2, Dangling: []string{"data/2/x.parquet"}},
+	}}
+	err := reconcileExitError(failed)
+	if err == nil {
+		t.Fatal("schema errors must surface as a tool failure")
+	}
+	var ec interface{ ExitCode() int }
+	if errors.As(err, &ec) {
+		t.Fatalf("tool failure must be a plain error (exit 1), got exit code %d", ec.ExitCode())
+	}
+
+	residual := reconcile.Report{Schemas: []reconcile.SchemaReport{
+		{SchemaID: 1, Dangling: []string{"data/1/x.parquet"}},
+		{SchemaID: 2, Skipped: true},
+	}}
+	err = reconcileExitError(residual)
+	if !errors.As(err, &ec) || ec.ExitCode() != 2 {
+		t.Fatalf("residual discrepancies must exit 2, got %v", err)
+	}
+
+	if err := reconcileExitError(reconcile.Report{Schemas: []reconcile.SchemaReport{{SchemaID: 1}}}); err != nil {
+		t.Fatalf("clean report must exit 0, got %v", err)
+	}
+}
+
+func TestQuotePGConnValue(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"plain", "'plain'"},
+		{"pa ss", "'pa ss'"},
+		{"it's", `'it\'s'`},
+		{`back\slash`, `'back\\slash'`},
+		{"", "''"},
+	}
+	for _, tt := range tests {
+		if got := quotePGConnValue(tt.in); got != tt.want {
+			t.Fatalf("quotePGConnValue(%q) = %s, want %s", tt.in, got, tt.want)
+		}
 	}
 }
 

--- a/cmd/tools/manifest_reconcile_test.go
+++ b/cmd/tools/manifest_reconcile_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunToolMain_ManifestReconcileExitCodes(t *testing.T) {
+	old := runManifestReconcileFn
+	defer func() { runManifestReconcileFn = old }()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+	}{
+		{"clean run", nil, 0},
+		{"discrepancies found", &discrepancyError{count: 3}, 2},
+		{"tool failure", errors.New("s3 unavailable"), 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runManifestReconcileFn = func(ctx context.Context, args []string) error {
+				return tt.err
+			}
+			var out bytes.Buffer
+			code := runToolMain(context.Background(), []string{"manifest-reconcile"}, &out)
+			if code != tt.wantCode {
+				t.Fatalf("exit code = %d, want %d (output %q)", code, tt.wantCode, out.String())
+			}
+		})
+	}
+}
+
+func TestRunToolMain_DiscrepancyExitPrintsNoErrorLine(t *testing.T) {
+	old := runManifestReconcileFn
+	defer func() { runManifestReconcileFn = old }()
+	runManifestReconcileFn = func(ctx context.Context, args []string) error {
+		return &discrepancyError{count: 2}
+	}
+
+	var out bytes.Buffer
+	code := runToolMain(context.Background(), []string{"manifest-reconcile"}, &out)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if strings.Contains(out.String(), "manifest-reconcile:") {
+		t.Fatalf("discrepancy exit must not print an error line (report already rendered), got %q", out.String())
+	}
+}
+
+func TestParseReconcileFlags_Defaults(t *testing.T) {
+	opts, err := parseReconcileFlags([]string{
+		"--s3-bucket", "bkt",
+		"--schema-registry-table", "schema_registry",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if opts.dataPrefix != "data" {
+		t.Fatalf("dataPrefix = %q, want data", opts.dataPrefix)
+	}
+	if opts.manifest.PathTemplate != "manifest/{{.SchemaID}}.json" {
+		t.Fatalf("manifest template = %q", opts.manifest.PathTemplate)
+	}
+	if opts.manifest.Bucket != "bkt" {
+		t.Fatalf("manifest bucket = %q, want bkt", opts.manifest.Bucket)
+	}
+	if opts.gcGrace != 15*time.Minute {
+		t.Fatalf("gcGrace = %v, want 15m", opts.gcGrace)
+	}
+	if opts.etagRetries != 3 {
+		t.Fatalf("etagRetries = %d, want 3", opts.etagRetries)
+	}
+	if opts.repair || opts.gc {
+		t.Fatalf("repair/gc must default to false")
+	}
+	if opts.schemaID != 0 {
+		t.Fatalf("schemaID = %d, want 0 (all schemas)", opts.schemaID)
+	}
+}
+
+func TestParseReconcileFlags_RequiredAndModes(t *testing.T) {
+	if _, err := parseReconcileFlags([]string{"--schema-registry-table", "t"}); err == nil {
+		t.Fatal("missing --s3-bucket must error")
+	}
+	if _, err := parseReconcileFlags([]string{"--s3-bucket", "bkt"}); err == nil {
+		t.Fatal("missing --schema-registry-table must error")
+	}
+
+	opts, err := parseReconcileFlags([]string{
+		"--s3-bucket", "bkt",
+		"--schema-registry-table", "t",
+		"--schema-id", "7",
+		"--repair", "--gc", "--gc-grace", "1m",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !opts.repair || !opts.gc || opts.gcGrace != time.Minute || opts.schemaID != 7 {
+		t.Fatalf("mode flags not parsed: %+v", opts)
+	}
+
+	opts, err = parseReconcileFlags([]string{"--help"})
+	if err != nil {
+		t.Fatalf("help must not error, got %v", err)
+	}
+	if opts != nil {
+		t.Fatal("help must return nil options")
+	}
+}

--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -1,0 +1,63 @@
+# manifest-reconcile — S3 对象与 manifest 对账工具（#203）
+
+`forma-tools manifest-reconcile` 逐 schema 比对 S3 上的 parquet 对象与该 schema 的
+manifest 条目，双向报告差异，并可选修复。它是两条既有故障路径的官方恢复工具：
+
+- **#197 flush 孤儿**：delta flush 导出成功、行已标记 `flushed_at != 0`，但 manifest
+  append 失败。文件在最终 key 上、数据只存在于该文件，重跑 flush 不会补录。
+- **#188 compaction 遗留**：rewrite 崩溃留下的 `_tmp/` staging 对象与未列入 manifest 的
+  `base-{uuid}.parquet`，以及 manifest 提交后删除失败的 merged source。这些对象的数据
+  已并入 merged base，属于纯垃圾。
+
+## 差异分类
+
+按文件名形态把「S3 存在、manifest 未列」的对象分为三类，处置方向相反：
+
+| 类别 | 形态 | 来源 | 处置 |
+|------|------|------|------|
+| delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | #197 | `--repair` 补录回 manifest |
+| base 孤儿 | `{min}_{max}.parquet` / `base-{uuid}.parquet` | #188 | `--gc` 删除（宽限期后） |
+| `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | #188 staging | `--gc` 删除（宽限期后） |
+
+另报告两类只读发现：
+
+- **dangling**：manifest 条目指向的对象已不存在。移除条目会让数据从读路径消失，
+  本工具**不**自动删除，保持人工处置。
+- **unverifiable**：指向其他 bucket 或带 glob 的条目、以及不在本次 list 前缀下的
+  key——本次列举无法证明其缺席，只做信息展示。
+
+无法识别形态的 `.parquet`（unknown）只报告，永不 repair / GC。
+
+## 用法
+
+```bash
+# 只读巡检（可周期运行；退出码 0=一致，2=有差异，1=工具故障）
+forma-tools manifest-reconcile \
+  --s3-bucket my-bucket --data-prefix data \
+  --schema-registry-table schema_registry \
+  --pg-host ... --pg-db forma
+
+# 修复 #197 孤儿：按 parquet 实际内容重算 RowCount/RowIDMin/Max/CreatedMin/Max
+forma-tools manifest-reconcile ... --repair
+
+# 清理 #188 遗留：只删 base/_tmp 形态、且对象最后修改时间早于宽限期的孤儿
+forma-tools manifest-reconcile ... --gc --gc-grace 15m
+```
+
+要点：
+
+- **`--data-prefix` 必须与 flusher/compactor 的数据前缀一致**（cdc-flush 的
+  `--s3-prefix`、compactor 的 `--data-prefix`）。前缀不一致时列举落空，所有 manifest
+  条目会被误报为 unverifiable/dangling、所有对象被误报为孤儿。
+- 工具需要 Postgres：逐 schema 取与 flusher 同款 advisory lock
+  （`pg_try_advisory_lock(schemaID, schemaID)`），消除「list 与 manifest 加载之间新
+  上传文件被误判孤儿」的假阳性；拿不到锁的 schema 跳过并计入差异退出码。manifest
+  写入另有 ETag 条件写保护（compactor 不持这把锁）。
+- `--repair` 幂等：绝不重复已有 `Path`；统计读取失败的文件跳过并保留为孤儿。
+  一个 delta 孤儿也可能是 #188 中删除失败的 merged source——补录它是安全的
+  （联邦读按 row_id LWW 去重，下轮 compaction 会重新合并），而误删真正的 #197
+  孤儿等于丢数据，因此对 delta 形态一律偏向补录。
+- `--gc` 的宽限期兜住 in-flight reader 竞态：持有 splice 前对象清单的查询在
+  manifest 提交后约一个查询时长内仍可能引用已解除列出的 key。默认 15m 远超查询
+  超时；残余窗口（对象很老、恰在 GC 前一刻才被 splice）在实践中可忽略。
+- 退出码：`0` 一致；`2` 存在残余差异（含跳过的 schema）；`1` 工具自身失败。

--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -16,9 +16,12 @@ manifest 条目，双向报告差异，并可选修复。它是两条既有故�
 | 类别 | 形态 | 来源 | 处置 |
 |------|------|------|------|
 | delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | #197 或 #188 删除失败的 merged source | `--repair` 经守卫判定后补录或转残留（见下） |
-| merged base 孤儿 | `base-{uuid}.parquet` | #188 | `--gc` 删除（宽限期后） |
-| init base 孤儿 | `{min}_{max}.parquet` | cdc-init 导出 | 只报告，**永不自动删除**：in-flight cdc-init 先落对象、跑完才发布 manifest，且不持 advisory lock |
-| `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | staging 残留 | `--gc` 删除（宽限期后） |
+| merged base 孤儿 | `base-{uuid}.parquet` | #188 | `--gc` 两阶段删除（见下） |
+| init base 孤儿 | `{min}_{max}.parquet` | cdc-init 导出 | 只报告，**永不自动删除**：in-flight cdc-init 先落对象、跑完才发布 manifest，且不持 advisory lock（自动处置需 init 先持锁，见 follow-up） |
+| `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | staging 残留 | `--gc` 两阶段删除（见下） |
+
+形态匹配是严格的：`base-` 后缀与 `{min}_{max}` 两段都必须是合法 UUID，否则归
+unknown（只报告，永不删除）。
 
 另报告两类只读发现：
 
@@ -39,13 +42,37 @@ manifest 条目，双向报告差异，并可选修复。它是两条既有故�
 1. **覆盖探测**（DuckDB 反连接）：孤儿中有哪些 row_id 不出现在任何 manifest 已列文件里；
 2. **活性探测**（Postgres `entity_main`，`--entity-main-table`）：这些未覆盖行是否仍存活。
 
-裁决：
+覆盖判定是**版本感知**的：孤儿中某行只有当某个已列文件携带同 row_id 且
+`changed_at >=` 该版本时才算被覆盖（相等平局按 LWW base-wins，#183）——因此「同
+row_id 的更新丢失」（孤儿携带比所有已列文件更新的版本）会被正确判为未覆盖，而不是
+被 row_id 级比较误判成可删残留。活性判定对齐 cdc-init 的导出口径：行存在于
+entity_main 且 `ltbase_deleted_at IS NULL`。
 
-- 存在未覆盖行且**全部存活** → 真 #197 孤儿，补录（元数据从 parquet 内容重算，幂等，
-  绝不重复已有 Path）；
-- 无未覆盖行，或未覆盖行**全部已删除**（其墓碑赢了合并后被丢弃）→ 判定为合并残留
-  （报告列在 `delta leftover`），在 `--repair --gc` 同时开启且过宽限期时删除；
-- 未覆盖行**存活/已删混杂** → 拒绝自动补录与自动删除，留人工处置（保持非零退出码）。
+逐未覆盖行裁决（取该行未覆盖版本中最新者）：
+
+- **活版本 + PG 存活** → #197 丢失数据，须补录；
+- **墓碑 + PG 已删除** → 丢失的删除标记：它缺席时更老的已列版本正在读路径上复活，
+  补录恢复删除语义；
+- **活版本 + PG 已删除** → 复活风险：该行墓碑赢了合并后被物理丢弃，补录会复活它；
+- **墓碑 + PG 存活** → 与实体状态矛盾，永不自动处理。
+
+文件级裁决：存在须补录行且无风险/矛盾行 → 补录（元数据从 parquet 内容重算，幂等，
+绝不重复已有 Path）；无未覆盖行或仅有复活风险行 → 判定为合并残留（报告列在
+`delta leftover`），在 `--repair --gc` 同时开启时按下述两阶段删除；混杂 → 拒绝自动
+补录与自动删除，留人工处置（保持非零退出码）。
+
+## `--gc` 的两阶段删除（unlisted 时长语义）
+
+#188 follow-up 要求「对象解除列出超过最大查询时长后才删除」。对象的 LastModified
+无法表达该时长（一个很老的 source 可能刚刚被 compactor splice 出 manifest），因此
+工具在 manifest 旁持久化目击状态（`<manifest path>.gc-state`，同 ETag 乐观并发）：
+
+1. 第一次观察到某候选对象未被列出 → 只记录 first-unlisted 时间戳，不删除；
+2. 后续运行中，当「已观察的未列出时长」与「对象年龄」**都**超过 `--gc-grace` 时才
+   删除；重新回到 manifest 的 key 会从状态中剪除，宽限时钟重新起算。
+
+状态丢失/写入失败只会让下次运行重新记录（推迟删除，绝不提前）；状态读取失败拒绝
+删除并按工具故障退出。
 
 ## 用法
 
@@ -75,8 +102,16 @@ forma-tools manifest-reconcile ... --repair --gc --gc-grace 15m
   条件创建，绝不覆写并发新建的 manifest），dangling 判定做二次确认，init 形态对象
   排除在 GC 之外。
 - `--schema-id` 指向未注册 schema 时直接报错退出 1（而不是空跑报「一致」）。
-- `--gc-grace` 必须为正（默认 15m），兜住 in-flight reader 竞态：持有 splice 前对象
-  清单的查询在 manifest 提交后约一个查询时长内仍可能引用已解除列出的 key。残余窗口
-  （对象很老、恰在 GC 前一刻才被 splice）在实践中可忽略。
-- 退出码：`0` 一致；`2` 存在残余差异（含跳过的 schema、拒绝自动处理的混杂文件）；
-  `1` 工具自身失败（含任一 schema 的 list/load/lock 失败——不会伪装成「有差异」）。
+- `--gc-grace` 必须为正（默认 15m）。
+- `--data-prefix` 允许为空（对象 key 形如 `/7/{uuid}.parquet`，与 cdc path builder
+  一致，比较时不做任何前导斜杠归一化）。
+- 退出码：`0` 一致；`2` 存在残余差异（含跳过的 schema、拒绝自动处理的混杂文件、
+  记录目击但尚未过宽限期的残留）；`1` 工具自身失败（含任一 schema 的
+  list/load/lock/dangling 复核/GC 状态读取失败——不会伪装成「有差异」）。
+
+## 已知范围限制（follow-up）
+
+cdc-init 的 manifest 发布失败（导出成功但 `ReplaceTierFiles` 失败）没有自动恢复路
+径：init 形态对象既不补录也不删除，因为 in-flight init 与「发布失败的 init」从对象
+层面不可区分——init 不持 schema advisory lock。安全的自动处置需要 init 先持锁，见
+follow-up issue。

--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -11,22 +11,41 @@ manifest 条目，双向报告差异，并可选修复。它是两条既有故�
 
 ## 差异分类
 
-按文件名形态把「S3 存在、manifest 未列」的对象分为三类，处置方向相反：
+按文件名形态把「S3 存在、manifest 未列」的对象分为四类：
 
 | 类别 | 形态 | 来源 | 处置 |
 |------|------|------|------|
-| delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | #197 | `--repair` 补录回 manifest |
-| base 孤儿 | `{min}_{max}.parquet` / `base-{uuid}.parquet` | #188 | `--gc` 删除（宽限期后） |
-| `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | #188 staging | `--gc` 删除（宽限期后） |
+| delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | #197 或 #188 删除失败的 merged source | `--repair` 经守卫判定后补录或转残留（见下） |
+| merged base 孤儿 | `base-{uuid}.parquet` | #188 | `--gc` 删除（宽限期后） |
+| init base 孤儿 | `{min}_{max}.parquet` | cdc-init 导出 | 只报告，**永不自动删除**：in-flight cdc-init 先落对象、跑完才发布 manifest，且不持 advisory lock |
+| `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | staging 残留 | `--gc` 删除（宽限期后） |
 
 另报告两类只读发现：
 
-- **dangling**：manifest 条目指向的对象已不存在。移除条目会让数据从读路径消失，
-  本工具**不**自动删除，保持人工处置。
-- **unverifiable**：指向其他 bucket 或带 glob 的条目、以及不在本次 list 前缀下的
-  key——本次列举无法证明其缺席，只做信息展示。
+- **dangling**：manifest 条目指向的对象已不存在（经二次确认：重载 manifest 后条目仍在
+  且逐 key 探测仍缺席才判定，规避与无锁 compactor 的竞态假阳性）。移除条目会让数据从
+  读路径消失，本工具**不**自动删除，保持人工处置。
+- **unverifiable**：指向其他 bucket、带 glob、或不在本次 list 前缀下的条目——本次列举
+  无法证明其缺席，只做信息展示。
 
 无法识别形态的 `.parquet`（unknown）只报告，永不 repair / GC。
+
+## `--repair` 的安全守卫（防墓碑复活）
+
+一个 delta 形态孤儿有两种截然相反的身份：#197 孤儿（数据仅存于该文件，必须补录）或
+#188 中删除失败的 merged source（数据已并入 merged base，其中墓碑行在合并时被物理丢弃
+——**补录会让已删除的行复活**）。工具用两级探测区分：
+
+1. **覆盖探测**（DuckDB 反连接）：孤儿中有哪些 row_id 不出现在任何 manifest 已列文件里；
+2. **活性探测**（Postgres `entity_main`，`--entity-main-table`）：这些未覆盖行是否仍存活。
+
+裁决：
+
+- 存在未覆盖行且**全部存活** → 真 #197 孤儿，补录（元数据从 parquet 内容重算，幂等，
+  绝不重复已有 Path）；
+- 无未覆盖行，或未覆盖行**全部已删除**（其墓碑赢了合并后被丢弃）→ 判定为合并残留
+  （报告列在 `delta leftover`），在 `--repair --gc` 同时开启且过宽限期时删除；
+- 未覆盖行**存活/已删混杂** → 拒绝自动补录与自动删除，留人工处置（保持非零退出码）。
 
 ## 用法
 
@@ -37,11 +56,11 @@ forma-tools manifest-reconcile \
   --schema-registry-table schema_registry \
   --pg-host ... --pg-db forma
 
-# 修复 #197 孤儿：按 parquet 实际内容重算 RowCount/RowIDMin/Max/CreatedMin/Max
+# 修复 #197 孤儿（经守卫判定）
 forma-tools manifest-reconcile ... --repair
 
-# 清理 #188 遗留：只删 base/_tmp 形态、且对象最后修改时间早于宽限期的孤儿
-forma-tools manifest-reconcile ... --gc --gc-grace 15m
+# 清理 #188 遗留：merged base / _tmp / 已判定的 delta 残留
+forma-tools manifest-reconcile ... --repair --gc --gc-grace 15m
 ```
 
 要点：
@@ -50,14 +69,14 @@ forma-tools manifest-reconcile ... --gc --gc-grace 15m
   `--s3-prefix`、compactor 的 `--data-prefix`）。前缀不一致时列举落空，所有 manifest
   条目会被误报为 unverifiable/dangling、所有对象被误报为孤儿。
 - 工具需要 Postgres：逐 schema 取与 flusher 同款 advisory lock
-  （`pg_try_advisory_lock(schemaID, schemaID)`），消除「list 与 manifest 加载之间新
-  上传文件被误判孤儿」的假阳性；拿不到锁的 schema 跳过并计入差异退出码。manifest
-  写入另有 ETag 条件写保护（compactor 不持这把锁）。
-- `--repair` 幂等：绝不重复已有 `Path`；统计读取失败的文件跳过并保留为孤儿。
-  一个 delta 孤儿也可能是 #188 中删除失败的 merged source——补录它是安全的
-  （联邦读按 row_id LWW 去重，下轮 compaction 会重新合并），而误删真正的 #197
-  孤儿等于丢数据，因此对 delta 形态一律偏向补录。
-- `--gc` 的宽限期兜住 in-flight reader 竞态：持有 splice 前对象清单的查询在
-  manifest 提交后约一个查询时长内仍可能引用已解除列出的 key。默认 15m 远超查询
-  超时；残余窗口（对象很老、恰在 GC 前一刻才被 splice）在实践中可忽略。
-- 退出码：`0` 一致；`2` 存在残余差异（含跳过的 schema）；`1` 工具自身失败。
+  （`pg_try_advisory_lock(schemaID, schemaID)`，钉在单一连接上），消除与 flusher 的
+  list/load 竞态；拿不到锁的 schema 跳过并计入差异退出码。compactor 与 cdc-init 不持
+  这把锁，故 manifest 写入另有 ETag 条件写保护（不存在的 manifest 用 If-None-Match
+  条件创建，绝不覆写并发新建的 manifest），dangling 判定做二次确认，init 形态对象
+  排除在 GC 之外。
+- `--schema-id` 指向未注册 schema 时直接报错退出 1（而不是空跑报「一致」）。
+- `--gc-grace` 必须为正（默认 15m），兜住 in-flight reader 竞态：持有 splice 前对象
+  清单的查询在 manifest 提交后约一个查询时长内仍可能引用已解除列出的 key。残余窗口
+  （对象很老、恰在 GC 前一刻才被 splice）在实践中可忽略。
+- 退出码：`0` 一致；`2` 存在残余差异（含跳过的 schema、拒绝自动处理的混杂文件）；
+  `1` 工具自身失败（含任一 schema 的 list/load/lock 失败——不会伪装成「有差异」）。

--- a/internal/cdc/flush_batch.go
+++ b/internal/cdc/flush_batch.go
@@ -87,7 +87,9 @@ func (e *flushBatchExecutor) executeBatch(ctx context.Context, batchIDs []uuid.U
 		// them: a delta file missing from the manifest stays invisible to
 		// manifest consumers (e.g. compaction) forever. Propagate so the run
 		// reports failure; the final key in the error is the operator's
-		// pointer to the orphaned file for manual reconciliation (#197).
+		// pointer to the orphaned file. Recovery: run
+		// `forma-tools manifest-reconcile --repair` (#203), which appends
+		// the orphaned delta with metadata recomputed from its contents.
 		if err := updateManifest(ctx, e.manifestStore, e.manifestResolver, e.schemaID, finalKey, "delta", updatedIDs, flushedAt, sizeBytes, e.logger); err != nil {
 			return fmt.Errorf("manifest update (%s) for %s: %w", batchKind, finalKey, err)
 		}

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -403,7 +403,8 @@ func exportSchemaBatch(ctx context.Context, runCtx *initRunContext, state *schem
 // re-export, so the base tier is replaced wholesale with this run's files:
 // reruns neither duplicate entries nor leave stale ranges behind (#176).
 // Obsolete S3 objects are not deleted here — glob-based readers stay exact
-// via LWW/tombstones, and object reconciliation is #203.
+// via LWW/tombstones, and object cleanup belongs to
+// `forma-tools manifest-reconcile --gc` (#203).
 func updateSchemaManifest(ctx context.Context, runCtx *initRunContext, state *schemaInitState) error {
 	if runCtx.manifestStore == nil || len(state.fileEntries) == 0 || runCtx.dryRun {
 		return nil

--- a/internal/compaction/rewrite.go
+++ b/internal/compaction/rewrite.go
@@ -165,7 +165,7 @@ func (c *Compactor) deleteObjects(ctx context.Context, schemaID int16, paths []s
 			key = trimmed
 		}
 		if err := cdc.DeleteObjectKey(ctx, c.S3, c.Bucket, key); err != nil {
-			c.Logger.Warn("failed to delete merged source object; leaving orphan for manifest-reconcile --gc (#203)",
+			c.Logger.Warn("failed to delete merged source object; leaving orphan for manifest-reconcile (#203; base/tmp shapes need --gc, delta shapes --repair --gc)",
 				zap.Int16("schema_id", schemaID), zap.String("key", key), zap.Error(err))
 		}
 	}

--- a/internal/compaction/rewrite.go
+++ b/internal/compaction/rewrite.go
@@ -165,7 +165,7 @@ func (c *Compactor) deleteObjects(ctx context.Context, schemaID int16, paths []s
 			key = trimmed
 		}
 		if err := cdc.DeleteObjectKey(ctx, c.S3, c.Bucket, key); err != nil {
-			c.Logger.Warn("failed to delete merged source object; leaving orphan for reconciliation (#203)",
+			c.Logger.Warn("failed to delete merged source object; leaving orphan for manifest-reconcile --gc (#203)",
 				zap.Int16("schema_id", schemaID), zap.String("key", key), zap.Error(err))
 		}
 	}

--- a/internal/compaction/single_file_stats.go
+++ b/internal/compaction/single_file_stats.go
@@ -1,0 +1,41 @@
+package compaction
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// SingleFileStats recomputes one parquet file's manifest metadata (row
+// count, row_id min/max, changed_at min/max) from its contents via the
+// given DuckDB session. It runs the same stats query the merge path uses
+// for a freshly merged file, so a manifest entry rebuilt from it matches
+// what compaction itself would have written. The manifest-reconcile tool
+// uses this to repair orphaned delta files (#203) without trusting
+// filenames.
+func SingleFileStats(ctx context.Context, db *sql.DB, uri string) (MergeStats, error) {
+	statsSQL, err := buildMergeStatsSQL(uri)
+	if err != nil {
+		return MergeStats{}, fmt.Errorf("build single-file stats sql: %w", err)
+	}
+	var stats MergeStats
+	if err := db.QueryRowContext(ctx, statsSQL).Scan(
+		&stats.RowsOut, &stats.RowIDMin, &stats.RowIDMax, &stats.CreatedMin, &stats.CreatedMax,
+	); err != nil {
+		return MergeStats{}, fmt.Errorf("collect parquet stats from %s: %w", uri, err)
+	}
+	stats.RowsIn = stats.RowsOut
+	return stats, nil
+}
+
+// IsConcurrentModification reports whether err is a confirmed HTTP 412
+// conditional-put rejection — the only save failure that proves the write
+// did not commit. Exported for callers outside this package (the
+// manifest-reconcile tool) that save manifests under an etag without going
+// through the compactor's saveManifestChecked.
+func IsConcurrentModification(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isPreconditionFailed(err)
+}

--- a/internal/compaction/single_file_stats_test.go
+++ b/internal/compaction/single_file_stats_test.go
@@ -1,0 +1,47 @@
+package compaction
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleFileStats_ReadsParquetMetadata(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	path := filepath.Join(t.TempDir(), "delta.parquet")
+	writeParquetFixture(t, db, path, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 100, deletedAt: "NULL", title: "a"},
+		{rowID: rowC, changedAt: 300, deletedAt: "NULL", title: "c"},
+		{rowID: rowB, changedAt: 200, deletedAt: "150", title: "NULL"},
+	})
+
+	stats, err := SingleFileStats(context.Background(), db, path)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), stats.RowsOut)
+	require.Equal(t, rowA, stats.RowIDMin)
+	require.Equal(t, rowC, stats.RowIDMax)
+	require.Equal(t, int64(100), stats.CreatedMin)
+	require.Equal(t, int64(300), stats.CreatedMax)
+}
+
+func TestSingleFileStats_RejectsInvalidURI(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = SingleFileStats(context.Background(), db, "s3://bkt/it's.parquet")
+	require.Error(t, err)
+}
+
+func TestIsConcurrentModification(t *testing.T) {
+	require.True(t, IsConcurrentModification(errRewriteTestConflict))
+	require.False(t, IsConcurrentModification(errors.New("network timeout")))
+	require.False(t, IsConcurrentModification(nil))
+}

--- a/internal/compaction/uncovered_rows.go
+++ b/internal/compaction/uncovered_rows.go
@@ -1,0 +1,58 @@
+package compaction
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// UncoveredRowIDs returns the distinct row_ids present in the orphan parquet
+// that appear in none of the listed parquet files. The manifest-reconcile
+// tool (#203) uses it to decide whether a delta-shaped orphan still carries
+// rows the manifest-listed inventory does not cover: only such files are
+// candidates for re-appending, everything else is a compaction leftover
+// whose re-registration could resurrect rows whose tombstones the merge
+// already dropped.
+func UncoveredRowIDs(ctx context.Context, db *sql.DB, orphanURI string, listedURIs []string) ([]string, error) {
+	if err := validateMergeURI(orphanURI); err != nil {
+		return nil, fmt.Errorf("uncovered-rows orphan: %w", err)
+	}
+	query := fmt.Sprintf(
+		"SELECT DISTINCT CAST(row_id AS VARCHAR) FROM read_parquet('%s') ORDER BY 1", orphanURI)
+	if len(listedURIs) > 0 {
+		quoted := make([]string, 0, len(listedURIs))
+		for _, uri := range listedURIs {
+			if err := validateMergeURI(uri); err != nil {
+				return nil, fmt.Errorf("uncovered-rows listed file: %w", err)
+			}
+			quoted = append(quoted, "'"+uri+"'")
+		}
+		query = fmt.Sprintf(
+			`SELECT DISTINCT CAST(o.row_id AS VARCHAR)
+FROM read_parquet('%s') o
+WHERE NOT EXISTS (
+  SELECT 1 FROM read_parquet([%s], union_by_name=true) l WHERE l.row_id = o.row_id
+)
+ORDER BY 1`, orphanURI, strings.Join(quoted, ", "))
+	}
+
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("query uncovered row ids of %s: %w", orphanURI, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan uncovered row id of %s: %w", orphanURI, err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate uncovered row ids of %s: %w", orphanURI, err)
+	}
+	return ids, nil
+}

--- a/internal/compaction/uncovered_rows.go
+++ b/internal/compaction/uncovered_rows.go
@@ -7,19 +7,29 @@ import (
 	"strings"
 )
 
-// UncoveredRowIDs returns the distinct row_ids present in the orphan parquet
-// that appear in none of the listed parquet files. The manifest-reconcile
-// tool (#203) uses it to decide whether a delta-shaped orphan still carries
-// rows the manifest-listed inventory does not cover: only such files are
-// candidates for re-appending, everything else is a compaction leftover
-// whose re-registration could resurrect rows whose tombstones the merge
-// already dropped.
-func UncoveredRowIDs(ctx context.Context, db *sql.DB, orphanURI string, listedURIs []string) ([]string, error) {
+// UncoveredRow is one row_id in an orphan parquet whose newest uncovered
+// version is not superseded by any manifest-listed file. Tombstone reports
+// whether that version is a delete marker — re-appending an uncovered
+// tombstone RESTORES a lost delete, while re-appending an uncovered live
+// version of a Postgres-deleted row resurrects it.
+type UncoveredRow struct {
+	RowID     string
+	Tombstone bool
+}
+
+// UncoveredRows returns, per row_id, the orphan parquet's versions that no
+// listed file supersedes. Coverage is version-aware: a listed version with
+// changed_at >= the orphan version's covers it (equal ties resolve
+// base-wins in LWW, #183), so a same-row lost update — an orphan carrying a
+// NEWER version than anything listed — still counts as uncovered. The
+// manifest-reconcile tool (#203) builds its repair verdict on this: a
+// row_id-only anti-join would misclassify lost updates as deletable
+// leftovers.
+func UncoveredRows(ctx context.Context, db *sql.DB, orphanURI string, listedURIs []string) ([]UncoveredRow, error) {
 	if err := validateMergeURI(orphanURI); err != nil {
 		return nil, fmt.Errorf("uncovered-rows orphan: %w", err)
 	}
-	query := fmt.Sprintf(
-		"SELECT DISTINCT CAST(row_id AS VARCHAR) FROM read_parquet('%s') ORDER BY 1", orphanURI)
+	notSuperseded := ""
 	if len(listedURIs) > 0 {
 		quoted := make([]string, 0, len(listedURIs))
 		for _, uri := range listedURIs {
@@ -28,31 +38,37 @@ func UncoveredRowIDs(ctx context.Context, db *sql.DB, orphanURI string, listedUR
 			}
 			quoted = append(quoted, "'"+uri+"'")
 		}
-		query = fmt.Sprintf(
-			`SELECT DISTINCT CAST(o.row_id AS VARCHAR)
-FROM read_parquet('%s') o
+		notSuperseded = fmt.Sprintf(`
 WHERE NOT EXISTS (
-  SELECT 1 FROM read_parquet([%s], union_by_name=true) l WHERE l.row_id = o.row_id
-)
-ORDER BY 1`, orphanURI, strings.Join(quoted, ", "))
+  SELECT 1 FROM read_parquet([%s], union_by_name=true) l
+  WHERE l.row_id = o.row_id AND l.changed_at >= o.changed_at
+)`, strings.Join(quoted, ", "))
 	}
+	// arg_max picks the newest uncovered version per row; its deleted_at
+	// decides the tombstone flag.
+	query := fmt.Sprintf(`
+SELECT CAST(row_id AS VARCHAR) AS rid,
+       (arg_max(COALESCE(deleted_at, 0), changed_at) > 0) AS tomb
+FROM read_parquet('%s') o%s
+GROUP BY row_id
+ORDER BY rid`, orphanURI, notSuperseded)
 
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("query uncovered row ids of %s: %w", orphanURI, err)
+		return nil, fmt.Errorf("query uncovered rows of %s: %w", orphanURI, err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	var ids []string
+	var uncovered []UncoveredRow
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("scan uncovered row id of %s: %w", orphanURI, err)
+		var row UncoveredRow
+		if err := rows.Scan(&row.RowID, &row.Tombstone); err != nil {
+			return nil, fmt.Errorf("scan uncovered row of %s: %w", orphanURI, err)
 		}
-		ids = append(ids, id)
+		uncovered = append(uncovered, row)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate uncovered row ids of %s: %w", orphanURI, err)
+		return nil, fmt.Errorf("iterate uncovered rows of %s: %w", orphanURI, err)
 	}
-	return ids, nil
+	return uncovered, nil
 }

--- a/internal/compaction/uncovered_rows_test.go
+++ b/internal/compaction/uncovered_rows_test.go
@@ -9,69 +9,94 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUncoveredRowIDs_AntiJoinAgainstListedFiles(t *testing.T) {
+func uncoveredDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
 	db, err := sql.Open("duckdb", "")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
-	dir := t.TempDir()
+	return db, t.TempDir()
+}
+
+func TestUncoveredRows_CoverageIsVersionAware(t *testing.T) {
+	db, dir := uncoveredDB(t)
 
 	orphan := filepath.Join(dir, "orphan.parquet")
 	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
-		{rowID: rowA, changedAt: 100, deletedAt: "NULL", title: "a"},
-		{rowID: rowB, changedAt: 200, deletedAt: "NULL", title: "b"},
-		{rowID: rowC, changedAt: 300, deletedAt: "NULL", title: "c"},
+		{rowID: rowA, changedAt: 500, deletedAt: "NULL", title: "a-newer"}, // lost update: listed only has @100
+		{rowID: rowB, changedAt: 200, deletedAt: "NULL", title: "b-old"},   // superseded: listed has @400
+		{rowID: rowC, changedAt: 300, deletedAt: "NULL", title: "c"},       // row absent from listed entirely
 	})
 	listed := filepath.Join(dir, "base.parquet")
 	writeParquetFixture(t, db, listed, []mergeFixtureRow{
-		{rowID: rowB, changedAt: 400, deletedAt: "0", title: "b2"},
+		{rowID: rowA, changedAt: 100, deletedAt: "0", title: "a-old"},
+		{rowID: rowB, changedAt: 400, deletedAt: "0", title: "b-new"},
 	})
 
-	uncovered, err := UncoveredRowIDs(context.Background(), db, orphan, []string{listed})
+	uncovered, err := UncoveredRows(context.Background(), db, orphan, []string{listed})
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{rowA, rowC}, uncovered, "rowB is covered by the listed base")
+	require.Equal(t, []UncoveredRow{
+		{RowID: rowA, Tombstone: false},
+		{RowID: rowC, Tombstone: false},
+	}, uncovered, "a lost update (newer version than any listed) must count as uncovered; a superseded version must not")
 }
 
-func TestUncoveredRowIDs_NoListedFilesEverythingUncovered(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
+func TestUncoveredRows_TombstoneFlagged(t *testing.T) {
+	db, dir := uncoveredDB(t)
+
+	orphan := filepath.Join(dir, "orphan.parquet")
+	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 300, deletedAt: "250", title: "NULL"}, // tombstone newer than listed live version
+	})
+	listed := filepath.Join(dir, "base.parquet")
+	writeParquetFixture(t, db, listed, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 100, deletedAt: "0", title: "a-live"},
+	})
+
+	uncovered, err := UncoveredRows(context.Background(), db, orphan, []string{listed})
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-	dir := t.TempDir()
+	require.Equal(t, []UncoveredRow{{RowID: rowA, Tombstone: true}}, uncovered,
+		"an uncovered tombstone must be flagged — re-appending it RESTORES the delete rather than resurrecting data")
+}
+
+func TestUncoveredRows_EqualChangedAtIsCovered(t *testing.T) {
+	db, dir := uncoveredDB(t)
 
 	orphan := filepath.Join(dir, "orphan.parquet")
 	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
 		{rowID: rowA, changedAt: 100, deletedAt: "NULL", title: "a"},
 	})
-
-	uncovered, err := UncoveredRowIDs(context.Background(), db, orphan, nil)
-	require.NoError(t, err)
-	require.Equal(t, []string{rowA}, uncovered)
-}
-
-func TestUncoveredRowIDs_FullyCoveredReturnsEmpty(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-	dir := t.TempDir()
-
-	orphan := filepath.Join(dir, "orphan.parquet")
-	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
-		{rowID: rowA, changedAt: 100, deletedAt: "NULL", title: "a"},
-	})
-	listed := filepath.Join(dir, "merged.parquet")
+	listed := filepath.Join(dir, "base.parquet")
 	writeParquetFixture(t, db, listed, []mergeFixtureRow{
 		{rowID: rowA, changedAt: 100, deletedAt: "0", title: "a"},
 	})
 
-	uncovered, err := UncoveredRowIDs(context.Background(), db, orphan, []string{listed})
+	uncovered, err := UncoveredRows(context.Background(), db, orphan, []string{listed})
 	require.NoError(t, err)
-	require.Empty(t, uncovered)
+	require.Empty(t, uncovered, "equal changed_at ties resolve base-wins in LWW (#183), so the listed version covers the orphan's")
 }
 
-func TestUncoveredRowIDs_RejectsInvalidURI(t *testing.T) {
-	db, err := sql.Open("duckdb", "")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
+func TestUncoveredRows_NoListedFilesEverythingUncovered(t *testing.T) {
+	db, dir := uncoveredDB(t)
 
-	_, err = UncoveredRowIDs(context.Background(), db, "bad'uri.parquet", nil)
+	orphan := filepath.Join(dir, "orphan.parquet")
+	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 100, deletedAt: "NULL", title: "a"},
+		{rowID: rowB, changedAt: 200, deletedAt: "150", title: "NULL"},
+	})
+
+	uncovered, err := UncoveredRows(context.Background(), db, orphan, nil)
+	require.NoError(t, err)
+	require.Equal(t, []UncoveredRow{
+		{RowID: rowA, Tombstone: false},
+		{RowID: rowB, Tombstone: true},
+	}, uncovered)
+}
+
+func TestUncoveredRows_RejectsInvalidURI(t *testing.T) {
+	db, _ := uncoveredDB(t)
+
+	_, err := UncoveredRows(context.Background(), db, "bad'uri.parquet", nil)
+	require.Error(t, err)
+	_, err = UncoveredRows(context.Background(), db, "ok.parquet", []string{"bad'listed.parquet"})
 	require.Error(t, err)
 }

--- a/internal/compaction/uncovered_rows_test.go
+++ b/internal/compaction/uncovered_rows_test.go
@@ -1,0 +1,77 @@
+package compaction
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUncoveredRowIDs_AntiJoinAgainstListedFiles(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dir := t.TempDir()
+
+	orphan := filepath.Join(dir, "orphan.parquet")
+	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 100, deletedAt: "NULL", title: "a"},
+		{rowID: rowB, changedAt: 200, deletedAt: "NULL", title: "b"},
+		{rowID: rowC, changedAt: 300, deletedAt: "NULL", title: "c"},
+	})
+	listed := filepath.Join(dir, "base.parquet")
+	writeParquetFixture(t, db, listed, []mergeFixtureRow{
+		{rowID: rowB, changedAt: 400, deletedAt: "0", title: "b2"},
+	})
+
+	uncovered, err := UncoveredRowIDs(context.Background(), db, orphan, []string{listed})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{rowA, rowC}, uncovered, "rowB is covered by the listed base")
+}
+
+func TestUncoveredRowIDs_NoListedFilesEverythingUncovered(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dir := t.TempDir()
+
+	orphan := filepath.Join(dir, "orphan.parquet")
+	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 100, deletedAt: "NULL", title: "a"},
+	})
+
+	uncovered, err := UncoveredRowIDs(context.Background(), db, orphan, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{rowA}, uncovered)
+}
+
+func TestUncoveredRowIDs_FullyCoveredReturnsEmpty(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	dir := t.TempDir()
+
+	orphan := filepath.Join(dir, "orphan.parquet")
+	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 100, deletedAt: "NULL", title: "a"},
+	})
+	listed := filepath.Join(dir, "merged.parquet")
+	writeParquetFixture(t, db, listed, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 100, deletedAt: "0", title: "a"},
+	})
+
+	uncovered, err := UncoveredRowIDs(context.Background(), db, orphan, []string{listed})
+	require.NoError(t, err)
+	require.Empty(t, uncovered)
+}
+
+func TestUncoveredRowIDs_RejectsInvalidURI(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = UncoveredRowIDs(context.Background(), db, "bad'uri.parquet", nil)
+	require.Error(t, err)
+}

--- a/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
+++ b/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
@@ -1,0 +1,395 @@
+//go:build e2e
+
+package production
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
+
+	"github.com/lychee-technology/forma/internal/cdc"
+	"github.com/lychee-technology/forma/internal/manifest"
+	"github.com/lychee-technology/forma/internal/reconcile"
+)
+
+// newReconcileHarness wires a real reconcile.Reconciler the way the
+// manifest-reconcile tool does: real S3 listing/deletion, etag manifest
+// store, the flusher's advisory lock over a database/sql handle, registry
+// enumeration, and (when withStats) a DuckDB stats engine reading parquet
+// through httpfs. The returned cleanup closes both handles.
+func newReconcileHarness(t *testing.T, ctx context.Context, env *Env, schema SchemaRef, opts reconcile.Options, withStats bool) (*reconcile.Reconciler, func()) {
+	t.Helper()
+
+	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		env.CDC.PGHost, env.CDC.PGPort, env.CDC.PGUser, env.CDC.PGPassword, env.CDC.PGDB, env.CDC.PGSSLMode)
+	db, err := sql.Open("pgx", connStr)
+	if err != nil {
+		t.Fatalf("open pg for reconcile: %v", err)
+	}
+
+	store := &reconcile.S3ObjectStore{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket}
+	r := &reconcile.Reconciler{
+		Lister:  store,
+		Deleter: store,
+		Manifests: &reconcile.ResolverManifestStore{
+			Store:    &manifest.S3Store{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket},
+			Resolver: manifest.PathResolver{Prefix: env.CDC.ManifestPrefix, PathTemplate: env.CDC.ManifestTemplate},
+		},
+		Locker:     &reconcile.PGAdvisoryLocker{DB: db},
+		Schemas:    &reconcile.RegistrySchemaEnumerator{DB: db, Table: env.Tables.SchemaRegistry, SchemaIDFilter: int(schema.ID)},
+		Now:        time.Now,
+		Bucket:     env.Cluster.Bucket,
+		DataPrefix: env.S3Prefix,
+		Logger:     env.logger,
+		Opts:       opts,
+	}
+
+	cleanup := func() { _ = db.Close() }
+	if withStats {
+		exporter, err := cdc.NewDuckExporter(ctx, env.CDC, env.CDC.S3AccessKeyID, env.CDC.S3SecretAccessKey, env.logger)
+		if err != nil {
+			_ = db.Close()
+			t.Fatalf("open stats duckdb: %v", err)
+		}
+		exporter.DB.SetMaxOpenConns(1)
+		r.Stats = &reconcile.DuckStatsReader{DB: exporter.DB, Bucket: env.Cluster.Bucket}
+		cleanup = func() {
+			_ = exporter.DB.Close()
+			_ = db.Close()
+		}
+	}
+	return r, cleanup
+}
+
+func loadManifestWithETag(t *testing.T, ctx context.Context, env *Env, schema SchemaRef) (*manifest.Manifest, string) {
+	t.Helper()
+	store := &manifest.S3Store{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket}
+	resolver := manifest.PathResolver{Prefix: env.CDC.ManifestPrefix, PathTemplate: env.CDC.ManifestTemplate}
+	path, err := resolver.Resolve(schema.ID)
+	if err != nil {
+		t.Fatalf("resolve manifest path: %v", err)
+	}
+	m, etag, err := manifest.Load(ctx, store, path)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	return m, etag
+}
+
+func saveManifestWithETag(t *testing.T, ctx context.Context, env *Env, schema SchemaRef, m *manifest.Manifest, etag string) {
+	t.Helper()
+	store := &manifest.S3Store{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket}
+	resolver := manifest.PathResolver{Prefix: env.CDC.ManifestPrefix, PathTemplate: env.CDC.ManifestTemplate}
+	path, err := resolver.Resolve(schema.ID)
+	if err != nil {
+		t.Fatalf("resolve manifest path: %v", err)
+	}
+	if _, err := manifest.Save(ctx, store, path, m, etag); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+}
+
+func putJunkObject(t *testing.T, ctx context.Context, env *Env, key string) {
+	t.Helper()
+	_, err := env.Cluster.S3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(env.Cluster.Bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader([]byte("junk parquet placeholder")),
+	})
+	if err != nil {
+		t.Fatalf("put junk object %s: %v", key, err)
+	}
+}
+
+// TestManifestReconcile_RepairsDeltaOrphan drives the #197 recovery path
+// end to end: a flushed delta whose manifest append was lost is invisible
+// to federated reads; report mode names it without mutating anything, and
+// --repair appends an entry whose metadata — recomputed from the parquet
+// via DuckDB — matches what the flusher originally wrote, restoring query
+// visibility. A second repair run proves idempotency.
+func TestManifestReconcile_RepairsDeltaOrphan(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	schema := DefaultSchemaFixtures()[0] // e2e_simple
+
+	// Two flush batches so the manifest stays non-empty after stripping one
+	// entry: an empty manifest sends reads to the legacy glob fallback
+	// (manifest/query_source.go), which would see the orphan and defeat the
+	// visibility oracle.
+	seed := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 4})
+	if err := env.ApplyEvents(ctx, seed...); err != nil {
+		t.Fatalf("apply seed events: %v", err)
+	}
+	mustFlush(ctx, t, env)
+	mKept, _ := loadManifestWithETag(t, ctx, env, schema)
+	keptPaths := make(map[string]bool, len(mKept.Files))
+	for _, f := range mKept.Files {
+		keptPaths[f.Path] = true
+	}
+
+	second := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 3})
+	if err := env.ApplyEvents(ctx, second...); err != nil {
+		t.Fatalf("apply second batch: %v", err)
+	}
+	mustFlush(ctx, t, env)
+
+	// Capture the second flush's delta entry, then strip it — the exact
+	// post-state of a #197 manifest append failure (file at its final key,
+	// rows marked flushed, manifest without the entry).
+	m, etag := loadManifestWithETag(t, ctx, env, schema)
+	var original *manifest.FileEntry
+	var kept []manifest.FileEntry
+	for _, f := range m.Files {
+		if f.Tier == "delta" && !keptPaths[f.Path] && original == nil {
+			e := f
+			original = &e
+			continue
+		}
+		kept = append(kept, f)
+	}
+	if original == nil {
+		t.Fatal("second flush produced no new delta manifest entry to strip")
+	}
+	m.Files = kept
+	saveManifestWithETag(t, ctx, env, schema, m, etag)
+
+	stripped, err := env.Query(ctx, Query{Schema: schema, Limit: 100})
+	if err != nil {
+		t.Fatalf("query after strip: %v", err)
+	}
+	if len(stripped.Records) != 4 {
+		t.Fatalf("stripped manifest yields %d records, want 4 (second batch must be invisible)", len(stripped.Records))
+	}
+
+	t.Run("report_only_names_diff_and_mutates_nothing", func(t *testing.T) {
+		// Dangling probe: a manifest entry pointing at a key that never
+		// existed. Removed again at the end of this subtest so the ghost
+		// does not break later read-path assertions.
+		ghostKey := fmt.Sprintf("%s/%d/%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
+		if err := env.RegisterParquetInManifest(ctx, schema, ghostKey, "delta"); err != nil {
+			t.Fatalf("register ghost manifest entry: %v", err)
+		}
+
+		mBefore, _ := loadManifestWithETag(t, ctx, env, schema)
+		r, cleanup := newReconcileHarness(t, ctx, env, schema, reconcile.Options{}, false)
+		defer cleanup()
+
+		report, err := r.Run(ctx)
+		if err != nil {
+			t.Fatalf("reconcile report run: %v", err)
+		}
+		if len(report.Schemas) != 1 {
+			t.Fatalf("expected 1 schema report, got %d", len(report.Schemas))
+		}
+		s := report.Schemas[0]
+		if len(s.DeltaOrphans) != 1 || s.DeltaOrphans[0] != original.Path {
+			t.Fatalf("delta orphans = %v, want [%s]", s.DeltaOrphans, original.Path)
+		}
+		if len(s.Dangling) != 1 || s.Dangling[0] != ghostKey {
+			t.Fatalf("dangling = %v, want [%s]", s.Dangling, ghostKey)
+		}
+		if !report.HasResidualDiscrepancies() {
+			t.Fatal("report run must flag residual discrepancies")
+		}
+		mAfter, etagAfter := loadManifestWithETag(t, ctx, env, schema)
+		if mAfter.Version != mBefore.Version {
+			t.Fatalf("report mode bumped manifest version %d -> %d", mBefore.Version, mAfter.Version)
+		}
+
+		// Remove the ghost entry again.
+		var files []manifest.FileEntry
+		for _, f := range mAfter.Files {
+			if f.Path != ghostKey {
+				files = append(files, f)
+			}
+		}
+		mAfter.Files = files
+		saveManifestWithETag(t, ctx, env, schema, mAfter, etagAfter)
+	})
+
+	t.Run("repair_restores_entry_and_visibility", func(t *testing.T) {
+		r, cleanup := newReconcileHarness(t, ctx, env, schema,
+			reconcile.Options{Repair: true, MaxETagRetries: 3}, true)
+		defer cleanup()
+
+		report, err := r.Run(ctx)
+		if err != nil {
+			t.Fatalf("reconcile repair run: %v", err)
+		}
+		s := report.Schemas[0]
+		if len(s.Repaired) != 1 || s.Repaired[0] != original.Path {
+			t.Fatalf("repaired = %v, want [%s]", s.Repaired, original.Path)
+		}
+
+		mAfter, _ := loadManifestWithETag(t, ctx, env, schema)
+		var repaired *manifest.FileEntry
+		for _, f := range mAfter.Files {
+			if f.Path == original.Path {
+				e := f
+				repaired = &e
+				break
+			}
+		}
+		if repaired == nil {
+			t.Fatalf("repaired entry %s missing from manifest: %+v", original.Path, mAfter.Files)
+		}
+		// The recomputed identity metadata must match what the flusher
+		// originally wrote — recovery may not fabricate different stats.
+		if repaired.Tier != original.Tier ||
+			repaired.RowCount != original.RowCount ||
+			repaired.RowIDMin != original.RowIDMin ||
+			repaired.RowIDMax != original.RowIDMax ||
+			repaired.SizeBytes != original.SizeBytes {
+			t.Fatalf("repaired entry diverges from original:\n got %+v\nwant %+v", *repaired, *original)
+		}
+		// Created* semantics differ by design (#203): the flusher stamps
+		// both with the flush timestamp, while reconcile recomputes them
+		// from the parquet's changed_at range — the same contents-derived
+		// convention compaction uses for merged files. Row changed_at is
+		// always <= the flush timestamp.
+		if repaired.CreatedMin <= 0 || repaired.CreatedMin > repaired.CreatedMax ||
+			repaired.CreatedMax > original.CreatedMax {
+			t.Fatalf("repaired Created range [%d, %d] outside (0, %d]",
+				repaired.CreatedMin, repaired.CreatedMax, original.CreatedMax)
+		}
+
+		result, err := env.Query(ctx, Query{Schema: schema, Limit: 100})
+		if err != nil {
+			t.Fatalf("query after repair: %v", err)
+		}
+		if len(result.Records) != 7 {
+			t.Fatalf("query after repair returned %d records, want 7 (both flush batches)", len(result.Records))
+		}
+		if !result.Plan.Routing.UseDuckDB {
+			t.Errorf("post-repair query did not route through duckdb: %+v", result.Plan.Routing)
+		}
+	})
+
+	t.Run("second_repair_run_is_idempotent", func(t *testing.T) {
+		mBefore, _ := loadManifestWithETag(t, ctx, env, schema)
+		r, cleanup := newReconcileHarness(t, ctx, env, schema,
+			reconcile.Options{Repair: true, MaxETagRetries: 3}, true)
+		defer cleanup()
+
+		report, err := r.Run(ctx)
+		if err != nil {
+			t.Fatalf("second reconcile repair run: %v", err)
+		}
+		if len(report.Schemas[0].Repaired) != 0 {
+			t.Fatalf("second run repaired %v, want nothing", report.Schemas[0].Repaired)
+		}
+		mAfter, _ := loadManifestWithETag(t, ctx, env, schema)
+		if mAfter.Version != mBefore.Version {
+			t.Fatalf("idempotent run bumped manifest version %d -> %d", mBefore.Version, mAfter.Version)
+		}
+		assertNoDuplicateManifestEntries(t, mAfter)
+	})
+}
+
+// TestManifestReconcile_GCRemovesRewriteLeftovers drives the #188 recovery
+// path: staged _tmp objects and unlisted base files from a crashed or
+// half-cleaned compaction rewrite are deleted by --gc only once they age
+// past the grace period, while delta-shaped orphans and manifest-listed
+// objects are never touched.
+func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	schema := DefaultSchemaFixtures()[0] // e2e_simple
+
+	seed := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 3})
+	if err := env.ApplyEvents(ctx, seed...); err != nil {
+		t.Fatalf("apply seed events: %v", err)
+	}
+	mustFlush(ctx, t, env)
+
+	staleBase := fmt.Sprintf("%s/%d/base-%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
+	staleTmp := fmt.Sprintf("%s/%d/_tmp/%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
+	deltaOrphan := fmt.Sprintf("%s/%d/%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
+	putJunkObject(t, ctx, env, staleBase)
+	putJunkObject(t, ctx, env, staleTmp)
+	putJunkObject(t, ctx, env, deltaOrphan)
+
+	gcOpts := reconcile.Options{GC: true, GCGrace: 15 * time.Minute}
+
+	t.Run("within_grace_nothing_deleted", func(t *testing.T) {
+		r, cleanup := newReconcileHarness(t, ctx, env, schema, gcOpts, false)
+		defer cleanup()
+
+		report, err := r.Run(ctx)
+		if err != nil {
+			t.Fatalf("gc run within grace: %v", err)
+		}
+		s := report.Schemas[0]
+		if len(s.Deleted) != 0 {
+			t.Fatalf("gc within grace deleted %v, want nothing", s.Deleted)
+		}
+		if len(s.BaseOrphans) != 1 || len(s.TmpOrphans) != 1 || len(s.DeltaOrphans) != 1 {
+			t.Fatalf("expected 1 orphan per class, got %+v", s)
+		}
+	})
+
+	t.Run("past_grace_deletes_leftovers_only", func(t *testing.T) {
+		mBefore, _ := loadManifestWithETag(t, ctx, env, schema)
+		r, cleanup := newReconcileHarness(t, ctx, env, schema, gcOpts, false)
+		defer cleanup()
+		// Pretend the run happens an hour later instead of sleeping past
+		// the grace period.
+		r.Now = func() time.Time { return time.Now().Add(time.Hour) }
+
+		report, err := r.Run(ctx)
+		if err != nil {
+			t.Fatalf("gc run past grace: %v", err)
+		}
+		s := report.Schemas[0]
+		if len(s.Deleted) != 2 {
+			t.Fatalf("gc deleted %v, want the base and _tmp leftovers", s.Deleted)
+		}
+
+		keys, err := env.listS3Keys(ctx)
+		if err != nil {
+			t.Fatalf("list s3 keys: %v", err)
+		}
+		remaining := make(map[string]bool, len(keys))
+		for _, k := range keys {
+			remaining[k] = true
+		}
+		if remaining[staleBase] || remaining[staleTmp] {
+			t.Fatalf("gc left leftovers behind: base=%v tmp=%v", remaining[staleBase], remaining[staleTmp])
+		}
+		if !remaining[deltaOrphan] {
+			t.Fatal("gc deleted a delta-shaped orphan; delta orphans carry unique data")
+		}
+		for _, f := range mBefore.Files {
+			if key, ok := normalizedManifestKey(env, f.Path); ok && !remaining[key] {
+				t.Fatalf("gc deleted manifest-listed object %s", key)
+			}
+		}
+
+		mAfter, _ := loadManifestWithETag(t, ctx, env, schema)
+		if mAfter.Version != mBefore.Version {
+			t.Fatalf("gc bumped manifest version %d -> %d", mBefore.Version, mAfter.Version)
+		}
+	})
+}
+
+// normalizedManifestKey reduces a manifest path to a bucket-relative key
+// for listing comparison (mirrors the tool's normalization).
+func normalizedManifestKey(env *Env, path string) (string, bool) {
+	prefix := "s3://" + env.Cluster.Bucket + "/"
+	if len(path) > len(prefix) && path[:len(prefix)] == prefix {
+		return path[len(prefix):], true
+	}
+	if len(path) > 5 && path[:5] == "s3://" {
+		return "", false
+	}
+	return path, true
+}

--- a/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
+++ b/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
@@ -60,6 +60,7 @@ func newReconcileHarness(t *testing.T, ctx context.Context, env *Env, schema Sch
 		}
 		exporter.DB.SetMaxOpenConns(1)
 		r.Stats = &reconcile.DuckStatsReader{DB: exporter.DB, Bucket: env.Cluster.Bucket}
+		r.LiveRows = &reconcile.PGLiveRows{DB: db, Table: env.Tables.EntityMain}
 		cleanup = func() {
 			_ = exporter.DB.Close()
 			_ = db.Close()
@@ -245,10 +246,17 @@ func TestManifestReconcile_RepairsDeltaOrphan(t *testing.T) {
 		// originally wrote — recovery may not fabricate different stats.
 		if repaired.Tier != original.Tier ||
 			repaired.RowCount != original.RowCount ||
-			repaired.RowIDMin != original.RowIDMin ||
-			repaired.RowIDMax != original.RowIDMax ||
 			repaired.SizeBytes != original.SizeBytes {
 			t.Fatalf("repaired entry diverges from original:\n got %+v\nwant %+v", *repaired, *original)
+		}
+		// RowID bounds: repair recomputes lexicographic MIN/MAX over the
+		// varchar row_id, while the flusher's minMaxRowID tie-breaks
+		// same-millisecond UUIDv7s by first-seen order — over the same set,
+		// the lexicographic min/max always bound the flusher's picks.
+		if repaired.RowIDMin == "" || repaired.RowIDMin > original.RowIDMin ||
+			repaired.RowIDMax < original.RowIDMax {
+			t.Fatalf("repaired RowID range [%s, %s] does not bound original [%s, %s]",
+				repaired.RowIDMin, repaired.RowIDMax, original.RowIDMin, original.RowIDMax)
 		}
 		// Created* semantics differ by design (#203): the flusher stamps
 		// both with the flush timestamp, while reconcile recomputes them
@@ -314,9 +322,12 @@ func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
 	staleBase := fmt.Sprintf("%s/%d/base-%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
 	staleTmp := fmt.Sprintf("%s/%d/_tmp/%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
 	deltaOrphan := fmt.Sprintf("%s/%d/%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
+	initShaped := fmt.Sprintf("%s/%d/%s_%s.parquet", env.S3Prefix, schema.ID,
+		uuid.Must(uuid.NewV7()).String(), uuid.Must(uuid.NewV7()).String())
 	putJunkObject(t, ctx, env, staleBase)
 	putJunkObject(t, ctx, env, staleTmp)
 	putJunkObject(t, ctx, env, deltaOrphan)
+	putJunkObject(t, ctx, env, initShaped)
 
 	gcOpts := reconcile.Options{GC: true, GCGrace: 15 * time.Minute}
 
@@ -332,8 +343,8 @@ func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
 		if len(s.Deleted) != 0 {
 			t.Fatalf("gc within grace deleted %v, want nothing", s.Deleted)
 		}
-		if len(s.BaseOrphans) != 1 || len(s.TmpOrphans) != 1 || len(s.DeltaOrphans) != 1 {
-			t.Fatalf("expected 1 orphan per class, got %+v", s)
+		if len(s.BaseOrphans) != 2 || len(s.TmpOrphans) != 1 || len(s.DeltaOrphans) != 1 {
+			t.Fatalf("expected 2 base (merged+init) / 1 tmp / 1 delta orphans, got %+v", s)
 		}
 	})
 
@@ -367,6 +378,9 @@ func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
 		}
 		if !remaining[deltaOrphan] {
 			t.Fatal("gc deleted a delta-shaped orphan; delta orphans carry unique data")
+		}
+		if !remaining[initShaped] {
+			t.Fatal("gc deleted an init-shaped base orphan; an in-flight cdc-init writes these before publishing its manifest")
 		}
 		for _, f := range mBefore.Files {
 			if key, ok := normalizedManifestKey(env, f.Path); ok && !remaining[key] {

--- a/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
+++ b/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
@@ -35,13 +35,13 @@ func newReconcileHarness(t *testing.T, ctx context.Context, env *Env, schema Sch
 	}
 
 	store := &reconcile.S3ObjectStore{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket}
+	manifestStore := &manifest.S3Store{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket}
+	resolver := manifest.PathResolver{Prefix: env.CDC.ManifestPrefix, PathTemplate: env.CDC.ManifestTemplate}
 	r := &reconcile.Reconciler{
-		Lister:  store,
-		Deleter: store,
-		Manifests: &reconcile.ResolverManifestStore{
-			Store:    &manifest.S3Store{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket},
-			Resolver: manifest.PathResolver{Prefix: env.CDC.ManifestPrefix, PathTemplate: env.CDC.ManifestTemplate},
-		},
+		Lister:     store,
+		Deleter:    store,
+		Manifests:  &reconcile.ResolverManifestStore{Store: manifestStore, Resolver: resolver},
+		GCStates:   &reconcile.ManifestGCStateStore{Store: manifestStore, Resolver: resolver},
 		Locker:     &reconcile.PGAdvisoryLocker{DB: db},
 		Schemas:    &reconcile.RegistrySchemaEnumerator{DB: db, Table: env.Tables.SchemaRegistry, SchemaIDFilter: int(schema.ID)},
 		Now:        time.Now,
@@ -121,10 +121,28 @@ func TestManifestReconcile_RepairsDeltaOrphan(t *testing.T) {
 	ctx := context.Background()
 	schema := DefaultSchemaFixtures()[0] // e2e_simple
 
-	// Two flush batches so the manifest stays non-empty after stripping one
-	// entry: an empty manifest sends reads to the legacy glob fallback
-	// (manifest/query_source.go), which would see the orphan and defeat the
-	// visibility oracle.
+	original := seedStrippedDeltaOrphan(t, ctx, env, schema)
+
+	t.Run("report_only_names_diff_and_mutates_nothing", func(t *testing.T) {
+		testReconcileReportOnly(t, ctx, env, schema, original)
+	})
+	t.Run("repair_restores_entry_and_visibility", func(t *testing.T) {
+		testReconcileRepairRestores(t, ctx, env, schema, original)
+	})
+	t.Run("second_repair_run_is_idempotent", func(t *testing.T) {
+		testReconcileRepairIdempotent(t, ctx, env, schema)
+	})
+}
+
+// seedStrippedDeltaOrphan flushes two batches and strips the second flush's
+// delta entry from the manifest — the exact post-state of a #197 manifest
+// append failure (file at its final key, rows marked flushed, manifest
+// without the entry). Two batches keep the manifest non-empty: an empty
+// manifest sends reads to the legacy glob fallback
+// (manifest/query_source.go), which would see the orphan and defeat the
+// visibility oracle. Returns the stripped entry.
+func seedStrippedDeltaOrphan(t *testing.T, ctx context.Context, env *Env, schema SchemaRef) *manifest.FileEntry {
+	t.Helper()
 	seed := env.GenerateScript(ScriptSpec{Schema: schema, Creates: 4})
 	if err := env.ApplyEvents(ctx, seed...); err != nil {
 		t.Fatalf("apply seed events: %v", err)
@@ -142,9 +160,6 @@ func TestManifestReconcile_RepairsDeltaOrphan(t *testing.T) {
 	}
 	mustFlush(ctx, t, env)
 
-	// Capture the second flush's delta entry, then strip it — the exact
-	// post-state of a #197 manifest append failure (file at its final key,
-	// rows marked flushed, manifest without the entry).
 	m, etag := loadManifestWithETag(t, ctx, env, schema)
 	var original *manifest.FileEntry
 	var kept []manifest.FileEntry
@@ -169,144 +184,148 @@ func TestManifestReconcile_RepairsDeltaOrphan(t *testing.T) {
 	if len(stripped.Records) != 4 {
 		t.Fatalf("stripped manifest yields %d records, want 4 (second batch must be invisible)", len(stripped.Records))
 	}
+	return original
+}
 
-	t.Run("report_only_names_diff_and_mutates_nothing", func(t *testing.T) {
-		// Dangling probe: a manifest entry pointing at a key that never
-		// existed. Removed again at the end of this subtest so the ghost
-		// does not break later read-path assertions.
-		ghostKey := fmt.Sprintf("%s/%d/%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
-		if err := env.RegisterParquetInManifest(ctx, schema, ghostKey, "delta"); err != nil {
-			t.Fatalf("register ghost manifest entry: %v", err)
-		}
+func testReconcileReportOnly(t *testing.T, ctx context.Context, env *Env, schema SchemaRef, original *manifest.FileEntry) {
+	// Dangling probe: a manifest entry pointing at a key that never
+	// existed. Removed again at the end so the ghost does not break later
+	// read-path assertions.
+	ghostKey := fmt.Sprintf("%s/%d/%s.parquet", env.S3Prefix, schema.ID, uuid.Must(uuid.NewV7()).String())
+	if err := env.RegisterParquetInManifest(ctx, schema, ghostKey, "delta"); err != nil {
+		t.Fatalf("register ghost manifest entry: %v", err)
+	}
 
-		mBefore, _ := loadManifestWithETag(t, ctx, env, schema)
-		r, cleanup := newReconcileHarness(t, ctx, env, schema, reconcile.Options{}, false)
-		defer cleanup()
+	mBefore, _ := loadManifestWithETag(t, ctx, env, schema)
+	r, cleanup := newReconcileHarness(t, ctx, env, schema, reconcile.Options{}, false)
+	defer cleanup()
 
-		report, err := r.Run(ctx)
-		if err != nil {
-			t.Fatalf("reconcile report run: %v", err)
-		}
-		if len(report.Schemas) != 1 {
-			t.Fatalf("expected 1 schema report, got %d", len(report.Schemas))
-		}
-		s := report.Schemas[0]
-		if len(s.DeltaOrphans) != 1 || s.DeltaOrphans[0] != original.Path {
-			t.Fatalf("delta orphans = %v, want [%s]", s.DeltaOrphans, original.Path)
-		}
-		if len(s.Dangling) != 1 || s.Dangling[0] != ghostKey {
-			t.Fatalf("dangling = %v, want [%s]", s.Dangling, ghostKey)
-		}
-		if !report.HasResidualDiscrepancies() {
-			t.Fatal("report run must flag residual discrepancies")
-		}
-		mAfter, etagAfter := loadManifestWithETag(t, ctx, env, schema)
-		if mAfter.Version != mBefore.Version {
-			t.Fatalf("report mode bumped manifest version %d -> %d", mBefore.Version, mAfter.Version)
-		}
+	report, err := r.Run(ctx)
+	if err != nil {
+		t.Fatalf("reconcile report run: %v", err)
+	}
+	if len(report.Schemas) != 1 {
+		t.Fatalf("expected 1 schema report, got %d", len(report.Schemas))
+	}
+	s := report.Schemas[0]
+	if len(s.DeltaOrphans) != 1 || s.DeltaOrphans[0] != original.Path {
+		t.Fatalf("delta orphans = %v, want [%s]", s.DeltaOrphans, original.Path)
+	}
+	if len(s.Dangling) != 1 || s.Dangling[0] != ghostKey {
+		t.Fatalf("dangling = %v, want [%s]", s.Dangling, ghostKey)
+	}
+	if !report.HasResidualDiscrepancies() {
+		t.Fatal("report run must flag residual discrepancies")
+	}
+	mAfter, etagAfter := loadManifestWithETag(t, ctx, env, schema)
+	if mAfter.Version != mBefore.Version {
+		t.Fatalf("report mode bumped manifest version %d -> %d", mBefore.Version, mAfter.Version)
+	}
 
-		// Remove the ghost entry again.
-		var files []manifest.FileEntry
-		for _, f := range mAfter.Files {
-			if f.Path != ghostKey {
-				files = append(files, f)
-			}
+	// Remove the ghost entry again.
+	var files []manifest.FileEntry
+	for _, f := range mAfter.Files {
+		if f.Path != ghostKey {
+			files = append(files, f)
 		}
-		mAfter.Files = files
-		saveManifestWithETag(t, ctx, env, schema, mAfter, etagAfter)
-	})
+	}
+	mAfter.Files = files
+	saveManifestWithETag(t, ctx, env, schema, mAfter, etagAfter)
+}
 
-	t.Run("repair_restores_entry_and_visibility", func(t *testing.T) {
-		r, cleanup := newReconcileHarness(t, ctx, env, schema,
-			reconcile.Options{Repair: true, MaxETagRetries: 3}, true)
-		defer cleanup()
+func testReconcileRepairRestores(t *testing.T, ctx context.Context, env *Env, schema SchemaRef, original *manifest.FileEntry) {
+	r, cleanup := newReconcileHarness(t, ctx, env, schema,
+		reconcile.Options{Repair: true, MaxETagRetries: 3}, true)
+	defer cleanup()
 
-		report, err := r.Run(ctx)
-		if err != nil {
-			t.Fatalf("reconcile repair run: %v", err)
-		}
-		s := report.Schemas[0]
-		if len(s.Repaired) != 1 || s.Repaired[0] != original.Path {
-			t.Fatalf("repaired = %v, want [%s]", s.Repaired, original.Path)
-		}
+	report, err := r.Run(ctx)
+	if err != nil {
+		t.Fatalf("reconcile repair run: %v", err)
+	}
+	s := report.Schemas[0]
+	if len(s.Repaired) != 1 || s.Repaired[0] != original.Path {
+		t.Fatalf("repaired = %v, want [%s]", s.Repaired, original.Path)
+	}
 
-		mAfter, _ := loadManifestWithETag(t, ctx, env, schema)
-		var repaired *manifest.FileEntry
-		for _, f := range mAfter.Files {
-			if f.Path == original.Path {
-				e := f
-				repaired = &e
-				break
-			}
+	mAfter, _ := loadManifestWithETag(t, ctx, env, schema)
+	var repaired *manifest.FileEntry
+	for _, f := range mAfter.Files {
+		if f.Path == original.Path {
+			e := f
+			repaired = &e
+			break
 		}
-		if repaired == nil {
-			t.Fatalf("repaired entry %s missing from manifest: %+v", original.Path, mAfter.Files)
-		}
-		// The recomputed identity metadata must match what the flusher
-		// originally wrote — recovery may not fabricate different stats.
-		if repaired.Tier != original.Tier ||
-			repaired.RowCount != original.RowCount ||
-			repaired.SizeBytes != original.SizeBytes {
-			t.Fatalf("repaired entry diverges from original:\n got %+v\nwant %+v", *repaired, *original)
-		}
-		// RowID bounds: repair recomputes lexicographic MIN/MAX over the
-		// varchar row_id, while the flusher's minMaxRowID tie-breaks
-		// same-millisecond UUIDv7s by first-seen order — over the same set,
-		// the lexicographic min/max always bound the flusher's picks.
-		if repaired.RowIDMin == "" || repaired.RowIDMin > original.RowIDMin ||
-			repaired.RowIDMax < original.RowIDMax {
-			t.Fatalf("repaired RowID range [%s, %s] does not bound original [%s, %s]",
-				repaired.RowIDMin, repaired.RowIDMax, original.RowIDMin, original.RowIDMax)
-		}
-		// Created* semantics differ by design (#203): the flusher stamps
-		// both with the flush timestamp, while reconcile recomputes them
-		// from the parquet's changed_at range — the same contents-derived
-		// convention compaction uses for merged files. Row changed_at is
-		// always <= the flush timestamp.
-		if repaired.CreatedMin <= 0 || repaired.CreatedMin > repaired.CreatedMax ||
-			repaired.CreatedMax > original.CreatedMax {
-			t.Fatalf("repaired Created range [%d, %d] outside (0, %d]",
-				repaired.CreatedMin, repaired.CreatedMax, original.CreatedMax)
-		}
+	}
+	if repaired == nil {
+		t.Fatalf("repaired entry %s missing from manifest: %+v", original.Path, mAfter.Files)
+	}
+	assertRepairedEntryMatches(t, repaired, original)
 
-		result, err := env.Query(ctx, Query{Schema: schema, Limit: 100})
-		if err != nil {
-			t.Fatalf("query after repair: %v", err)
-		}
-		if len(result.Records) != 7 {
-			t.Fatalf("query after repair returned %d records, want 7 (both flush batches)", len(result.Records))
-		}
-		if !result.Plan.Routing.UseDuckDB {
-			t.Errorf("post-repair query did not route through duckdb: %+v", result.Plan.Routing)
-		}
-	})
+	result, err := env.Query(ctx, Query{Schema: schema, Limit: 100})
+	if err != nil {
+		t.Fatalf("query after repair: %v", err)
+	}
+	if len(result.Records) != 7 {
+		t.Fatalf("query after repair returned %d records, want 7 (both flush batches)", len(result.Records))
+	}
+	if !result.Plan.Routing.UseDuckDB {
+		t.Errorf("post-repair query did not route through duckdb: %+v", result.Plan.Routing)
+	}
+}
 
-	t.Run("second_repair_run_is_idempotent", func(t *testing.T) {
-		mBefore, _ := loadManifestWithETag(t, ctx, env, schema)
-		r, cleanup := newReconcileHarness(t, ctx, env, schema,
-			reconcile.Options{Repair: true, MaxETagRetries: 3}, true)
-		defer cleanup()
+// assertRepairedEntryMatches compares a repaired entry against the
+// flusher-written original: identity metadata must match exactly; RowID
+// bounds tolerate the flusher's same-millisecond first-seen tie-break
+// (repair recomputes lexicographic MIN/MAX, which always bounds the
+// flusher's picks over the same set); Created* semantics differ by design —
+// the flusher stamps the flush timestamp, reconcile recomputes the
+// parquet's changed_at range (compaction's convention for merged files),
+// and row changed_at is always <= the flush timestamp.
+func assertRepairedEntryMatches(t *testing.T, repaired, original *manifest.FileEntry) {
+	t.Helper()
+	if repaired.Tier != original.Tier ||
+		repaired.RowCount != original.RowCount ||
+		repaired.SizeBytes != original.SizeBytes {
+		t.Fatalf("repaired entry diverges from original:\n got %+v\nwant %+v", *repaired, *original)
+	}
+	if repaired.RowIDMin == "" || repaired.RowIDMin > original.RowIDMin ||
+		repaired.RowIDMax < original.RowIDMax {
+		t.Fatalf("repaired RowID range [%s, %s] does not bound original [%s, %s]",
+			repaired.RowIDMin, repaired.RowIDMax, original.RowIDMin, original.RowIDMax)
+	}
+	if repaired.CreatedMin <= 0 || repaired.CreatedMin > repaired.CreatedMax ||
+		repaired.CreatedMax > original.CreatedMax {
+		t.Fatalf("repaired Created range [%d, %d] outside (0, %d]",
+			repaired.CreatedMin, repaired.CreatedMax, original.CreatedMax)
+	}
+}
 
-		report, err := r.Run(ctx)
-		if err != nil {
-			t.Fatalf("second reconcile repair run: %v", err)
-		}
-		if len(report.Schemas[0].Repaired) != 0 {
-			t.Fatalf("second run repaired %v, want nothing", report.Schemas[0].Repaired)
-		}
-		mAfter, _ := loadManifestWithETag(t, ctx, env, schema)
-		if mAfter.Version != mBefore.Version {
-			t.Fatalf("idempotent run bumped manifest version %d -> %d", mBefore.Version, mAfter.Version)
-		}
-		assertNoDuplicateManifestEntries(t, mAfter)
-	})
+func testReconcileRepairIdempotent(t *testing.T, ctx context.Context, env *Env, schema SchemaRef) {
+	mBefore, _ := loadManifestWithETag(t, ctx, env, schema)
+	r, cleanup := newReconcileHarness(t, ctx, env, schema,
+		reconcile.Options{Repair: true, MaxETagRetries: 3}, true)
+	defer cleanup()
+
+	report, err := r.Run(ctx)
+	if err != nil {
+		t.Fatalf("second reconcile repair run: %v", err)
+	}
+	if len(report.Schemas[0].Repaired) != 0 {
+		t.Fatalf("second run repaired %v, want nothing", report.Schemas[0].Repaired)
+	}
+	mAfter, _ := loadManifestWithETag(t, ctx, env, schema)
+	if mAfter.Version != mBefore.Version {
+		t.Fatalf("idempotent run bumped manifest version %d -> %d", mBefore.Version, mAfter.Version)
+	}
+	assertNoDuplicateManifestEntries(t, mAfter)
 }
 
 // TestManifestReconcile_GCRemovesRewriteLeftovers drives the #188 recovery
-// path: staged _tmp objects and unlisted base files from a crashed or
-// half-cleaned compaction rewrite are deleted by --gc only once they age
-// past the grace period, while delta-shaped orphans and manifest-listed
-// objects are never touched.
+// path with the two-phase sighting contract: the first --gc run only
+// records each leftover's first-unlisted sighting (persisted next to the
+// manifest), and a later run deletes it once BOTH the observed-unlisted
+// duration and the object age exceed the grace period. Delta-shaped and
+// init-shaped orphans and manifest-listed objects are never touched.
 func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
@@ -332,6 +351,8 @@ func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
 	gcOpts := reconcile.Options{GC: true, GCGrace: 15 * time.Minute}
 
 	t.Run("within_grace_nothing_deleted", func(t *testing.T) {
+		// This run doubles as the sighting-recording phase: it persists
+		// each candidate's first-unlisted timestamp for the next run.
 		r, cleanup := newReconcileHarness(t, ctx, env, schema, gcOpts, false)
 		defer cleanup()
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -124,6 +124,17 @@ func Decode(r io.Reader) (*Manifest, error) {
 	return &m, nil
 }
 
+// IsNotFound reports whether a Store.Load error means the object does not
+// exist. Most S3-compatible stores return an error containing "NoSuchKey"
+// or "not found".
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "nosuchkey") || strings.Contains(errStr, "not found") || strings.Contains(errStr, "does not exist")
+}
+
 // LoadOrCreate loads an existing manifest or creates a new empty one for the schema.
 // Returns the manifest, etag (empty if new), and any error.
 func LoadOrCreate(ctx context.Context, st Store, path string, schemaID int16) (*Manifest, string, error) {
@@ -131,10 +142,7 @@ func LoadOrCreate(ctx context.Context, st Store, path string, schemaID int16) (*
 	if err == nil {
 		return m, etag, nil
 	}
-	// If file doesn't exist, create new manifest
-	// Most S3-compatible stores return an error containing "NoSuchKey" or "not found"
-	errStr := strings.ToLower(err.Error())
-	if strings.Contains(errStr, "nosuchkey") || strings.Contains(errStr, "not found") || strings.Contains(errStr, "does not exist") {
+	if IsNotFound(err) {
 		return &Manifest{
 			SchemaID: schemaID,
 			Version:  0,

--- a/internal/manifest/store_s3.go
+++ b/internal/manifest/store_s3.go
@@ -65,7 +65,7 @@ func (s *S3Store) Save(ctx context.Context, path string, data []byte, etag strin
 	}
 	out, err := s.Client.PutObject(ctx, input)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("put manifest object %s/%s: %w", s.Bucket, path, err)
 	}
 	newETag := ""
 	if out.ETag != nil {

--- a/internal/manifest/store_s3.go
+++ b/internal/manifest/store_s3.go
@@ -55,6 +55,13 @@ func (s *S3Store) Save(ctx context.Context, path string, data []byte, etag strin
 	}
 	if etag != "" {
 		input.IfMatch = aws.String(etag)
+	} else {
+		// An empty etag means the caller loaded no existing manifest. An
+		// unconditional PUT here would silently clobber a manifest another
+		// writer created in the meantime (#203 review); If-None-Match makes
+		// the create fail with 412 instead, so callers can reload and retry
+		// against the real object.
+		input.IfNoneMatch = aws.String("*")
 	}
 	out, err := s.Client.PutObject(ctx, input)
 	if err != nil {

--- a/internal/manifest/store_s3_test.go
+++ b/internal/manifest/store_s3_test.go
@@ -1,0 +1,52 @@
+package manifest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type capturingS3Client struct {
+	lastPut *s3.PutObjectInput
+}
+
+func (c *capturingS3Client) GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return nil, nil
+}
+
+func (c *capturingS3Client) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	c.lastPut = in
+	return &s3.PutObjectOutput{ETag: aws.String("new-etag")}, nil
+}
+
+func TestS3StoreSave_EmptyETagUsesConditionalCreate(t *testing.T) {
+	client := &capturingS3Client{}
+	store := &S3Store{Client: client, Bucket: "bkt"}
+
+	if _, err := store.Save(context.Background(), "manifest/7.json", []byte("{}"), ""); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if client.lastPut.IfMatch != nil {
+		t.Fatal("empty etag must not set If-Match")
+	}
+	if client.lastPut.IfNoneMatch == nil || *client.lastPut.IfNoneMatch != "*" {
+		t.Fatalf("empty etag must set If-None-Match:* so a create cannot clobber a concurrently created manifest, got %v", client.lastPut.IfNoneMatch)
+	}
+}
+
+func TestS3StoreSave_ETagUsesIfMatch(t *testing.T) {
+	client := &capturingS3Client{}
+	store := &S3Store{Client: client, Bucket: "bkt"}
+
+	if _, err := store.Save(context.Background(), "manifest/7.json", []byte("{}"), "abc"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if client.lastPut.IfMatch == nil || *client.lastPut.IfMatch != "abc" {
+		t.Fatalf("etag save must set If-Match, got %v", client.lastPut.IfMatch)
+	}
+	if client.lastPut.IfNoneMatch != nil {
+		t.Fatal("etag save must not set If-None-Match")
+	}
+}

--- a/internal/reconcile/classify.go
+++ b/internal/reconcile/classify.go
@@ -2,9 +2,10 @@
 // (issue #203). It reports orphans — live objects the manifest does not list,
 // classified by filename shape — and dangling entries — manifest paths whose
 // object is gone. Optional repair appends delta-shaped orphans back to the
-// manifest (the #197 flush failure mode: rows already marked flushed, data
-// exists only in the orphaned file); optional GC deletes base-shaped and
-// _tmp/ orphans left behind by compaction rewrites (#188).
+// manifest when the coverage + Postgres-liveness guard proves they are the
+// #197 flush failure mode (data exists nowhere else); provable compaction
+// leftovers are instead classified for GC, which also deletes merged-base
+// and _tmp/ orphans left behind by compaction rewrites (#188).
 package reconcile
 
 import (
@@ -17,15 +18,19 @@ import (
 )
 
 // OrphanClass is the filename-shape class of an unlisted parquet object. The
-// class decides the recovery direction: delta orphans carry data that exists
-// nowhere else and are appended back to the manifest, base and _tmp orphans
-// are compaction leftovers whose data already lives in the merged base and
-// are garbage-collected. Unknown shapes are reported and never touched.
+// class decides the recovery direction: delta orphans may carry data that
+// exists nowhere else and are candidates for repair (guarded by row coverage
+// and Postgres liveness), merged-base and _tmp orphans are compaction
+// leftovers eligible for GC, and init-shaped base orphans are only reported —
+// an in-flight cdc-init promotes them long before it publishes the manifest
+// and holds no advisory lock, so deleting them could destroy a running
+// re-export. Unknown shapes are reported and never touched.
 type OrphanClass int
 
 const (
-	ClassDelta OrphanClass = iota
-	ClassBase
+	ClassDelta      OrphanClass = iota
+	ClassBaseInit               // {minRowID}_{maxRowID}.parquet (cdc-init export)
+	ClassBaseMerged             // base-{uuid}.parquet (compaction rewrite)
 	ClassTmp
 	ClassUnknown
 )
@@ -53,9 +58,9 @@ func classifyObjectKey(prefix, key string) (OrphanClass, bool) {
 	stem := strings.TrimSuffix(rel, ".parquet")
 	switch {
 	case strings.HasPrefix(stem, "base-"):
-		return ClassBase, true // cdc.BuildMergedBasePath: base-{uuid}.parquet
+		return ClassBaseMerged, true // cdc.BuildMergedBasePath: base-{uuid}.parquet
 	case strings.Contains(stem, "_"):
-		return ClassBase, true // cdc.BuildBasePath: {minRowID}_{maxRowID}.parquet
+		return ClassBaseInit, true // cdc.BuildBasePath: {minRowID}_{maxRowID}.parquet
 	case uuid.Validate(stem) == nil:
 		return ClassDelta, true // cdc.BuildDeltaPath: {uuid}.parquet
 	default:
@@ -85,12 +90,13 @@ func normalizeKey(bucket, path string) (string, bool) {
 // diffResult is one schema's raw two-way diff between listed objects and
 // manifest entries, before repair or GC acts on it.
 type diffResult struct {
-	deltaOrphans []ObjectInfo
-	baseOrphans  []ObjectInfo
-	tmpOrphans   []ObjectInfo
-	unknown      []ObjectInfo
-	dangling     []string
-	unverifiable []string
+	deltaOrphans      []ObjectInfo
+	baseInitOrphans   []ObjectInfo
+	baseMergedOrphans []ObjectInfo
+	tmpOrphans        []ObjectInfo
+	unknown           []ObjectInfo
+	dangling          []string
+	unverifiable      []string
 }
 
 // diffSchema computes the two-way diff for one schema: objects absent from
@@ -123,8 +129,10 @@ func diffSchema(bucket, dataPrefix string, schemaID int16, objects []ObjectInfo,
 		switch class {
 		case ClassDelta:
 			d.deltaOrphans = append(d.deltaOrphans, obj)
-		case ClassBase:
-			d.baseOrphans = append(d.baseOrphans, obj)
+		case ClassBaseInit:
+			d.baseInitOrphans = append(d.baseInitOrphans, obj)
+		case ClassBaseMerged:
+			d.baseMergedOrphans = append(d.baseMergedOrphans, obj)
 		case ClassTmp:
 			d.tmpOrphans = append(d.tmpOrphans, obj)
 		case ClassUnknown:

--- a/internal/reconcile/classify.go
+++ b/internal/reconcile/classify.go
@@ -55,22 +55,34 @@ func classifyObjectKey(prefix, key string) (OrphanClass, bool) {
 		}
 		return ClassUnknown, true
 	}
+	// Shapes are matched strictly — the class drives repair/GC actions, so
+	// anything that merely resembles a known shape must stay Unknown
+	// (report-only) rather than become deletable.
 	stem := strings.TrimSuffix(rel, ".parquet")
-	switch {
-	case strings.HasPrefix(stem, "base-"):
-		return ClassBaseMerged, true // cdc.BuildMergedBasePath: base-{uuid}.parquet
-	case strings.Contains(stem, "_"):
-		return ClassBaseInit, true // cdc.BuildBasePath: {minRowID}_{maxRowID}.parquet
-	case uuid.Validate(stem) == nil:
-		return ClassDelta, true // cdc.BuildDeltaPath: {uuid}.parquet
-	default:
+	if rest, found := strings.CutPrefix(stem, "base-"); found {
+		if uuid.Validate(rest) == nil {
+			return ClassBaseMerged, true // cdc.BuildMergedBasePath: base-{uuid}.parquet
+		}
 		return ClassUnknown, true
 	}
+	if minID, maxID, found := strings.Cut(stem, "_"); found {
+		if uuid.Validate(minID) == nil && uuid.Validate(maxID) == nil {
+			return ClassBaseInit, true // cdc.BuildBasePath: {minRowID}_{maxRowID}.parquet
+		}
+		return ClassUnknown, true
+	}
+	if uuid.Validate(stem) == nil {
+		return ClassDelta, true // cdc.BuildDeltaPath: {uuid}.parquet
+	}
+	return ClassUnknown, true
 }
 
 // normalizeKey reduces a manifest FileEntry.Path to a bucket-relative key.
 // Manifest paths appear both bucket-relative and as absolute s3:// URIs
-// (manifest/query_source.go tolerates either). ok is false for paths whose
+// (manifest/query_source.go tolerates either). Relative keys are compared
+// verbatim: with an empty data prefix cdc.Build*Path emits keys with a
+// leading slash, and the manifest stores that literal key, so stripping it
+// would break the match against the S3 listing. ok is false for paths whose
 // existence this bucket's listing cannot prove — foreign-bucket URIs and
 // glob entries — which must surface as unverifiable, never as dangling.
 func normalizeKey(bucket, path string) (string, bool) {
@@ -84,7 +96,7 @@ func normalizeKey(bucket, path string) (string, bool) {
 		}
 		return key, true
 	}
-	return strings.TrimPrefix(path, "/"), true
+	return path, true
 }
 
 // diffResult is one schema's raw two-way diff between listed objects and

--- a/internal/reconcile/classify.go
+++ b/internal/reconcile/classify.go
@@ -1,0 +1,151 @@
+// Package reconcile diffs a schema's S3 parquet objects against its manifest
+// (issue #203). It reports orphans — live objects the manifest does not list,
+// classified by filename shape — and dangling entries — manifest paths whose
+// object is gone. Optional repair appends delta-shaped orphans back to the
+// manifest (the #197 flush failure mode: rows already marked flushed, data
+// exists only in the orphaned file); optional GC deletes base-shaped and
+// _tmp/ orphans left behind by compaction rewrites (#188).
+package reconcile
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// OrphanClass is the filename-shape class of an unlisted parquet object. The
+// class decides the recovery direction: delta orphans carry data that exists
+// nowhere else and are appended back to the manifest, base and _tmp orphans
+// are compaction leftovers whose data already lives in the merged base and
+// are garbage-collected. Unknown shapes are reported and never touched.
+type OrphanClass int
+
+const (
+	ClassDelta OrphanClass = iota
+	ClassBase
+	ClassTmp
+	ClassUnknown
+)
+
+// schemaDataPrefix returns the S3 listing prefix owning one schema's parquet
+// objects, mirroring cdc.BuildDeltaPath / BuildBasePath layout.
+func schemaDataPrefix(dataPrefix string, schemaID int16) string {
+	return fmt.Sprintf("%s/%d/", strings.TrimSuffix(dataPrefix, "/"), schemaID)
+}
+
+// classifyObjectKey classifies a listed object key relative to the schema
+// data prefix. ok is false for keys the reconciler ignores entirely:
+// non-parquet objects and keys outside the prefix.
+func classifyObjectKey(prefix, key string) (OrphanClass, bool) {
+	rel, found := strings.CutPrefix(key, prefix)
+	if !found || !strings.HasSuffix(rel, ".parquet") {
+		return 0, false
+	}
+	if dir, _, nested := strings.Cut(rel, "/"); nested {
+		if dir == "_tmp" {
+			return ClassTmp, true
+		}
+		return ClassUnknown, true
+	}
+	stem := strings.TrimSuffix(rel, ".parquet")
+	switch {
+	case strings.HasPrefix(stem, "base-"):
+		return ClassBase, true // cdc.BuildMergedBasePath: base-{uuid}.parquet
+	case strings.Contains(stem, "_"):
+		return ClassBase, true // cdc.BuildBasePath: {minRowID}_{maxRowID}.parquet
+	case uuid.Validate(stem) == nil:
+		return ClassDelta, true // cdc.BuildDeltaPath: {uuid}.parquet
+	default:
+		return ClassUnknown, true
+	}
+}
+
+// normalizeKey reduces a manifest FileEntry.Path to a bucket-relative key.
+// Manifest paths appear both bucket-relative and as absolute s3:// URIs
+// (manifest/query_source.go tolerates either). ok is false for paths whose
+// existence this bucket's listing cannot prove — foreign-bucket URIs and
+// glob entries — which must surface as unverifiable, never as dangling.
+func normalizeKey(bucket, path string) (string, bool) {
+	if strings.ContainsAny(path, "*?[") {
+		return "", false
+	}
+	if strings.HasPrefix(path, "s3://") {
+		key, found := strings.CutPrefix(path, "s3://"+bucket+"/")
+		if !found {
+			return "", false
+		}
+		return key, true
+	}
+	return strings.TrimPrefix(path, "/"), true
+}
+
+// diffResult is one schema's raw two-way diff between listed objects and
+// manifest entries, before repair or GC acts on it.
+type diffResult struct {
+	deltaOrphans []ObjectInfo
+	baseOrphans  []ObjectInfo
+	tmpOrphans   []ObjectInfo
+	unknown      []ObjectInfo
+	dangling     []string
+	unverifiable []string
+}
+
+// diffSchema computes the two-way diff for one schema: objects absent from
+// the manifest become orphans classified by shape, and in-bucket manifest
+// entries absent from the listing become dangling.
+func diffSchema(bucket, dataPrefix string, schemaID int16, objects []ObjectInfo, m *manifest.Manifest) diffResult {
+	prefix := schemaDataPrefix(dataPrefix, schemaID)
+
+	manifestKeys := make(map[string]struct{}, len(m.Files))
+	var d diffResult
+	for _, f := range m.Files {
+		key, ok := normalizeKey(bucket, f.Path)
+		if !ok {
+			d.unverifiable = append(d.unverifiable, f.Path)
+			continue
+		}
+		manifestKeys[key] = struct{}{}
+	}
+
+	listedKeys := make(map[string]struct{}, len(objects))
+	for _, obj := range objects {
+		listedKeys[obj.Key] = struct{}{}
+		class, ok := classifyObjectKey(prefix, obj.Key)
+		if !ok {
+			continue
+		}
+		if _, listed := manifestKeys[obj.Key]; listed {
+			continue
+		}
+		switch class {
+		case ClassDelta:
+			d.deltaOrphans = append(d.deltaOrphans, obj)
+		case ClassBase:
+			d.baseOrphans = append(d.baseOrphans, obj)
+		case ClassTmp:
+			d.tmpOrphans = append(d.tmpOrphans, obj)
+		case ClassUnknown:
+			d.unknown = append(d.unknown, obj)
+		}
+	}
+
+	for _, f := range m.Files {
+		key, ok := normalizeKey(bucket, f.Path)
+		if !ok {
+			continue // already reported unverifiable above
+		}
+		if !strings.HasPrefix(key, prefix) {
+			// The listing only covers this schema's data prefix; absence of
+			// an out-of-prefix key cannot be proven from it.
+			d.unverifiable = append(d.unverifiable, f.Path)
+			continue
+		}
+		if _, live := listedKeys[key]; !live {
+			d.dangling = append(d.dangling, key)
+		}
+	}
+	return d
+}

--- a/internal/reconcile/classify_test.go
+++ b/internal/reconcile/classify_test.go
@@ -51,7 +51,11 @@ func TestNormalizeKey(t *testing.T) {
 	}{
 		{"relative key", "data/7/a.parquet", "data/7/a.parquet", true},
 		{"absolute same bucket", "s3://bkt/data/7/a.parquet", "data/7/a.parquet", true},
-		{"leading slash", "/data/7/a.parquet", "data/7/a.parquet", true},
+		// An empty data prefix makes cdc.Build*Path emit keys with a
+		// leading slash (`/7/a.parquet`); the manifest stores the same
+		// literal key, so it must NOT be stripped or listing comparison
+		// breaks and --gc could delete manifest-listed objects.
+		{"leading slash preserved", "/7/a.parquet", "/7/a.parquet", true},
 		{"foreign bucket", "s3://other/data/7/a.parquet", "", false},
 		{"glob entry", "data/7/*.parquet", "", false},
 	}
@@ -115,6 +119,51 @@ func TestDiffSchema_CleanManifestNoFindings(t *testing.T) {
 	}
 	if len(d.dangling)+len(d.unverifiable) != 0 {
 		t.Fatalf("expected no dangling/unverifiable, got %+v", d)
+	}
+}
+
+func TestDiffSchema_EmptyDataPrefixKeysMatch(t *testing.T) {
+	// cdc.BuildDeltaPath("", 7, uuid) emits "/7/{uuid}.parquet"; the same
+	// literal key lands in the manifest. The diff must treat them as the
+	// same object — a mismatch here turns every real file into an orphan
+	// and every manifest entry into a dangling report.
+	listed := ObjectInfo{Key: "/7/" + uuidA + ".parquet"}
+	m := &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: "/7/" + uuidA + ".parquet"},
+	}}
+	d := diffSchema("bkt", "", 7, []ObjectInfo{listed}, m)
+	if len(d.deltaOrphans) != 0 {
+		t.Fatalf("manifest-listed key reported as orphan under empty prefix: %+v", d.deltaOrphans)
+	}
+	if len(d.dangling) != 0 {
+		t.Fatalf("live key reported dangling under empty prefix: %+v", d.dangling)
+	}
+}
+
+func TestClassifyObjectKey_RequiresUUIDShapes(t *testing.T) {
+	prefix := "data/7/"
+	tests := []struct {
+		name  string
+		key   string
+		class OrphanClass
+	}{
+		// base- prefix without a UUID is NOT a merged base — GC must never
+		// delete an unrecognized object.
+		{"base prefix junk", "data/7/base-foo.parquet", ClassUnknown},
+		{"base prefix valid uuid", "data/7/base-" + uuidA + ".parquet", ClassBaseMerged},
+		{"underscore junk", "data/7/a_b.parquet", ClassUnknown},
+		{"underscore valid uuids", "data/7/" + uuidA + "_" + uuidB + ".parquet", ClassBaseInit},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, ok := classifyObjectKey(prefix, tt.key)
+			if !ok {
+				t.Fatalf("classifyObjectKey(%q) unexpectedly ignored", tt.key)
+			}
+			if class != tt.class {
+				t.Fatalf("classifyObjectKey(%q) = %v, want %v", tt.key, class, tt.class)
+			}
+		})
 	}
 }
 

--- a/internal/reconcile/classify_test.go
+++ b/internal/reconcile/classify_test.go
@@ -1,0 +1,139 @@
+package reconcile
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+const (
+	uuidA = "019bed54-48eb-7cdc-aed3-8d38ec9c1394"
+	uuidB = "019bed54-48eb-7cdc-aed3-8d38ec9c1395"
+)
+
+func TestClassifyObjectKey(t *testing.T) {
+	prefix := "data/7/"
+	tests := []struct {
+		name  string
+		key   string
+		class OrphanClass
+		ok    bool
+	}{
+		{"delta uuid", "data/7/" + uuidA + ".parquet", ClassDelta, true},
+		{"init base min_max", "data/7/" + uuidA + "_" + uuidB + ".parquet", ClassBase, true},
+		{"merged base", "data/7/base-" + uuidA + ".parquet", ClassBase, true},
+		{"tmp staged", "data/7/_tmp/" + uuidA + ".parquet", ClassTmp, true},
+		{"unrecognized stem", "data/7/weird.parquet", ClassUnknown, true},
+		{"nested non-tmp dir", "data/7/sub/" + uuidA + ".parquet", ClassUnknown, true},
+		{"non parquet ignored", "data/7/notes.txt", 0, false},
+		{"outside prefix ignored", "data/8/" + uuidA + ".parquet", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, ok := classifyObjectKey(prefix, tt.key)
+			if ok != tt.ok {
+				t.Fatalf("classifyObjectKey(%q) ok = %v, want %v", tt.key, ok, tt.ok)
+			}
+			if ok && class != tt.class {
+				t.Fatalf("classifyObjectKey(%q) class = %v, want %v", tt.key, class, tt.class)
+			}
+		})
+	}
+}
+
+func TestNormalizeKey(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+		ok   bool
+	}{
+		{"relative key", "data/7/a.parquet", "data/7/a.parquet", true},
+		{"absolute same bucket", "s3://bkt/data/7/a.parquet", "data/7/a.parquet", true},
+		{"leading slash", "/data/7/a.parquet", "data/7/a.parquet", true},
+		{"foreign bucket", "s3://other/data/7/a.parquet", "", false},
+		{"glob entry", "data/7/*.parquet", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := normalizeKey("bkt", tt.path)
+			if ok != tt.ok {
+				t.Fatalf("normalizeKey(%q) ok = %v, want %v", tt.path, ok, tt.ok)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("normalizeKey(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiffSchema_OrphansDanglingUnverifiable(t *testing.T) {
+	now := time.Now()
+	listedDelta := ObjectInfo{Key: "data/7/" + uuidA + ".parquet", Size: 10, LastModified: now}
+	listedBase := ObjectInfo{Key: "data/7/base-" + uuidB + ".parquet", Size: 20, LastModified: now}
+	listedTmp := ObjectInfo{Key: "data/7/_tmp/" + uuidB + ".parquet", Size: 5, LastModified: now}
+	listedKnown := ObjectInfo{Key: "data/7/" + uuidB + ".parquet", Size: 30, LastModified: now}
+	listedUnknown := ObjectInfo{Key: "data/7/weird.parquet", Size: 1, LastModified: now}
+	ignoredTxt := ObjectInfo{Key: "data/7/notes.txt", Size: 1, LastModified: now}
+
+	m := &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		// Absolute form must match the listed relative key (normalization).
+		{Tier: "delta", Path: "s3://bkt/data/7/" + uuidB + ".parquet"},
+		// Dangling: no live object under this key.
+		{Tier: "base", Path: "data/7/base-" + uuidA + ".parquet"},
+		// Foreign bucket: unverifiable, never dangling.
+		{Tier: "base", Path: "s3://other/data/7/gone.parquet"},
+		// Outside the listed schema prefix: this listing cannot prove
+		// absence, so unverifiable — never dangling.
+		{Tier: "base", Path: "olddata/7/legacy.parquet"},
+	}}
+
+	d := diffSchema("bkt", "data", 7,
+		[]ObjectInfo{listedDelta, listedBase, listedTmp, listedKnown, listedUnknown, ignoredTxt}, m)
+
+	assertKeys(t, "delta orphans", objectKeys(d.deltaOrphans), []string{listedDelta.Key})
+	assertKeys(t, "base orphans", objectKeys(d.baseOrphans), []string{listedBase.Key})
+	assertKeys(t, "tmp orphans", objectKeys(d.tmpOrphans), []string{listedTmp.Key})
+	assertKeys(t, "unknown", objectKeys(d.unknown), []string{listedUnknown.Key})
+	assertKeys(t, "dangling", d.dangling, []string{"data/7/base-" + uuidA + ".parquet"})
+	assertKeys(t, "unverifiable", d.unverifiable, []string{
+		"s3://other/data/7/gone.parquet",
+		"olddata/7/legacy.parquet",
+	})
+}
+
+func TestDiffSchema_CleanManifestNoFindings(t *testing.T) {
+	m := &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: "data/7/" + uuidA + ".parquet"},
+	}}
+	d := diffSchema("bkt", "data", 7,
+		[]ObjectInfo{{Key: "data/7/" + uuidA + ".parquet"}}, m)
+
+	if len(d.deltaOrphans)+len(d.baseOrphans)+len(d.tmpOrphans)+len(d.unknown) != 0 {
+		t.Fatalf("expected no orphans, got %+v", d)
+	}
+	if len(d.dangling)+len(d.unverifiable) != 0 {
+		t.Fatalf("expected no dangling/unverifiable, got %+v", d)
+	}
+}
+
+func objectKeys(objs []ObjectInfo) []string {
+	keys := make([]string, 0, len(objs))
+	for _, o := range objs {
+		keys = append(keys, o.Key)
+	}
+	return keys
+}
+
+func assertKeys(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", label, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s = %v, want %v", label, got, want)
+		}
+	}
+}

--- a/internal/reconcile/classify_test.go
+++ b/internal/reconcile/classify_test.go
@@ -21,8 +21,8 @@ func TestClassifyObjectKey(t *testing.T) {
 		ok    bool
 	}{
 		{"delta uuid", "data/7/" + uuidA + ".parquet", ClassDelta, true},
-		{"init base min_max", "data/7/" + uuidA + "_" + uuidB + ".parquet", ClassBase, true},
-		{"merged base", "data/7/base-" + uuidA + ".parquet", ClassBase, true},
+		{"init base min_max", "data/7/" + uuidA + "_" + uuidB + ".parquet", ClassBaseInit, true},
+		{"merged base", "data/7/base-" + uuidA + ".parquet", ClassBaseMerged, true},
 		{"tmp staged", "data/7/_tmp/" + uuidA + ".parquet", ClassTmp, true},
 		{"unrecognized stem", "data/7/weird.parquet", ClassUnknown, true},
 		{"nested non-tmp dir", "data/7/sub/" + uuidA + ".parquet", ClassUnknown, true},
@@ -93,7 +93,7 @@ func TestDiffSchema_OrphansDanglingUnverifiable(t *testing.T) {
 		[]ObjectInfo{listedDelta, listedBase, listedTmp, listedKnown, listedUnknown, ignoredTxt}, m)
 
 	assertKeys(t, "delta orphans", objectKeys(d.deltaOrphans), []string{listedDelta.Key})
-	assertKeys(t, "base orphans", objectKeys(d.baseOrphans), []string{listedBase.Key})
+	assertKeys(t, "merged base orphans", objectKeys(d.baseMergedOrphans), []string{listedBase.Key})
 	assertKeys(t, "tmp orphans", objectKeys(d.tmpOrphans), []string{listedTmp.Key})
 	assertKeys(t, "unknown", objectKeys(d.unknown), []string{listedUnknown.Key})
 	assertKeys(t, "dangling", d.dangling, []string{"data/7/base-" + uuidA + ".parquet"})
@@ -110,7 +110,7 @@ func TestDiffSchema_CleanManifestNoFindings(t *testing.T) {
 	d := diffSchema("bkt", "data", 7,
 		[]ObjectInfo{{Key: "data/7/" + uuidA + ".parquet"}}, m)
 
-	if len(d.deltaOrphans)+len(d.baseOrphans)+len(d.tmpOrphans)+len(d.unknown) != 0 {
+	if len(d.deltaOrphans)+len(d.baseInitOrphans)+len(d.baseMergedOrphans)+len(d.tmpOrphans)+len(d.unknown) != 0 {
 		t.Fatalf("expected no orphans, got %+v", d)
 	}
 	if len(d.dangling)+len(d.unverifiable) != 0 {

--- a/internal/reconcile/db.go
+++ b/internal/reconcile/db.go
@@ -1,0 +1,90 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/lychee-technology/forma/internal/sqlutil"
+)
+
+// RegistrySchemaEnumerator enumerates schema IDs from the schema registry
+// table, mirroring cdc-init's getSchemaIDsToInit: every registered schema
+// reconciles, not just those with pending CDC work.
+type RegistrySchemaEnumerator struct {
+	DB             *sql.DB
+	Table          string
+	SchemaIDFilter int // 0 = all schemas
+}
+
+func (e *RegistrySchemaEnumerator) SchemaIDs(ctx context.Context) ([]int16, error) {
+	table := sqlutil.SanitizeIdentifier(e.Table)
+	var rows *sql.Rows
+	var err error
+	if e.SchemaIDFilter > 0 {
+		rows, err = e.DB.QueryContext(ctx,
+			fmt.Sprintf("SELECT schema_id FROM %s WHERE schema_id = $1", table), e.SchemaIDFilter)
+	} else {
+		rows, err = e.DB.QueryContext(ctx,
+			fmt.Sprintf("SELECT schema_id FROM %s ORDER BY schema_id", table))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query schema ids from %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []int16
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan schema id: %w", err)
+		}
+		if id < -32768 || id > 32767 {
+			return nil, fmt.Errorf("schema id %d from %s overflows int16", id, table)
+		}
+		ids = append(ids, int16(id))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate schema ids from %s: %w", table, err)
+	}
+	return ids, nil
+}
+
+// PGAdvisoryLocker takes the flusher's per-schema advisory lock
+// (pg_try_advisory_lock(schemaID, schemaID), cdc.AcquireSchemaLock). Unlike
+// the flusher it pins one physical connection for the lock's lifetime: on a
+// pool, acquire and release could land on different connections, and a
+// session-scoped lock released on the wrong session silently fails.
+type PGAdvisoryLocker struct {
+	DB *sql.DB
+}
+
+func (l *PGAdvisoryLocker) TryLock(ctx context.Context, schemaID int16) (bool, func(), error) {
+	conn, err := l.DB.Conn(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("pin connection for schema %d lock: %w", schemaID, err)
+	}
+	var locked bool
+	row := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1, $2)", int32(schemaID), int32(schemaID))
+	if err := row.Scan(&locked); err != nil {
+		_ = conn.Close()
+		return false, nil, fmt.Errorf("acquire schema %d advisory lock: %w", schemaID, err)
+	}
+	if !locked {
+		_ = conn.Close()
+		return false, nil, nil
+	}
+	unlock := func() {
+		// Background context: the unlock must run even when the reconcile
+		// context is already cancelled; closing the pinned connection
+		// releases the session-scoped lock regardless.
+		_, _ = conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1, $2)", int32(schemaID), int32(schemaID))
+		_ = conn.Close()
+	}
+	return true, unlock, nil
+}
+
+var (
+	_ SchemaEnumerator = (*RegistrySchemaEnumerator)(nil)
+	_ Locker           = (*PGAdvisoryLocker)(nil)
+)

--- a/internal/reconcile/db.go
+++ b/internal/reconcile/db.go
@@ -5,6 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 
+	"strings"
+
+	"github.com/google/uuid"
+
 	"github.com/lychee-technology/forma/internal/sqlutil"
 )
 
@@ -47,6 +51,12 @@ func (e *RegistrySchemaEnumerator) SchemaIDs(ctx context.Context) ([]int16, erro
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate schema ids from %s: %w", table, err)
 	}
+	if e.SchemaIDFilter > 0 && len(ids) == 0 {
+		// A silent empty run would report "consistent" for a schema that
+		// was never inspected (typo'd --schema-id, or a deregistered
+		// schema whose S3 objects linger).
+		return nil, fmt.Errorf("schema %d is not registered in %s; nothing was inspected", e.SchemaIDFilter, table)
+	}
 	return ids, nil
 }
 
@@ -84,7 +94,55 @@ func (l *PGAdvisoryLocker) TryLock(ctx context.Context, schemaID int16) (bool, f
 	return true, unlock, nil
 }
 
+// PGLiveRows implements LiveRowChecker over the entity main table. Deletes
+// are physical (postgres_persistent_repository issues DELETE), so liveness
+// is row existence under the (schema_id, row_id) primary key.
+type PGLiveRows struct {
+	DB    *sql.DB
+	Table string // entity_main table name
+}
+
+func (p *PGLiveRows) MissingLiveRows(ctx context.Context, schemaID int16, rowIDs []string) ([]string, error) {
+	if len(rowIDs) == 0 {
+		return nil, nil
+	}
+	for _, id := range rowIDs {
+		if err := uuid.Validate(id); err != nil {
+			return nil, fmt.Errorf("row id %q from parquet is not a UUID: %w", id, err)
+		}
+	}
+	query := fmt.Sprintf(
+		"SELECT ltbase_row_id::text FROM %s WHERE ltbase_schema_id = $1 AND ltbase_row_id = ANY(string_to_array($2, ',')::uuid[])",
+		sqlutil.SanitizeIdentifier(p.Table))
+	rows, err := p.DB.QueryContext(ctx, query, schemaID, strings.Join(rowIDs, ","))
+	if err != nil {
+		return nil, fmt.Errorf("query live rows of schema %d from %s: %w", schemaID, p.Table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	live := make(map[string]bool, len(rowIDs))
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan live row id: %w", err)
+		}
+		live[strings.ToLower(id)] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate live rows of schema %d: %w", schemaID, err)
+	}
+
+	var missing []string
+	for _, id := range rowIDs {
+		if !live[strings.ToLower(id)] {
+			missing = append(missing, id)
+		}
+	}
+	return missing, nil
+}
+
 var (
 	_ SchemaEnumerator = (*RegistrySchemaEnumerator)(nil)
 	_ Locker           = (*PGAdvisoryLocker)(nil)
+	_ LiveRowChecker   = (*PGLiveRows)(nil)
 )

--- a/internal/reconcile/db.go
+++ b/internal/reconcile/db.go
@@ -94,9 +94,11 @@ func (l *PGAdvisoryLocker) TryLock(ctx context.Context, schemaID int16) (bool, f
 	return true, unlock, nil
 }
 
-// PGLiveRows implements LiveRowChecker over the entity main table. Deletes
-// are physical (postgres_persistent_repository issues DELETE), so liveness
-// is row existence under the (schema_id, row_id) primary key.
+// PGLiveRows implements LiveRowChecker over the entity main table. Liveness
+// mirrors cdc-init's export filter (init.go): the row exists under the
+// (schema_id, row_id) primary key AND ltbase_deleted_at IS NULL — writes can
+// soft-delete by setting the column, and treating such rows as live would
+// let repair re-append data whose tombstone compaction already dropped.
 type PGLiveRows struct {
 	DB    *sql.DB
 	Table string // entity_main table name
@@ -112,7 +114,7 @@ func (p *PGLiveRows) MissingLiveRows(ctx context.Context, schemaID int16, rowIDs
 		}
 	}
 	query := fmt.Sprintf(
-		"SELECT ltbase_row_id::text FROM %s WHERE ltbase_schema_id = $1 AND ltbase_row_id = ANY(string_to_array($2, ',')::uuid[])",
+		"SELECT ltbase_row_id::text FROM %s WHERE ltbase_schema_id = $1 AND ltbase_deleted_at IS NULL AND ltbase_row_id = ANY(string_to_array($2, ',')::uuid[])",
 		sqlutil.SanitizeIdentifier(p.Table))
 	rows, err := p.DB.QueryContext(ctx, query, schemaID, strings.Join(rowIDs, ","))
 	if err != nil {

--- a/internal/reconcile/db_test.go
+++ b/internal/reconcile/db_test.go
@@ -46,13 +46,10 @@ func TestRegistrySchemaEnumerator_Filter(t *testing.T) {
 	}
 }
 
-func TestRegistrySchemaEnumerator_FilterMissingSchemaEmpty(t *testing.T) {
+func TestRegistrySchemaEnumerator_FilterMissingSchemaErrors(t *testing.T) {
 	enum := &RegistrySchemaEnumerator{DB: openRegistryDB(t), Table: "schema_registry", SchemaIDFilter: 42}
-	ids, err := enum.SchemaIDs(context.Background())
-	if err != nil {
-		t.Fatalf("SchemaIDs: %v", err)
-	}
-	if len(ids) != 0 {
-		t.Fatalf("SchemaIDs = %v, want empty", ids)
+	_, err := enum.SchemaIDs(context.Background())
+	if err == nil {
+		t.Fatal("an unregistered --schema-id must error, not report an empty (clean) run")
 	}
 }

--- a/internal/reconcile/db_test.go
+++ b/internal/reconcile/db_test.go
@@ -1,0 +1,58 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func openRegistryDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE schema_registry (schema_id SMALLINT, definition VARCHAR)`); err != nil {
+		t.Fatalf("create registry: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_registry VALUES (2, 'b'), (1, 'a'), (9, 'c')`); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+	return db
+}
+
+func TestRegistrySchemaEnumerator_AllOrdered(t *testing.T) {
+	enum := &RegistrySchemaEnumerator{DB: openRegistryDB(t), Table: "schema_registry"}
+	ids, err := enum.SchemaIDs(context.Background())
+	if err != nil {
+		t.Fatalf("SchemaIDs: %v", err)
+	}
+	if len(ids) != 3 || ids[0] != 1 || ids[1] != 2 || ids[2] != 9 {
+		t.Fatalf("SchemaIDs = %v, want [1 2 9]", ids)
+	}
+}
+
+func TestRegistrySchemaEnumerator_Filter(t *testing.T) {
+	enum := &RegistrySchemaEnumerator{DB: openRegistryDB(t), Table: "schema_registry", SchemaIDFilter: 2}
+	ids, err := enum.SchemaIDs(context.Background())
+	if err != nil {
+		t.Fatalf("SchemaIDs: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != 2 {
+		t.Fatalf("SchemaIDs = %v, want [2]", ids)
+	}
+}
+
+func TestRegistrySchemaEnumerator_FilterMissingSchemaEmpty(t *testing.T) {
+	enum := &RegistrySchemaEnumerator{DB: openRegistryDB(t), Table: "schema_registry", SchemaIDFilter: 42}
+	ids, err := enum.SchemaIDs(context.Background())
+	if err != nil {
+		t.Fatalf("SchemaIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("SchemaIDs = %v, want empty", ids)
+	}
+}

--- a/internal/reconcile/deps.go
+++ b/internal/reconcile/deps.go
@@ -1,0 +1,107 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/lychee-technology/forma/internal/compaction"
+)
+
+// ObjectInfo is one listed S3 object with the metadata reconcile needs:
+// Size feeds repaired FileEntry.SizeBytes, LastModified feeds the GC grace
+// check.
+type ObjectInfo struct {
+	Key          string
+	Size         int64
+	LastModified time.Time
+}
+
+// ObjectLister lists every object under a prefix. Implementations own
+// pagination — callers always receive the complete listing.
+type ObjectLister interface {
+	ListObjects(ctx context.Context, prefix string) ([]ObjectInfo, error)
+}
+
+// ObjectDeleter deletes a single object by bucket-relative key.
+type ObjectDeleter interface {
+	DeleteObject(ctx context.Context, key string) error
+}
+
+// s3ObjectAPI is the slice of *s3.Client the reconciler consumes. None of
+// the production S3 interfaces (cdc.S3ObjectClient, manifest.S3Client)
+// expose ListObjectsV2, so the tool declares its own.
+type s3ObjectAPI interface {
+	ListObjectsV2(ctx context.Context, in *s3.ListObjectsV2Input, opts ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, opts ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+// S3ObjectStore implements ObjectLister and ObjectDeleter over an
+// *s3.Client (or any compatible API subset).
+type S3ObjectStore struct {
+	Client s3ObjectAPI
+	Bucket string
+}
+
+// ListObjects lists all objects under prefix, following continuation tokens
+// until the listing is exhausted.
+func (s *S3ObjectStore) ListObjects(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	var objs []ObjectInfo
+	var token *string
+	for {
+		out, err := s.Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(s.Bucket),
+			Prefix:            aws.String(prefix),
+			ContinuationToken: token,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list s3 objects under %s/%s: %w", s.Bucket, prefix, err)
+		}
+		for _, obj := range out.Contents {
+			objs = append(objs, ObjectInfo{
+				Key:          aws.ToString(obj.Key),
+				Size:         aws.ToInt64(obj.Size),
+				LastModified: aws.ToTime(obj.LastModified),
+			})
+		}
+		if !aws.ToBool(out.IsTruncated) || out.NextContinuationToken == nil {
+			return objs, nil
+		}
+		token = out.NextContinuationToken
+	}
+}
+
+// DeleteObject deletes one object by key.
+func (s *S3ObjectStore) DeleteObject(ctx context.Context, key string) error {
+	_, err := s.Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("delete s3 object %s/%s: %w", s.Bucket, key, err)
+	}
+	return nil
+}
+
+// DuckStatsReader recomputes parquet stats over a DuckDB session with
+// httpfs and S3 credentials already configured (cdc.NewDuckExporter's DB).
+// Keep the pool at one connection: the exporter's S3 SETs are
+// session-scoped and only reach the connection they ran on (#285).
+type DuckStatsReader struct {
+	DB     *sql.DB
+	Bucket string
+}
+
+func (d *DuckStatsReader) FileStats(ctx context.Context, key string) (compaction.MergeStats, error) {
+	return compaction.SingleFileStats(ctx, d.DB, fmt.Sprintf("s3://%s/%s", d.Bucket, key))
+}
+
+var (
+	_ ObjectLister  = (*S3ObjectStore)(nil)
+	_ ObjectDeleter = (*S3ObjectStore)(nil)
+	_ StatsReader   = (*DuckStatsReader)(nil)
+)

--- a/internal/reconcile/deps.go
+++ b/internal/reconcile/deps.go
@@ -100,6 +100,14 @@ func (d *DuckStatsReader) FileStats(ctx context.Context, key string) (compaction
 	return compaction.SingleFileStats(ctx, d.DB, fmt.Sprintf("s3://%s/%s", d.Bucket, key))
 }
 
+func (d *DuckStatsReader) UncoveredRowIDs(ctx context.Context, key string, listedKeys []string) ([]string, error) {
+	listed := make([]string, 0, len(listedKeys))
+	for _, k := range listedKeys {
+		listed = append(listed, fmt.Sprintf("s3://%s/%s", d.Bucket, k))
+	}
+	return compaction.UncoveredRowIDs(ctx, d.DB, fmt.Sprintf("s3://%s/%s", d.Bucket, key), listed)
+}
+
 var (
 	_ ObjectLister  = (*S3ObjectStore)(nil)
 	_ ObjectDeleter = (*S3ObjectStore)(nil)

--- a/internal/reconcile/deps.go
+++ b/internal/reconcile/deps.go
@@ -100,12 +100,12 @@ func (d *DuckStatsReader) FileStats(ctx context.Context, key string) (compaction
 	return compaction.SingleFileStats(ctx, d.DB, fmt.Sprintf("s3://%s/%s", d.Bucket, key))
 }
 
-func (d *DuckStatsReader) UncoveredRowIDs(ctx context.Context, key string, listedKeys []string) ([]string, error) {
+func (d *DuckStatsReader) UncoveredRows(ctx context.Context, key string, listedKeys []string) ([]compaction.UncoveredRow, error) {
 	listed := make([]string, 0, len(listedKeys))
 	for _, k := range listedKeys {
 		listed = append(listed, fmt.Sprintf("s3://%s/%s", d.Bucket, k))
 	}
-	return compaction.UncoveredRowIDs(ctx, d.DB, fmt.Sprintf("s3://%s/%s", d.Bucket, key), listed)
+	return compaction.UncoveredRows(ctx, d.DB, fmt.Sprintf("s3://%s/%s", d.Bucket, key), listed)
 }
 
 var (

--- a/internal/reconcile/deps_test.go
+++ b/internal/reconcile/deps_test.go
@@ -1,0 +1,79 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+type pagingS3 struct {
+	pages   [][]types.Object
+	calls   []s3.ListObjectsV2Input
+	listErr error
+}
+
+func (p *pagingS3) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if p.listErr != nil {
+		return nil, p.listErr
+	}
+	p.calls = append(p.calls, *in)
+	page := 0
+	if in.ContinuationToken != nil {
+		if _, err := fmt.Sscanf(*in.ContinuationToken, "page-%d", &page); err != nil {
+			return nil, fmt.Errorf("bad continuation token %q", *in.ContinuationToken)
+		}
+	}
+	out := &s3.ListObjectsV2Output{Contents: p.pages[page]}
+	if page+1 < len(p.pages) {
+		out.IsTruncated = aws.Bool(true)
+		out.NextContinuationToken = aws.String(fmt.Sprintf("page-%d", page+1))
+	}
+	return out, nil
+}
+
+func (p *pagingS3) DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+func TestS3ObjectStore_ListObjectsPaginates(t *testing.T) {
+	mod := time.Date(2026, 7, 19, 10, 0, 0, 0, time.UTC)
+	fake := &pagingS3{pages: [][]types.Object{
+		{
+			{Key: aws.String("data/7/a.parquet"), Size: aws.Int64(10), LastModified: aws.Time(mod)},
+			{Key: aws.String("data/7/b.parquet"), Size: aws.Int64(20), LastModified: aws.Time(mod)},
+		},
+		{
+			{Key: aws.String("data/7/c.parquet"), Size: aws.Int64(30), LastModified: aws.Time(mod)},
+		},
+	}}
+
+	store := &S3ObjectStore{Client: fake, Bucket: "bkt"}
+	objs, err := store.ListObjects(context.Background(), "data/7/")
+	if err != nil {
+		t.Fatalf("ListObjects: %v", err)
+	}
+
+	assertKeys(t, "listed keys", objectKeys(objs), []string{
+		"data/7/a.parquet", "data/7/b.parquet", "data/7/c.parquet",
+	})
+	if objs[0].Size != 10 || !objs[0].LastModified.Equal(mod) {
+		t.Fatalf("ObjectInfo metadata not carried: %+v", objs[0])
+	}
+	if len(fake.calls) != 2 {
+		t.Fatalf("expected 2 paginated calls, got %d", len(fake.calls))
+	}
+	if got := aws.ToString(fake.calls[0].Prefix); got != "data/7/" {
+		t.Fatalf("first call prefix = %q, want data/7/", got)
+	}
+	if fake.calls[0].ContinuationToken != nil {
+		t.Fatalf("first call must not carry a continuation token")
+	}
+	if got := aws.ToString(fake.calls[1].ContinuationToken); got != "page-1" {
+		t.Fatalf("second call token = %q, want page-1", got)
+	}
+}

--- a/internal/reconcile/gc.go
+++ b/internal/reconcile/gc.go
@@ -2,49 +2,80 @@ package reconcile
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"time"
 
 	"go.uber.org/zap"
 )
 
-// gcSchema deletes base-shaped and _tmp orphans — compaction-rewrite
-// leftovers (#188): staging objects from crashed rewrites and merged
-// sources whose post-commit deletion failed. Their data already lives in
-// the manifest-listed merged base, so deletion loses nothing. Delta-shaped
-// orphans are never candidates: their data exists nowhere else.
+// gcSchema deletes provable garbage — merged-base and _tmp orphans (#188
+// rewrite leftovers) plus delta orphans the repair guard classified as
+// leftovers. Init-shaped base orphans never reach here (see
+// reconcileSchema), and delta orphans require the repair analysis first.
 //
-// The grace period guards the in-flight-reader race: a query that resolved
-// its object list from a pre-splice manifest can still reference an
-// unlisted key for about one query duration after the splice. Only objects
-// whose LastModified is older than the grace period are deleted; with the
-// default well above any query timeout the residual window is negligible.
-// Deletion is best-effort — a failed delete is logged and the key stays in
-// the report as an orphan, exactly like the compactor's own source cleanup.
-func (r *Reconciler) gcSchema(ctx context.Context, schemaID int16, candidates []ObjectInfo) []string {
+// Deletion implements the #188 follow-up's "unlisted longer than the grace
+// period" contract with a persisted sighting state: the first run that
+// observes a candidate unlisted only records the sighting; a later run
+// deletes it once BOTH the observed-unlisted duration and the object age
+// exceed the grace period. LastModified alone cannot express unlisted
+// duration — an old source freshly spliced out by the compactor must
+// survive the in-flight-reader window. Deletion is best-effort per key; an
+// unreadable sighting state refuses deletion and surfaces as a tool
+// failure.
+func (r *Reconciler) gcSchema(ctx context.Context, schemaID int16, candidates []ObjectInfo) ([]string, error) {
 	if r.Opts.GCGrace <= 0 {
-		// A zero grace would delete objects uploaded milliseconds ago —
-		// including a live compaction rewrite's staging files. Refuse
-		// instead of silently degrading the documented protection.
-		r.Logger.Error("gc requested with a non-positive grace period; refusing to delete anything",
-			zap.Int16("schema_id", schemaID), zap.Duration("gc_grace", r.Opts.GCGrace))
-		return nil
+		// A zero grace would delete objects the moment they are first
+		// seen. Refuse instead of silently degrading the documented
+		// protection.
+		return nil, fmt.Errorf("gc requested for schema %d with non-positive grace %v", schemaID, r.Opts.GCGrace)
 	}
-	cutoff := r.Now().Add(-r.Opts.GCGrace)
+	if r.GCStates == nil {
+		return nil, fmt.Errorf("gc requested for schema %d but no sighting state store is configured", schemaID)
+	}
+	state, etag, err := r.GCStates.Load(ctx, schemaID)
+	if err != nil {
+		return nil, fmt.Errorf("load schema %d gc sighting state: %w", schemaID, err)
+	}
+
+	now := r.Now()
+	cutoff := now.Add(-r.Opts.GCGrace)
+	next := make(map[string]int64, len(candidates))
 	var deleted []string
 	for _, obj := range candidates {
-		if !obj.LastModified.Before(cutoff) {
-			r.Logger.Info("orphan within GC grace period, keeping",
-				zap.Int16("schema_id", schemaID), zap.String("key", obj.Key),
-				zap.Time("last_modified", obj.LastModified))
+		firstSeen, seen := state[obj.Key]
+		if !seen {
+			next[obj.Key] = now.UnixMilli()
+			r.Logger.Info("recorded first unlisted sighting; deletable after the grace period",
+				zap.Int16("schema_id", schemaID), zap.String("key", obj.Key))
+			continue
+		}
+		unlistedLongEnough := time.UnixMilli(firstSeen).Before(cutoff)
+		objectOldEnough := obj.LastModified.Before(cutoff)
+		if !unlistedLongEnough || !objectOldEnough {
+			next[obj.Key] = firstSeen
 			continue
 		}
 		if err := r.Deleter.DeleteObject(ctx, obj.Key); err != nil {
 			r.Logger.Warn("failed to delete orphaned object; leaving it for the next run",
 				zap.Int16("schema_id", schemaID), zap.String("key", obj.Key), zap.Error(err))
+			next[obj.Key] = firstSeen
 			continue
 		}
 		r.Logger.Info("deleted orphaned compaction leftover",
 			zap.Int16("schema_id", schemaID), zap.String("key", obj.Key))
 		deleted = append(deleted, obj.Key)
 	}
-	return deleted
+
+	// Keys no longer among the candidates (re-listed or gone) drop out, so
+	// a later unlisting restarts their grace clock. Persisting is
+	// best-effort: a lost save only means the next run re-records, which
+	// delays deletion — never accelerates it.
+	if !maps.Equal(next, state) {
+		if _, err := r.GCStates.Save(ctx, schemaID, next, etag); err != nil {
+			r.Logger.Warn("failed to persist gc sighting state; next run will re-record",
+				zap.Int16("schema_id", schemaID), zap.Error(err))
+		}
+	}
+	return deleted, nil
 }

--- a/internal/reconcile/gc.go
+++ b/internal/reconcile/gc.go
@@ -1,0 +1,42 @@
+package reconcile
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// gcSchema deletes base-shaped and _tmp orphans — compaction-rewrite
+// leftovers (#188): staging objects from crashed rewrites and merged
+// sources whose post-commit deletion failed. Their data already lives in
+// the manifest-listed merged base, so deletion loses nothing. Delta-shaped
+// orphans are never candidates: their data exists nowhere else.
+//
+// The grace period guards the in-flight-reader race: a query that resolved
+// its object list from a pre-splice manifest can still reference an
+// unlisted key for about one query duration after the splice. Only objects
+// whose LastModified is older than the grace period are deleted; with the
+// default well above any query timeout the residual window is negligible.
+// Deletion is best-effort — a failed delete is logged and the key stays in
+// the report as an orphan, exactly like the compactor's own source cleanup.
+func (r *Reconciler) gcSchema(ctx context.Context, schemaID int16, candidates []ObjectInfo) []string {
+	cutoff := r.Now().Add(-r.Opts.GCGrace)
+	var deleted []string
+	for _, obj := range candidates {
+		if !obj.LastModified.Before(cutoff) {
+			r.Logger.Info("orphan within GC grace period, keeping",
+				zap.Int16("schema_id", schemaID), zap.String("key", obj.Key),
+				zap.Time("last_modified", obj.LastModified))
+			continue
+		}
+		if err := r.Deleter.DeleteObject(ctx, obj.Key); err != nil {
+			r.Logger.Warn("failed to delete orphaned object; leaving it for the next run",
+				zap.Int16("schema_id", schemaID), zap.String("key", obj.Key), zap.Error(err))
+			continue
+		}
+		r.Logger.Info("deleted orphaned compaction leftover",
+			zap.Int16("schema_id", schemaID), zap.String("key", obj.Key))
+		deleted = append(deleted, obj.Key)
+	}
+	return deleted
+}

--- a/internal/reconcile/gc.go
+++ b/internal/reconcile/gc.go
@@ -20,6 +20,14 @@ import (
 // Deletion is best-effort — a failed delete is logged and the key stays in
 // the report as an orphan, exactly like the compactor's own source cleanup.
 func (r *Reconciler) gcSchema(ctx context.Context, schemaID int16, candidates []ObjectInfo) []string {
+	if r.Opts.GCGrace <= 0 {
+		// A zero grace would delete objects uploaded milliseconds ago —
+		// including a live compaction rewrite's staging files. Refuse
+		// instead of silently degrading the documented protection.
+		r.Logger.Error("gc requested with a non-positive grace period; refusing to delete anything",
+			zap.Int16("schema_id", schemaID), zap.Duration("gc_grace", r.Opts.GCGrace))
+		return nil
+	}
 	cutoff := r.Now().Add(-r.Opts.GCGrace)
 	var deleted []string
 	for _, obj := range candidates {

--- a/internal/reconcile/gc_state_test.go
+++ b/internal/reconcile/gc_state_test.go
@@ -1,0 +1,139 @@
+package reconcile
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// The GC sighting state implements the #203 follow-up contract: an orphan
+// is deleted only after it has been OBSERVED unlisted for longer than the
+// grace period — LastModified alone cannot express "unlisted duration", so
+// an old source file freshly spliced out by the compactor would otherwise
+// be deleted inside the in-flight-reader window.
+
+func gcStateReconciler(t *testing.T, lister *fakeLister, deleter *fakeDeleter, states *fakeGCState) *Reconciler {
+	t.Helper()
+	r := newTestReconciler(lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.GCStates = states
+	r.Opts = Options{GC: true, GCGrace: 15 * time.Minute}
+	return r
+}
+
+func TestGC_FirstSightingRecordsInsteadOfDeleting(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour) // ancient object — age alone must NOT suffice
+	merged := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: merged, LastModified: old}},
+	}}
+	deleter := &fakeDeleter{}
+	states := newFakeGCState()
+	r := gcStateReconciler(t, lister, deleter, states)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, deleter.deleted, "an orphan seen unlisted for the first time must only be recorded")
+	require.Empty(t, report.Schemas[0].Deleted)
+	require.Equal(t, testClock().UnixMilli(), states.state[7][merged], "first-unlisted sighting must be persisted")
+}
+
+func TestGC_DeletesOnlyAfterUnlistedBeyondGrace(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour)
+	merged := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: merged, LastModified: old}},
+	}}
+	deleter := &fakeDeleter{}
+	states := newFakeGCState()
+	states.seed(7, merged, testClock().Add(-16*time.Minute)) // observed unlisted 16m ago > 15m grace
+	r := gcStateReconciler(t, lister, deleter, states)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{merged}, deleter.deleted)
+	require.Equal(t, []string{merged}, report.Schemas[0].Deleted)
+	require.NotContains(t, states.state[7], merged, "deleted key must leave the sighting state")
+}
+
+func TestGC_UnlistedWithinGraceNotDeleted(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour)
+	merged := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: merged, LastModified: old}},
+	}}
+	deleter := &fakeDeleter{}
+	states := newFakeGCState()
+	states.seed(7, merged, testClock().Add(-14*time.Minute)) // observed unlisted only 14m
+	r := gcStateReconciler(t, lister, deleter, states)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, deleter.deleted, "a freshly spliced-out old source must survive the grace window")
+	require.Empty(t, report.Schemas[0].Deleted)
+	require.Contains(t, states.state[7], merged, "pending sighting must be retained")
+}
+
+func TestGC_RelistedKeyPrunedFromState(t *testing.T) {
+	// A key that stops being a candidate (re-listed in the manifest, or
+	// gone) must drop out of the sighting state so a later unlisting
+	// restarts its grace clock.
+	stale := "data/7/base-" + uuidB + ".parquet"
+	listedKey := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: listedKey, LastModified: testClock().Add(-time.Hour)}},
+	}}
+	deleter := &fakeDeleter{}
+	states := newFakeGCState()
+	states.seed(7, stale, testClock().Add(-time.Hour))
+	r := gcStateReconciler(t, lister, deleter, states)
+	r.Manifests = newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: listedKey},
+	}})
+
+	_, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, deleter.deleted)
+	require.NotContains(t, states.state[7], stale)
+}
+
+func TestGC_StateLoadErrorIsToolFailure(t *testing.T) {
+	merged := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: merged, LastModified: testClock().Add(-time.Hour)}},
+	}}
+	deleter := &fakeDeleter{}
+	states := newFakeGCState()
+	states.loadErr = context.DeadlineExceeded
+	r := gcStateReconciler(t, lister, deleter, states)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, deleter.deleted, "unreadable sighting state must never allow deletion")
+	require.Error(t, report.Schemas[0].Err)
+}
+
+func TestManifestGCStateStore_RoundTripAndMissing(t *testing.T) {
+	store := &ManifestGCStateStore{
+		Store:    newMemManifestStore(),
+		Resolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
+	}
+	ctx := context.Background()
+
+	state, etag, err := store.Load(ctx, 7)
+	require.NoError(t, err, "missing state must load as empty")
+	require.Empty(t, state)
+	require.Empty(t, etag)
+
+	state = map[string]int64{"data/7/base-x.parquet": 1234}
+	_, err = store.Save(ctx, 7, state, etag)
+	require.NoError(t, err)
+
+	reloaded, etag2, err := store.Load(ctx, 7)
+	require.NoError(t, err)
+	require.NotEmpty(t, etag2)
+	require.Equal(t, state, reloaded)
+}

--- a/internal/reconcile/gc_test.go
+++ b/internal/reconcile/gc_test.go
@@ -1,0 +1,111 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+func gcReconciler(t *testing.T, lister *fakeLister, manifests *fakeManifests, deleter *fakeDeleter) *Reconciler {
+	t.Helper()
+	r := newTestReconciler(lister, manifests, deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Opts = Options{GC: true, GCGrace: 15 * time.Minute}
+	return r
+}
+
+func TestGC_DeletesBaseAndTmpPastGrace(t *testing.T) {
+	old := testClock().Add(-16 * time.Minute)
+	baseKey := "data/7/base-" + uuidA + ".parquet"
+	tmpKey := "data/7/_tmp/" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: baseKey, Size: 10, LastModified: old},
+			{Key: tmpKey, Size: 20, LastModified: old},
+		},
+	}}
+	deleter := &fakeDeleter{}
+	r := gcReconciler(t, lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{baseKey, tmpKey}, deleter.deleted)
+	require.ElementsMatch(t, []string{baseKey, tmpKey}, report.Schemas[0].Deleted)
+	require.False(t, report.HasResidualDiscrepancies())
+}
+
+func TestGC_GraceBoundaryNotDeleted(t *testing.T) {
+	atBoundary := testClock().Add(-15 * time.Minute) // exactly grace old: survives
+	within := testClock().Add(-14 * time.Minute)
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: "data/7/base-" + uuidA + ".parquet", LastModified: atBoundary},
+			{Key: "data/7/_tmp/" + uuidB + ".parquet", LastModified: within},
+		},
+	}}
+	deleter := &fakeDeleter{}
+	r := gcReconciler(t, lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, deleter.deleted)
+	require.Empty(t, report.Schemas[0].Deleted)
+	require.True(t, report.HasResidualDiscrepancies(), "orphans within grace remain residual")
+}
+
+func TestGC_SkipsDeltaOrphans(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour)
+	deltaKey := "data/7/" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: deltaKey, LastModified: old}},
+	}}
+	deleter := &fakeDeleter{}
+	r := gcReconciler(t, lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, deleter.deleted, "delta orphans carry unique data and must never be GCed")
+	require.Equal(t, []string{deltaKey}, report.Schemas[0].DeltaOrphans)
+}
+
+func TestGC_SkipsObjectPresentInManifest(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour)
+	baseKey := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: baseKey, LastModified: old}},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: baseKey},
+	}})
+	deleter := &fakeDeleter{}
+	r := gcReconciler(t, lister, manifests, deleter)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, deleter.deleted, "manifest-listed objects are live data, never GC candidates")
+	require.False(t, report.HasResidualDiscrepancies())
+}
+
+func TestGC_DeleteFailureBestEffortContinues(t *testing.T) {
+	old := testClock().Add(-16 * time.Minute)
+	failKey := "data/7/base-" + uuidA + ".parquet"
+	okKey := "data/7/_tmp/" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: failKey, LastModified: old},
+			{Key: okKey, LastModified: old},
+		},
+	}}
+	deleter := &fakeDeleter{errFor: map[string]error{failKey: fmt.Errorf("access denied")}}
+	r := gcReconciler(t, lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{okKey}, deleter.deleted)
+	require.Equal(t, []string{okKey}, report.Schemas[0].Deleted)
+	require.True(t, report.HasResidualDiscrepancies(), "undeleted orphan stays residual")
+}

--- a/internal/reconcile/gc_test.go
+++ b/internal/reconcile/gc_test.go
@@ -30,6 +30,7 @@ func TestGC_DeletesBaseAndTmpPastGrace(t *testing.T) {
 	}}
 	deleter := &fakeDeleter{}
 	r := gcReconciler(t, lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter)
+	seedGCSighting(t, r, 7, old, baseKey, tmpKey)
 
 	report, err := r.Run(context.Background())
 	require.NoError(t, err)
@@ -41,14 +42,18 @@ func TestGC_DeletesBaseAndTmpPastGrace(t *testing.T) {
 func TestGC_GraceBoundaryNotDeleted(t *testing.T) {
 	atBoundary := testClock().Add(-15 * time.Minute) // exactly grace old: survives
 	within := testClock().Add(-14 * time.Minute)
+	baseKey := "data/7/base-" + uuidA + ".parquet"
+	tmpKey := "data/7/_tmp/" + uuidB + ".parquet"
 	lister := &fakeLister{objects: map[string][]ObjectInfo{
 		"data/7/": {
-			{Key: "data/7/base-" + uuidA + ".parquet", LastModified: atBoundary},
-			{Key: "data/7/_tmp/" + uuidB + ".parquet", LastModified: within},
+			{Key: baseKey, LastModified: atBoundary},
+			{Key: tmpKey, LastModified: within},
 		},
 	}}
 	deleter := &fakeDeleter{}
 	r := gcReconciler(t, lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter)
+	// Sightings are old enough — the object-age gate alone must hold.
+	seedGCSighting(t, r, 7, testClock().Add(-time.Hour), baseKey, tmpKey)
 
 	report, err := r.Run(context.Background())
 	require.NoError(t, err)
@@ -102,6 +107,7 @@ func TestGC_DeleteFailureBestEffortContinues(t *testing.T) {
 	}}
 	deleter := &fakeDeleter{errFor: map[string]error{failKey: fmt.Errorf("access denied")}}
 	r := gcReconciler(t, lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter)
+	seedGCSighting(t, r, 7, old, failKey, okKey)
 
 	report, err := r.Run(context.Background())
 	require.NoError(t, err)

--- a/internal/reconcile/gcstate.go
+++ b/internal/reconcile/gcstate.go
@@ -1,0 +1,74 @@
+package reconcile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// gcStateDoc is the persisted shape of one schema's GC sighting state.
+type gcStateDoc struct {
+	// FirstUnlistedMs maps a bucket-relative key to the unix-ms timestamp
+	// of the first reconcile run that observed it unlisted.
+	FirstUnlistedMs map[string]int64 `json:"first_unlisted_ms"`
+}
+
+// ManifestGCStateStore persists GC sighting state next to the schema's
+// manifest (at "<manifest path>.gc-state") through the same etag-aware
+// store, inheriting its optimistic concurrency incl. the If-None-Match
+// create guard. The state object lives under the manifest prefix, so it
+// never pollutes the data-prefix listing the reconciler classifies.
+type ManifestGCStateStore struct {
+	Store    manifest.Store
+	Resolver manifest.PathResolver
+}
+
+func (s *ManifestGCStateStore) statePath(schemaID int16) (string, error) {
+	path, err := s.Resolver.Resolve(schemaID)
+	if err != nil {
+		return "", fmt.Errorf("resolve schema %d manifest path for gc state: %w", schemaID, err)
+	}
+	return path + ".gc-state", nil
+}
+
+func (s *ManifestGCStateStore) Load(ctx context.Context, schemaID int16) (map[string]int64, string, error) {
+	path, err := s.statePath(schemaID)
+	if err != nil {
+		return nil, "", err
+	}
+	data, etag, err := s.Store.Load(ctx, path)
+	if err != nil {
+		if manifest.IsNotFound(err) {
+			return map[string]int64{}, "", nil
+		}
+		return nil, "", fmt.Errorf("load gc state %s: %w", path, err)
+	}
+	var doc gcStateDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, "", fmt.Errorf("parse gc state %s: %w", path, err)
+	}
+	if doc.FirstUnlistedMs == nil {
+		doc.FirstUnlistedMs = map[string]int64{}
+	}
+	return doc.FirstUnlistedMs, etag, nil
+}
+
+func (s *ManifestGCStateStore) Save(ctx context.Context, schemaID int16, state map[string]int64, etag string) (string, error) {
+	path, err := s.statePath(schemaID)
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(gcStateDoc{FirstUnlistedMs: state})
+	if err != nil {
+		return "", fmt.Errorf("encode gc state %s: %w", path, err)
+	}
+	newETag, err := s.Store.Save(ctx, path, data, etag)
+	if err != nil {
+		return "", fmt.Errorf("save gc state %s: %w", path, err)
+	}
+	return newETag, nil
+}
+
+var _ GCStateStore = (*ManifestGCStateStore)(nil)

--- a/internal/reconcile/manifests.go
+++ b/internal/reconcile/manifests.go
@@ -1,0 +1,45 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// ResolverManifestStore implements ManifestStore over a manifest.Store and
+// PathResolver. Load has LoadOrCreate semantics — a schema whose manifest
+// does not exist yet reconciles as empty instead of erroring (the
+// compaction ManifestProvider errors on a missing manifest, which is wrong
+// for reconciliation: an empty manifest with live objects is exactly the
+// all-orphans case the tool must report).
+type ResolverManifestStore struct {
+	Store    manifest.Store
+	Resolver manifest.PathResolver
+}
+
+func (s *ResolverManifestStore) Load(ctx context.Context, schemaID int16) (*manifest.Manifest, string, error) {
+	path, err := s.Resolver.Resolve(schemaID)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve schema %d manifest path: %w", schemaID, err)
+	}
+	m, etag, err := manifest.LoadOrCreate(ctx, s.Store, path, schemaID)
+	if err != nil {
+		return nil, "", fmt.Errorf("load manifest %s: %w", path, err)
+	}
+	return m, etag, nil
+}
+
+func (s *ResolverManifestStore) Save(ctx context.Context, schemaID int16, m *manifest.Manifest, etag string) (string, error) {
+	path, err := s.Resolver.Resolve(schemaID)
+	if err != nil {
+		return "", fmt.Errorf("resolve schema %d manifest path: %w", schemaID, err)
+	}
+	newETag, err := manifest.Save(ctx, s.Store, path, m, etag)
+	if err != nil {
+		return "", fmt.Errorf("save manifest %s: %w", path, err)
+	}
+	return newETag, nil
+}
+
+var _ ManifestStore = (*ResolverManifestStore)(nil)

--- a/internal/reconcile/manifests_test.go
+++ b/internal/reconcile/manifests_test.go
@@ -1,0 +1,72 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// memManifestStore is an in-memory manifest.Store: not-found until first
+// save, etag bumps per save (mirrors internal/cdc/init_test.go).
+type memManifestStore struct {
+	data  map[string][]byte
+	etags map[string]string
+	saves int
+}
+
+func newMemManifestStore() *memManifestStore {
+	return &memManifestStore{data: map[string][]byte{}, etags: map[string]string{}}
+}
+
+func (s *memManifestStore) Load(_ context.Context, path string) ([]byte, string, error) {
+	b, ok := s.data[path]
+	if !ok {
+		return nil, "", fmt.Errorf("NoSuchKey: manifest %s not found", path)
+	}
+	return b, s.etags[path], nil
+}
+
+func (s *memManifestStore) Save(_ context.Context, path string, data []byte, _ string) (string, error) {
+	s.saves++
+	s.data[path] = data
+	etag := fmt.Sprintf("v%d", s.saves)
+	s.etags[path] = etag
+	return etag, nil
+}
+
+func TestResolverManifestStore_MissingManifestLoadsEmpty(t *testing.T) {
+	store := &ResolverManifestStore{
+		Store:    newMemManifestStore(),
+		Resolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
+	}
+	m, etag, err := store.Load(context.Background(), 7)
+	require.NoError(t, err, "a schema without a manifest must reconcile as empty")
+	require.Equal(t, int16(7), m.SchemaID)
+	require.Empty(t, m.Files)
+	require.Empty(t, etag)
+}
+
+func TestResolverManifestStore_SaveRoundTrip(t *testing.T) {
+	store := &ResolverManifestStore{
+		Store:    newMemManifestStore(),
+		Resolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
+	}
+	ctx := context.Background()
+
+	m, etag, err := store.Load(ctx, 7)
+	require.NoError(t, err)
+	m.Files = append(m.Files, manifest.FileEntry{Tier: "delta", Path: "data/7/a.parquet"})
+	_, err = store.Save(ctx, 7, m, etag)
+	require.NoError(t, err)
+
+	reloaded, etag2, err := store.Load(ctx, 7)
+	require.NoError(t, err)
+	require.NotEmpty(t, etag2)
+	require.Len(t, reloaded.Files, 1)
+	require.Equal(t, "data/7/a.parquet", reloaded.Files[0].Path)
+	require.Greater(t, reloaded.Version, int64(0), "manifest.Save must bump the version")
+}

--- a/internal/reconcile/mocks_test.go
+++ b/internal/reconcile/mocks_test.go
@@ -1,0 +1,143 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/lychee-technology/forma/internal/compaction"
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+type fakeLister struct {
+	objects map[string][]ObjectInfo // prefix -> listing
+	calls   []string
+	err     error
+}
+
+func (f *fakeLister) ListObjects(_ context.Context, prefix string) ([]ObjectInfo, error) {
+	f.calls = append(f.calls, prefix)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.objects[prefix], nil
+}
+
+type savedManifest struct {
+	schemaID int16
+	m        manifest.Manifest
+	etag     string
+}
+
+type fakeManifests struct {
+	mu             sync.Mutex
+	manifests      map[int16]*manifest.Manifest
+	etags          map[int16]string
+	saves          []savedManifest
+	saveErrs       []error // consumed per Save call; nil entry = success
+	loadErr        error
+	onSaveConflict func(*fakeManifests) // invoked after a non-nil saveErr is consumed
+}
+
+func newFakeManifests(ms ...*manifest.Manifest) *fakeManifests {
+	f := &fakeManifests{
+		manifests: map[int16]*manifest.Manifest{},
+		etags:     map[int16]string{},
+	}
+	for _, m := range ms {
+		f.manifests[m.SchemaID] = m
+		f.etags[m.SchemaID] = fmt.Sprintf("etag-%d-0", m.SchemaID)
+	}
+	return f
+}
+
+func (f *fakeManifests) Load(_ context.Context, schemaID int16) (*manifest.Manifest, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.loadErr != nil {
+		return nil, "", f.loadErr
+	}
+	m, ok := f.manifests[schemaID]
+	if !ok {
+		return &manifest.Manifest{SchemaID: schemaID, Files: []manifest.FileEntry{}}, "", nil
+	}
+	cp := *m
+	cp.Files = append([]manifest.FileEntry(nil), m.Files...)
+	return &cp, f.etags[schemaID], nil
+}
+
+func (f *fakeManifests) Save(_ context.Context, schemaID int16, m *manifest.Manifest, etag string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.saveErrs) > 0 {
+		err := f.saveErrs[0]
+		f.saveErrs = f.saveErrs[1:]
+		if err != nil {
+			if f.onSaveConflict != nil {
+				f.onSaveConflict(f)
+			}
+			return "", err
+		}
+	}
+	cp := *m
+	cp.Files = append([]manifest.FileEntry(nil), m.Files...)
+	f.saves = append(f.saves, savedManifest{schemaID: schemaID, m: cp, etag: etag})
+	f.manifests[schemaID] = &cp
+	newETag := fmt.Sprintf("etag-%d-%d", schemaID, len(f.saves))
+	f.etags[schemaID] = newETag
+	return newETag, nil
+}
+
+type fakeLocker struct {
+	denied   map[int16]bool
+	err      error
+	locked   []int16
+	unlocked []int16
+}
+
+func (f *fakeLocker) TryLock(_ context.Context, schemaID int16) (bool, func(), error) {
+	if f.err != nil {
+		return false, nil, f.err
+	}
+	if f.denied[schemaID] {
+		return false, nil, nil
+	}
+	f.locked = append(f.locked, schemaID)
+	return true, func() { f.unlocked = append(f.unlocked, schemaID) }, nil
+}
+
+type fakeDeleter struct {
+	deleted []string
+	errFor  map[string]error
+}
+
+func (f *fakeDeleter) DeleteObject(_ context.Context, key string) error {
+	if err := f.errFor[key]; err != nil {
+		return err
+	}
+	f.deleted = append(f.deleted, key)
+	return nil
+}
+
+type fakeStats struct {
+	stats  map[string]compaction.MergeStats // uri -> stats
+	errFor map[string]error
+	calls  []string
+}
+
+func (f *fakeStats) FileStats(_ context.Context, uri string) (compaction.MergeStats, error) {
+	f.calls = append(f.calls, uri)
+	if err := f.errFor[uri]; err != nil {
+		return compaction.MergeStats{}, err
+	}
+	return f.stats[uri], nil
+}
+
+type fakeEnum struct {
+	ids []int16
+	err error
+}
+
+func (f *fakeEnum) SchemaIDs(context.Context) ([]int16, error) {
+	return f.ids, f.err
+}

--- a/internal/reconcile/mocks_test.go
+++ b/internal/reconcile/mocks_test.go
@@ -36,7 +36,9 @@ type fakeManifests struct {
 	saves          []savedManifest
 	saveErrs       []error // consumed per Save call; nil entry = success
 	loadErr        error
+	loads          int
 	onSaveConflict func(*fakeManifests) // invoked after a non-nil saveErr is consumed
+	onLoad         func(*fakeManifests) // invoked before each Load returns
 }
 
 func newFakeManifests(ms ...*manifest.Manifest) *fakeManifests {
@@ -54,6 +56,10 @@ func newFakeManifests(ms ...*manifest.Manifest) *fakeManifests {
 func (f *fakeManifests) Load(_ context.Context, schemaID int16) (*manifest.Manifest, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.loads++
+	if f.onLoad != nil {
+		f.onLoad(f)
+	}
 	if f.loadErr != nil {
 		return nil, "", f.loadErr
 	}
@@ -120,17 +126,56 @@ func (f *fakeDeleter) DeleteObject(_ context.Context, key string) error {
 }
 
 type fakeStats struct {
-	stats  map[string]compaction.MergeStats // uri -> stats
+	stats  map[string]compaction.MergeStats // key -> stats
 	errFor map[string]error
 	calls  []string
+	// uncovered maps orphan key -> row ids absent from every listed file.
+	// Keys not in the map default to one synthetic uncovered row, so
+	// append-path tests behave like a genuine #197 orphan.
+	uncovered      map[string][]string
+	uncoveredCalls [][]string // listedKeys per UncoveredRowIDs call
+	uncoveredErr   map[string]error
 }
 
-func (f *fakeStats) FileStats(_ context.Context, uri string) (compaction.MergeStats, error) {
-	f.calls = append(f.calls, uri)
-	if err := f.errFor[uri]; err != nil {
+func (f *fakeStats) FileStats(_ context.Context, key string) (compaction.MergeStats, error) {
+	f.calls = append(f.calls, key)
+	if err := f.errFor[key]; err != nil {
 		return compaction.MergeStats{}, err
 	}
-	return f.stats[uri], nil
+	return f.stats[key], nil
+}
+
+func (f *fakeStats) UncoveredRowIDs(_ context.Context, key string, listedKeys []string) ([]string, error) {
+	f.uncoveredCalls = append(f.uncoveredCalls, listedKeys)
+	if err := f.uncoveredErr[key]; err != nil {
+		return nil, err
+	}
+	if rows, ok := f.uncovered[key]; ok {
+		return rows, nil
+	}
+	return []string{"synthetic-uncovered-row"}, nil
+}
+
+// fakeLiveRows reports which row ids are missing from entity_main. The
+// zero value treats every row as live (the safe-append case).
+type fakeLiveRows struct {
+	missing map[string]bool // row id -> deleted in Postgres
+	err     error
+	queried [][]string
+}
+
+func (f *fakeLiveRows) MissingLiveRows(_ context.Context, _ int16, rowIDs []string) ([]string, error) {
+	f.queried = append(f.queried, rowIDs)
+	if f.err != nil {
+		return nil, f.err
+	}
+	var missing []string
+	for _, id := range rowIDs {
+		if f.missing[id] {
+			missing = append(missing, id)
+		}
+	}
+	return missing, nil
 }
 
 type fakeEnum struct {

--- a/internal/reconcile/mocks_test.go
+++ b/internal/reconcile/mocks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/lychee-technology/forma/internal/compaction"
 	"github.com/lychee-technology/forma/internal/manifest"
@@ -129,11 +130,11 @@ type fakeStats struct {
 	stats  map[string]compaction.MergeStats // key -> stats
 	errFor map[string]error
 	calls  []string
-	// uncovered maps orphan key -> row ids absent from every listed file.
-	// Keys not in the map default to one synthetic uncovered row, so
-	// append-path tests behave like a genuine #197 orphan.
-	uncovered      map[string][]string
-	uncoveredCalls [][]string // listedKeys per UncoveredRowIDs call
+	// uncovered maps orphan key -> uncovered rows. Keys not in the map
+	// default to one synthetic live uncovered row, so append-path tests
+	// behave like a genuine #197 orphan.
+	uncovered      map[string][]compaction.UncoveredRow
+	uncoveredCalls [][]string // listedKeys per UncoveredRows call
 	uncoveredErr   map[string]error
 }
 
@@ -145,7 +146,7 @@ func (f *fakeStats) FileStats(_ context.Context, key string) (compaction.MergeSt
 	return f.stats[key], nil
 }
 
-func (f *fakeStats) UncoveredRowIDs(_ context.Context, key string, listedKeys []string) ([]string, error) {
+func (f *fakeStats) UncoveredRows(_ context.Context, key string, listedKeys []string) ([]compaction.UncoveredRow, error) {
 	f.uncoveredCalls = append(f.uncoveredCalls, listedKeys)
 	if err := f.uncoveredErr[key]; err != nil {
 		return nil, err
@@ -153,7 +154,7 @@ func (f *fakeStats) UncoveredRowIDs(_ context.Context, key string, listedKeys []
 	if rows, ok := f.uncovered[key]; ok {
 		return rows, nil
 	}
-	return []string{"synthetic-uncovered-row"}, nil
+	return []compaction.UncoveredRow{{RowID: "synthetic-uncovered-row"}}, nil
 }
 
 // fakeLiveRows reports which row ids are missing from entity_main. The
@@ -185,4 +186,49 @@ type fakeEnum struct {
 
 func (f *fakeEnum) SchemaIDs(context.Context) ([]int16, error) {
 	return f.ids, f.err
+}
+
+type fakeGCState struct {
+	state   map[int16]map[string]int64
+	etags   map[int16]string
+	saves   int
+	loadErr error
+	saveErr error
+}
+
+func newFakeGCState() *fakeGCState {
+	return &fakeGCState{state: map[int16]map[string]int64{}, etags: map[int16]string{}}
+}
+
+func (f *fakeGCState) seed(schemaID int16, key string, at time.Time) {
+	if f.state[schemaID] == nil {
+		f.state[schemaID] = map[string]int64{}
+	}
+	f.state[schemaID][key] = at.UnixMilli()
+}
+
+func (f *fakeGCState) Load(_ context.Context, schemaID int16) (map[string]int64, string, error) {
+	if f.loadErr != nil {
+		return nil, "", f.loadErr
+	}
+	cp := make(map[string]int64, len(f.state[schemaID]))
+	for k, v := range f.state[schemaID] {
+		cp[k] = v
+	}
+	return cp, f.etags[schemaID], nil
+}
+
+func (f *fakeGCState) Save(_ context.Context, schemaID int16, state map[string]int64, _ string) (string, error) {
+	if f.saveErr != nil {
+		return "", f.saveErr
+	}
+	f.saves++
+	cp := make(map[string]int64, len(state))
+	for k, v := range state {
+		cp[k] = v
+	}
+	f.state[schemaID] = cp
+	etag := fmt.Sprintf("gc-etag-%d", f.saves)
+	f.etags[schemaID] = etag
+	return etag, nil
 }

--- a/internal/reconcile/race_guard_test.go
+++ b/internal/reconcile/race_guard_test.go
@@ -1,0 +1,123 @@
+package reconcile
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+func TestGC_SkipsInitShapedBaseOrphans(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour)
+	initShaped := "data/7/" + uuidA + "_" + uuidB + ".parquet"
+	merged := "data/7/base-" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: initShaped, LastModified: old},
+			{Key: merged, LastModified: old},
+		},
+	}}
+	deleter := &fakeDeleter{}
+	r := newTestReconciler(lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Opts = Options{GC: true, GCGrace: 15 * time.Minute}
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	// An in-flight cdc-init promotes {min}_{max} base files long before it
+	// publishes the manifest and holds no advisory lock — GC must never
+	// touch that shape, no matter how old.
+	require.Equal(t, []string{merged}, deleter.deleted)
+	require.ElementsMatch(t, []string{initShaped, merged}, report.Schemas[0].BaseOrphans)
+	require.True(t, report.HasResidualDiscrepancies(), "undeletable init-shaped orphan stays residual")
+}
+
+func TestGC_ZeroGraceRefusesDeletion(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour)
+	merged := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: merged, LastModified: old}},
+	}}
+	deleter := &fakeDeleter{}
+	r := newTestReconciler(lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Opts = Options{GC: true} // zero-value grace: must refuse, not delete everything
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, deleter.deleted)
+	require.Empty(t, report.Schemas[0].Deleted)
+}
+
+func TestReconcileSchema_LoadsManifestBeforeListing(t *testing.T) {
+	var order []string
+	lister := listerFunc(func(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+		order = append(order, "list")
+		return nil, nil
+	})
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7})
+	manifests.onLoad = func(*fakeManifests) { order = append(order, "load") }
+
+	r := newTestReconciler(nil, manifests, &fakeDeleter{}, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Lister = lister
+	_, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, order)
+	// Loading first means a file created after the manifest snapshot still
+	// appears in the listing, so a racing compactor's freshly committed
+	// base entry can never be reported dangling.
+	require.Equal(t, "load", order[0])
+}
+
+func TestDangling_DroppedWhenObjectAppearsOnReprobe(t *testing.T) {
+	key := "data/7/base-" + uuidA + ".parquet"
+	// Initial listing misses the object (compactor wrote it mid-run), but
+	// the per-key re-probe finds it.
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {},
+		key:       {{Key: key, LastModified: testClock()}},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: key},
+	}})
+	r := newTestReconciler(lister, manifests, &fakeDeleter{}, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, report.Schemas[0].Dangling, "live object found on re-probe must not be reported dangling")
+	require.False(t, report.HasResidualDiscrepancies())
+}
+
+func TestDangling_DroppedWhenEntryRemovedOnReload(t *testing.T) {
+	key := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{"data/7/": {}}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: key},
+	}})
+	// A concurrent compactor spliced the entry out (and deleted its object)
+	// between our load and the dangling confirmation reload.
+	manifests.onLoad = func(f *fakeManifests) {
+		if f.loads > 1 {
+			f.manifests[7] = &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}}
+		}
+	}
+	r := newTestReconciler(lister, manifests, &fakeDeleter{}, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, report.Schemas[0].Dangling, "entry already spliced out is not dangling")
+}
+
+func TestDangling_ConfirmedWhenStillListedAndAbsent(t *testing.T) {
+	key := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{"data/7/": {}}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: key},
+	}})
+	r := newTestReconciler(lister, manifests, &fakeDeleter{}, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{key}, report.Schemas[0].Dangling)
+}

--- a/internal/reconcile/race_guard_test.go
+++ b/internal/reconcile/race_guard_test.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -23,12 +24,13 @@ func TestGC_SkipsInitShapedBaseOrphans(t *testing.T) {
 	deleter := &fakeDeleter{}
 	r := newTestReconciler(lister, newFakeManifests(&manifest.Manifest{SchemaID: 7}), deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
 	r.Opts = Options{GC: true, GCGrace: 15 * time.Minute}
+	seedGCSighting(t, r, 7, old, initShaped, merged)
 
 	report, err := r.Run(context.Background())
 	require.NoError(t, err)
 	// An in-flight cdc-init promotes {min}_{max} base files long before it
 	// publishes the manifest and holds no advisory lock — GC must never
-	// touch that shape, no matter how old.
+	// touch that shape, no matter how old or how long unlisted.
 	require.Equal(t, []string{merged}, deleter.deleted)
 	require.ElementsMatch(t, []string{initShaped, merged}, report.Schemas[0].BaseOrphans)
 	require.True(t, report.HasResidualDiscrepancies(), "undeletable init-shaped orphan stays residual")
@@ -107,6 +109,47 @@ func TestDangling_DroppedWhenEntryRemovedOnReload(t *testing.T) {
 	report, err := r.Run(context.Background())
 	require.NoError(t, err)
 	require.Empty(t, report.Schemas[0].Dangling, "entry already spliced out is not dangling")
+}
+
+func TestDangling_ProbeErrorIsToolFailureNotDiscrepancy(t *testing.T) {
+	// PR #289 review finding 4: a failed re-probe (or manifest reload)
+	// leaves dangling UNCONFIRMED — reporting it as confirmed would map a
+	// storage outage to exit 2 "data drift" instead of exit 1.
+	key := "data/7/base-" + uuidA + ".parquet"
+	probeErr := errors.New("s3 transient outage")
+	lister := listerFunc(func(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+		if prefix == key {
+			return nil, probeErr
+		}
+		return nil, nil
+	})
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: key},
+	}})
+	r := newTestReconciler(nil, manifests, &fakeDeleter{}, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Lister = lister
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Error(t, report.Schemas[0].Err, "an unconfirmable dangling candidate must surface as a schema failure")
+}
+
+func TestDangling_ReloadErrorIsToolFailure(t *testing.T) {
+	key := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{"data/7/": {}}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: key},
+	}})
+	manifests.onLoad = func(f *fakeManifests) {
+		if f.loads > 1 {
+			f.loadErr = errors.New("manifest store outage")
+		}
+	}
+	r := newTestReconciler(lister, manifests, &fakeDeleter{}, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Error(t, report.Schemas[0].Err)
 }
 
 func TestDangling_ConfirmedWhenStillListedAndAbsent(t *testing.T) {

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,0 +1,141 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/lychee-technology/forma/internal/compaction"
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// ManifestStore loads and saves one schema's manifest with optimistic
+// concurrency. Load must have LoadOrCreate semantics: a schema without a
+// manifest reconciles as empty instead of erroring.
+type ManifestStore interface {
+	Load(ctx context.Context, schemaID int16) (*manifest.Manifest, string, error)
+	Save(ctx context.Context, schemaID int16, m *manifest.Manifest, etag string) (string, error)
+}
+
+// StatsReader recomputes one parquet file's manifest metadata from its
+// contents. Only consulted under --repair.
+type StatsReader interface {
+	FileStats(ctx context.Context, uri string) (compaction.MergeStats, error)
+}
+
+// Locker serializes reconciliation against the live flusher per schema.
+// unlock is non-nil exactly when locked is true.
+type Locker interface {
+	TryLock(ctx context.Context, schemaID int16) (locked bool, unlock func(), err error)
+}
+
+// SchemaEnumerator yields the schema IDs to reconcile.
+type SchemaEnumerator interface {
+	SchemaIDs(ctx context.Context) ([]int16, error)
+}
+
+// Options selects the reconcile actions. The zero value is a read-only
+// report.
+type Options struct {
+	Repair         bool          // append delta-shaped orphans back to the manifest
+	GC             bool          // delete base-shaped and _tmp orphans past the grace period
+	GCGrace        time.Duration // minimum object age before GC may delete it
+	MaxETagRetries int           // manifest save retries on optimistic-concurrency conflict
+}
+
+// Reconciler diffs S3 parquet objects against per-schema manifests and
+// optionally repairs (append delta orphans) or garbage-collects (delete
+// compaction leftovers). See the package comment for the recovery model.
+type Reconciler struct {
+	Lister     ObjectLister
+	Deleter    ObjectDeleter
+	Manifests  ManifestStore
+	Stats      StatsReader // may be nil unless Opts.Repair
+	Locker     Locker
+	Schemas    SchemaEnumerator
+	Now        func() time.Time
+	Bucket     string
+	DataPrefix string
+	Logger     *zap.Logger
+	Opts       Options
+}
+
+// Run reconciles every enumerated schema. Per-schema failures are recorded
+// in the report and do not abort the run; the returned error is reserved
+// for failures that prevent reconciling anything at all.
+func (r *Reconciler) Run(ctx context.Context) (Report, error) {
+	ids, err := r.Schemas.SchemaIDs(ctx)
+	if err != nil {
+		return Report{}, fmt.Errorf("enumerate schemas: %w", err)
+	}
+	report := Report{Schemas: make([]SchemaReport, 0, len(ids))}
+	for _, schemaID := range ids {
+		report.Schemas = append(report.Schemas, r.reconcileSchema(ctx, schemaID))
+	}
+	return report, nil
+}
+
+func (r *Reconciler) reconcileSchema(ctx context.Context, schemaID int16) SchemaReport {
+	s := SchemaReport{SchemaID: schemaID}
+
+	locked, unlock, err := r.Locker.TryLock(ctx, schemaID)
+	if err != nil {
+		s.Err = fmt.Errorf("acquire schema %d advisory lock: %w", schemaID, err)
+		return s
+	}
+	if !locked {
+		s.Skipped = true
+		r.Logger.Info("schema lock not acquired, skipping", zap.Int16("schema_id", schemaID))
+		return s
+	}
+	defer unlock()
+
+	prefix := schemaDataPrefix(r.DataPrefix, schemaID)
+	objects, err := r.Lister.ListObjects(ctx, prefix)
+	if err != nil {
+		s.Err = fmt.Errorf("list schema %d objects under %s: %w", schemaID, prefix, err)
+		return s
+	}
+
+	m, etag, err := r.Manifests.Load(ctx, schemaID)
+	if err != nil {
+		s.Err = fmt.Errorf("load schema %d manifest: %w", schemaID, err)
+		return s
+	}
+
+	d := diffSchema(r.Bucket, r.DataPrefix, schemaID, objects, m)
+	s.DeltaOrphans = objectKeyList(d.deltaOrphans)
+	s.BaseOrphans = objectKeyList(d.baseOrphans)
+	s.TmpOrphans = objectKeyList(d.tmpOrphans)
+	s.Unknown = objectKeyList(d.unknown)
+	s.Dangling = d.dangling
+	s.Unverifiable = d.unverifiable
+
+	if r.Opts.Repair && len(d.deltaOrphans) > 0 {
+		s.Repaired, err = r.repairSchema(ctx, schemaID, m, etag, d.deltaOrphans)
+		if err != nil {
+			s.Err = err
+			return s
+		}
+	}
+	if r.Opts.GC {
+		candidates := append(append([]ObjectInfo(nil), d.baseOrphans...), d.tmpOrphans...)
+		if len(candidates) > 0 {
+			s.Deleted = r.gcSchema(ctx, schemaID, candidates)
+		}
+	}
+	return s
+}
+
+func objectKeyList(objs []ObjectInfo) []string {
+	if len(objs) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(objs))
+	for _, o := range objs {
+		keys = append(keys, o.Key)
+	}
+	return keys
+}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -20,12 +20,13 @@ type ManifestStore interface {
 }
 
 // StatsReader inspects one parquet file's contents: FileStats recomputes
-// manifest metadata; UncoveredRowIDs returns the file's row_ids absent from
-// every listed file (the repair guard's coverage probe). Both take
-// bucket-relative keys. Only consulted under --repair.
+// manifest metadata; UncoveredRows returns the rows whose newest version no
+// listed file supersedes, with a tombstone flag (the repair guard's
+// version-aware coverage probe). Both take bucket-relative keys. Only
+// consulted under --repair.
 type StatsReader interface {
 	FileStats(ctx context.Context, key string) (compaction.MergeStats, error)
-	UncoveredRowIDs(ctx context.Context, key string, listedKeys []string) ([]string, error)
+	UncoveredRows(ctx context.Context, key string, listedKeys []string) ([]compaction.UncoveredRow, error)
 }
 
 // LiveRowChecker reports which of the given row ids are NOT live in the
@@ -45,6 +46,17 @@ type Locker interface {
 // SchemaEnumerator yields the schema IDs to reconcile.
 type SchemaEnumerator interface {
 	SchemaIDs(ctx context.Context) ([]int16, error)
+}
+
+// GCStateStore persists per-schema first-unlisted sighting timestamps
+// (key -> unix ms) with optimistic concurrency. GC deletes an orphan only
+// after it has been observed unlisted for longer than the grace period —
+// LastModified alone cannot express "unlisted duration" (#188 follow-up:
+// an old source freshly spliced out by the compactor would otherwise be
+// deleted inside the in-flight-reader window).
+type GCStateStore interface {
+	Load(ctx context.Context, schemaID int16) (map[string]int64, string, error)
+	Save(ctx context.Context, schemaID int16, state map[string]int64, etag string) (string, error)
 }
 
 // Options selects the reconcile actions. The zero value is a read-only
@@ -67,6 +79,7 @@ type Reconciler struct {
 	LiveRows   LiveRowChecker // may be nil unless Opts.Repair
 	Locker     Locker
 	Schemas    SchemaEnumerator
+	GCStates   GCStateStore // may be nil unless Opts.GC
 	Now        func() time.Time
 	Bucket     string
 	DataPrefix string
@@ -125,8 +138,14 @@ func (r *Reconciler) reconcileSchema(ctx context.Context, schemaID int16) Schema
 	s.BaseOrphans = append(objectKeyList(d.baseInitOrphans), objectKeyList(d.baseMergedOrphans)...)
 	s.TmpOrphans = objectKeyList(d.tmpOrphans)
 	s.Unknown = objectKeyList(d.unknown)
-	s.Dangling = r.confirmDangling(ctx, schemaID, d.dangling)
 	s.Unverifiable = d.unverifiable
+	s.Dangling, err = r.confirmDangling(ctx, schemaID, d.dangling)
+	if err != nil {
+		// An unconfirmable candidate is a tool failure, not a data-drift
+		// verdict: the caller maps s.Err to exit 1, never 2.
+		s.Err = fmt.Errorf("confirm schema %d dangling candidates: %w", schemaID, err)
+		return s
+	}
 
 	var deltaLeftovers []ObjectInfo
 	if r.Opts.Repair && len(d.deltaOrphans) > 0 {
@@ -146,8 +165,13 @@ func (r *Reconciler) reconcileSchema(ctx context.Context, schemaID int16) Schema
 		// analysis, so they are only deletable under --repair --gc.
 		candidates := append(append([]ObjectInfo(nil), d.baseMergedOrphans...), d.tmpOrphans...)
 		candidates = append(candidates, deltaLeftovers...)
-		if len(candidates) > 0 {
-			s.Deleted = r.gcSchema(ctx, schemaID, candidates)
+		// Run even with zero candidates: sighting-state entries for keys
+		// that stopped being orphans must be pruned so a later unlisting
+		// restarts their grace clock.
+		s.Deleted, err = r.gcSchema(ctx, schemaID, candidates)
+		if err != nil {
+			s.Err = err
+			return s
 		}
 	}
 	return s
@@ -156,24 +180,22 @@ func (r *Reconciler) reconcileSchema(ctx context.Context, schemaID int16) Schema
 // confirmDangling re-verifies dangling candidates against a fresh manifest
 // load and a per-key existence probe. The lock excludes the flusher but not
 // the compactor or cdc-init, so a splice landing mid-run could otherwise
-// surface a properly handled (or freshly created) object as dangling.
-func (r *Reconciler) confirmDangling(ctx context.Context, schemaID int16, dangling []string) []string {
+// surface a properly handled (or freshly created) object as dangling. A
+// failed reload or probe leaves the candidate UNCONFIRMED and is returned
+// as an error — a storage outage must surface as a tool failure (exit 1),
+// never as a confirmed data-drift report (exit 2).
+func (r *Reconciler) confirmDangling(ctx context.Context, schemaID int16, dangling []string) ([]string, error) {
 	if len(dangling) == 0 {
-		return nil
+		return nil, nil
 	}
-	still := make(map[string]bool, len(dangling))
 	m2, _, err := r.Manifests.Load(ctx, schemaID)
 	if err != nil {
-		r.Logger.Warn("could not reload manifest to confirm dangling entries; reporting unconfirmed",
-			zap.Int16("schema_id", schemaID), zap.Error(err))
-		for _, key := range dangling {
+		return nil, fmt.Errorf("reload manifest: %w", err)
+	}
+	still := make(map[string]bool, len(m2.Files))
+	for _, f := range m2.Files {
+		if key, ok := normalizeKey(r.Bucket, f.Path); ok {
 			still[key] = true
-		}
-	} else {
-		for _, f := range m2.Files {
-			if key, ok := normalizeKey(r.Bucket, f.Path); ok {
-				still[key] = true
-			}
 		}
 	}
 
@@ -184,10 +206,7 @@ func (r *Reconciler) confirmDangling(ctx context.Context, schemaID int16, dangli
 		}
 		objs, err := r.Lister.ListObjects(ctx, key)
 		if err != nil {
-			r.Logger.Warn("dangling re-probe failed; keeping candidate",
-				zap.Int16("schema_id", schemaID), zap.String("key", key), zap.Error(err))
-			confirmed = append(confirmed, key)
-			continue
+			return nil, fmt.Errorf("re-probe candidate %s: %w", key, err)
 		}
 		exists := false
 		for _, o := range objs {
@@ -200,7 +219,7 @@ func (r *Reconciler) confirmDangling(ctx context.Context, schemaID int16, dangli
 			confirmed = append(confirmed, key)
 		}
 	}
-	return confirmed
+	return confirmed, nil
 }
 
 func objectKeyList(objs []ObjectInfo) []string {

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -19,10 +19,21 @@ type ManifestStore interface {
 	Save(ctx context.Context, schemaID int16, m *manifest.Manifest, etag string) (string, error)
 }
 
-// StatsReader recomputes one parquet file's manifest metadata from its
-// contents. Only consulted under --repair.
+// StatsReader inspects one parquet file's contents: FileStats recomputes
+// manifest metadata; UncoveredRowIDs returns the file's row_ids absent from
+// every listed file (the repair guard's coverage probe). Both take
+// bucket-relative keys. Only consulted under --repair.
 type StatsReader interface {
-	FileStats(ctx context.Context, uri string) (compaction.MergeStats, error)
+	FileStats(ctx context.Context, key string) (compaction.MergeStats, error)
+	UncoveredRowIDs(ctx context.Context, key string, listedKeys []string) ([]string, error)
+}
+
+// LiveRowChecker reports which of the given row ids are NOT live in the
+// Postgres entity store. A row absent from every manifest-listed parquet
+// AND missing from Postgres was deleted — its tombstone won a compaction
+// merge and was dropped, so re-appending the file would resurrect it.
+type LiveRowChecker interface {
+	MissingLiveRows(ctx context.Context, schemaID int16, rowIDs []string) ([]string, error)
 }
 
 // Locker serializes reconciliation against the live flusher per schema.
@@ -52,7 +63,8 @@ type Reconciler struct {
 	Lister     ObjectLister
 	Deleter    ObjectDeleter
 	Manifests  ManifestStore
-	Stats      StatsReader // may be nil unless Opts.Repair
+	Stats      StatsReader    // may be nil unless Opts.Repair
+	LiveRows   LiveRowChecker // may be nil unless Opts.Repair
 	Locker     Locker
 	Schemas    SchemaEnumerator
 	Now        func() time.Time
@@ -92,6 +104,15 @@ func (r *Reconciler) reconcileSchema(ctx context.Context, schemaID int16) Schema
 	}
 	defer unlock()
 
+	// Load the manifest BEFORE listing: a file created after the manifest
+	// snapshot then still appears in the listing, so a racing compactor's
+	// freshly committed base entry can never be reported dangling.
+	m, etag, err := r.Manifests.Load(ctx, schemaID)
+	if err != nil {
+		s.Err = fmt.Errorf("load schema %d manifest: %w", schemaID, err)
+		return s
+	}
+
 	prefix := schemaDataPrefix(r.DataPrefix, schemaID)
 	objects, err := r.Lister.ListObjects(ctx, prefix)
 	if err != nil {
@@ -99,34 +120,87 @@ func (r *Reconciler) reconcileSchema(ctx context.Context, schemaID int16) Schema
 		return s
 	}
 
-	m, etag, err := r.Manifests.Load(ctx, schemaID)
-	if err != nil {
-		s.Err = fmt.Errorf("load schema %d manifest: %w", schemaID, err)
-		return s
-	}
-
 	d := diffSchema(r.Bucket, r.DataPrefix, schemaID, objects, m)
 	s.DeltaOrphans = objectKeyList(d.deltaOrphans)
-	s.BaseOrphans = objectKeyList(d.baseOrphans)
+	s.BaseOrphans = append(objectKeyList(d.baseInitOrphans), objectKeyList(d.baseMergedOrphans)...)
 	s.TmpOrphans = objectKeyList(d.tmpOrphans)
 	s.Unknown = objectKeyList(d.unknown)
-	s.Dangling = d.dangling
+	s.Dangling = r.confirmDangling(ctx, schemaID, d.dangling)
 	s.Unverifiable = d.unverifiable
 
+	var deltaLeftovers []ObjectInfo
 	if r.Opts.Repair && len(d.deltaOrphans) > 0 {
-		s.Repaired, err = r.repairSchema(ctx, schemaID, m, etag, d.deltaOrphans)
+		outcome, err := r.repairSchema(ctx, schemaID, m, etag, d.deltaOrphans)
 		if err != nil {
 			s.Err = err
 			return s
 		}
+		s.Repaired = outcome.repaired
+		s.DeltaLeftovers = objectKeyList(outcome.leftovers)
+		deltaLeftovers = outcome.leftovers
 	}
 	if r.Opts.GC {
-		candidates := append(append([]ObjectInfo(nil), d.baseOrphans...), d.tmpOrphans...)
+		// Init-shaped base orphans are never GC candidates: an in-flight
+		// cdc-init promotes them long before publishing the manifest and
+		// holds no advisory lock. Delta leftovers require the repair
+		// analysis, so they are only deletable under --repair --gc.
+		candidates := append(append([]ObjectInfo(nil), d.baseMergedOrphans...), d.tmpOrphans...)
+		candidates = append(candidates, deltaLeftovers...)
 		if len(candidates) > 0 {
 			s.Deleted = r.gcSchema(ctx, schemaID, candidates)
 		}
 	}
 	return s
+}
+
+// confirmDangling re-verifies dangling candidates against a fresh manifest
+// load and a per-key existence probe. The lock excludes the flusher but not
+// the compactor or cdc-init, so a splice landing mid-run could otherwise
+// surface a properly handled (or freshly created) object as dangling.
+func (r *Reconciler) confirmDangling(ctx context.Context, schemaID int16, dangling []string) []string {
+	if len(dangling) == 0 {
+		return nil
+	}
+	still := make(map[string]bool, len(dangling))
+	m2, _, err := r.Manifests.Load(ctx, schemaID)
+	if err != nil {
+		r.Logger.Warn("could not reload manifest to confirm dangling entries; reporting unconfirmed",
+			zap.Int16("schema_id", schemaID), zap.Error(err))
+		for _, key := range dangling {
+			still[key] = true
+		}
+	} else {
+		for _, f := range m2.Files {
+			if key, ok := normalizeKey(r.Bucket, f.Path); ok {
+				still[key] = true
+			}
+		}
+	}
+
+	var confirmed []string
+	for _, key := range dangling {
+		if !still[key] {
+			continue // spliced out concurrently; nothing dangling anymore
+		}
+		objs, err := r.Lister.ListObjects(ctx, key)
+		if err != nil {
+			r.Logger.Warn("dangling re-probe failed; keeping candidate",
+				zap.Int16("schema_id", schemaID), zap.String("key", key), zap.Error(err))
+			confirmed = append(confirmed, key)
+			continue
+		}
+		exists := false
+		for _, o := range objs {
+			if o.Key == key {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			confirmed = append(confirmed, key)
+		}
+	}
+	return confirmed
 }
 
 func objectKeyList(objs []ObjectInfo) []string {

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -21,10 +21,24 @@ func newTestReconciler(lister *fakeLister, manifests *fakeManifests, deleter *fa
 		Manifests:  manifests,
 		Locker:     locker,
 		Schemas:    enum,
+		GCStates:   newFakeGCState(),
 		Now:        testClock,
 		Bucket:     "bkt",
 		DataPrefix: "data",
 		Logger:     zap.NewNop(),
+	}
+}
+
+// seedGCSighting marks keys as already observed unlisted at the given time,
+// so single-run GC tests can exercise the deletion path directly.
+func seedGCSighting(t *testing.T, r *Reconciler, schemaID int16, at time.Time, keys ...string) {
+	t.Helper()
+	fake, ok := r.GCStates.(*fakeGCState)
+	if !ok {
+		t.Fatalf("reconciler GCStates is %T, want *fakeGCState", r.GCStates)
+	}
+	for _, key := range keys {
+		fake.seed(schemaID, key, at)
 	}
 }
 

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -1,0 +1,147 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+	"go.uber.org/zap"
+)
+
+func testClock() time.Time {
+	return time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+}
+
+func newTestReconciler(lister *fakeLister, manifests *fakeManifests, deleter *fakeDeleter, locker *fakeLocker, enum *fakeEnum) *Reconciler {
+	return &Reconciler{
+		Lister:     lister,
+		Deleter:    deleter,
+		Manifests:  manifests,
+		Locker:     locker,
+		Schemas:    enum,
+		Now:        testClock,
+		Bucket:     "bkt",
+		DataPrefix: "data",
+		Logger:     zap.NewNop(),
+	}
+}
+
+func TestReconcileSchema_LockNotAcquired_Skips(t *testing.T) {
+	lister := &fakeLister{}
+	locker := &fakeLocker{denied: map[int16]bool{7: true}}
+	r := newTestReconciler(lister, newFakeManifests(), &fakeDeleter{}, locker, &fakeEnum{ids: []int16{7}})
+
+	report, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(report.Schemas) != 1 || !report.Schemas[0].Skipped {
+		t.Fatalf("expected schema 7 skipped, got %+v", report.Schemas)
+	}
+	if len(lister.calls) != 0 {
+		t.Fatalf("skipped schema must not be listed, got calls %v", lister.calls)
+	}
+	if !report.HasResidualDiscrepancies() {
+		t.Fatal("skipped schema must count as residual discrepancy")
+	}
+}
+
+func TestRun_EnumeratesAllSchemasAndReleasesLocks(t *testing.T) {
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/1/": {{Key: "data/1/" + uuidA + ".parquet", Size: 10, LastModified: testClock()}},
+		"data/2/": {{Key: "data/2/" + uuidB + ".parquet", Size: 20, LastModified: testClock()}},
+	}}
+	manifests := newFakeManifests(
+		&manifest.Manifest{SchemaID: 1, Files: []manifest.FileEntry{}},
+		&manifest.Manifest{SchemaID: 2, Files: []manifest.FileEntry{
+			{Tier: "delta", Path: "data/2/" + uuidB + ".parquet"},
+		}},
+	)
+	locker := &fakeLocker{}
+	r := newTestReconciler(lister, manifests, &fakeDeleter{}, locker, &fakeEnum{ids: []int16{1, 2}})
+
+	report, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(report.Schemas) != 2 {
+		t.Fatalf("expected 2 schema reports, got %d", len(report.Schemas))
+	}
+	assertKeys(t, "schema 1 delta orphans", report.Schemas[0].DeltaOrphans,
+		[]string{"data/1/" + uuidA + ".parquet"})
+	if len(report.Schemas[1].DeltaOrphans) != 0 {
+		t.Fatalf("schema 2 must be clean, got %+v", report.Schemas[1])
+	}
+	if len(locker.locked) != 2 || len(locker.unlocked) != 2 {
+		t.Fatalf("locks acquired=%v released=%v, want both [1 2]", locker.locked, locker.unlocked)
+	}
+}
+
+func TestRun_ReportOnly_MutatesNothing(t *testing.T) {
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: "data/7/" + uuidA + ".parquet", LastModified: testClock().Add(-time.Hour)},
+			{Key: "data/7/base-" + uuidB + ".parquet", LastModified: testClock().Add(-time.Hour)},
+			{Key: "data/7/_tmp/" + uuidB + ".parquet", LastModified: testClock().Add(-time.Hour)},
+		},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: "data/7/gone.parquet"},
+	}})
+	deleter := &fakeDeleter{}
+	r := newTestReconciler(lister, manifests, deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+
+	report, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(manifests.saves) != 0 {
+		t.Fatalf("report mode must not save manifests, got %d saves", len(manifests.saves))
+	}
+	if len(deleter.deleted) != 0 {
+		t.Fatalf("report mode must not delete objects, got %v", deleter.deleted)
+	}
+	s := report.Schemas[0]
+	if len(s.DeltaOrphans) != 1 || len(s.BaseOrphans) != 1 || len(s.TmpOrphans) != 1 || len(s.Dangling) != 1 {
+		t.Fatalf("expected full diff in report, got %+v", s)
+	}
+}
+
+func TestRun_LockErrorRecorded_OtherSchemasContinue(t *testing.T) {
+	lister := &fakeLister{objects: map[string][]ObjectInfo{}}
+	locker := &fakeLocker{}
+	r := newTestReconciler(lister, newFakeManifests(), &fakeDeleter{}, locker, &fakeEnum{ids: []int16{1, 2}})
+
+	// Fail only schema 1's listing; schema 2 must still reconcile.
+	lister.err = errors.New("s3 unavailable")
+	failOnce := lister.err
+	lister.err = nil
+	r.Lister = listerFunc(func(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+		if prefix == "data/1/" {
+			return nil, failOnce
+		}
+		return nil, nil
+	})
+
+	report, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if report.Schemas[0].Err == nil {
+		t.Fatal("schema 1 error must be recorded")
+	}
+	if report.Schemas[1].Err != nil || report.Schemas[1].Skipped {
+		t.Fatalf("schema 2 must reconcile normally, got %+v", report.Schemas[1])
+	}
+	if !report.HasResidualDiscrepancies() {
+		t.Fatal("schema error must count as residual discrepancy")
+	}
+}
+
+type listerFunc func(ctx context.Context, prefix string) ([]ObjectInfo, error)
+
+func (f listerFunc) ListObjects(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	return f(ctx, prefix)
+}

--- a/internal/reconcile/repair.go
+++ b/internal/reconcile/repair.go
@@ -19,16 +19,12 @@ type repairOutcome struct {
 }
 
 // repairSchema handles delta-shaped orphans. A file is appended back to the
-// manifest ONLY when it still carries rows the manifest-listed inventory
-// does not cover and every such row is live in Postgres — the #197 failure
-// mode, where the data exists nowhere else. Everything else is refused:
-//
-//   - No uncovered rows, or every uncovered row deleted in Postgres: the
-//     file is a compaction leftover (#188 failed post-commit delete) whose
-//     tombstone winners the full merge already dropped — re-appending it
-//     would resurrect deleted rows. Classified as a leftover for --gc.
-//   - A mix of live and deleted uncovered rows: appending resurrects the
-//     dead ones, deleting loses the live ones — left for manual surgery.
+// manifest ONLY when the version-aware guard (classifyDeltaOrphan) proves
+// it still carries versions the manifest-listed inventory lost — the #197
+// failure mode. Provable compaction leftovers (#188 failed post-commit
+// deletes) are classified for --gc instead: their tombstone winners were
+// dropped by the merge, so re-appending them would resurrect deleted rows.
+// Ambiguous files are refused and left for manual surgery.
 //
 // Entry metadata is recomputed from the parquet contents, never trusted
 // from filenames. Runs under the schema advisory lock; the manifest save
@@ -47,86 +43,98 @@ func (r *Reconciler) repairSchema(ctx context.Context, schemaID int16, m *manife
 	entryCache := make(map[string]manifest.FileEntry, len(orphans))
 
 	for attempt := 0; ; attempt++ {
-		known := make(map[string]struct{}, len(m.Files))
-		listedKeys := make([]string, 0, len(m.Files))
-		for _, f := range m.Files {
-			if key, ok := normalizeKey(r.Bucket, f.Path); ok {
-				known[key] = struct{}{}
-				listedKeys = append(listedKeys, key)
-			}
-		}
-
-		var outcome repairOutcome
-		var appended []manifest.FileEntry
-		for _, obj := range orphans {
-			if _, listed := known[obj.Key]; listed {
-				outcome.repaired = append(outcome.repaired, obj.Key)
-				continue
-			}
-			verdict, err := r.classifyDeltaOrphan(ctx, schemaID, obj, listedKeys)
-			if err != nil {
-				r.Logger.Warn("skipping delta orphan the repair guard could not classify",
-					zap.Int16("schema_id", schemaID), zap.String("key", obj.Key), zap.Error(err))
-				continue
-			}
-			switch verdict {
-			case deltaLeftover:
-				outcome.leftovers = append(outcome.leftovers, obj)
-				continue
-			case deltaMixed:
-				r.Logger.Warn("delta orphan mixes live and deleted uncovered rows; refusing auto-repair and auto-GC — manual reconciliation required",
-					zap.Int16("schema_id", schemaID), zap.String("key", obj.Key))
-				continue
-			}
-
-			entry, ok := entryCache[obj.Key]
-			if !ok {
-				stats, err := r.Stats.FileStats(ctx, obj.Key)
-				if err != nil {
-					r.Logger.Warn("skipping orphan with unreadable parquet stats; leaving it orphaned",
-						zap.Int16("schema_id", schemaID), zap.String("key", obj.Key), zap.Error(err))
-					continue
-				}
-				entry = manifest.FileEntry{
-					Tier:       "delta",
-					Path:       obj.Key,
-					RowIDMin:   stats.RowIDMin,
-					RowIDMax:   stats.RowIDMax,
-					CreatedMin: stats.CreatedMin,
-					CreatedMax: stats.CreatedMax,
-					RowCount:   stats.RowsOut,
-					SizeBytes:  obj.Size,
-				}
-				entryCache[obj.Key] = entry
-			}
-			appended = append(appended, entry)
-			outcome.repaired = append(outcome.repaired, obj.Key)
-		}
-
+		outcome, appended := r.planRepair(ctx, schemaID, m, orphans, entryCache)
 		if len(appended) == 0 {
 			return outcome, nil
 		}
 
 		m.Files = append(m.Files, appended...)
-		if _, err := r.Manifests.Save(ctx, schemaID, m, etag); err == nil {
+		_, err := r.Manifests.Save(ctx, schemaID, m, etag)
+		if err == nil {
 			for _, e := range appended {
 				r.Logger.Info("appended orphaned delta to manifest",
 					zap.Int16("schema_id", schemaID), zap.String("key", e.Path), zap.Int64("row_count", e.RowCount))
 			}
 			return outcome, nil
-		} else if !compaction.IsConcurrentModification(err) {
+		}
+		if !compaction.IsConcurrentModification(err) {
 			return repairOutcome{}, fmt.Errorf("save schema %d manifest: %w", schemaID, err)
-		} else if attempt >= r.Opts.MaxETagRetries {
+		}
+		if attempt >= r.Opts.MaxETagRetries {
 			return repairOutcome{}, fmt.Errorf("save schema %d manifest: still conflicting after %d optimistic-concurrency retries: %w",
 				schemaID, r.Opts.MaxETagRetries, err)
 		}
-
-		var err error
-		m, etag, err = r.Manifests.Load(ctx, schemaID)
-		if err != nil {
+		if m, etag, err = r.Manifests.Load(ctx, schemaID); err != nil {
 			return repairOutcome{}, fmt.Errorf("reload schema %d manifest after save conflict: %w", schemaID, err)
 		}
 	}
+}
+
+// planRepair classifies every orphan against the current manifest snapshot
+// and returns the outcome plus the entries to append in this attempt.
+func (r *Reconciler) planRepair(ctx context.Context, schemaID int16, m *manifest.Manifest, orphans []ObjectInfo, entryCache map[string]manifest.FileEntry) (repairOutcome, []manifest.FileEntry) {
+	known := make(map[string]struct{}, len(m.Files))
+	listedKeys := make([]string, 0, len(m.Files))
+	for _, f := range m.Files {
+		if key, ok := normalizeKey(r.Bucket, f.Path); ok {
+			known[key] = struct{}{}
+			listedKeys = append(listedKeys, key)
+		}
+	}
+
+	var outcome repairOutcome
+	var appended []manifest.FileEntry
+	for _, obj := range orphans {
+		if _, listed := known[obj.Key]; listed {
+			outcome.repaired = append(outcome.repaired, obj.Key)
+			continue
+		}
+		switch verdict, err := r.classifyDeltaOrphan(ctx, schemaID, obj, listedKeys); {
+		case err != nil:
+			r.Logger.Warn("skipping delta orphan the repair guard could not classify",
+				zap.Int16("schema_id", schemaID), zap.String("key", obj.Key), zap.Error(err))
+			continue
+		case verdict == deltaLeftover:
+			outcome.leftovers = append(outcome.leftovers, obj)
+			continue
+		case verdict == deltaMixed:
+			r.Logger.Warn("delta orphan mixes restorable and resurrecting rows; refusing auto-repair and auto-GC — manual reconciliation required",
+				zap.Int16("schema_id", schemaID), zap.String("key", obj.Key))
+			continue
+		}
+		entry, ok := r.buildRepairEntry(ctx, schemaID, obj, entryCache)
+		if !ok {
+			continue
+		}
+		appended = append(appended, entry)
+		outcome.repaired = append(outcome.repaired, obj.Key)
+	}
+	return outcome, appended
+}
+
+// buildRepairEntry recomputes (or reuses) the manifest entry for one orphan.
+func (r *Reconciler) buildRepairEntry(ctx context.Context, schemaID int16, obj ObjectInfo, entryCache map[string]manifest.FileEntry) (manifest.FileEntry, bool) {
+	if entry, ok := entryCache[obj.Key]; ok {
+		return entry, true
+	}
+	stats, err := r.Stats.FileStats(ctx, obj.Key)
+	if err != nil {
+		r.Logger.Warn("skipping orphan with unreadable parquet stats; leaving it orphaned",
+			zap.Int16("schema_id", schemaID), zap.String("key", obj.Key), zap.Error(err))
+		return manifest.FileEntry{}, false
+	}
+	entry := manifest.FileEntry{
+		Tier:       "delta",
+		Path:       obj.Key,
+		RowIDMin:   stats.RowIDMin,
+		RowIDMax:   stats.RowIDMax,
+		CreatedMin: stats.CreatedMin,
+		CreatedMax: stats.CreatedMax,
+		RowCount:   stats.RowsOut,
+		SizeBytes:  obj.Size,
+	}
+	entryCache[obj.Key] = entry
+	return entry, true
 }
 
 type deltaVerdict int
@@ -137,26 +145,63 @@ const (
 	deltaMixed
 )
 
-// classifyDeltaOrphan decides an orphan's fate from its row coverage and
-// Postgres liveness (see repairSchema's contract).
+// classifyDeltaOrphan decides an orphan's fate from its version-aware row
+// coverage (compaction.UncoveredRows) and Postgres liveness. Per uncovered
+// row (the newest version no listed file supersedes):
+//
+//   - live version + row live in Postgres  → the #197 lost data, append.
+//   - tombstone   + row dead in Postgres   → a lost delete whose absence is
+//     actively resurrecting older listed versions, append (restores it).
+//   - live version + row dead in Postgres  → resurrection risk: the row's
+//     tombstone won a compaction merge and was dropped; appending would
+//     revive it.
+//   - tombstone   + row live in Postgres   → contradicts the entity state;
+//     never auto-handled.
+//
+// No uncovered rows, or only resurrection-risk rows → provable leftover
+// (GC-eligible). Any append-worthy rows alongside risk/contradiction rows →
+// mixed, refused entirely.
 func (r *Reconciler) classifyDeltaOrphan(ctx context.Context, schemaID int16, obj ObjectInfo, listedKeys []string) (deltaVerdict, error) {
-	uncovered, err := r.Stats.UncoveredRowIDs(ctx, obj.Key, listedKeys)
+	uncovered, err := r.Stats.UncoveredRows(ctx, obj.Key, listedKeys)
 	if err != nil {
 		return 0, fmt.Errorf("probe uncovered rows of %s: %w", obj.Key, err)
 	}
 	if len(uncovered) == 0 {
 		return deltaLeftover, nil
 	}
-	missing, err := r.LiveRows.MissingLiveRows(ctx, schemaID, uncovered)
+
+	rowIDs := make([]string, 0, len(uncovered))
+	for _, row := range uncovered {
+		rowIDs = append(rowIDs, row.RowID)
+	}
+	missing, err := r.LiveRows.MissingLiveRows(ctx, schemaID, rowIDs)
 	if err != nil {
 		return 0, fmt.Errorf("check live rows of %s: %w", obj.Key, err)
 	}
+	dead := make(map[string]bool, len(missing))
+	for _, id := range missing {
+		dead[id] = true
+	}
+
+	appendNeeded, resurrectRisk, contradiction := false, false, false
+	for _, row := range uncovered {
+		switch {
+		case row.Tombstone && dead[row.RowID]:
+			appendNeeded = true // lost delete: restore the tombstone
+		case row.Tombstone && !dead[row.RowID]:
+			contradiction = true
+		case !row.Tombstone && dead[row.RowID]:
+			resurrectRisk = true
+		default:
+			appendNeeded = true // lost live data
+		}
+	}
 	switch {
-	case len(missing) == 0:
-		return deltaAppend, nil
-	case len(missing) == len(uncovered):
-		return deltaLeftover, nil
-	default:
+	case contradiction, appendNeeded && resurrectRisk:
 		return deltaMixed, nil
+	case appendNeeded:
+		return deltaAppend, nil
+	default:
+		return deltaLeftover, nil
 	}
 }

--- a/internal/reconcile/repair.go
+++ b/internal/reconcile/repair.go
@@ -1,0 +1,97 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/lychee-technology/forma/internal/compaction"
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// repairSchema appends manifest entries for delta-shaped orphans — the #197
+// failure mode where the file was exported and its rows marked flushed but
+// the manifest append failed. Entry metadata is recomputed from the parquet
+// contents, never trusted from filenames. Runs under the schema advisory
+// lock; the manifest save still goes through etag optimistic concurrency
+// because manifest writers (compactor) do not take the lock.
+//
+// Returns the keys resolved: appended entries plus orphans a concurrent
+// writer already listed by the time the manifest was (re)loaded. Only a
+// confirmed 412 precondition failure is retried — after an ambiguous save
+// error the write may have landed, and a blind retry could duplicate
+// entries.
+func (r *Reconciler) repairSchema(ctx context.Context, schemaID int16, m *manifest.Manifest, etag string, orphans []ObjectInfo) ([]string, error) {
+	if r.Stats == nil {
+		return nil, fmt.Errorf("repair requested for schema %d but no stats reader is configured", schemaID)
+	}
+
+	// Stats survive across etag retries: a conflict changes the manifest,
+	// not the parquet contents.
+	entryCache := make(map[string]manifest.FileEntry, len(orphans))
+
+	for attempt := 0; ; attempt++ {
+		known := make(map[string]struct{}, len(m.Files))
+		for _, f := range m.Files {
+			if key, ok := normalizeKey(r.Bucket, f.Path); ok {
+				known[key] = struct{}{}
+			}
+		}
+
+		var appended []manifest.FileEntry
+		var resolved []string
+		for _, obj := range orphans {
+			if _, listed := known[obj.Key]; listed {
+				resolved = append(resolved, obj.Key)
+				continue
+			}
+			entry, ok := entryCache[obj.Key]
+			if !ok {
+				stats, err := r.Stats.FileStats(ctx, obj.Key)
+				if err != nil {
+					r.Logger.Warn("skipping orphan with unreadable parquet stats; leaving it orphaned",
+						zap.Int16("schema_id", schemaID), zap.String("key", obj.Key), zap.Error(err))
+					continue
+				}
+				entry = manifest.FileEntry{
+					Tier:       "delta",
+					Path:       obj.Key,
+					RowIDMin:   stats.RowIDMin,
+					RowIDMax:   stats.RowIDMax,
+					CreatedMin: stats.CreatedMin,
+					CreatedMax: stats.CreatedMax,
+					RowCount:   stats.RowsOut,
+					SizeBytes:  obj.Size,
+				}
+				entryCache[obj.Key] = entry
+			}
+			appended = append(appended, entry)
+			resolved = append(resolved, obj.Key)
+		}
+
+		if len(appended) == 0 {
+			return resolved, nil
+		}
+
+		m.Files = append(m.Files, appended...)
+		if _, err := r.Manifests.Save(ctx, schemaID, m, etag); err == nil {
+			for _, e := range appended {
+				r.Logger.Info("appended orphaned delta to manifest",
+					zap.Int16("schema_id", schemaID), zap.String("key", e.Path), zap.Int64("row_count", e.RowCount))
+			}
+			return resolved, nil
+		} else if !compaction.IsConcurrentModification(err) {
+			return nil, fmt.Errorf("save schema %d manifest: %w", schemaID, err)
+		} else if attempt >= r.Opts.MaxETagRetries {
+			return nil, fmt.Errorf("save schema %d manifest: still conflicting after %d optimistic-concurrency retries: %w",
+				schemaID, r.Opts.MaxETagRetries, err)
+		}
+
+		var err error
+		m, etag, err = r.Manifests.Load(ctx, schemaID)
+		if err != nil {
+			return nil, fmt.Errorf("reload schema %d manifest after save conflict: %w", schemaID, err)
+		}
+	}
+}

--- a/internal/reconcile/repair.go
+++ b/internal/reconcile/repair.go
@@ -10,21 +10,36 @@ import (
 	"github.com/lychee-technology/forma/internal/manifest"
 )
 
-// repairSchema appends manifest entries for delta-shaped orphans — the #197
-// failure mode where the file was exported and its rows marked flushed but
-// the manifest append failed. Entry metadata is recomputed from the parquet
-// contents, never trusted from filenames. Runs under the schema advisory
-// lock; the manifest save still goes through etag optimistic concurrency
-// because manifest writers (compactor) do not take the lock.
+// repairOutcome is repairSchema's per-schema result: keys resolved by
+// appending (or found concurrently listed) and delta orphans classified as
+// compaction leftovers, which the GC pass may delete.
+type repairOutcome struct {
+	repaired  []string
+	leftovers []ObjectInfo
+}
+
+// repairSchema handles delta-shaped orphans. A file is appended back to the
+// manifest ONLY when it still carries rows the manifest-listed inventory
+// does not cover and every such row is live in Postgres — the #197 failure
+// mode, where the data exists nowhere else. Everything else is refused:
 //
-// Returns the keys resolved: appended entries plus orphans a concurrent
-// writer already listed by the time the manifest was (re)loaded. Only a
+//   - No uncovered rows, or every uncovered row deleted in Postgres: the
+//     file is a compaction leftover (#188 failed post-commit delete) whose
+//     tombstone winners the full merge already dropped — re-appending it
+//     would resurrect deleted rows. Classified as a leftover for --gc.
+//   - A mix of live and deleted uncovered rows: appending resurrects the
+//     dead ones, deleting loses the live ones — left for manual surgery.
+//
+// Entry metadata is recomputed from the parquet contents, never trusted
+// from filenames. Runs under the schema advisory lock; the manifest save
+// still goes through etag optimistic concurrency (creates are If-None-Match
+// guarded) because compaction and init do not take the lock. Only a
 // confirmed 412 precondition failure is retried — after an ambiguous save
 // error the write may have landed, and a blind retry could duplicate
 // entries.
-func (r *Reconciler) repairSchema(ctx context.Context, schemaID int16, m *manifest.Manifest, etag string, orphans []ObjectInfo) ([]string, error) {
-	if r.Stats == nil {
-		return nil, fmt.Errorf("repair requested for schema %d but no stats reader is configured", schemaID)
+func (r *Reconciler) repairSchema(ctx context.Context, schemaID int16, m *manifest.Manifest, etag string, orphans []ObjectInfo) (repairOutcome, error) {
+	if r.Stats == nil || r.LiveRows == nil {
+		return repairOutcome{}, fmt.Errorf("repair requested for schema %d but stats reader or live-row checker is not configured", schemaID)
 	}
 
 	// Stats survive across etag retries: a conflict changes the manifest,
@@ -33,19 +48,37 @@ func (r *Reconciler) repairSchema(ctx context.Context, schemaID int16, m *manife
 
 	for attempt := 0; ; attempt++ {
 		known := make(map[string]struct{}, len(m.Files))
+		listedKeys := make([]string, 0, len(m.Files))
 		for _, f := range m.Files {
 			if key, ok := normalizeKey(r.Bucket, f.Path); ok {
 				known[key] = struct{}{}
+				listedKeys = append(listedKeys, key)
 			}
 		}
 
+		var outcome repairOutcome
 		var appended []manifest.FileEntry
-		var resolved []string
 		for _, obj := range orphans {
 			if _, listed := known[obj.Key]; listed {
-				resolved = append(resolved, obj.Key)
+				outcome.repaired = append(outcome.repaired, obj.Key)
 				continue
 			}
+			verdict, err := r.classifyDeltaOrphan(ctx, schemaID, obj, listedKeys)
+			if err != nil {
+				r.Logger.Warn("skipping delta orphan the repair guard could not classify",
+					zap.Int16("schema_id", schemaID), zap.String("key", obj.Key), zap.Error(err))
+				continue
+			}
+			switch verdict {
+			case deltaLeftover:
+				outcome.leftovers = append(outcome.leftovers, obj)
+				continue
+			case deltaMixed:
+				r.Logger.Warn("delta orphan mixes live and deleted uncovered rows; refusing auto-repair and auto-GC — manual reconciliation required",
+					zap.Int16("schema_id", schemaID), zap.String("key", obj.Key))
+				continue
+			}
+
 			entry, ok := entryCache[obj.Key]
 			if !ok {
 				stats, err := r.Stats.FileStats(ctx, obj.Key)
@@ -67,11 +100,11 @@ func (r *Reconciler) repairSchema(ctx context.Context, schemaID int16, m *manife
 				entryCache[obj.Key] = entry
 			}
 			appended = append(appended, entry)
-			resolved = append(resolved, obj.Key)
+			outcome.repaired = append(outcome.repaired, obj.Key)
 		}
 
 		if len(appended) == 0 {
-			return resolved, nil
+			return outcome, nil
 		}
 
 		m.Files = append(m.Files, appended...)
@@ -80,18 +113,50 @@ func (r *Reconciler) repairSchema(ctx context.Context, schemaID int16, m *manife
 				r.Logger.Info("appended orphaned delta to manifest",
 					zap.Int16("schema_id", schemaID), zap.String("key", e.Path), zap.Int64("row_count", e.RowCount))
 			}
-			return resolved, nil
+			return outcome, nil
 		} else if !compaction.IsConcurrentModification(err) {
-			return nil, fmt.Errorf("save schema %d manifest: %w", schemaID, err)
+			return repairOutcome{}, fmt.Errorf("save schema %d manifest: %w", schemaID, err)
 		} else if attempt >= r.Opts.MaxETagRetries {
-			return nil, fmt.Errorf("save schema %d manifest: still conflicting after %d optimistic-concurrency retries: %w",
+			return repairOutcome{}, fmt.Errorf("save schema %d manifest: still conflicting after %d optimistic-concurrency retries: %w",
 				schemaID, r.Opts.MaxETagRetries, err)
 		}
 
 		var err error
 		m, etag, err = r.Manifests.Load(ctx, schemaID)
 		if err != nil {
-			return nil, fmt.Errorf("reload schema %d manifest after save conflict: %w", schemaID, err)
+			return repairOutcome{}, fmt.Errorf("reload schema %d manifest after save conflict: %w", schemaID, err)
 		}
+	}
+}
+
+type deltaVerdict int
+
+const (
+	deltaAppend deltaVerdict = iota
+	deltaLeftover
+	deltaMixed
+)
+
+// classifyDeltaOrphan decides an orphan's fate from its row coverage and
+// Postgres liveness (see repairSchema's contract).
+func (r *Reconciler) classifyDeltaOrphan(ctx context.Context, schemaID int16, obj ObjectInfo, listedKeys []string) (deltaVerdict, error) {
+	uncovered, err := r.Stats.UncoveredRowIDs(ctx, obj.Key, listedKeys)
+	if err != nil {
+		return 0, fmt.Errorf("probe uncovered rows of %s: %w", obj.Key, err)
+	}
+	if len(uncovered) == 0 {
+		return deltaLeftover, nil
+	}
+	missing, err := r.LiveRows.MissingLiveRows(ctx, schemaID, uncovered)
+	if err != nil {
+		return 0, fmt.Errorf("check live rows of %s: %w", obj.Key, err)
+	}
+	switch {
+	case len(missing) == 0:
+		return deltaAppend, nil
+	case len(missing) == len(uncovered):
+		return deltaLeftover, nil
+	default:
+		return deltaMixed, nil
 	}
 }

--- a/internal/reconcile/repair_guard_test.go
+++ b/internal/reconcile/repair_guard_test.go
@@ -1,0 +1,131 @@
+package reconcile
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma/internal/compaction"
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// The repair guard (#203 review): a delta-shaped orphan is only appended
+// when it still carries rows the manifest-listed inventory does not cover
+// AND every such row is live in Postgres. Anything else is a compaction
+// leftover (or ambiguous) — re-appending it could resurrect rows whose
+// tombstones the full merge already dropped.
+
+func guardReconciler(t *testing.T, lister *fakeLister, manifests *fakeManifests, stats *fakeStats, live *fakeLiveRows, deleter *fakeDeleter, opts Options) *Reconciler {
+	t.Helper()
+	r := newTestReconciler(lister, manifests, deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Stats = stats
+	r.LiveRows = live
+	r.Opts = opts
+	return r
+}
+
+func oldObject(key string) ObjectInfo {
+	return ObjectInfo{Key: key, Size: 10, LastModified: testClock().Add(-time.Hour)}
+}
+
+func TestRepair_FullyCoveredLeftoverNotAppended(t *testing.T) {
+	leftover := "data/7/" + uuidA + ".parquet"
+	mergedBase := "data/7/base-" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {oldObject(leftover), oldObject(mergedBase)},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: mergedBase},
+	}})
+	stats := &fakeStats{uncovered: map[string][]string{leftover: {}}} // every row covered by the merged base
+	r := guardReconciler(t, lister, manifests, stats, &fakeLiveRows{}, &fakeDeleter{}, Options{Repair: true, MaxETagRetries: 3})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, report.Schemas[0].Repaired, "covered leftover must not be re-appended")
+	require.Empty(t, manifests.saves)
+	require.Equal(t, []string{leftover}, report.Schemas[0].DeltaLeftovers)
+	require.True(t, report.HasResidualDiscrepancies(), "leftover not yet deleted stays residual")
+}
+
+func TestRepair_TombstoneDroppedLeftoverNotAppended(t *testing.T) {
+	leftover := "data/7/" + uuidA + ".parquet"
+	mergedBase := "data/7/base-" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {oldObject(leftover), oldObject(mergedBase)},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: mergedBase},
+	}})
+	// The orphan's uncovered row was deleted in Postgres: its tombstone won
+	// the merge and was dropped — re-appending would resurrect it.
+	stats := &fakeStats{uncovered: map[string][]string{leftover: {uuidA}}}
+	live := &fakeLiveRows{missing: map[string]bool{uuidA: true}}
+	r := guardReconciler(t, lister, manifests, stats, live, &fakeDeleter{}, Options{Repair: true, MaxETagRetries: 3})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, report.Schemas[0].Repaired)
+	require.Empty(t, manifests.saves)
+	require.Equal(t, []string{leftover}, report.Schemas[0].DeltaLeftovers)
+}
+
+func TestRepair_MixedLiveDeadRefusedEntirely(t *testing.T) {
+	orphan := "data/7/" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{"data/7/": {oldObject(orphan)}}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	stats := &fakeStats{uncovered: map[string][]string{orphan: {uuidA, uuidB}}}
+	live := &fakeLiveRows{missing: map[string]bool{uuidB: true}} // uuidA live, uuidB deleted
+	deleter := &fakeDeleter{}
+	r := guardReconciler(t, lister, manifests, stats, live, deleter,
+		Options{Repair: true, GC: true, GCGrace: 15 * time.Minute, MaxETagRetries: 3})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	s := report.Schemas[0]
+	require.Empty(t, s.Repaired, "mixed live/dead file needs manual surgery, not auto-append")
+	require.Empty(t, s.DeltaLeftovers, "mixed file is not a provable leftover")
+	require.Empty(t, deleter.deleted, "mixed file must never be deleted")
+	require.Empty(t, manifests.saves)
+	require.True(t, report.HasResidualDiscrepancies())
+}
+
+func TestRepair_GCDeletesClassifiedLeftoverPastGrace(t *testing.T) {
+	leftover := "data/7/" + uuidA + ".parquet"
+	mergedBase := "data/7/base-" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {oldObject(leftover), oldObject(mergedBase)},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: mergedBase},
+	}})
+	stats := &fakeStats{uncovered: map[string][]string{leftover: {}}}
+	deleter := &fakeDeleter{}
+	r := guardReconciler(t, lister, manifests, stats, &fakeLiveRows{}, deleter,
+		Options{Repair: true, GC: true, GCGrace: 15 * time.Minute, MaxETagRetries: 3})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{leftover}, deleter.deleted)
+	require.Equal(t, []string{leftover}, report.Schemas[0].Deleted)
+	require.False(t, report.HasResidualDiscrepancies(), "deleted leftover is resolved")
+}
+
+func TestRepair_UncoveredProbeErrorSkipsFile(t *testing.T) {
+	orphan := "data/7/" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{"data/7/": {oldObject(orphan)}}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	stats := &fakeStats{
+		uncoveredErr: map[string]error{orphan: context.DeadlineExceeded},
+		stats:        map[string]compaction.MergeStats{orphan: {RowsOut: 1}},
+	}
+	r := guardReconciler(t, lister, manifests, stats, &fakeLiveRows{}, &fakeDeleter{}, Options{Repair: true, MaxETagRetries: 3})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, report.Schemas[0].Repaired)
+	require.Empty(t, manifests.saves)
+	require.True(t, report.HasResidualDiscrepancies())
+}

--- a/internal/reconcile/repair_guard_test.go
+++ b/internal/reconcile/repair_guard_test.go
@@ -39,7 +39,7 @@ func TestRepair_FullyCoveredLeftoverNotAppended(t *testing.T) {
 	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
 		{Tier: "base", Path: mergedBase},
 	}})
-	stats := &fakeStats{uncovered: map[string][]string{leftover: {}}} // every row covered by the merged base
+	stats := &fakeStats{uncovered: map[string][]compaction.UncoveredRow{leftover: {}}} // every version superseded by the merged base
 	r := guardReconciler(t, lister, manifests, stats, &fakeLiveRows{}, &fakeDeleter{}, Options{Repair: true, MaxETagRetries: 3})
 
 	report, err := r.Run(context.Background())
@@ -59,9 +59,10 @@ func TestRepair_TombstoneDroppedLeftoverNotAppended(t *testing.T) {
 	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
 		{Tier: "base", Path: mergedBase},
 	}})
-	// The orphan's uncovered row was deleted in Postgres: its tombstone won
-	// the merge and was dropped — re-appending would resurrect it.
-	stats := &fakeStats{uncovered: map[string][]string{leftover: {uuidA}}}
+	// The orphan's uncovered LIVE version belongs to a Postgres-deleted
+	// row: its tombstone won the merge and was dropped — re-appending
+	// would resurrect it.
+	stats := &fakeStats{uncovered: map[string][]compaction.UncoveredRow{leftover: {{RowID: uuidA}}}}
 	live := &fakeLiveRows{missing: map[string]bool{uuidA: true}}
 	r := guardReconciler(t, lister, manifests, stats, live, &fakeDeleter{}, Options{Repair: true, MaxETagRetries: 3})
 
@@ -76,8 +77,8 @@ func TestRepair_MixedLiveDeadRefusedEntirely(t *testing.T) {
 	orphan := "data/7/" + uuidA + ".parquet"
 	lister := &fakeLister{objects: map[string][]ObjectInfo{"data/7/": {oldObject(orphan)}}}
 	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
-	stats := &fakeStats{uncovered: map[string][]string{orphan: {uuidA, uuidB}}}
-	live := &fakeLiveRows{missing: map[string]bool{uuidB: true}} // uuidA live, uuidB deleted
+	stats := &fakeStats{uncovered: map[string][]compaction.UncoveredRow{orphan: {{RowID: uuidA}, {RowID: uuidB}}}}
+	live := &fakeLiveRows{missing: map[string]bool{uuidB: true}} // uuidA live (append-worthy), uuidB deleted (resurrect risk)
 	deleter := &fakeDeleter{}
 	r := guardReconciler(t, lister, manifests, stats, live, deleter,
 		Options{Repair: true, GC: true, GCGrace: 15 * time.Minute, MaxETagRetries: 3})
@@ -101,16 +102,98 @@ func TestRepair_GCDeletesClassifiedLeftoverPastGrace(t *testing.T) {
 	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
 		{Tier: "base", Path: mergedBase},
 	}})
-	stats := &fakeStats{uncovered: map[string][]string{leftover: {}}}
+	stats := &fakeStats{uncovered: map[string][]compaction.UncoveredRow{leftover: {}}}
 	deleter := &fakeDeleter{}
 	r := guardReconciler(t, lister, manifests, stats, &fakeLiveRows{}, deleter,
 		Options{Repair: true, GC: true, GCGrace: 15 * time.Minute, MaxETagRetries: 3})
+	seedGCSighting(t, r, 7, testClock().Add(-16*time.Minute), leftover)
 
 	report, err := r.Run(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, []string{leftover}, deleter.deleted)
 	require.Equal(t, []string{leftover}, report.Schemas[0].Deleted)
 	require.False(t, report.HasResidualDiscrepancies(), "deleted leftover is resolved")
+}
+
+func TestRepair_LostUpdateAppendedNotLeftover(t *testing.T) {
+	// P0 regression (PR #289 review finding 1): an orphan carrying a NEWER
+	// version of a row the listed files also contain is the #197 lost
+	// update — a row_id-only coverage check would call it a leftover and
+	// --repair --gc would delete the only copy of the newest version.
+	orphan := "data/7/" + uuidA + ".parquet"
+	mergedBase := "data/7/base-" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {oldObject(orphan), oldObject(mergedBase)},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: mergedBase},
+	}})
+	// Version-aware probe reports the updated row as uncovered even though
+	// the base contains an older version of the same row_id.
+	stats := &fakeStats{
+		uncovered: map[string][]compaction.UncoveredRow{orphan: {{RowID: uuidA}}},
+		stats:     map[string]compaction.MergeStats{orphan: {RowsOut: 1, RowIDMin: uuidA, RowIDMax: uuidA}},
+	}
+	deleter := &fakeDeleter{}
+	r := guardReconciler(t, lister, manifests, stats, &fakeLiveRows{}, deleter,
+		Options{Repair: true, GC: true, GCGrace: 15 * time.Minute, MaxETagRetries: 3})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{orphan}, report.Schemas[0].Repaired)
+	require.Empty(t, report.Schemas[0].DeltaLeftovers)
+	require.Empty(t, deleter.deleted, "a lost-update orphan must never be GCed")
+}
+
+func TestRepair_LostTombstoneAppendedToRestoreDelete(t *testing.T) {
+	// An orphan whose uncovered newest version is a TOMBSTONE of a
+	// Postgres-deleted row is a lost delete: while unlisted, older listed
+	// versions of the row resurrect in reads. Appending restores the
+	// delete — classifying it as a leftover and GCing it would bake the
+	// resurrection in permanently.
+	orphan := "data/7/" + uuidA + ".parquet"
+	mergedBase := "data/7/base-" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {oldObject(orphan), oldObject(mergedBase)},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "base", Path: mergedBase},
+	}})
+	stats := &fakeStats{
+		uncovered: map[string][]compaction.UncoveredRow{orphan: {{RowID: uuidA, Tombstone: true}}},
+		stats:     map[string]compaction.MergeStats{orphan: {RowsOut: 1, RowIDMin: uuidA, RowIDMax: uuidA}},
+	}
+	live := &fakeLiveRows{missing: map[string]bool{uuidA: true}} // deleted in Postgres, consistent with the tombstone
+	deleter := &fakeDeleter{}
+	r := guardReconciler(t, lister, manifests, stats, live, deleter,
+		Options{Repair: true, GC: true, GCGrace: 15 * time.Minute, MaxETagRetries: 3})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{orphan}, report.Schemas[0].Repaired)
+	require.Empty(t, deleter.deleted)
+}
+
+func TestRepair_TombstoneOfLivePGRowRefused(t *testing.T) {
+	// A tombstone for a row Postgres still considers live contradicts the
+	// entity state — never auto-handled in either direction.
+	orphan := "data/7/" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{"data/7/": {oldObject(orphan)}}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	stats := &fakeStats{
+		uncovered: map[string][]compaction.UncoveredRow{orphan: {{RowID: uuidA, Tombstone: true}}},
+	}
+	deleter := &fakeDeleter{}
+	r := guardReconciler(t, lister, manifests, stats, &fakeLiveRows{}, deleter,
+		Options{Repair: true, GC: true, GCGrace: 15 * time.Minute, MaxETagRetries: 3})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	s := report.Schemas[0]
+	require.Empty(t, s.Repaired)
+	require.Empty(t, s.DeltaLeftovers)
+	require.Empty(t, deleter.deleted)
+	require.True(t, report.HasResidualDiscrepancies())
 }
 
 func TestRepair_UncoveredProbeErrorSkipsFile(t *testing.T) {

--- a/internal/reconcile/repair_test.go
+++ b/internal/reconcile/repair_test.go
@@ -27,6 +27,14 @@ func (l *localStatsReader) FileStats(ctx context.Context, key string) (compactio
 	return compaction.SingleFileStats(ctx, l.db, filepath.Join(l.dir, filepath.Base(key)))
 }
 
+func (l *localStatsReader) UncoveredRowIDs(ctx context.Context, key string, listedKeys []string) ([]string, error) {
+	listed := make([]string, 0, len(listedKeys))
+	for _, k := range listedKeys {
+		listed = append(listed, filepath.Join(l.dir, filepath.Base(k)))
+	}
+	return compaction.UncoveredRowIDs(ctx, l.db, filepath.Join(l.dir, filepath.Base(key)), listed)
+}
+
 func writeDeltaFixture(t *testing.T, db *sql.DB, path string) {
 	t.Helper()
 	q := fmt.Sprintf(`COPY (
@@ -43,6 +51,7 @@ func repairReconciler(t *testing.T, lister *fakeLister, manifests *fakeManifests
 	t.Helper()
 	r := newTestReconciler(lister, manifests, &fakeDeleter{}, &fakeLocker{}, enum)
 	r.Stats = stats
+	r.LiveRows = &fakeLiveRows{} // every row live: the safe-append default
 	r.Opts = Options{Repair: true, MaxETagRetries: 3}
 	return r
 }

--- a/internal/reconcile/repair_test.go
+++ b/internal/reconcile/repair_test.go
@@ -1,0 +1,232 @@
+package reconcile
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma/internal/compaction"
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+var errTestConflict = &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "test conflict"}
+
+// localStatsReader resolves bucket-relative keys to local fixture files and
+// recomputes stats with the real DuckDB query the production reader uses.
+type localStatsReader struct {
+	db  *sql.DB
+	dir string
+}
+
+func (l *localStatsReader) FileStats(ctx context.Context, key string) (compaction.MergeStats, error) {
+	return compaction.SingleFileStats(ctx, l.db, filepath.Join(l.dir, filepath.Base(key)))
+}
+
+func writeDeltaFixture(t *testing.T, db *sql.DB, path string) {
+	t.Helper()
+	q := fmt.Sprintf(`COPY (
+		SELECT CAST('%s' AS UUID) AS row_id, CAST(100 AS BIGINT) AS changed_at, CAST(NULL AS BIGINT) AS deleted_at, 'a' AS title
+		UNION ALL
+		SELECT CAST('%s' AS UUID) AS row_id, CAST(300 AS BIGINT) AS changed_at, CAST(NULL AS BIGINT) AS deleted_at, 'b' AS title
+	) TO '%s' (FORMAT PARQUET)`, uuidA, uuidB, path)
+	if _, err := db.Exec(q); err != nil {
+		t.Fatalf("write delta fixture: %v", err)
+	}
+}
+
+func repairReconciler(t *testing.T, lister *fakeLister, manifests *fakeManifests, enum *fakeEnum, stats StatsReader) *Reconciler {
+	t.Helper()
+	r := newTestReconciler(lister, manifests, &fakeDeleter{}, &fakeLocker{}, enum)
+	r.Stats = stats
+	r.Opts = Options{Repair: true, MaxETagRetries: 3}
+	return r
+}
+
+func TestRepair_AppendsDeltaOrphanWithRecomputedStats(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	dir := t.TempDir()
+	orphanKey := "data/7/" + uuidA + ".parquet"
+	writeDeltaFixture(t, db, filepath.Join(dir, uuidA+".parquet"))
+
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: orphanKey, Size: 4242, LastModified: testClock()}},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	r := repairReconciler(t, lister, manifests, &fakeEnum{ids: []int16{7}}, &localStatsReader{db: db, dir: dir})
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, manifests.saves, 1)
+	saved := manifests.saves[0].m
+	require.Len(t, saved.Files, 1)
+	entry := saved.Files[0]
+	require.Equal(t, "delta", entry.Tier)
+	require.Equal(t, orphanKey, entry.Path)
+	require.Equal(t, uuidA, entry.RowIDMin)
+	require.Equal(t, uuidB, entry.RowIDMax)
+	require.Equal(t, int64(100), entry.CreatedMin)
+	require.Equal(t, int64(300), entry.CreatedMax)
+	require.Equal(t, int64(2), entry.RowCount)
+	require.Equal(t, int64(4242), entry.SizeBytes)
+
+	require.Equal(t, []string{orphanKey}, report.Schemas[0].Repaired)
+	require.False(t, report.HasResidualDiscrepancies())
+}
+
+func TestRepair_Idempotent_SecondRunAppendsNothing(t *testing.T) {
+	orphanKey := "data/7/" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: orphanKey, Size: 10, LastModified: testClock()}},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	stats := &fakeStats{stats: map[string]compaction.MergeStats{
+		orphanKey: {RowsOut: 1, RowIDMin: uuidA, RowIDMax: uuidA, CreatedMin: 1, CreatedMax: 1},
+	}}
+	r := repairReconciler(t, lister, manifests, &fakeEnum{ids: []int16{7}}, stats)
+
+	_, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, manifests.saves, 1)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, manifests.saves, 1, "second run must not save again")
+	require.Empty(t, report.Schemas[0].DeltaOrphans, "repaired file is no longer an orphan")
+	require.Len(t, manifests.manifests[7].Files, 1, "no duplicate path entries")
+}
+
+func TestRepair_SkipsBaseAndTmpOrphans(t *testing.T) {
+	deltaKey := "data/7/" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: deltaKey, Size: 10, LastModified: testClock()},
+			{Key: "data/7/base-" + uuidB + ".parquet", Size: 20, LastModified: testClock()},
+			{Key: "data/7/_tmp/" + uuidB + ".parquet", Size: 30, LastModified: testClock()},
+		},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	stats := &fakeStats{stats: map[string]compaction.MergeStats{
+		deltaKey: {RowsOut: 1, RowIDMin: uuidA, RowIDMax: uuidA, CreatedMin: 1, CreatedMax: 1},
+	}}
+	r := repairReconciler(t, lister, manifests, &fakeEnum{ids: []int16{7}}, stats)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{deltaKey}, report.Schemas[0].Repaired)
+	require.Len(t, manifests.manifests[7].Files, 1)
+	require.Equal(t, deltaKey, manifests.manifests[7].Files[0].Path)
+	require.Equal(t, []string{deltaKey}, stats.calls, "stats must only be read for delta orphans")
+}
+
+func TestRepair_StatsErrorSkipsFileLeavesResidual(t *testing.T) {
+	goodKey := "data/7/" + uuidA + ".parquet"
+	badKey := "data/7/" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: goodKey, Size: 10, LastModified: testClock()},
+			{Key: badKey, Size: 20, LastModified: testClock()},
+		},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	stats := &fakeStats{
+		stats:  map[string]compaction.MergeStats{goodKey: {RowsOut: 1, RowIDMin: uuidA, RowIDMax: uuidA}},
+		errFor: map[string]error{badKey: fmt.Errorf("corrupt footer")},
+	}
+	r := repairReconciler(t, lister, manifests, &fakeEnum{ids: []int16{7}}, stats)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{goodKey}, report.Schemas[0].Repaired)
+	require.Len(t, manifests.manifests[7].Files, 1)
+	require.True(t, report.HasResidualDiscrepancies(), "unreadable orphan stays residual")
+}
+
+func TestRepair_ETagConflictReloadsAndRetries(t *testing.T) {
+	keyA := "data/7/" + uuidA + ".parquet"
+	keyB := "data/7/" + uuidB + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: keyA, Size: 10, LastModified: testClock()},
+			{Key: keyB, Size: 20, LastModified: testClock()},
+		},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	// First save hits a 412; the concurrent writer that won the race added
+	// keyB. The retry must reload, drop keyB from its append set, and save
+	// only keyA — never a duplicate keyB entry.
+	manifests.saveErrs = []error{errTestConflict}
+	manifests.onSaveConflict = func(f *fakeManifests) {
+		f.manifests[7] = &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+			{Tier: "delta", Path: keyB},
+		}}
+		f.etags[7] = "etag-7-concurrent"
+	}
+	stats := &fakeStats{stats: map[string]compaction.MergeStats{
+		keyA: {RowsOut: 1, RowIDMin: uuidA, RowIDMax: uuidA},
+		keyB: {RowsOut: 1, RowIDMin: uuidB, RowIDMax: uuidB},
+	}}
+	r := repairReconciler(t, lister, manifests, &fakeEnum{ids: []int16{7}}, stats)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, report.Schemas[0].Err)
+
+	final := manifests.manifests[7]
+	require.Len(t, final.Files, 2)
+	paths := []string{final.Files[0].Path, final.Files[1].Path}
+	require.ElementsMatch(t, []string{keyA, keyB}, paths)
+	require.ElementsMatch(t, []string{keyA, keyB}, report.Schemas[0].Repaired)
+	require.False(t, report.HasResidualDiscrepancies())
+	// The successful retry save carries the reloaded etag.
+	require.Equal(t, "etag-7-concurrent", manifests.saves[len(manifests.saves)-1].etag)
+}
+
+func TestRepair_ETagConflictExhaustsRetries(t *testing.T) {
+	keyA := "data/1/" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/1/": {{Key: keyA, Size: 10, LastModified: testClock()}},
+		"data/2/": nil,
+	}}
+	manifests := newFakeManifests(
+		&manifest.Manifest{SchemaID: 1, Files: []manifest.FileEntry{}},
+		&manifest.Manifest{SchemaID: 2, Files: []manifest.FileEntry{}},
+	)
+	manifests.saveErrs = []error{errTestConflict, errTestConflict, errTestConflict, errTestConflict}
+	stats := &fakeStats{stats: map[string]compaction.MergeStats{
+		keyA: {RowsOut: 1, RowIDMin: uuidA, RowIDMax: uuidA},
+	}}
+	r := repairReconciler(t, lister, manifests, &fakeEnum{ids: []int16{1, 2}}, stats)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Error(t, report.Schemas[0].Err, "retry exhaustion must surface per schema")
+	require.NoError(t, report.Schemas[1].Err, "other schemas still reconcile")
+	require.True(t, report.HasResidualDiscrepancies())
+}
+
+func TestRepair_NonConflictSaveErrorFailsSchema(t *testing.T) {
+	keyA := "data/7/" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: keyA, Size: 10, LastModified: testClock()}},
+	}}
+	manifests := newFakeManifests(&manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{}})
+	manifests.saveErrs = []error{fmt.Errorf("s3 timeout")}
+	stats := &fakeStats{stats: map[string]compaction.MergeStats{
+		keyA: {RowsOut: 1, RowIDMin: uuidA, RowIDMax: uuidA},
+	}}
+	r := repairReconciler(t, lister, manifests, &fakeEnum{ids: []int16{7}}, stats)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Error(t, report.Schemas[0].Err)
+	require.Len(t, manifests.saves, 0, "ambiguous save error must not retry blindly")
+}

--- a/internal/reconcile/repair_test.go
+++ b/internal/reconcile/repair_test.go
@@ -27,12 +27,12 @@ func (l *localStatsReader) FileStats(ctx context.Context, key string) (compactio
 	return compaction.SingleFileStats(ctx, l.db, filepath.Join(l.dir, filepath.Base(key)))
 }
 
-func (l *localStatsReader) UncoveredRowIDs(ctx context.Context, key string, listedKeys []string) ([]string, error) {
+func (l *localStatsReader) UncoveredRows(ctx context.Context, key string, listedKeys []string) ([]compaction.UncoveredRow, error) {
 	listed := make([]string, 0, len(listedKeys))
 	for _, k := range listedKeys {
 		listed = append(listed, filepath.Join(l.dir, filepath.Base(k)))
 	}
-	return compaction.UncoveredRowIDs(ctx, l.db, filepath.Join(l.dir, filepath.Base(key)), listed)
+	return compaction.UncoveredRows(ctx, l.db, filepath.Join(l.dir, filepath.Base(key)), listed)
 }
 
 func writeDeltaFixture(t *testing.T, db *sql.DB, path string) {

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -18,8 +18,12 @@ type SchemaReport struct {
 	Dangling     []string // manifest entries with no live object; removal stays manual
 	Unverifiable []string // manifest paths this listing cannot prove absent
 	Repaired     []string // delta orphans appended to the manifest (--repair)
-	Deleted      []string // base/tmp orphans removed (--gc)
-	Err          error    // per-schema failure; other schemas still reconcile
+	// DeltaLeftovers are delta orphans the repair guard classified as
+	// compaction leftovers (no uncovered rows, or every uncovered row
+	// deleted in Postgres): never appended, GC-eligible under --gc.
+	DeltaLeftovers []string
+	Deleted        []string // leftover/merged-base/tmp orphans removed (--gc)
+	Err            error    // per-schema failure; other schemas still reconcile
 }
 
 // Report is a full reconcile run across schemas.
@@ -79,6 +83,7 @@ func (r Report) Render(w io.Writer) {
 		}
 		fmt.Fprintf(w, "schema %d:\n", s.SchemaID)
 		renderKeys(w, "delta orphan", s.DeltaOrphans)
+		renderKeys(w, "delta leftover (gc-eligible)", s.DeltaLeftovers)
 		renderKeys(w, "base orphan", s.BaseOrphans)
 		renderKeys(w, "tmp orphan", s.TmpOrphans)
 		renderKeys(w, "unknown shape", s.Unknown)
@@ -93,8 +98,8 @@ func (r Report) Render(w io.Writer) {
 }
 
 func (s SchemaReport) clean() bool {
-	return len(s.DeltaOrphans)+len(s.BaseOrphans)+len(s.TmpOrphans)+
-		len(s.Unknown)+len(s.Dangling)+len(s.Unverifiable)+
+	return len(s.DeltaOrphans)+len(s.DeltaLeftovers)+len(s.BaseOrphans)+
+		len(s.TmpOrphans)+len(s.Unknown)+len(s.Dangling)+len(s.Unverifiable)+
 		len(s.Repaired)+len(s.Deleted) == 0 && s.Err == nil
 }
 

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -1,0 +1,105 @@
+package reconcile
+
+import (
+	"fmt"
+	"io"
+)
+
+// SchemaReport is one schema's reconcile outcome. Key slices hold
+// bucket-relative keys except Unverifiable, which preserves the manifest
+// path verbatim (the raw path is what the operator must inspect).
+type SchemaReport struct {
+	SchemaID     int16
+	Skipped      bool // advisory lock not acquired; nothing inspected
+	DeltaOrphans []string
+	BaseOrphans  []string
+	TmpOrphans   []string
+	Unknown      []string // unrecognized shapes; reported, never repaired or deleted
+	Dangling     []string // manifest entries with no live object; removal stays manual
+	Unverifiable []string // manifest paths this listing cannot prove absent
+	Repaired     []string // delta orphans appended to the manifest (--repair)
+	Deleted      []string // base/tmp orphans removed (--gc)
+	Err          error    // per-schema failure; other schemas still reconcile
+}
+
+// Report is a full reconcile run across schemas.
+type Report struct {
+	Schemas []SchemaReport
+}
+
+// HasResidualDiscrepancies reports whether anything actionable is left after
+// repair and GC: orphans not repaired or deleted, dangling entries, skipped
+// schemas, unknown shapes, or per-schema failures. Unverifiable paths are
+// informational — they cannot be proven inconsistent from this run.
+func (r Report) HasResidualDiscrepancies() bool {
+	for _, s := range r.Schemas {
+		if s.Residual() {
+			return true
+		}
+	}
+	return false
+}
+
+// Residual reports whether this schema still has actionable discrepancies
+// after repair and GC.
+func (s SchemaReport) Residual() bool {
+	if s.Skipped || s.Err != nil {
+		return true
+	}
+	if len(s.Dangling) > 0 || len(s.Unknown) > 0 {
+		return true
+	}
+	resolved := make(map[string]struct{}, len(s.Repaired)+len(s.Deleted))
+	for _, k := range s.Repaired {
+		resolved[k] = struct{}{}
+	}
+	for _, k := range s.Deleted {
+		resolved[k] = struct{}{}
+	}
+	for _, orphans := range [][]string{s.DeltaOrphans, s.BaseOrphans, s.TmpOrphans} {
+		for _, k := range orphans {
+			if _, ok := resolved[k]; !ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Render writes the human-readable report: exact keys per class per schema.
+func (r Report) Render(w io.Writer) {
+	for _, s := range r.Schemas {
+		if s.Skipped {
+			fmt.Fprintf(w, "schema %d: skipped (advisory lock not acquired)\n", s.SchemaID)
+			continue
+		}
+		if s.clean() {
+			fmt.Fprintf(w, "schema %d: clean\n", s.SchemaID)
+			continue
+		}
+		fmt.Fprintf(w, "schema %d:\n", s.SchemaID)
+		renderKeys(w, "delta orphan", s.DeltaOrphans)
+		renderKeys(w, "base orphan", s.BaseOrphans)
+		renderKeys(w, "tmp orphan", s.TmpOrphans)
+		renderKeys(w, "unknown shape", s.Unknown)
+		renderKeys(w, "dangling entry", s.Dangling)
+		renderKeys(w, "unverifiable entry", s.Unverifiable)
+		renderKeys(w, "repaired", s.Repaired)
+		renderKeys(w, "deleted", s.Deleted)
+		if s.Err != nil {
+			fmt.Fprintf(w, "  error: %v\n", s.Err)
+		}
+	}
+}
+
+func (s SchemaReport) clean() bool {
+	return len(s.DeltaOrphans)+len(s.BaseOrphans)+len(s.TmpOrphans)+
+		len(s.Unknown)+len(s.Dangling)+len(s.Unverifiable)+
+		len(s.Repaired)+len(s.Deleted) == 0 && s.Err == nil
+}
+
+func renderKeys(w io.Writer, label string, keys []string) {
+	for _, k := range keys {
+		fmt.Fprintf(w, "  %s: %s\n", label, k)
+	}
+}

--- a/internal/reconcile/report_test.go
+++ b/internal/reconcile/report_test.go
@@ -1,0 +1,80 @@
+package reconcile
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReport_HasResidualDiscrepancies(t *testing.T) {
+	tests := []struct {
+		name   string
+		report Report
+		want   bool
+	}{
+		{"clean", Report{Schemas: []SchemaReport{{SchemaID: 1}}}, false},
+		{"dangling only", Report{Schemas: []SchemaReport{
+			{SchemaID: 1, Dangling: []string{"data/1/x.parquet"}},
+		}}, true},
+		{"skipped locked schema", Report{Schemas: []SchemaReport{
+			{SchemaID: 1, Skipped: true},
+		}}, true},
+		{"unknown shape", Report{Schemas: []SchemaReport{
+			{SchemaID: 1, Unknown: []string{"data/1/weird.parquet"}},
+		}}, true},
+		{"delta orphan left unrepaired", Report{Schemas: []SchemaReport{
+			{SchemaID: 1, DeltaOrphans: []string{"data/1/a.parquet"}},
+		}}, true},
+		{"repaired delta orphan is resolved", Report{Schemas: []SchemaReport{
+			{SchemaID: 1, DeltaOrphans: []string{"data/1/a.parquet"}, Repaired: []string{"data/1/a.parquet"}},
+		}}, false},
+		{"gc deleted base orphan is resolved", Report{Schemas: []SchemaReport{
+			{SchemaID: 1, BaseOrphans: []string{"data/1/base-x.parquet"}, Deleted: []string{"data/1/base-x.parquet"}},
+		}}, false},
+		{"tmp orphan within grace stays residual", Report{Schemas: []SchemaReport{
+			{SchemaID: 1, TmpOrphans: []string{"data/1/_tmp/x.parquet"}},
+		}}, true},
+		{"unverifiable is informational only", Report{Schemas: []SchemaReport{
+			{SchemaID: 1, Unverifiable: []string{"s3://other/x.parquet"}},
+		}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.report.HasResidualDiscrepancies(); got != tt.want {
+				t.Fatalf("HasResidualDiscrepancies() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReport_RenderNamesExactKeys(t *testing.T) {
+	r := Report{Schemas: []SchemaReport{{
+		SchemaID:     7,
+		DeltaOrphans: []string{"data/7/a.parquet"},
+		BaseOrphans:  []string{"data/7/base-b.parquet"},
+		TmpOrphans:   []string{"data/7/_tmp/c.parquet"},
+		Dangling:     []string{"data/7/gone.parquet"},
+		Repaired:     []string{"data/7/a.parquet"},
+		Deleted:      []string{"data/7/base-b.parquet"},
+	}, {
+		SchemaID: 9,
+		Skipped:  true,
+	}}}
+
+	var sb strings.Builder
+	r.Render(&sb)
+	out := sb.String()
+
+	for _, want := range []string{
+		"schema 7",
+		"data/7/a.parquet",
+		"data/7/base-b.parquet",
+		"data/7/_tmp/c.parquet",
+		"data/7/gone.parquet",
+		"schema 9",
+		"skipped",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("Render output missing %q:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Closes #203

## What

New `cmd/tools manifest-reconcile` subcommand backed by a new `internal/reconcile` package. Per schema — under the flusher's advisory lock (`pg_try_advisory_lock(schemaID, schemaID)`, pinned to a single connection) — it lists `{data-prefix}/{schemaID}/`, diffs both directions against the manifest, and classifies unlisted objects by filename shape:

| Class | Shape | Origin | Action |
|---|---|---|---|
| delta orphan | `{uuid}.parquet` | #197 flush failure or #188 failed source delete | `--repair`, gated by the resurrection guard below |
| merged base orphan | `base-{uuid}.parquet` | #188 rewrite leftovers | `--gc` past `--gc-grace` |
| init base orphan | `{min}_{max}.parquet` | cdc-init exports | report only — never auto-deleted |
| `_tmp` orphan | `_tmp/*` | staging leftovers | `--gc` past `--gc-grace` |

Dangling manifest entries (object gone) are reported after a two-step confirmation (fresh manifest reload + per-key existence probe); removal stays manual. Foreign-bucket / glob / out-of-prefix paths surface as unverifiable, never dangling. Exit codes: `0` clean, `2` residual discrepancies (incl. lock-skipped schemas), `1` tool failure — per-schema list/load/lock errors exit 1, not 2.

## The repair resurrection guard

A delta-shaped orphan is ambiguous: it is either the #197 failure mode (rows marked flushed, data existing **only** in that file — must be appended) or a #188 merged source whose post-commit delete failed (data already merged into base, tombstone winners physically dropped — re-appending would **resurrect deleted rows**). `--repair` distinguishes them by content:

1. `compaction.UncoveredRowIDs` (DuckDB anti-join) — which of the orphan's row_ids appear in no manifest-listed file;
2. `reconcile.PGLiveRows` — whether those rows are live in `entity_main` (deletes are physical).

All uncovered rows live → genuine #197 orphan, appended with metadata recomputed from parquet contents (`compaction.SingleFileStats`, the merge-stats SQL) — never trusted from filenames, idempotent, one etag-conditional save per schema with reload-dedup-retry on confirmed 412s only. No uncovered rows, or all uncovered rows deleted → provable compaction leftover, deletable under `--repair --gc`. Mixed → refused entirely (manual surgery), stays non-zero exit.

## Concurrency safety

- Advisory lock excludes the flusher; compactor/cdc-init do not hold it, so: manifest loads before the listing (a racing compactor commit can't produce false dangling), `manifest.S3Store.Save` with an empty etag now sends `If-None-Match: *` (a first-manifest repair can't clobber a concurrently created manifest), and GC never touches init-shaped base files (an in-flight cdc-init promotes them hours before publishing its manifest).
- `--gc-grace` must be positive (flag validation + runtime guard) and bounds the in-flight-reader race window.
- An unregistered `--schema-id` errors instead of reporting an empty run as consistent.

## Shared-code changes

- `internal/manifest`: `S3Store.Save` conditional create (above).
- `internal/compaction`: exports `SingleFileStats`, `UncoveredRowIDs`, `IsConcurrentModification`; rewrite failure log now names the tool's actual recovery flags.
- `internal/cdc`: flush/init comments point the documented manual-reconciliation recovery path at the tool.

## Review

A high-effort multi-agent review ran before this PR; all 10 confirmed findings are fixed in the second commit (tombstone resurrection, init writer race, empty-etag clobber, list/load dangling race, silent empty `--schema-id` run, exit-code contract, zero-grace guard, DSN quoting, log wording, e2e RowID-ordering flake). Known follow-up worth an issue: the hand-built keyword/value DSN exists in 3 more copies (`internal/cdc/flusher.go`, `internal/cdc/init.go`, e2e harness) without quoting — this PR fixes only its own copy.

## Testing

- ~50 new unit tests across `internal/reconcile` (classification, normalization, pagination, diff, dangling re-verification, repair guard matrix, etag conflict matrix, GC grace/shape exclusions, report/exit semantics), `internal/compaction` (real-DuckDB stats + anti-join over parquet fixtures), `internal/manifest` (conditional create), `cmd/tools` (flags, exit codes, DSN quoting). No Docker needed.
- 2 new e2e scenarios (`internal/e2e_harness/production/manifest_reconcile_e2e_test.go`): #197 repair end-to-end (strip a real flushed delta's manifest entry → report-only proves read-only → repair restores entry with content-recomputed metadata matching the flusher's original → federated query visibility restored → second run idempotent) and #188 GC (junk base/_tmp/delta/init-shaped orphans; within-grace survives, past-grace deletes only merged-base+tmp).
- `make test`, `make lint`, full production e2e suite (`-tags=e2e ./internal/e2e_harness/production/`, 120s) all green — the latter also regression-covers the `If-None-Match` manifest-create change across every flush/init/compaction scenario.

Docs: `docs/manifest-reconcile.md` (ops guide: classes, guard semantics, exit codes, prefix pitfalls), `cmd/tools/README.md`, usage line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)