### PR TITLE
feat(cdc): #290 cdc-init holds per-schema advisory lock; manifest-reconcile --gc handles init-shaped orphans

### DIFF
--- a/cmd/tools/main.go
+++ b/cmd/tools/main.go
@@ -92,5 +92,5 @@ func printUsage(out io.Writer) {
 	fmt.Fprintln(out, "  cdc-flush             Run CDC change_log flush to S3 parquet files")
 	fmt.Fprintln(out, "  cdc-init              Initialize S3 parquet base files from existing data")
 	fmt.Fprintln(out, "  compactor             Run compaction on parquet files for a schema")
-	fmt.Fprintln(out, "  manifest-reconcile    Diff S3 parquet objects against manifests; report, --repair orphaned deltas, --gc compaction leftovers")
+	fmt.Fprintln(out, "  manifest-reconcile    Diff S3 parquet objects against manifests; report, --repair orphaned deltas, --gc stale base/tmp leftovers (compaction + init-shaped)")
 }

--- a/cmd/tools/manifest_reconcile.go
+++ b/cmd/tools/manifest_reconcile.go
@@ -257,25 +257,18 @@ func openReconcileStatsEngine(ctx context.Context, opts *reconcileOptions, logge
 // buildToolSQLDB opens a database/sql handle (pgx driver) for tools that
 // need session-scoped Postgres features — the reconcile advisory lock pins
 // a single connection, which pgxpool does not expose. Values are quoted so
-// passwords with spaces or quotes survive DSN parsing (the sibling copies
-// in internal/cdc/flusher.go and init.go still interpolate raw — follow-up:
-// extract one shared DSN builder).
 func buildToolSQLDB(pg postgresFlags) (*sql.DB, error) {
-	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		quotePGConnValue(pg.host), pg.port, quotePGConnValue(pg.user),
-		quotePGConnValue(pg.resolvedPassword("PGPASSWORD")),
-		quotePGConnValue(pg.database), quotePGConnValue(pg.sslMode))
+	connStr := cdc.BuildPGDSN(cdc.PGDSNParams{
+		Host:     pg.host,
+		Port:     pg.port,
+		User:     pg.user,
+		Password: pg.resolvedPassword("PGPASSWORD"),
+		DB:       pg.database,
+		SSLMode:  pg.sslMode,
+	})
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
 		return nil, fmt.Errorf("open pg: %w", err)
 	}
 	return db, nil
-}
-
-// quotePGConnValue quotes one keyword/value DSN value per libpq rules:
-// wrapped in single quotes with backslash and single-quote escaped.
-func quotePGConnValue(v string) string {
-	v = strings.ReplaceAll(v, `\`, `\\`)
-	v = strings.ReplaceAll(v, `'`, `\'`)
-	return "'" + v + "'"
 }

--- a/cmd/tools/manifest_reconcile_test.go
+++ b/cmd/tools/manifest_reconcile_test.go
@@ -86,21 +86,6 @@ func TestReconcileExitError_ToolFailureBeatsDiscrepancy(t *testing.T) {
 	}
 }
 
-func TestQuotePGConnValue(t *testing.T) {
-	tests := []struct{ in, want string }{
-		{"plain", "'plain'"},
-		{"pa ss", "'pa ss'"},
-		{"it's", `'it\'s'`},
-		{`back\slash`, `'back\\slash'`},
-		{"", "''"},
-	}
-	for _, tt := range tests {
-		if got := quotePGConnValue(tt.in); got != tt.want {
-			t.Fatalf("quotePGConnValue(%q) = %s, want %s", tt.in, got, tt.want)
-		}
-	}
-}
-
 func TestParseReconcileFlags_Defaults(t *testing.T) {
 	opts, err := parseReconcileFlags([]string{
 		"--s3-bucket", "bkt",

--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -25,7 +25,7 @@ manifest 条目，双向报告差异，并可选修复。它是两条既有故�
 |------|------|------|------|
 | delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | #197 或 #188 删除失败的 merged source | `--repair` 经守卫判定后补录或转残留（见下） |
 | merged base 孤儿 | `base-{uuid}.parquet` | #188 | `--gc` 两阶段删除（见下） |
-| init base 孤儿 | `{min}_{max}.parquet` | cdc-init 导出 | 只报告，**永不自动删除**：in-flight cdc-init 先落对象、跑完才发布 manifest，且不持 advisory lock（自动处置需 init 先持锁，见 follow-up） |
+| init base 孤儿 | `{min}_{max}.parquet` | cdc-init 导出 | `--gc` 两阶段删除（见下）。#290 起 cdc-init 与 reconcile 持同一把 per-schema advisory lock，故此锁下的 init 形态孤儿必非 in-flight init——只可能是发布失败的 manifest 或被后续 init 覆盖的旧文件（`--repair` 自动重建留 follow-up） |
 | `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | staging 残留（#188 崩溃 / #226 swallowed-delete） | `--gc` 两阶段删除（见下） |
 
 形态匹配是严格的：`base-` 后缀与 `{min}_{max}` 两段都必须是合法 UUID，否则归
@@ -107,12 +107,12 @@ forma-tools manifest-reconcile ... --repair --gc --gc-grace 15m
 - **`--data-prefix` 必须与 flusher/compactor 的数据前缀一致**（cdc-flush 的
   `--s3-prefix`、compactor 的 `--data-prefix`）。前缀不一致时列举落空，所有 manifest
   条目会被误报为 unverifiable/dangling、所有对象被误报为孤儿。
-- 工具需要 Postgres：逐 schema 取与 flusher 同款 advisory lock
+- 工具需要 Postgres：逐 schema 取与 flusher/cdc-init 同款 advisory lock
   （`pg_try_advisory_lock(schemaID, schemaID)`，钉在单一连接上），消除与 flusher 的
-  list/load 竞态；拿不到锁的 schema 跳过并计入差异退出码。compactor 与 cdc-init 不持
-  这把锁，故 manifest 写入另有 ETag 条件写保护（不存在的 manifest 用 If-None-Match
-  条件创建，绝不覆写并发新建的 manifest），dangling 判定做二次确认，init 形态对象
-  排除在 GC 之外。
+  list/load 竞态；拿不到锁的 schema 跳过并计入差异退出码。#290 起 cdc-init 也持这把锁，
+  故此锁下的 init 形态孤儿必非 in-flight init，纳入 `--gc` 候选。compactor 仍不持这把锁，
+  故 manifest 写入另有 ETag 条件写保护（不存在的 manifest 用 If-None-Match
+  条件创建，绝不覆写并发新建的 manifest），dangling 判定做二次确认。
 - `--schema-id` 指向未注册 schema 时直接报错退出 1（而不是空跑报「一致」）。
 - `--gc-grace` 必须为正（默认 15m）。
 - `--data-prefix` 允许为空（对象 key 形如 `/7/{uuid}.parquet`，与 cdc path builder
@@ -123,7 +123,8 @@ forma-tools manifest-reconcile ... --repair --gc --gc-grace 15m
 
 ## 已知范围限制（follow-up）
 
-cdc-init 的 manifest 发布失败（导出成功但 `ReplaceTierFiles` 失败）没有自动恢复路
-径：init 形态对象既不补录也不删除，因为 in-flight init 与「发布失败的 init」从对象
-层面不可区分——init 不持 schema advisory lock。安全的自动处置需要 init 先持锁，见
-follow-up issue。
+cdc-init 的 manifest 发布失败（导出成功但 `ReplaceTierFiles` 失败）留下的 init 形态
+孤儿自 #290 起可由 `--gc` 两阶段删除（cdc-init 与 reconcile 持同一把 per-schema
+advisory lock，故此锁下的 init 形态孤儿必非 in-flight init）。删除后重跑 cdc-init 即
+可从 entity_main 重新导出；把孤儿直接自动补录进 manifest（`--repair` 提升 init 形态）
+仍留 follow-up issue——部分导出误提升风险尚未有守卫。

--- a/docs/superpowers/plans/2026-07-20-issue-290-init-advisory-lock.md
+++ b/docs/superpowers/plans/2026-07-20-issue-290-init-advisory-lock.md
@@ -1,0 +1,361 @@
+# Issue #290: cdc-init 持有 per-schema advisory lock + reconcile GC 化 init 形状孤儿 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> 执行开始时：按仓库 workflow 建 worktree（先清已合并分支、FF main），并把本计划复制为 `docs/superpowers/plans/2026-07-20-issue-290-init-advisory-lock.md` 随 PR 入库。
+
+**Goal:** `cdc-init` 在每个 schema 的 export + manifest publish 期间持有 `pg_try_advisory_lock(schemaID, schemaID)`（钉单连接），从而 `manifest-reconcile --gc` 可以安全删除 init 形状 `{min}_{max}.parquet` 孤儿（失败 publish 的输出 + 被新 init 取代的旧文件）；顺带完成 issue Notes 的两项清理：锁 helper 合并（修 flusher 池上 acquire/release 落不同连接的 latent bug）与共享 quoted DSN builder。
+
+**Architecture:** 在 `internal/cdc` 新增钉单连接的 `TrySchemaLock`（以 `reconcile.PGAdvisoryLocker.TryLock` 为蓝本），四个调用方（init 新增、flusher 迁移、reconcile 委托、federated harness 委托）统一走它；reconcile 侧把 `ClassBaseInit` 加入现有两阶段 sighting GC 候选（分类与 report/退出码逻辑不动）。`--repair` 自动重建 base tier **不做**（部分导出误提升风险），留 follow-up issue。
+
+**Tech Stack:** Go, database/sql + pgx (stdlib driver), PG advisory locks, testify。
+
+## Global Constraints（用户已裁决）
+
+- init 拿不到锁：该 schema 计入 `schemaErrors`（`errors.Is` 可匹配新 sentinel `ErrSchemaLockContended`），继续其他 schema，最终 `errors.Join` 非零返回。**不是** silent skip。
+- reconcile 只做 `--gc`；`--repair` 提升 init 孤儿留 follow-up（收尾时开 issue）。
+- 锁 helper 合并（含 flusher 迁移）与共享 DSN builder 均入本 PR。
+- 仓库规范：文件 ≤500 行、函数 ≤100 行、错误 `fmt.Errorf("...: %w")` 包装、TDD 红先行、频繁提交。
+- dry-run init 也拿锁（语义一致，dry-run 同样读 PG）。
+- 请不要自动合并 PR；PR body 引用 `Closes #290`。
+
+## 已核实事实（行号基于 main @ da56a4c）
+
+- 无 import 环：`internal/cdc` 不 import `reconcile`/`compaction`；`reconcile` 已（经 `compaction`）传递依赖 `cdc`。委托方向安全。
+- `report.go` **零改动**：`SchemaReport.Residual()` 已把 Deleted 键视为 resolved，init 孤儿被删后自动清出 residual；within-grace 仍 residual → exit 2，语义自洽。
+- gc-state 无兼容问题：旧 state 文件从未含 init 键（此前被显式排除）。
+- 旧 `AcquireSchemaLock`/`ReleaseSchemaLock`（helpers.go:29-46）生产调用方仅 flusher.go:301/305，**无测试引用**，可干净删除。
+- flusher 锁测试 4 处注入闭包：flusher_test.go:307/336/368/401。
+- init 单测直接构造 `initRunContext`（init_test.go、init_preflight_test.go:13），沿用此缝隙；flusher 已有 `processSchemaFn` 注入先例（flusher.go:256）。
+
+---
+
+### Task A: 共享 DSN builder（独立，可先做）
+
+**Files:**
+- Create: `internal/cdc/pgdsn.go`, `internal/cdc/pgdsn_test.go`
+- Modify: `internal/cdc/init.go:84-89`、`internal/cdc/flusher.go:202-207`（`setupPostgresConnection`）与 `flusher.go:369-370` 附近（`executeFlush` 的 `pgConnForDuck`，同形状手拼一并换）、`cmd/tools/manifest_reconcile.go:263-281`（`buildToolSQLDB`，删本地 `quotePGConnValue`）
+- Test migrate: `cmd/tools/manifest_reconcile_test.go:90-101` 的 quote 用例移入 `pgdsn_test.go`
+
+**Interfaces:**
+- Produces: `cdc.PGDSNParams{Host string; Port int; User, Password, DB, SSLMode string}`；`func BuildPGDSN(p PGDSNParams) string`
+
+- [ ] **Step A1: 红** — 写 `internal/cdc/pgdsn_test.go`：
+
+```go
+func TestBuildPGDSN_QuotesValues(t *testing.T) {
+	got := BuildPGDSN(PGDSNParams{Host: "h", Port: 5432, User: "u u", Password: `p'w\d`, DB: "d", SSLMode: "require"})
+	want := `host='h' port=5432 user='u u' password='p\'w\\d' dbname='d' sslmode='require'`
+	if got != want {
+		t.Fatalf("BuildPGDSN = %s, want %s", got, want)
+	}
+}
+```
+
+注意转义顺序：先 `\`→`\\` 再 `'`→`\'`（与现 `quotePGConnValue` manifest_reconcile.go:277-281 一致），期望串按此推导核对。
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run TestBuildPGDSN -v` → FAIL (undefined)
+
+- [ ] **Step A2: 绿** — 写 `internal/cdc/pgdsn.go`：
+
+```go
+package cdc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PGDSNParams are the inputs for a libpq keyword/value connection string.
+type PGDSNParams struct {
+	Host     string
+	Port     int
+	User     string
+	Password string
+	DB       string
+	SSLMode  string
+}
+
+// BuildPGDSN renders a libpq keyword/value DSN with every string value quoted
+// (single-quote wrapped, backslash and single-quote escaped) so passwords with
+// spaces or quotes survive parsing by pgx and DuckDB's postgres scanner.
+func BuildPGDSN(p PGDSNParams) string {
+	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		quotePGConnValue(p.Host), p.Port, quotePGConnValue(p.User),
+		quotePGConnValue(p.Password), quotePGConnValue(p.DB), quotePGConnValue(p.SSLMode))
+}
+
+func quotePGConnValue(v string) string {
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, `'`, `\'`)
+	return "'" + v + "'"
+}
+```
+
+- [ ] **Step A3: 行为保持重构** — 三处替换（既有测试当守卫）：
+  - `init.go:88-89` → `pgConnStr := BuildPGDSN(PGDSNParams{Host: cfg.PGHost, Port: cfg.PGPort, User: cfg.PGUser, Password: cfg.PGPassword, DB: cfg.PGDB, SSLMode: sslMode})`
+  - `flusher.go:206-207` → 同上但 `Password: pgPassword`（IAM 分支 :192-200 不动，token 已先解析进 `pgPassword`，builder 只负责格式化）；`flusher.go` 中 `pgConnForDuck` 的第二处手拼同样替换（redacted 日志串保持现状）
+  - `cmd/tools/manifest_reconcile.go` `buildToolSQLDB` → `cdc.BuildPGDSN(cdc.PGDSNParams{...， Password: pg.resolvedPassword("PGPASSWORD"), ...})`，删除本地 `quotePGConnValue` 及其在 manifest_reconcile_test.go 的用例（已迁移）
+- [ ] **Step A4:** `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc ./cmd/tools` → PASS；`make lint` → PASS
+- [ ] **Step A5: Commit** — `git commit -m "refactor(cdc): #290 shared quoted PG DSN builder replaces three hand-built copies"`
+
+---
+
+### Task B: 钉单连接 TrySchemaLock + flusher/reconcile/harness 迁移
+
+**Files:**
+- Create: `internal/cdc/schema_lock.go`, `internal/cdc/schema_lock_test.go`
+- Modify: `internal/cdc/helpers.go`（删 `AcquireSchemaLock`/`ReleaseSchemaLock` :29-46）、`internal/cdc/flusher.go`（字段 :252-253 合并为一、`processSchema` :296-317 重写）、`internal/cdc/flusher_test.go`（:307/336/368/401 四处注入改签名）、`internal/reconcile/db.go`（`PGAdvisoryLocker.TryLock` :72-95 委托 + 注释 :63-67 更新）、`internal/e2e_harness/federated/cdc.go`（`tryAcquireSchemaLock` :77-100 委托）
+
+**Interfaces:**
+- Produces: `var ErrSchemaLockContended = errors.New("schema advisory lock contended")`；`func TrySchemaLock(ctx context.Context, db *sql.DB, schemaID int16) (bool, func(), error)`（unlock 非 nil 当且仅当 locked；unlock 用 `context.Background()` 并 `conn.Close()`）
+- Consumes: Task C 的 init 接线依赖此签名
+
+- [ ] **Step B1: 红** — 改写 flusher_test.go 第一处锁测试（:307 附近）为单一注入字段：
+
+```go
+tryLock: func(context.Context, *sql.DB, int16) (bool, func(), error) {
+	lockAttempts++
+	return false, nil, nil
+},
+```
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run TestProcessSchema -v` → FAIL（编译错，unknown field tryLock）
+（保留原断言语义：not-locked 时 skip 返回 nil、release 不被调；locked 用例断言返回的 unlock 闭包被调用。）
+
+- [ ] **Step B2: 绿** — 写 `internal/cdc/schema_lock.go`（正文照搬 `reconcile/db.go:72-95` 的钉连接实现，泛化 schemaID 入参；执行者请对照原文逐行核对语义，尤其 Scan 失败关连接、!locked 关连接、unlock 用 background ctx）：
+
+```go
+package cdc
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrSchemaLockContended reports that another holder (flusher, cdc-init, or
+// manifest-reconcile) owns the per-schema advisory lock.
+var ErrSchemaLockContended = errors.New("schema advisory lock contended")
+
+// TrySchemaLock pins one physical connection and takes
+// pg_try_advisory_lock(schemaID, schemaID). The lock is session-scoped: on a
+// pool, acquire and release could land on different connections, and a lock
+// released on the wrong session silently fails — so unlock runs on the same
+// pinned conn and closes it to end the session. unlock is non-nil iff locked;
+// it uses a background context so the lock is released even after ctx cancel.
+func TrySchemaLock(ctx context.Context, db *sql.DB, schemaID int16) (bool, func(), error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("pin connection for schema %d advisory lock: %w", schemaID, err)
+	}
+	var locked bool
+	row := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1, $2)", int32(schemaID), int32(schemaID))
+	if err := row.Scan(&locked); err != nil {
+		_ = conn.Close()
+		return false, nil, fmt.Errorf("acquire schema %d advisory lock: %w", schemaID, err)
+	}
+	if !locked {
+		_ = conn.Close()
+		return false, nil, nil
+	}
+	unlock := func() {
+		_, _ = conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1, $2)", int32(schemaID), int32(schemaID))
+		_ = conn.Close()
+	}
+	return true, unlock, nil
+}
+```
+
+flusher 改造：`schemaFlushContext` 的 `acquireLock`/`releaseLock` 两字段（:252-253）合并为 `tryLock func(context.Context, *sql.DB, int16) (bool, func(), error)`；`processSchema` 锁段（:299-317）改为：
+
+```go
+tryLock := c.tryLock
+if tryLock == nil {
+	tryLock = TrySchemaLock
+}
+locked, unlock, err := tryLock(ctx, c.db, schemaID)
+if err != nil {
+	return fmt.Errorf("acquire schema lock: %w", err)
+}
+if !locked {
+	c.logger.Sugar().Infow("lock not acquired, skipping", "schema_id", schemaID)
+	return nil
+}
+defer unlock()
+```
+
+（flusher contended 语义**不变**：skip + return nil。）删除 helpers.go 的 `AcquireSchemaLock`/`ReleaseSchemaLock`。
+
+- [ ] **Step B3:** 逐一改剩余三处 flusher 锁测试注入（:336/368/401）为 `tryLock` 形式；`schema_lock_test.go` 只做轻量单测（无 PG 环境）：验证 `ErrSchemaLockContended` 的 `errors.Is` 身份、以及 `db.Conn(ctx)` 失败路径返回包装错误（可用已关闭的 `sql.DB`）；真实锁行为由 reconcile/production e2e 覆盖（`PGAdvisoryLocker` 现状同此）。
+- [ ] **Step B4:** 委托两处：
+  - `internal/reconcile/db.go`：`func (l *PGAdvisoryLocker) TryLock(ctx context.Context, schemaID int16) (bool, func(), error) { return cdc.TrySchemaLock(ctx, l.DB, schemaID) }`，注释改为指向 `cdc.TrySchemaLock` 为单一实现来源
+  - `internal/e2e_harness/federated/cdc.go:77-100`：`tryAcquireSchemaLock` 改为 `return cdc.TrySchemaLock(ctx, h.PGDB, h.SchemaID)`（原 2s unlock 超时被共享实现的 background ctx 取代，属预期变化）
+- [ ] **Step B5:** `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc ./internal/reconcile` → PASS；`make lint` → PASS
+- [ ] **Step B6: Commit** — `git commit -m "refactor(cdc): #290 single pinned-connection TrySchemaLock; flusher/reconcile/harness converge on it"`
+
+---
+
+### Task C: cdc-init 每 schema 持锁
+
+**Files:**
+- Modify: `internal/cdc/init.go`（`initRunContext` 加字段、`processInitSchemas` :194-204 循环改调包装函数、新增 `initSchemaUnderLock`）
+- Create/Modify test: `internal/cdc/init_lock_test.go`（新文件，构造 `initRunContext` 的手法沿用 init_preflight_test.go:13）
+
+**Interfaces:**
+- Consumes: Task B 的 `TrySchemaLock`、`ErrSchemaLockContended`
+- Produces: `initRunContext.tryLock func(context.Context, *sql.DB, int16) (bool, func(), error)`（nil→真实现）；`initRunContext.initSchemaFn func(context.Context, *initRunContext, int16) (int64, int, error)`（nil→`initSchema`，测试缝隙，镜像 flusher 的 `processSchemaFn` 先例）
+
+- [ ] **Step C1: 红** — 写 `internal/cdc/init_lock_test.go`：
+
+```go
+func TestProcessInitSchemas_ContendedLockRecordsErrorAndContinues(t *testing.T) {
+	var initCalled []int16
+	var unlockCalled []int16
+	runCtx := &initRunContext{
+		logger:         zap.NewNop(),
+		schemaRegistry: /* 复用 init_preflight_test.go 的 fake registry，为 schema 7、8 提供 attrCache */,
+		tryLock: func(_ context.Context, _ *sql.DB, sid int16) (bool, func(), error) {
+			if sid == 7 {
+				return false, nil, nil
+			}
+			return true, func() { unlockCalled = append(unlockCalled, sid) }, nil
+		},
+		initSchemaFn: func(_ context.Context, _ *initRunContext, sid int16) (int64, int, error) {
+			initCalled = append(initCalled, sid)
+			return 5, 1, nil
+		},
+	}
+	summary, err := processInitSchemas(context.Background(), runCtx, []int64{7, 8})
+	if !errors.Is(err, ErrSchemaLockContended) {
+		t.Fatalf("want ErrSchemaLockContended in joined error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "schema 7") {
+		t.Fatalf("error must name the contended schema: %v", err)
+	}
+	if len(initCalled) != 1 || initCalled[0] != 8 {
+		t.Fatalf("schema 8 must still be processed, got %v", initCalled)
+	}
+	if len(unlockCalled) != 1 || unlockCalled[0] != 8 {
+		t.Fatalf("unlock must run for locked schema 8, got %v", unlockCalled)
+	}
+	if summary.TotalRowsExported != 5 || summary.TotalFilesCreated != 1 {
+		t.Fatalf("summary must reflect the successful schema, got %+v", summary)
+	}
+}
+```
+
+（若 fake registry 不便复用则就地写最小 fake；错误消息须命名 schema 与锁状态，符合 error-semantics 规范。）
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run TestProcessInitSchemas_Contended -v` → FAIL（unknown fields）
+
+- [ ] **Step C2: 绿** — `init.go`：`initRunContext` 加 `tryLock`、`initSchemaFn` 两字段；`processInitSchemas` 循环把 `initSchema(...)` 调用换成 `initSchemaUnderLock(...)`（错误收集逻辑 :197-201 不动，外层已 wrap "schema %d: %w"）；新增：
+
+```go
+// initSchemaUnderLock holds the per-schema advisory lock for the whole
+// export + manifest publish, so manifest-reconcile (which reconciles under
+// the same lock) can never race an in-flight init (#290). Contended is an
+// error, not a skip: init is operator-initiated and a silently skipped
+// schema would stay uninitialized unnoticed.
+func initSchemaUnderLock(ctx context.Context, runCtx *initRunContext, schemaID int16) (int64, int, error) {
+	tryLock := runCtx.tryLock
+	if tryLock == nil {
+		tryLock = TrySchemaLock
+	}
+	locked, unlock, err := tryLock(ctx, runCtx.db, schemaID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("acquire advisory lock: %w", err)
+	}
+	if !locked {
+		return 0, 0, ErrSchemaLockContended
+	}
+	defer unlock()
+
+	initSchemaFn := runCtx.initSchemaFn
+	if initSchemaFn == nil {
+		initSchemaFn = initSchema
+	}
+	return initSchemaFn(ctx, runCtx, schemaID)
+}
+```
+
+（锁覆盖整个 `initSchema` 含 0 行提前返回与 dry-run 路径；`defer unlock()` 保证释放。）
+
+- [ ] **Step C3:** `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -run TestProcessInitSchemas -v` → PASS；全包 `go test ./internal/cdc` → PASS
+- [ ] **Step C4: Commit** — `git commit -m "feat(cdc): #290 cdc-init holds the per-schema advisory lock across export + manifest publish"`
+
+---
+
+### Task D: reconcile 把 ClassBaseInit 纳入 --gc 候选
+
+**Files:**
+- Modify: `internal/reconcile/reconcile.go:161-167`（候选构造 + 注释）、`internal/reconcile/classify.go:20-27`（类文档注释）、`internal/reconcile/gc.go:12-25` 附近（"init-shaped never reach here" 注释）
+- Modify test: `internal/reconcile/race_guard_test.go:14-37`（语义反转）、`internal/e2e_harness/production/manifest_reconcile_e2e_test.go`（:323-328 注释、:353-370 within-grace 断言不变、:372-416 past_grace 断言反转——initShaped 应被删，deltaOrphan 仍幸存）
+
+**Interfaces:**
+- Consumes: 无代码依赖 Task A-C（可并行开发），但**语义前提**是 Task C（init 持锁）已入同一 PR
+- Produces: 无新导出；`classifyObjectKey`、`diffSchema`、`report.go` 均零改动
+
+- [ ] **Step D1: 红** — 反转 `race_guard_test.go`：`TestGC_SkipsInitShapedBaseOrphans` → `TestGC_CollectsInitShapedBaseOrphans`，fixture 不变（initShaped + merged 均 seed 过期 sighting），断言改为：
+
+```go
+require.ElementsMatch(t, []string{initShaped, merged}, report.Schemas[0].Deleted)
+require.ElementsMatch(t, []string{initShaped, merged}, report.Schemas[0].BaseOrphans)
+require.False(t, report.HasResidualDiscrepancies())
+```
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/reconcile -run TestGC_Collects -v` → FAIL（initShaped 未被删）
+
+- [ ] **Step D2: 绿** — `reconcile.go:161-167` 候选构造改为：
+
+```go
+// Init-shaped base orphans are GC candidates since #290: cdc-init holds
+// the same per-schema advisory lock, so under this lock an init-shaped
+// orphan is provably not from an in-flight init — it is either the output
+// of a failed manifest publish or a file superseded by a later init run.
+// Recovery for a failed publish is re-running cdc-init (the source of
+// truth is entity_main); auto-promotion (--repair) is a follow-up.
+// Delta leftovers require the repair analysis, so they are only deletable
+// under --repair --gc.
+candidates := append([]ObjectInfo(nil), d.baseInitOrphans...)
+candidates = append(candidates, d.baseMergedOrphans...)
+candidates = append(candidates, d.tmpOrphans...)
+candidates = append(candidates, deltaLeftovers...)
+```
+
+同步改 `classify.go:20-27` 与 `gc.go` 头部注释中 "holds no advisory lock / never GC candidates" 的过时理由。
+
+- [ ] **Step D3:** `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/reconcile` → PASS
+- [ ] **Step D4:** 反转 production e2e：`manifest_reconcile_e2e_test.go` `past_grace_deletes_leftovers_only` 子测预期删除对象从 {staleBase, staleTmp} 扩为 {staleBase, staleTmp, initShaped}（deltaOrphan 仍幸存，未 --repair）；相应 count 与注释更新。within-grace 子测断言不变。
+- [ ] **Step D5: 注释/文档扫尾** — `grep -rn "init-shaped\|ClassBaseInit" --include="*.go" .` 与 `grep -rn "init-shaped" docs/ cmd/` 全量过一遍，更新仍宣称 "report-only / holds no advisory lock" 的注释、log 文本（如 `internal/compaction/rewrite.go:168`、`cmd/tools/main.go` 帮助文本、`internal/cdc/init.go:399-407` 的 updateSchemaManifest 文档注释——现在可明确指向 `--gc`）与 manifest-reconcile 相关 docs。
+- [ ] **Step D6: Commit** — `git commit -m "feat(reconcile): #290 init-shaped base orphans join two-phase --gc now cdc-init locks"`
+
+---
+
+### Task E: e2e 验证 + 并发 init 测试 revisit + 收尾
+
+- [ ] **Step E1:** 单测全绿 + lint：`make test && make lint`
+- [ ] **Step E2:** 定向 e2e（需 Docker）：
+  - `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test -v -tags=e2e ./internal/e2e_harness/production/ -run 'TestManifestReconcile' -timeout 20m` → 反转后断言 PASS
+  - `... -run 'TestInit' -timeout 30m` → 覆盖 `TestInitUnderConcurrentMutation`（mutator 直写 PG 不拿锁，预期不受影响，绿）与 init_rerun 等；若该测试内 harness flusher 与 init 抢锁导致行为变化，按实际观察调整（issue 第 3 点 "revisit" 的落点：预期是**注释说明新锁语义**而非改断言；contended 行为已由 Task C 单测覆盖，不加新 e2e）
+  - federated 冒烟（harness cdc.go 被改）：`go test -v -tags=e2e -short ./internal/e2e_harness/federated/... -timeout 15m`
+- [ ] **Step E3:** DSN 换用 quoted 形式后重点确认 DuckDB postgres_scanner 路径（init/flush e2e 已覆盖；若 e2e 失败先查引号解析）
+- [ ] **Step E4:** 开 follow-up issue：`manifest-reconcile --repair` 自动重建 base tier（带覆盖完整性验证：DuckDB stats + PG live rows 证明孤儿集覆盖全部存活行后才 ReplaceTierFiles 提升；引用 #290 讨论）
+- [ ] **Step E5:** 提 PR：body 引用 `Closes #290`，说明四块改动（init 锁、reconcile GC 化、锁 helper 合并、DSN builder）与 flusher latent bug 修复；**不自动合并**
+
+## 风险与注意点
+
+1. **init 长时间持锁饿 flusher**：init 导出期间 flusher 对该 schema 每轮 skip（返回 nil，安全）。不做 per-batch 放锁（会重新打开 #290 要关的竞态窗口）。PR body 注明运维影响。
+2. **本 PR 只关 init↔reconcile 竞态**：init 的 `ReplaceTierFiles` 与 compactor 的 manifest 写仍靠 etag 乐观并发（compactor 不拿此锁），维持现状，issue 范围内。
+3. **reconcile→cdc 依赖面变大**：无环（已核实），若 review 反对可退到独立小包 `internal/pglock`，默认按 issue 指向放 `internal/cdc`。
+4. **federated harness 丢 2s unlock 超时**：共享实现用 background ctx，行为等价偏强，PR 里注明防 reviewer 误判回归。
+5. **flusher_test 断言迁移**：not-locked 用例的 "release 不被调" 断言在新签名下变为 "unlock 为 nil 且无泄漏"，保持原语义覆盖。
+
+## Verification（端到端）
+
+```bash
+make lint && make test
+go test -v -tags=e2e ./internal/e2e_harness/production/ -run 'TestManifestReconcile|TestInit' -timeout 30m
+go test -v -tags=e2e -short ./internal/e2e_harness/federated/... -timeout 15m
+```
+
+预期：manifest-reconcile e2e 中 initShaped 对象 past-grace 被 --gc 删除且 residual 清零（exit 语义自洽）；`TestInitUnderConcurrentMutation` 保持绿；flusher/init/cmd-tools 全部单测绿；lint 干净。

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -203,8 +203,7 @@ func setupPostgresConnection(ctx context.Context, cfg CDCConfig, region string, 
 	if sslMode == "" {
 		sslMode = DefaultPGSSLMode
 	}
-	pgConnStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		cfg.PGHost, cfg.PGPort, cfg.PGUser, pgPassword, cfg.PGDB, sslMode)
+	pgConnStr := BuildPGDSN(PGDSNParams{Host: cfg.PGHost, Port: cfg.PGPort, User: cfg.PGUser, Password: pgPassword, DB: cfg.PGDB, SSLMode: sslMode})
 
 	db, err := sql.Open("pgx", pgConnStr)
 	if err != nil {
@@ -366,8 +365,7 @@ func (c *schemaFlushContext) executeFlush(ctx context.Context, schemaID int16) e
 	if sslMode == "" {
 		sslMode = DefaultPGSSLMode
 	}
-	pgConnForDuck := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		c.cfg.PGHost, c.cfg.PGPort, c.cfg.PGUser, c.pgPassword, c.cfg.PGDB, sslMode)
+	pgConnForDuck := BuildPGDSN(PGDSNParams{Host: c.cfg.PGHost, Port: c.cfg.PGPort, User: c.cfg.PGUser, Password: c.pgPassword, DB: c.cfg.PGDB, SSLMode: sslMode})
 	pgConnForDuckLoggable := fmt.Sprintf("host=%s port=%d user=%s password=***REDACTED*** dbname=%s sslmode=%s",
 		c.cfg.PGHost, c.cfg.PGPort, c.cfg.PGUser, c.cfg.PGDB, sslMode)
 	c.logger.Sugar().Infow("export snapshot", "schema_id", schemaID, "snapshot_ts", snapshot, "rows", len(ids), "pgConnForDuck", pgConnForDuckLoggable)

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -248,8 +248,7 @@ type schemaFlushContext struct {
 	attrCaches       map[int16]forma.SchemaAttributeCache
 	manifestStore    manifest.Store
 	manifestResolver manifest.PathResolver
-	acquireLock      func(context.Context, *sql.DB, int16) (bool, error)
-	releaseLock      func(context.Context, *sql.DB, int16) error
+	tryLock          func(context.Context, *sql.DB, int16) (bool, func(), error)
 	executeSingle    func(*flushBatchExecutor, []uuid.UUID) error
 	executeInChunks  func(*flushBatchExecutor, []uuid.UUID, int) error
 	processSchemaFn  func(context.Context, int16) error
@@ -295,17 +294,11 @@ func (c *schemaFlushContext) processSchemas(ctx context.Context, schemaIDs []int
 func (c *schemaFlushContext) processSchema(ctx context.Context, schemaID int16) error {
 	c.logger.Sugar().Infow("processing schema", "schema_id", schemaID)
 
-	acquireLock := c.acquireLock
-	if acquireLock == nil {
-		acquireLock = AcquireSchemaLock
+	tryLock := c.tryLock
+	if tryLock == nil {
+		tryLock = TrySchemaLock
 	}
-	releaseLock := c.releaseLock
-	if releaseLock == nil {
-		releaseLock = ReleaseSchemaLock
-	}
-
-	// Try advisory lock
-	locked, err := acquireLock(ctx, c.db, schemaID)
+	locked, unlock, err := tryLock(ctx, c.db, schemaID)
 	if err != nil {
 		return fmt.Errorf("acquire schema lock: %w", err)
 	}
@@ -313,7 +306,7 @@ func (c *schemaFlushContext) processSchema(ctx context.Context, schemaID int16) 
 		c.logger.Sugar().Infow("lock not acquired, skipping", "schema_id", schemaID)
 		return nil
 	}
-	defer func() { _ = releaseLock(ctx, c.db, schemaID) }()
+	defer unlock()
 
 	// Check if flush is needed
 	cnt, oldest, err := GetChangeLogStats(ctx, c.db, c.tableName, schemaID)

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -359,9 +359,9 @@ func (c *schemaFlushContext) executeFlush(ctx context.Context, schemaID int16) e
 		sslMode = DefaultPGSSLMode
 	}
 	pgConnForDuck := BuildPGDSN(PGDSNParams{Host: c.cfg.PGHost, Port: c.cfg.PGPort, User: c.cfg.PGUser, Password: c.pgPassword, DB: c.cfg.PGDB, SSLMode: sslMode})
-	pgConnForDuckLoggable := fmt.Sprintf("host=%s port=%d user=%s password=***REDACTED*** dbname=%s sslmode=%s",
-		c.cfg.PGHost, c.cfg.PGPort, c.cfg.PGUser, c.cfg.PGDB, sslMode)
-	c.logger.Sugar().Infow("export snapshot", "schema_id", schemaID, "snapshot_ts", snapshot, "rows", len(ids), "pgConnForDuck", pgConnForDuckLoggable)
+	// Redact the real (quoted) wire DSN rather than hand-building a stale preview
+	// that no longer matches what DuckDB receives (#290).
+	c.logger.Sugar().Infow("export snapshot", "schema_id", schemaID, "snapshot_ts", snapshot, "rows", len(ids), "pgConnForDuck", redactConnStr(pgConnForDuck))
 
 	// Cache was resolved and validated by the processSchemas pre-flight (#193).
 	attrCache := c.attrCaches[schemaID]

--- a/internal/cdc/flusher_test.go
+++ b/internal/cdc/flusher_test.go
@@ -306,6 +306,11 @@ func TestProcessSchema_SkipsWhenSchemaLockIsAlreadyHeld(t *testing.T) {
 		logger: zap.NewNop(),
 		tryLock: func(context.Context, *sql.DB, int16) (bool, func(), error) {
 			lockAttempts++
+			// Intentionally returns a non-nil unlock alongside locked=false,
+			// violating the "unlock non-nil iff locked" contract on purpose:
+			// the require.Zero(unlockCalls) below proves the skip path never
+			// invokes unlock. Do NOT "fix" this to a nil unlock — that would
+			// hollow the assertion (a nil call would panic instead of counting).
 			return false, func() { unlockCalls++ }, nil
 		},
 	}

--- a/internal/cdc/flusher_test.go
+++ b/internal/cdc/flusher_test.go
@@ -299,25 +299,21 @@ func TestProcessSchema_SkipsWhenSchemaLockIsAlreadyHeld(t *testing.T) {
 	})
 
 	lockAttempts := 0
-	releaseCalls := 0
+	unlockCalls := 0
 	flushCtx := &schemaFlushContext{
 		db:     db,
 		cfg:    CDCConfig{MinRecords: 1, MaxAgeMs: 1000},
 		logger: zap.NewNop(),
-		acquireLock: func(context.Context, *sql.DB, int16) (bool, error) {
+		tryLock: func(context.Context, *sql.DB, int16) (bool, func(), error) {
 			lockAttempts++
-			return false, nil
-		},
-		releaseLock: func(context.Context, *sql.DB, int16) error {
-			releaseCalls++
-			return nil
+			return false, func() { unlockCalls++ }, nil
 		},
 	}
 
 	err = flushCtx.processSchema(context.Background(), 7)
 	require.NoError(t, err)
 	require.Equal(t, 1, lockAttempts)
-	require.Zero(t, releaseCalls)
+	require.Zero(t, unlockCalls)
 }
 
 func TestProcessSchema_ReturnsErrorWhenChangeLogStatsCannotBeRead(t *testing.T) {
@@ -327,25 +323,21 @@ func TestProcessSchema_ReturnsErrorWhenChangeLogStatsCannotBeRead(t *testing.T) 
 		require.NoError(t, db.Close())
 	})
 
-	releaseCalls := 0
+	unlockCalls := 0
 	flushCtx := &schemaFlushContext{
 		db:        db,
 		cfg:       CDCConfig{MinRecords: 1, MaxAgeMs: 1000},
 		tableName: "missing_change_log",
 		logger:    zap.NewNop(),
-		acquireLock: func(context.Context, *sql.DB, int16) (bool, error) {
-			return true, nil
-		},
-		releaseLock: func(context.Context, *sql.DB, int16) error {
-			releaseCalls++
-			return nil
+		tryLock: func(context.Context, *sql.DB, int16) (bool, func(), error) {
+			return true, func() { unlockCalls++ }, nil
 		},
 	}
 
 	err = flushCtx.processSchema(context.Background(), 7)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "get changelog stats")
-	require.Equal(t, 1, releaseCalls)
+	require.Equal(t, 1, unlockCalls)
 }
 
 func TestProcessSchema_SkipsWhenNoPendingRowsExist(t *testing.T) {
@@ -359,24 +351,20 @@ func TestProcessSchema_SkipsWhenNoPendingRowsExist(t *testing.T) {
 	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, changed_at BIGINT, flushed_at BIGINT)")
 	require.NoError(t, err)
 
-	releaseCalls := 0
+	unlockCalls := 0
 	flushCtx := &schemaFlushContext{
 		db:        db,
 		cfg:       CDCConfig{MinRecords: 1, MaxAgeMs: 1000},
 		tableName: "change_log",
 		logger:    zap.NewNop(),
-		acquireLock: func(context.Context, *sql.DB, int16) (bool, error) {
-			return true, nil
-		},
-		releaseLock: func(context.Context, *sql.DB, int16) error {
-			releaseCalls++
-			return nil
+		tryLock: func(context.Context, *sql.DB, int16) (bool, func(), error) {
+			return true, func() { unlockCalls++ }, nil
 		},
 	}
 
 	err = flushCtx.processSchema(ctx, 7)
 	require.NoError(t, err)
-	require.Equal(t, 1, releaseCalls)
+	require.Equal(t, 1, unlockCalls)
 }
 
 func TestProcessSchema_SkipsWhenThresholdsAreNotMet(t *testing.T) {
@@ -392,24 +380,20 @@ func TestProcessSchema_SkipsWhenThresholdsAreNotMet(t *testing.T) {
 	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, 0)", time.Now().UnixMilli())
 	require.NoError(t, err)
 
-	releaseCalls := 0
+	unlockCalls := 0
 	flushCtx := &schemaFlushContext{
 		db:        db,
 		cfg:       CDCConfig{MinRecords: 10, MaxAgeMs: 1_000_000},
 		tableName: "change_log",
 		logger:    zap.NewNop(),
-		acquireLock: func(context.Context, *sql.DB, int16) (bool, error) {
-			return true, nil
-		},
-		releaseLock: func(context.Context, *sql.DB, int16) error {
-			releaseCalls++
-			return nil
+		tryLock: func(context.Context, *sql.DB, int16) (bool, func(), error) {
+			return true, func() { unlockCalls++ }, nil
 		},
 	}
 
 	err = flushCtx.processSchema(ctx, 7)
 	require.NoError(t, err)
-	require.Equal(t, 1, releaseCalls)
+	require.Equal(t, 1, unlockCalls)
 }
 
 func TestProcessSchemas_AbortsWhenSchemaCacheUnavailable(t *testing.T) {

--- a/internal/cdc/helpers.go
+++ b/internal/cdc/helpers.go
@@ -15,9 +15,14 @@ import (
 )
 
 // reConnPassword matches the password= key-value pair in a libpq-style connection string,
-// including the quoted form used inside DuckDB ATTACH statements.
-// It handles both  password=value  and  password='value'  forms.
-var reConnPassword = regexp.MustCompile(`(?i)(password=)'?[^' \t\r\n;,)]*'?`)
+// including the quoted forms used inside DuckDB ATTACH statements. The alternation is
+// ordered from most- to least-quoted so the doubled form is consumed whole:
+//   - password=''value''  the escapeLiteral'd DSN embedded in a DuckDB SQL literal (#290);
+//     a naive password='?…'? regex matches the empty string between the doubled quotes
+//     and leaks the real value, so this branch must be tried first.
+//   - password='value'    the raw quoted BuildPGDSN output.
+//   - password=value      the legacy unquoted form.
+var reConnPassword = regexp.MustCompile(`(?i)(password=)(''(?:[^']|'')*?''|'[^']*'|[^' \t\r\n;,)]*)`)
 
 // redactConnStr replaces any password value in a connection string (or an SQL
 // string that embeds one) with "***REDACTED***".  It is safe to call on any

--- a/internal/cdc/helpers.go
+++ b/internal/cdc/helpers.go
@@ -26,25 +26,6 @@ func redactConnStr(s string) string {
 	return reConnPassword.ReplaceAllString(s, "${1}***REDACTED***")
 }
 
-// AcquireSchemaLock tries to grab an advisory lock for the schema to avoid
-// concurrent flush/compaction on the same schema.
-func AcquireSchemaLock(ctx context.Context, db *sql.DB, schemaID int16) (bool, error) {
-	row := db.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1, $2)", int32(schemaID), int32(schemaID))
-	var locked bool
-	if err := row.Scan(&locked); err != nil {
-		return false, fmt.Errorf("acquire lock: %w", err)
-	}
-	return locked, nil
-}
-
-// ReleaseSchemaLock releases the advisory lock for the schema.
-func ReleaseSchemaLock(ctx context.Context, db *sql.DB, schemaID int16) error {
-	if _, err := db.ExecContext(ctx, "SELECT pg_advisory_unlock($1, $2)", int32(schemaID), int32(schemaID)); err != nil {
-		return fmt.Errorf("release lock: %w", err)
-	}
-	return nil
-}
-
 // GetChangeLogStats returns count and oldest changed_at for unflushed rows.
 func GetChangeLogStats(ctx context.Context, db *sql.DB, table string, schemaID int16) (int64, int64, error) {
 	if table == "" {

--- a/internal/cdc/helpers.go
+++ b/internal/cdc/helpers.go
@@ -16,13 +16,21 @@ import (
 
 // reConnPassword matches the password= key-value pair in a libpq-style connection string,
 // including the quoted forms used inside DuckDB ATTACH statements. The alternation is
-// ordered from most- to least-quoted so the doubled form is consumed whole:
-//   - password=''value''  the escapeLiteral'd DSN embedded in a DuckDB SQL literal (#290);
-//     a naive password='?…'? regex matches the empty string between the doubled quotes
-//     and leaks the real value, so this branch must be tried first.
-//   - password='value'    the raw quoted BuildPGDSN output.
-//   - password=value      the legacy unquoted form.
-var reConnPassword = regexp.MustCompile(`(?i)(password=)(''(?:[^']|'')*?''|'[^']*'|[^' \t\r\n;,)]*)`)
+// ordered from most- to least-quoted so each form is consumed whole and no password
+// material survives past ***REDACTED***. libpq quoting escapes both ' and \ with a
+// backslash (quotePGConnValue), and escapeLiteral additionally doubles every ' when the
+// DSN is embedded in a DuckDB SQL literal — so the matcher must understand backslash
+// escapes, not just balanced quotes.
+//   - Branch 1 — password=''…''  the escapeLiteral'd doubled form (tried first). Content
+//     atoms are `\''` (a libpq escaped quote whose ' was doubled by escapeLiteral), `\[^']`
+//     (any other backslash escape, incl. `\\`), and `[^'\]` (a plain char). A bare `'`
+//     never matches an atom, so the closing `''` is unreachable from inside the content:
+//     greedy matching is safe and the old non-greedy early-close leak is structurally gone.
+//   - Branch 2 — password='…'  the raw quoted BuildPGDSN output. Standard libpq quoted
+//     value `'(?:\.|[^'\])*'` consumes `\'` and `\\` as escapes instead of terminating on
+//     the escaped quote (the old '[^']*' branch mistook `\'` for the closing quote).
+//   - Branch 3 — password=value  the legacy unquoted form (unchanged).
+var reConnPassword = regexp.MustCompile(`(?i)(password=)(''(?:\\''|\\[^']|[^'\\])*''|'(?:\\.|[^'\\])*'|[^' \t\r\n;,)]*)`)
 
 // redactConnStr replaces any password value in a connection string (or an SQL
 // string that embeds one) with "***REDACTED***".  It is safe to call on any

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -85,8 +85,7 @@ func newInitRunContext(ctx context.Context, opts InitOptions) (*initRunContext, 
 	if sslMode == "" {
 		sslMode = "require"
 	}
-	pgConnStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		cfg.PGHost, cfg.PGPort, cfg.PGUser, cfg.PGPassword, cfg.PGDB, sslMode)
+	pgConnStr := BuildPGDSN(PGDSNParams{Host: cfg.PGHost, Port: cfg.PGPort, User: cfg.PGUser, Password: cfg.PGPassword, DB: cfg.PGDB, SSLMode: sslMode})
 
 	db, err := sql.Open("pgx", pgConnStr)
 	if err != nil {

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -243,31 +243,6 @@ func getSchemaIDsToInit(ctx context.Context, db *sql.DB, schemaRegistryTable str
 	return schemaIDs, nil
 }
 
-// initSchemaUnderLock holds the per-schema advisory lock for the whole
-// export + manifest publish, so manifest-reconcile (which reconciles under
-// the same lock) can never race an in-flight init (#290). Contended is an
-// error, not a skip: init is operator-initiated and a silently skipped
-// schema would stay uninitialized unnoticed.
-func initSchemaUnderLock(ctx context.Context, runCtx *initRunContext, schemaID int16) (int64, int, error) {
-	tryLock := runCtx.tryLock
-	if tryLock == nil {
-		tryLock = TrySchemaLock
-	}
-	locked, unlock, err := tryLock(ctx, runCtx.db, schemaID)
-	if err != nil {
-		return 0, 0, fmt.Errorf("acquire advisory lock: %w", err)
-	}
-	if !locked {
-		return 0, 0, ErrSchemaLockContended
-	}
-	defer unlock()
-	initSchemaFn := runCtx.initSchemaFn
-	if initSchemaFn == nil {
-		initSchemaFn = initSchema
-	}
-	return initSchemaFn(ctx, runCtx, schemaID)
-}
-
 // initSchema exports all existing data for a single schema to S3 base files.
 func initSchema(ctx context.Context, runCtx *initRunContext, schemaID int16) (int64, int, error) {
 	state, err := prepareSchemaInit(ctx, runCtx, schemaID)

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -48,6 +48,9 @@ type initRunContext struct {
 	dryRun               bool
 	autoEstimateRowBytes bool
 	pgConnStr            string
+	// tryLock and initSchemaFn are test seams (nil→real impl below), mirroring the flusher's processSchemaFn seam.
+	tryLock      func(ctx context.Context, db *sql.DB, schemaID int16) (bool, func(), error)
+	initSchemaFn func(ctx context.Context, runCtx *initRunContext, schemaID int16) (int64, int, error)
 }
 
 // normalizeInitOptions applies the same config defaults as Runner.RunOnce.
@@ -192,7 +195,7 @@ func processInitSchemas(ctx context.Context, runCtx *initRunContext, schemaIDs [
 
 	for _, sid := range schemaIDs {
 		schemaID := int16(sid)
-		rowsExported, filesCreated, err := initSchema(ctx, runCtx, schemaID)
+		rowsExported, filesCreated, err := initSchemaUnderLock(ctx, runCtx, schemaID)
 		if err != nil {
 			runCtx.logger.Error("failed to init schema", zap.Int16("schema_id", schemaID), zap.Error(err))
 			schemaErrors = append(schemaErrors, fmt.Errorf("schema %d: %w", schemaID, err))
@@ -238,6 +241,31 @@ func getSchemaIDsToInit(ctx context.Context, db *sql.DB, schemaRegistryTable str
 		return nil, fmt.Errorf("iterate schema ids: %w", err)
 	}
 	return schemaIDs, nil
+}
+
+// initSchemaUnderLock holds the per-schema advisory lock for the whole
+// export + manifest publish, so manifest-reconcile (which reconciles under
+// the same lock) can never race an in-flight init (#290). Contended is an
+// error, not a skip: init is operator-initiated and a silently skipped
+// schema would stay uninitialized unnoticed.
+func initSchemaUnderLock(ctx context.Context, runCtx *initRunContext, schemaID int16) (int64, int, error) {
+	tryLock := runCtx.tryLock
+	if tryLock == nil {
+		tryLock = TrySchemaLock
+	}
+	locked, unlock, err := tryLock(ctx, runCtx.db, schemaID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("acquire advisory lock: %w", err)
+	}
+	if !locked {
+		return 0, 0, ErrSchemaLockContended
+	}
+	defer unlock()
+	initSchemaFn := runCtx.initSchemaFn
+	if initSchemaFn == nil {
+		initSchemaFn = initSchema
+	}
+	return initSchemaFn(ctx, runCtx, schemaID)
 }
 
 // initSchema exports all existing data for a single schema to S3 base files.

--- a/internal/cdc/init_lock.go
+++ b/internal/cdc/init_lock.go
@@ -1,0 +1,38 @@
+package cdc
+
+import (
+	"context"
+	"fmt"
+)
+
+// initSchemaUnderLock holds the per-schema advisory lock for the whole
+// export + manifest publish, so manifest-reconcile (which reconciles under
+// the same lock) can never race an in-flight init (#290). Contended is an
+// error, not a skip: init is operator-initiated and a silently skipped
+// schema would stay uninitialized unnoticed.
+func initSchemaUnderLock(ctx context.Context, runCtx *initRunContext, schemaID int16) (int64, int, error) {
+	tryLock := runCtx.tryLock
+	if tryLock == nil {
+		tryLock = TrySchemaLock
+	}
+	locked, unlock, err := tryLock(ctx, runCtx.db, schemaID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("acquire advisory lock: %w", err)
+	}
+	if !locked {
+		return 0, 0, ErrSchemaLockContended
+	}
+	defer unlock()
+	initSchemaFn := runCtx.initSchemaFn
+	if initSchemaFn == nil {
+		initSchemaFn = initSchema
+	}
+	// The caller (processInitSchemas) already wraps this with "schema %d: %w",
+	// so we name only the operation here — not the schema ID — to avoid the
+	// double-naming rejected in earlier review.
+	rowsExported, filesCreated, err := initSchemaFn(ctx, runCtx, schemaID)
+	if err != nil {
+		return rowsExported, filesCreated, fmt.Errorf("init export+publish under schema lock: %w", err)
+	}
+	return rowsExported, filesCreated, nil
+}

--- a/internal/cdc/init_lock_test.go
+++ b/internal/cdc/init_lock_test.go
@@ -1,0 +1,50 @@
+package cdc
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestProcessInitSchemas_ContendedLockRecordsErrorAndContinues verifies that a
+// contended per-schema advisory lock is treated as an error (not a silent
+// skip): the contended schema lands in the joined error naming it, while other
+// schemas still run and their locks are released.
+func TestProcessInitSchemas_ContendedLockRecordsErrorAndContinues(t *testing.T) {
+	var initCalled []int16
+	var unlockCalled []int16
+	runCtx := &initRunContext{
+		logger:         zap.NewNop(),
+		schemaRegistry: stubSchemaRegistry{cache: testAttrCache()},
+		tryLock: func(_ context.Context, _ *sql.DB, sid int16) (bool, func(), error) {
+			if sid == 7 {
+				return false, nil, nil
+			}
+			return true, func() { unlockCalled = append(unlockCalled, sid) }, nil
+		},
+		initSchemaFn: func(_ context.Context, _ *initRunContext, sid int16) (int64, int, error) {
+			initCalled = append(initCalled, sid)
+			return 5, 1, nil
+		},
+	}
+	summary, err := processInitSchemas(context.Background(), runCtx, []int64{7, 8})
+	if !errors.Is(err, ErrSchemaLockContended) {
+		t.Fatalf("want ErrSchemaLockContended in joined error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "schema 7") {
+		t.Fatalf("error must name the contended schema: %v", err)
+	}
+	if len(initCalled) != 1 || initCalled[0] != 8 {
+		t.Fatalf("schema 8 must still be processed, got %v", initCalled)
+	}
+	if len(unlockCalled) != 1 || unlockCalled[0] != 8 {
+		t.Fatalf("unlock must run for locked schema 8, got %v", unlockCalled)
+	}
+	if summary.TotalRowsExported != 5 || summary.TotalFilesCreated != 1 {
+		t.Fatalf("summary must reflect the successful schema, got %+v", summary)
+	}
+}

--- a/internal/cdc/pgdsn.go
+++ b/internal/cdc/pgdsn.go
@@ -1,0 +1,31 @@
+package cdc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PGDSNParams are the inputs for a libpq keyword/value connection string.
+type PGDSNParams struct {
+	Host     string
+	Port     int
+	User     string
+	Password string
+	DB       string
+	SSLMode  string
+}
+
+// BuildPGDSN renders a libpq keyword/value DSN with every string value quoted
+// (single-quote wrapped, backslash and single-quote escaped) so passwords with
+// spaces or quotes survive parsing by pgx and DuckDB's postgres scanner.
+func BuildPGDSN(p PGDSNParams) string {
+	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		quotePGConnValue(p.Host), p.Port, quotePGConnValue(p.User),
+		quotePGConnValue(p.Password), quotePGConnValue(p.DB), quotePGConnValue(p.SSLMode))
+}
+
+func quotePGConnValue(v string) string {
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, `'`, `\'`)
+	return "'" + v + "'"
+}

--- a/internal/cdc/pgdsn_test.go
+++ b/internal/cdc/pgdsn_test.go
@@ -1,0 +1,28 @@
+package cdc
+
+import (
+	"testing"
+)
+
+func TestBuildPGDSN_QuotesValues(t *testing.T) {
+	got := BuildPGDSN(PGDSNParams{Host: "h", Port: 5432, User: "u u", Password: `p'w\d`, DB: "d", SSLMode: "require"})
+	want := `host='h' port=5432 user='u u' password='p\'w\\d' dbname='d' sslmode='require'`
+	if got != want {
+		t.Fatalf("BuildPGDSN = %s, want %s", got, want)
+	}
+}
+
+func TestQuotePGConnValue(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"plain", "'plain'"},
+		{"pa ss", "'pa ss'"},
+		{"it's", `'it\'s'`},
+		{`back\slash`, `'back\\slash'`},
+		{"", "''"},
+	}
+	for _, tt := range tests {
+		if got := quotePGConnValue(tt.in); got != tt.want {
+			t.Fatalf("quotePGConnValue(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/cdc/redact_test.go
+++ b/internal/cdc/redact_test.go
@@ -1,0 +1,58 @@
+package cdc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const redactSecret = "secret123"
+
+func redactTestParams() PGDSNParams {
+	return PGDSNParams{
+		Host:     "db.internal",
+		Port:     5432,
+		User:     "flusher",
+		Password: redactSecret,
+		DB:       "forma",
+		SSLMode:  "require",
+	}
+}
+
+// TestRedactConnStr_EscapedQuotedDSN pins the #290 regression: the flusher/init
+// feed BuildPGDSN's quoted DSN through escapeLiteral (doubling single quotes)
+// into a DuckDB ATTACH literal, then log it via redactConnStr. The doubled-quote
+// form (password=''secret'') must still be fully redacted — the old regex
+// matched the empty string between the doubled quotes and leaked the password.
+func TestRedactConnStr_EscapedQuotedDSN(t *testing.T) {
+	sqlLiteral := escapeLiteral(BuildPGDSN(redactTestParams()))
+	require.Contains(t, sqlLiteral, "password=''"+redactSecret+"''",
+		"precondition: escaped DSN must carry the doubled-quote form")
+
+	redacted := redactConnStr(sqlLiteral)
+	require.NotContains(t, redacted, redactSecret, "password leaked in redacted output: %q", redacted)
+	require.Contains(t, redacted, "***REDACTED***")
+	// The trailing keys after password must survive redaction.
+	require.Contains(t, redacted, "dbname=")
+}
+
+// TestRedactConnStr_PlainQuotedDSN pins the un-escaped quoted form as produced
+// by BuildPGDSN directly (password='secret').
+func TestRedactConnStr_PlainQuotedDSN(t *testing.T) {
+	redacted := redactConnStr(BuildPGDSN(redactTestParams()))
+	require.NotContains(t, redacted, redactSecret, "password leaked: %q", redacted)
+	require.Contains(t, redacted, "***REDACTED***")
+	require.Contains(t, redacted, "dbname=")
+}
+
+// TestRedactConnStr_LegacyUnquotedDSN pins the pre-#290 bare form
+// (password=secret) so the fix keeps redacting it.
+func TestRedactConnStr_LegacyUnquotedDSN(t *testing.T) {
+	legacy := "host=db.internal port=5432 user=flusher password=" + redactSecret + " dbname=forma sslmode=require"
+	redacted := redactConnStr(legacy)
+	require.NotContains(t, redacted, redactSecret, "password leaked: %q", redacted)
+	require.Contains(t, redacted, "***REDACTED***")
+	require.Contains(t, redacted, "dbname=forma")
+	require.True(t, strings.HasPrefix(redacted, "host=db.internal"))
+}

--- a/internal/cdc/redact_test.go
+++ b/internal/cdc/redact_test.go
@@ -9,6 +9,19 @@ import (
 
 const redactSecret = "secret123"
 
+// redactHostileSecret is a password carrying both an embedded single quote and a
+// backslash (Go literal for p'w\d). Once quoted by BuildPGDSN it becomes
+// password='p\'w\\d', whose escaped quote \' fools a naive '[^']*' matcher into
+// treating the escape as the closing quote and leaking the tail (#290).
+const redactHostileSecret = "p'w\\d"
+
+// redactHostileFragment is the leaking password tail as it appears *after*
+// quoting: quotePGConnValue doubles the backslash, so the tail that a naive
+// matcher leaks is w\\d (Go literal for w, backslash, backslash, d). This is
+// the exact material the buggy '[^']*' branch surfaced past ***REDACTED***; it
+// must never survive redaction in any DSN form.
+const redactHostileFragment = "w\\\\d"
+
 func redactTestParams() PGDSNParams {
 	return PGDSNParams{
 		Host:     "db.internal",
@@ -18,6 +31,67 @@ func redactTestParams() PGDSNParams {
 		DB:       "forma",
 		SSLMode:  "require",
 	}
+}
+
+func redactHostileParams() PGDSNParams {
+	p := redactTestParams()
+	p.Password = redactHostileSecret
+	return p
+}
+
+// TestRedactConnStr_HostilePasswordRawQuoted feeds a password with an embedded
+// quote+backslash through BuildPGDSN's raw quoted form. The escaped \' must not
+// be mistaken for the closing quote: neither the password nor its w\d tail may
+// leak, and the trailing keys must survive un-mangled.
+func TestRedactConnStr_HostilePasswordRawQuoted(t *testing.T) {
+	dsn := BuildPGDSN(redactHostileParams())
+	redacted := redactConnStr(dsn)
+	t.Logf("raw dsn:      %q", dsn)
+	t.Logf("raw redacted: %q", redacted)
+
+	require.NotContains(t, redacted, redactHostileFragment, "password tail leaked in redacted output: %q", redacted)
+	require.NotContains(t, redacted, redactHostileSecret, "full password leaked in redacted output: %q", redacted)
+	require.Contains(t, redacted, "***REDACTED***")
+	require.Contains(t, redacted, "dbname=")
+	require.Contains(t, redacted, "sslmode=")
+}
+
+// TestRedactConnStr_HostilePasswordEscapedQuoted feeds the same hostile password
+// through the escapeLiteral'd (doubled-quote) form embedded in a DuckDB literal.
+func TestRedactConnStr_HostilePasswordEscapedQuoted(t *testing.T) {
+	sqlLiteral := escapeLiteral(BuildPGDSN(redactHostileParams()))
+	redacted := redactConnStr(sqlLiteral)
+	t.Logf("escaped literal:  %q", sqlLiteral)
+	t.Logf("escaped redacted: %q", redacted)
+
+	require.NotContains(t, redacted, redactHostileFragment, "password tail leaked in redacted output: %q", redacted)
+	require.NotContains(t, redacted, redactHostileSecret, "full password leaked in redacted output: %q", redacted)
+	require.Contains(t, redacted, "***REDACTED***")
+	// In the escaped form trailing keys look like dbname=''forma''.
+	require.Contains(t, redacted, "dbname=''")
+	require.Contains(t, redacted, "sslmode=''")
+}
+
+// TestRedactConnStr_EmptyPasswordRawQuoted pins that an empty password (raw
+// password='') does not derail redaction of surrounding keys.
+func TestRedactConnStr_EmptyPasswordRawQuoted(t *testing.T) {
+	p := redactTestParams()
+	p.Password = ""
+	redacted := redactConnStr(BuildPGDSN(p))
+	require.Contains(t, redacted, "***REDACTED***")
+	require.Contains(t, redacted, "dbname=")
+	require.Contains(t, redacted, "sslmode=")
+}
+
+// TestRedactConnStr_EmptyPasswordEscapedQuoted pins the doubled-quote empty form
+// (password='''') — the branch-1 fallback must not swallow the trailing keys.
+func TestRedactConnStr_EmptyPasswordEscapedQuoted(t *testing.T) {
+	p := redactTestParams()
+	p.Password = ""
+	redacted := redactConnStr(escapeLiteral(BuildPGDSN(p)))
+	require.Contains(t, redacted, "***REDACTED***")
+	require.Contains(t, redacted, "dbname=''")
+	require.Contains(t, redacted, "sslmode=''")
 }
 
 // TestRedactConnStr_EscapedQuotedDSN pins the #290 regression: the flusher/init

--- a/internal/cdc/schema_lock.go
+++ b/internal/cdc/schema_lock.go
@@ -1,0 +1,40 @@
+package cdc
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrSchemaLockContended reports that another holder (flusher, cdc-init, or
+// manifest-reconcile) owns the per-schema advisory lock.
+var ErrSchemaLockContended = errors.New("schema advisory lock contended")
+
+// TrySchemaLock pins one physical connection and takes
+// pg_try_advisory_lock(schemaID, schemaID). The lock is session-scoped: on a
+// pool, acquire and release could land on different connections, and a lock
+// released on the wrong session silently fails — so unlock runs on the same
+// pinned conn and closes it to end the session. unlock is non-nil iff locked;
+// it uses a background context so the lock is released even after ctx cancel.
+func TrySchemaLock(ctx context.Context, db *sql.DB, schemaID int16) (bool, func(), error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("pin connection for schema %d advisory lock: %w", schemaID, err)
+	}
+	var locked bool
+	row := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1, $2)", int32(schemaID), int32(schemaID))
+	if err := row.Scan(&locked); err != nil {
+		_ = conn.Close()
+		return false, nil, fmt.Errorf("acquire schema %d advisory lock: %w", schemaID, err)
+	}
+	if !locked {
+		_ = conn.Close()
+		return false, nil, nil
+	}
+	unlock := func() {
+		_, _ = conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1, $2)", int32(schemaID), int32(schemaID))
+		_ = conn.Close()
+	}
+	return true, unlock, nil
+}

--- a/internal/cdc/schema_lock_test.go
+++ b/internal/cdc/schema_lock_test.go
@@ -1,0 +1,34 @@
+package cdc
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrSchemaLockContendedIdentity pins the sentinel's errors.Is identity so
+// callers (cdc-init) can distinguish lock contention from other failures.
+func TestErrSchemaLockContendedIdentity(t *testing.T) {
+	wrapped := fmt.Errorf("schema 7 skipped: %w", ErrSchemaLockContended)
+	require.ErrorIs(t, wrapped, ErrSchemaLockContended)
+	require.False(t, errors.Is(errors.New("other"), ErrSchemaLockContended))
+}
+
+// TestTrySchemaLockConnFailureWraps verifies the db.Conn(ctx) failure path
+// returns a wrapped error and a nil unlock. Real advisory-lock behaviour is
+// covered by reconcile/production e2e against Postgres.
+func TestTrySchemaLockConnFailureWraps(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close()) // closed pool: Conn(ctx) must fail
+
+	locked, unlock, err := TrySchemaLock(context.Background(), db, 7)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pin connection for schema 7 advisory lock")
+	require.False(t, locked)
+	require.Nil(t, unlock)
+}

--- a/internal/e2e_harness/federated/cdc.go
+++ b/internal/e2e_harness/federated/cdc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/uuid"
+	"github.com/lychee-technology/forma/internal/cdc"
 )
 
 // RunCDCFlush triggers a CDC flush operation.
@@ -75,28 +76,7 @@ func (h *FederatedTestHarness) RunCDCFlush(ctx context.Context) (*FlushResult, e
 }
 
 func (h *FederatedTestHarness) tryAcquireSchemaLock(ctx context.Context) (bool, func(), error) {
-	conn, err := h.PGDB.Conn(ctx)
-	if err != nil {
-		return false, nil, fmt.Errorf("get postgres connection for advisory lock: %w", err)
-	}
-
-	var locked bool
-	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1, $2)", int32(h.SchemaID), int32(h.SchemaID)).Scan(&locked); err != nil {
-		_ = conn.Close()
-		return false, nil, fmt.Errorf("acquire advisory lock: %w", err)
-	}
-	if !locked {
-		_ = conn.Close()
-		return false, nil, nil
-	}
-
-	unlock := func() {
-		unlockCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_, _ = conn.ExecContext(unlockCtx, "SELECT pg_advisory_unlock($1, $2)", int32(h.SchemaID), int32(h.SchemaID))
-		_ = conn.Close()
-	}
-	return true, unlock, nil
+	return cdc.TrySchemaLock(ctx, h.PGDB, h.SchemaID)
 }
 
 // getUnflushedRowIDs fetches unflushed row IDs from change_log up to batch size.

--- a/internal/e2e_harness/production/init_concurrent_e2e_test.go
+++ b/internal/e2e_harness/production/init_concurrent_e2e_test.go
@@ -27,6 +27,13 @@ type raceCounters struct {
 // The started barrier plus counter snapshots around RunInit prove at least
 // one create and one update genuinely overlapped the init pagination
 // (review round 1: without them the scheduler could serialize the test).
+//
+// Since #290 cdc-init holds the per-schema advisory lock for each schema's
+// export + manifest publish. The mutator here writes entity rows directly
+// and takes no advisory lock, so the race window and every assertion below
+// are unchanged. What DID change: a concurrent init/flusher/reconcile on
+// the same schema now surfaces as ErrSchemaLockContended instead of racing
+// (unit-covered in internal/cdc/init_lock_test.go).
 func TestInitUnderConcurrentMutation(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)

--- a/internal/e2e_harness/production/init_concurrent_e2e_test.go
+++ b/internal/e2e_harness/production/init_concurrent_e2e_test.go
@@ -31,9 +31,12 @@ type raceCounters struct {
 // Since #290 cdc-init holds the per-schema advisory lock for each schema's
 // export + manifest publish. The mutator here writes entity rows directly
 // and takes no advisory lock, so the race window and every assertion below
-// are unchanged. What DID change: a concurrent init/flusher/reconcile on
-// the same schema now surfaces as ErrSchemaLockContended instead of racing
-// (unit-covered in internal/cdc/init_lock_test.go).
+// are unchanged. What DID change is how a caller contending on the same
+// schema lock reacts, and it differs per caller: cdc-init surfaces the
+// contention as ErrSchemaLockContended naming the schema (unit-covered in
+// internal/cdc/init_lock_test.go); a contended flusher silently skips the
+// schema and returns nil; a contended reconcile marks the schema Skipped and
+// (with residual discrepancies) exits 2.
 func TestInitUnderConcurrentMutation(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)

--- a/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
+++ b/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
@@ -324,8 +324,10 @@ func testReconcileRepairIdempotent(t *testing.T, ctx context.Context, env *Env, 
 // path with the two-phase sighting contract: the first --gc run only
 // records each leftover's first-unlisted sighting (persisted next to the
 // manifest), and a later run deletes it once BOTH the observed-unlisted
-// duration and the object age exceed the grace period. Delta-shaped and
-// init-shaped orphans and manifest-listed objects are never touched.
+// duration and the object age exceed the grace period. Init-shaped base
+// orphans join the sweep since #290 (cdc-init holds the same per-schema
+// advisory lock reconcile takes). Delta-shaped orphans and manifest-listed
+// objects are never touched.
 func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
@@ -382,8 +384,8 @@ func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
 			t.Fatalf("gc run past grace: %v", err)
 		}
 		s := report.Schemas[0]
-		if len(s.Deleted) != 2 {
-			t.Fatalf("gc deleted %v, want the base and _tmp leftovers", s.Deleted)
+		if len(s.Deleted) != 3 {
+			t.Fatalf("gc deleted %v, want the merged-base, _tmp, and init-shaped leftovers", s.Deleted)
 		}
 
 		keys, err := env.listS3Keys(ctx)
@@ -394,14 +396,12 @@ func TestManifestReconcile_GCRemovesRewriteLeftovers(t *testing.T) {
 		for _, k := range keys {
 			remaining[k] = true
 		}
-		if remaining[staleBase] || remaining[staleTmp] {
-			t.Fatalf("gc left leftovers behind: base=%v tmp=%v", remaining[staleBase], remaining[staleTmp])
+		if remaining[staleBase] || remaining[staleTmp] || remaining[initShaped] {
+			t.Fatalf("gc left leftovers behind: base=%v tmp=%v init=%v",
+				remaining[staleBase], remaining[staleTmp], remaining[initShaped])
 		}
 		if !remaining[deltaOrphan] {
-			t.Fatal("gc deleted a delta-shaped orphan; delta orphans carry unique data")
-		}
-		if !remaining[initShaped] {
-			t.Fatal("gc deleted an init-shaped base orphan; an in-flight cdc-init writes these before publishing its manifest")
+			t.Fatal("gc deleted a delta-shaped orphan; delta orphans carry unique data and need --repair analysis")
 		}
 		for _, f := range mBefore.Files {
 			if key, ok := normalizedManifestKey(env, f.Path); ok && !remaining[key] {

--- a/internal/reconcile/classify.go
+++ b/internal/reconcile/classify.go
@@ -20,11 +20,12 @@ import (
 // OrphanClass is the filename-shape class of an unlisted parquet object. The
 // class decides the recovery direction: delta orphans may carry data that
 // exists nowhere else and are candidates for repair (guarded by row coverage
-// and Postgres liveness), merged-base and _tmp orphans are compaction
-// leftovers eligible for GC, and init-shaped base orphans are only reported —
-// an in-flight cdc-init promotes them long before it publishes the manifest
-// and holds no advisory lock, so deleting them could destroy a running
-// re-export. Unknown shapes are reported and never touched.
+// and Postgres liveness), while merged-base, _tmp, and init-shaped base
+// orphans are all eligible for GC. Init-shaped orphans became GC candidates in
+// #290: cdc-init now holds the same per-schema advisory lock reconcile takes,
+// so under that lock an init-shaped orphan is provably not from an in-flight
+// init — it is either a failed manifest publish or a file superseded by a
+// later init run. Unknown shapes are reported and never touched.
 type OrphanClass int
 
 const (

--- a/internal/reconcile/db.go
+++ b/internal/reconcile/db.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/lychee-technology/forma/internal/cdc"
 	"github.com/lychee-technology/forma/internal/sqlutil"
 )
 
@@ -61,37 +62,17 @@ func (e *RegistrySchemaEnumerator) SchemaIDs(ctx context.Context) ([]int16, erro
 }
 
 // PGAdvisoryLocker takes the flusher's per-schema advisory lock
-// (pg_try_advisory_lock(schemaID, schemaID), cdc.AcquireSchemaLock). Unlike
-// the flusher it pins one physical connection for the lock's lifetime: on a
-// pool, acquire and release could land on different connections, and a
-// session-scoped lock released on the wrong session silently fails.
+// (pg_try_advisory_lock(schemaID, schemaID)). It delegates to cdc.TrySchemaLock,
+// the single source of truth for the pinned-connection acquire/release dance:
+// on a pool, acquire and release could land on different connections, and a
+// session-scoped lock released on the wrong session silently fails, so the lock
+// pins one physical connection for its lifetime and closes it to unlock.
 type PGAdvisoryLocker struct {
 	DB *sql.DB
 }
 
 func (l *PGAdvisoryLocker) TryLock(ctx context.Context, schemaID int16) (bool, func(), error) {
-	conn, err := l.DB.Conn(ctx)
-	if err != nil {
-		return false, nil, fmt.Errorf("pin connection for schema %d lock: %w", schemaID, err)
-	}
-	var locked bool
-	row := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1, $2)", int32(schemaID), int32(schemaID))
-	if err := row.Scan(&locked); err != nil {
-		_ = conn.Close()
-		return false, nil, fmt.Errorf("acquire schema %d advisory lock: %w", schemaID, err)
-	}
-	if !locked {
-		_ = conn.Close()
-		return false, nil, nil
-	}
-	unlock := func() {
-		// Background context: the unlock must run even when the reconcile
-		// context is already cancelled; closing the pinned connection
-		// releases the session-scoped lock regardless.
-		_, _ = conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1, $2)", int32(schemaID), int32(schemaID))
-		_ = conn.Close()
-	}
-	return true, unlock, nil
+	return cdc.TrySchemaLock(ctx, l.DB, schemaID)
 }
 
 // PGLiveRows implements LiveRowChecker over the entity main table. Liveness

--- a/internal/reconcile/gc.go
+++ b/internal/reconcile/gc.go
@@ -10,9 +10,11 @@ import (
 )
 
 // gcSchema deletes provable garbage — merged-base and _tmp orphans (#188
-// rewrite leftovers) plus delta orphans the repair guard classified as
-// leftovers. Init-shaped base orphans never reach here (see
-// reconcileSchema), and delta orphans require the repair analysis first.
+// rewrite leftovers), init-shaped base orphans (#290: cdc-init holds the same
+// per-schema advisory lock, so under it an init-shaped orphan is provably not
+// from an in-flight init), plus delta orphans the repair guard classified as
+// leftovers. Delta orphans require the repair analysis first (see
+// reconcileSchema).
 //
 // Deletion implements the #188 follow-up's "unlisted longer than the grace
 // period" contract with a persisted sighting state: the first run that
@@ -62,7 +64,7 @@ func (r *Reconciler) gcSchema(ctx context.Context, schemaID int16, candidates []
 			next[obj.Key] = firstSeen
 			continue
 		}
-		r.Logger.Info("deleted orphaned compaction leftover",
+		r.Logger.Info("deleted orphaned object past the grace period",
 			zap.Int16("schema_id", schemaID), zap.String("key", obj.Key))
 		deleted = append(deleted, obj.Key)
 	}

--- a/internal/reconcile/race_guard_test.go
+++ b/internal/reconcile/race_guard_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lychee-technology/forma/internal/manifest"
 )
 
-func TestGC_SkipsInitShapedBaseOrphans(t *testing.T) {
+func TestGC_CollectsInitShapedBaseOrphans(t *testing.T) {
 	old := testClock().Add(-24 * time.Hour)
 	initShaped := "data/7/" + uuidA + "_" + uuidB + ".parquet"
 	merged := "data/7/base-" + uuidB + ".parquet"
@@ -28,12 +28,14 @@ func TestGC_SkipsInitShapedBaseOrphans(t *testing.T) {
 
 	report, err := r.Run(context.Background())
 	require.NoError(t, err)
-	// An in-flight cdc-init promotes {min}_{max} base files long before it
-	// publishes the manifest and holds no advisory lock — GC must never
-	// touch that shape, no matter how old or how long unlisted.
-	require.Equal(t, []string{merged}, deleter.deleted)
+	// Since #290 cdc-init holds the same per-schema advisory lock, so under
+	// this lock an init-shaped {min}_{max} base orphan is provably not from
+	// an in-flight init — it is either a failed manifest publish or a file
+	// superseded by a later init run, and joins the two-phase --gc sweep.
+	require.ElementsMatch(t, []string{initShaped, merged}, deleter.deleted)
+	require.ElementsMatch(t, []string{initShaped, merged}, report.Schemas[0].Deleted)
 	require.ElementsMatch(t, []string{initShaped, merged}, report.Schemas[0].BaseOrphans)
-	require.True(t, report.HasResidualDiscrepancies(), "undeletable init-shaped orphan stays residual")
+	require.False(t, report.HasResidualDiscrepancies())
 }
 
 func TestGC_ZeroGraceRefusesDeletion(t *testing.T) {

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -159,11 +159,17 @@ func (r *Reconciler) reconcileSchema(ctx context.Context, schemaID int16) Schema
 		deltaLeftovers = outcome.leftovers
 	}
 	if r.Opts.GC {
-		// Init-shaped base orphans are never GC candidates: an in-flight
-		// cdc-init promotes them long before publishing the manifest and
-		// holds no advisory lock. Delta leftovers require the repair
-		// analysis, so they are only deletable under --repair --gc.
-		candidates := append(append([]ObjectInfo(nil), d.baseMergedOrphans...), d.tmpOrphans...)
+		// Init-shaped base orphans are GC candidates since #290: cdc-init holds
+		// the same per-schema advisory lock, so under this lock an init-shaped
+		// orphan is provably not from an in-flight init — it is either the output
+		// of a failed manifest publish or a file superseded by a later init run.
+		// Recovery for a failed publish is re-running cdc-init (the source of
+		// truth is entity_main); auto-promotion (--repair) is a follow-up.
+		// Delta leftovers require the repair analysis, so they are only deletable
+		// under --repair --gc.
+		candidates := append([]ObjectInfo(nil), d.baseInitOrphans...)
+		candidates = append(candidates, d.baseMergedOrphans...)
+		candidates = append(candidates, d.tmpOrphans...)
 		candidates = append(candidates, deltaLeftovers...)
 		// Run even with zero candidates: sighting-state entries for keys
 		// that stopped being orphans must be pruned so a later unlisting


### PR DESCRIPTION
Closes #290

## What

Four blocks, in dependency order:

1. **Shared quoted PG DSN builder** (`cdc.BuildPGDSN`, 2ec6f78) — replaces three hand-built raw-interpolation DSN copies (`internal/cdc/init.go`, `internal/cdc/flusher.go` ×2 sites, `cmd/tools` `buildToolSQLDB`); values quoted per libpq rules (`\`→`\\` then `'`→`\'`), so passwords with spaces/quotes survive pgx and DuckDB postgres_scanner parsing. The flusher IAM branch is untouched (token resolves into the password before formatting).
2. **Single pinned-connection `cdc.TrySchemaLock`** (bd81ba1) — the canonical `pg_try_advisory_lock(schemaID, schemaID)` try-lock, pinned to one physical connection with a closure unlock (background ctx + conn close). The flusher migrates off the pool-based `AcquireSchemaLock`/`ReleaseSchemaLock` pair — **fixing the latent bug where acquire and release could land on different pooled connections, silently leaking the session lock**. `reconcile.PGAdvisoryLocker` and the federated e2e harness now delegate to it; contended-flusher semantics unchanged (skip + nil).
3. **cdc-init holds the lock** (e69a25b) — each schema's entire export + manifest publish (including 0-row and dry-run paths) runs under the advisory lock via `initSchemaUnderLock`. Contended is an **error, not a skip**: the schema joins `schemaErrors` (`errors.Is`-matchable `ErrSchemaLockContended`), other schemas continue, the run returns non-zero — init is operator-initiated, so a silently skipped schema must not go unnoticed.
4. **`manifest-reconcile --gc` now collects init-shaped orphans** (9c1bc37) — with init under the same lock reconcile holds, an init-shaped `{min}_{max}.parquet` orphan observed under the lock is provably not from an in-flight init: it is either output of a failed manifest publish or a file superseded by a later init run. Both flow through the existing two-phase sighting + grace machinery. `classifyObjectKey`/`diffSchema`/`report.go` are zero-change; residual/exit-code semantics hold automatically. `--repair` auto-promotion is deliberately excluded (partial mid-export runs are indistinguishable at the object level; promoting a partial set would drop base-tier rows) → follow-up #292.

Review fix wave (ed9840a, b18685c): the whole-branch review caught a **Critical regression introduced by block 1** — the quoted DSN, after `escapeLiteral` quote-doubling, defeated `redactConnStr`, leaking the PG password in the Info-level `sql_preview` log on every flush/init export. Fixed in `redactConnStr` (ordered alternation handling doubled-quote/quoted/legacy-unquoted forms), pinned by `redact_test.go` composing the real pipeline `redactConnStr(escapeLiteral(BuildPGDSN(...)))`; `flusher.go`'s hand-built unquoted log preview replaced with the redacted real DSN.

## Contended matrix (after this PR)

| caller | on contention |
|---|---|
| cdc-init | per-schema error `ErrSchemaLockContended`, run exits non-zero |
| flusher | skip + log, returns nil (unchanged; next tick retries) |
| manifest-reconcile | schema reported Skipped (unchanged; exit 2 on residual) |

## Operational notes

- **Flusher starvation window**: while init exports a schema (potentially long), the flusher skips that schema every tick — no incremental flush progress until init finishes. Per-batch lock cycling was rejected: it would reopen the init↔reconcile race this PR closes.
- This PR closes only the init↔reconcile race. Init's `ReplaceTierFiles` vs the compactor's manifest writes still rely on etag optimistic concurrency (compactor takes no advisory lock) — unchanged, per issue scope.
- The federated e2e harness's 2s unlock timeout is replaced by the shared background-ctx unlock (strictly stronger).
- `internal/cdc/init.go` sits at exactly the 500-line ceiling; the next edit there should split the file.
- `internal/federated/engine.go:440` still hand-builds a raw DSN — deliberately out of scope (different shape); the new redact pin test protects it when it eventually migrates.

## Verification

- `make test` (27 packages) + `make lint` green at HEAD.
- Unit: new `TestProcessInitSchemas_ContendedLockRecordsErrorAndContinues` (real `processInitSchemas` path, stubbed seams), inverted `TestGC_CollectsInitShapedBaseOrphans`, 4 flusher lock tests migrated to the single `tryLock` seam preserving original assertions, `TestBuildPGDSN_QuotesValues` + migrated quote cases, 3 redaction pin tests (red run reproduced the leak verbatim).
- E2E (Docker, run at HEAD): production `TestManifestReconcile*` — past-grace `--gc` now deletes {staleBase, staleTmp, initShaped}, deltaOrphan survives, residual clears; production `TestInit*` including `TestInitUnderConcurrentMutation` (mutator takes no advisory lock — race window and assertions unchanged, comment documents the new per-caller matrix); federated `-short` suite + benchmark green (harness lock helper migrated).
- Subagent-driven execution with per-task spec+quality review and a final whole-branch review (findings fixed and re-verified); plan at `docs/superpowers/plans/2026-07-20-issue-290-init-advisory-lock.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)