### PR TITLE
fix(cdc/federated): #252 flush ordering — close the mark→append transient-invisibility window

### DIFF
--- a/config_duckdb.go
+++ b/config_duckdb.go
@@ -33,13 +33,14 @@ type DuckDBConfig struct {
 	// tripping. Zero means use the built-in default.
 	CircuitBreakerOpenDuration time.Duration `json:"circuitBreakerOpenDuration"`
 
-	// FlushVisibilityGraceMs widens the federated dirty barrier (#252): rows
-	// whose flushed_at is within this many milliseconds of query start stay
-	// hot-readable, covering the reader-side staleness between loading the
-	// manifest and scanning change_log while a flush publishes. Zero means the
-	// built-in default (60s); a negative value disables the grace and restores
-	// the exact flushed_at = 0 barrier. Widening is a safe over-approximation:
-	// affected rows are served from Postgres, which always holds current state.
+	// FlushVisibilityGraceMs is the #252 clock-skew margin for the federated
+	// dirty barrier. Each query anchors its cutoff at the instant it resolved
+	// its parquet path set: rows marked flushed after that instant (their
+	// delta may be missing from the resolved set) stay hot-readable, minus
+	// this margin to absorb CDC-host vs query-host clock skew. Zero (the
+	// default) is the exact anchor — the steady state is never widened; a
+	// positive value hot-serves rows flushed up to that long before the
+	// query; a negative value disables the widening (the pre-#252 barrier).
 	FlushVisibilityGraceMs int64 `json:"flushVisibilityGraceMs"`
 
 	Routing RoutingPolicy `json:"routing"` // routing policy for federated queries

--- a/config_duckdb.go
+++ b/config_duckdb.go
@@ -33,6 +33,15 @@ type DuckDBConfig struct {
 	// tripping. Zero means use the built-in default.
 	CircuitBreakerOpenDuration time.Duration `json:"circuitBreakerOpenDuration"`
 
+	// FlushVisibilityGraceMs widens the federated dirty barrier (#252): rows
+	// whose flushed_at is within this many milliseconds of query start stay
+	// hot-readable, covering the reader-side staleness between loading the
+	// manifest and scanning change_log while a flush publishes. Zero means the
+	// built-in default (60s); a negative value disables the grace and restores
+	// the exact flushed_at = 0 barrier. Widening is a safe over-approximation:
+	// affected rows are served from Postgres, which always holds current state.
+	FlushVisibilityGraceMs int64 `json:"flushVisibilityGraceMs"`
+
 	Routing RoutingPolicy `json:"routing"` // routing policy for federated queries
 }
 

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -47,7 +47,7 @@ Formula:
 
 $$Result = (S3_{Data} \notin DirtySet) \cup PG_{HotData}$$
 
-* **DirtySet:** The set of row_ids currently present in the PostgreSQL change_log with flushed_at = 0, widened by the **flush-visibility grace** (#252): rows marked flushed after the instant this query resolved its parquet path set (minus the `FlushVisibilityGraceMs` clock-skew margin, default 0) also count as dirty. Because the flush appends the manifest before marking, a row flushed before path resolution already has its delta listed — the widening therefore catches exactly the rows racing this query (their delta may be missing from the resolved set) and keeps them hot-readable, while the steady state is never widened. The widening renders only in the HasHot tier form: it is safe solely because pg_source serves the discarded rows, so hot-excluded queries keep the strict flushed_at = 0 barrier.
+* **DirtySet:** The set of row_ids currently present in the PostgreSQL change_log with flushed_at = 0, widened by the **flush-visibility grace** (#252): rows marked flushed at or after the instant this query resolved its parquet path set (minus the `FlushVisibilityGraceMs` clock-skew margin, default 0) also count as dirty — inclusive, because millisecond stamps cannot order a mark and a path resolution landing in the same tick. Because the flush appends the manifest before marking, a row flushed before path resolution already has its delta listed — the widening therefore catches exactly the rows racing this query (their delta may be missing from the resolved set) and keeps them hot-readable, while the steady state is never widened. The widening renders only in the HasHot tier form: it is safe solely because pg_source serves the discarded rows, so hot-excluded queries keep the strict flushed_at = 0 barrier.
 * Any record found in S3 that also exists in the DirtySet is **discarded** immediately during the read phase, regardless of its timestamp.
 * **Flush ordering (#252):** the CDC flush publishes `copy tmp→final → manifest-append → mark-flushed`, so a batch is never simultaneously absent from the hot tier and from the manifest-listed delta set. The listed-but-unmarked middle state is resolved by this anti-join: the S3 copies of still-dirty rows are discarded and the hot versions serve.
 
@@ -172,7 +172,7 @@ dirty_ids AS (
     SELECT row_id   
     FROM postgres_scan($PG_CONN, 'public', 'change_log')  
     WHERE schema_id = $SCHEMA_ID  
-        AND (flushed_at = 0 OR flushed_at > $FLUSH_GRACE_CUTOFF_MS)  
+        AND (flushed_at = 0 OR flushed_at >= $FLUSH_GRACE_CUTOFF_MS)
 ),
 
 -- =========================================================================  
@@ -242,7 +242,7 @@ pg_source AS (
       ON cl.schema_id = e.schema_id AND cl.row_id = e.row_id  
       
     WHERE cl.schema_id = $SCHEMA_ID  
-        AND (cl.flushed_at = 0 OR cl.flushed_at > $FLUSH_GRACE_CUTOFF_MS)  
+        AND (cl.flushed_at = 0 OR cl.flushed_at >= $FLUSH_GRACE_CUTOFF_MS)
         AND m.ltbase_schema_id = $SCHEMA_ID  
         AND ($PG_WHERE_CLAUSE)  
     GROUP BY m.ltbase_row_id, m.ltbase_created_at, cl.changed_at, cl.deleted_at, m.text_01, m.integer_01  

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -47,8 +47,9 @@ Formula:
 
 $$Result = (S3_{Data} \notin DirtySet) \cup PG_{HotData}$$
 
-* **DirtySet:** The set of row_ids currently present in the PostgreSQL change_log with flushed_at = 0.  
+* **DirtySet:** The set of row_ids currently present in the PostgreSQL change_log with flushed_at = 0, widened by the **flush-visibility grace** (#252): rows marked flushed after the instant this query resolved its parquet path set (minus the `FlushVisibilityGraceMs` clock-skew margin, default 0) also count as dirty. Because the flush appends the manifest before marking, a row flushed before path resolution already has its delta listed — the widening therefore catches exactly the rows racing this query (their delta may be missing from the resolved set) and keeps them hot-readable, while the steady state is never widened. The widening renders only in the HasHot tier form: it is safe solely because pg_source serves the discarded rows, so hot-excluded queries keep the strict flushed_at = 0 barrier.
 * Any record found in S3 that also exists in the DirtySet is **discarded** immediately during the read phase, regardless of its timestamp.
+* **Flush ordering (#252):** the CDC flush publishes `copy tmp→final → manifest-append → mark-flushed`, so a batch is never simultaneously absent from the hot tier and from the manifest-listed delta set. The listed-but-unmarked middle state is resolved by this anti-join: the S3 copies of still-dirty rows are discarded and the hot versions serve.
 
 ## **4. Query Translation Layer**
 
@@ -158,6 +159,9 @@ PRAGMA threads=4;
 -- $PG_CONN:         String (Postgres Connection String)  
 -- $PG_WHERE_CLAUSE: String (Generated Physical SQL for Pushdown)  
 -- $S3_PATHS:        List (e.g., ['s3://bucket/base/*.parquet'])
+-- $FLUSH_GRACE_CUTOFF_MS: BIGINT (the instant this query resolved $S3_PATHS,
+--                    minus the clock-skew margin, #252; MaxInt64 disables
+--                    the widening — hot-excluded renders omit it entirely)
 
 WITH   
 -- =========================================================================  
@@ -168,7 +172,7 @@ dirty_ids AS (
     SELECT row_id   
     FROM postgres_scan($PG_CONN, 'public', 'change_log')  
     WHERE schema_id = $SCHEMA_ID  
-        AND flushed_at = 0  
+        AND (flushed_at = 0 OR flushed_at > $FLUSH_GRACE_CUTOFF_MS)  
 ),
 
 -- =========================================================================  
@@ -238,7 +242,7 @@ pg_source AS (
       ON cl.schema_id = e.schema_id AND cl.row_id = e.row_id  
       
     WHERE cl.schema_id = $SCHEMA_ID  
-        AND cl.flushed_at = 0  
+        AND (cl.flushed_at = 0 OR cl.flushed_at > $FLUSH_GRACE_CUTOFF_MS)  
         AND m.ltbase_schema_id = $SCHEMA_ID  
         AND ($PG_WHERE_CLAUSE)  
     GROUP BY m.ltbase_row_id, m.ltbase_created_at, cl.changed_at, cl.deleted_at, m.text_01, m.integer_01  

--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -23,7 +23,7 @@ manifest 条目，双向报告差异，并可选修复。它是两条既有故�
 
 | 类别 | 形态 | 来源 | 处置 |
 |------|------|------|------|
-| delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | #197 或 #188 删除失败的 merged source | `--repair` 经守卫判定后补录或转残留（见下） |
+| delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | flush 的 manifest-append 失败（#252 起 append 先于 mark-flushed：行留 dirty、重试自愈覆盖，孤儿通常判为可 GC 残留；#252 前为 #197 丢失数据形态）或 #188 删除失败的 merged source | `--repair` 经守卫判定后补录或转残留（见下） |
 | merged base 孤儿 | `base-{uuid}.parquet` | #188 | `--gc` 两阶段删除（见下） |
 | init base 孤儿 | `{min}_{max}.parquet` | cdc-init 导出 | `--gc` 两阶段删除（见下）。#290 起 cdc-init 与 reconcile 持同一把 per-schema advisory lock，故此锁下的 init 形态孤儿必非 in-flight init——只可能是发布失败的 manifest 或被后续 init 覆盖的旧文件（`--repair` 自动重建留 follow-up） |
 | `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | staging 残留（#188 崩溃 / #226 swallowed-delete） | `--gc` 两阶段删除（见下） |
@@ -43,9 +43,11 @@ unknown（只报告，永不删除）。
 
 ## `--repair` 的安全守卫（防墓碑复活）
 
-一个 delta 形态孤儿有两种截然相反的身份：#197 孤儿（数据仅存于该文件，必须补录）或
-#188 中删除失败的 merged source（数据已并入 merged base，其中墓碑行在合并时被物理丢弃
-——**补录会让已删除的行复活**）。工具用两级探测区分：
+一个 delta 形态孤儿有两种截然相反的身份：数据仅存于该文件的丢失形态（#197；#252 把
+flush 改为 append 先于 mark 后，新产生的 append-失败孤儿其行仍 dirty、会被重试自愈覆盖，
+从而落入下面的残留分支——丢失形态只剩历史遗留与极端交错）或 #188 中删除失败的 merged
+source（数据已并入 merged base，其中墓碑行在合并时被物理丢弃——**补录会让已删除的行
+复活**）。工具用两级探测区分：
 
 1. **覆盖探测**（DuckDB 反连接）：孤儿中有哪些 row_id 不出现在任何 manifest 已列文件里；
 2. **活性探测**（Postgres `entity_main`，`--entity-main-table`）：这些未覆盖行是否仍存活。

--- a/internal/cdc/flush_batch.go
+++ b/internal/cdc/flush_batch.go
@@ -29,6 +29,7 @@ type flushBatchExecutor struct {
 	executeSingle    func(*flushBatchExecutor, []uuid.UUID) error
 	executeInChunks  func(*flushBatchExecutor, []uuid.UUID, int) error
 	exportSnapshot   func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error
+	markFlushed      func(context.Context, *sql.DB, string, int16, []uuid.UUID, int64, int64) ([]uuid.UUID, error)
 }
 
 func (e *flushBatchExecutor) executeBatch(ctx context.Context, batchIDs []uuid.UUID, tmpKey string, finalKey string, batchKind string) error {
@@ -78,8 +79,39 @@ func (e *flushBatchExecutor) executeBatch(ctx context.Context, batchIDs []uuid.U
 			"schema_id", e.schemaID, "final_key", finalKey, "err", err)
 	}
 
+	// Order (#252): manifest-append precedes mark-flushed, so no query ever
+	// lands in a state where the batch's rows are in neither tier. The middle
+	// state — delta listed but rows still flushed_at = 0 — is safe by
+	// construction: the dirty anti-join (advanced_query_template_duckdb.go)
+	// discards the S3 copies of unflushed rows and the hot pg_source serves
+	// them. Failure contract (supersedes #197):
+	//   - Append fails -> rows stay dirty (mark never ran); the retry
+	//     re-exports to a fresh UUIDv7 key and self-heals. The old copied
+	//     final is an unlisted orphan reclaimed by manifest-reconcile --gc
+	//     (ClassDelta). The final key in the error is observability, not a
+	//     --repair pointer.
+	//   - Mark fails after append -> the delta is LISTED and rows stay dirty;
+	//     the retry yields a second listed delta with identical
+	//     (row_id, ver_ts) rows, which LWW (rn=1 + #183 tie-break) dedups and
+	//     compaction later collapses.
+	// The entry is built from batchIDs (mark has not run, so the marked subset
+	// is unknown): RowCount/RowIDMin/Max may overcount rows that concurrently
+	// changed after the snapshot. That feeds only compaction's promotion
+	// heuristic; reconcile recomputes stats from parquet contents. A batch
+	// whose rows ALL changed concurrently leaves an LWW-inert junk delta
+	// listed — accepted, never rolled back.
 	flushedAt := time.Now().UnixMilli()
-	updatedIDs, err := MarkFlushedIDsAtSnapshot(ctx, e.db, e.tableName, e.schemaID, batchIDs, e.snapshot, flushedAt)
+	if e.manifestStore != nil {
+		if err := updateManifest(ctx, e.manifestStore, e.manifestResolver, e.schemaID, finalKey, "delta", batchIDs, flushedAt, sizeBytes, e.logger); err != nil {
+			return fmt.Errorf("manifest update (%s) for %s: %w", batchKind, finalKey, err)
+		}
+	}
+
+	markFlushed := e.markFlushed
+	if markFlushed == nil {
+		markFlushed = MarkFlushedIDsAtSnapshot
+	}
+	updatedIDs, err := markFlushed(ctx, e.db, e.tableName, e.schemaID, batchIDs, e.snapshot, flushedAt)
 	if err != nil {
 		return fmt.Errorf("mark flushed at snapshot (%s): %w", batchKind, err)
 	}
@@ -87,19 +119,6 @@ func (e *flushBatchExecutor) executeBatch(ctx context.Context, batchIDs []uuid.U
 	if len(updatedIDs) == 0 {
 		e.logger.Sugar().Infow("flush batch marked zero rows; possible concurrent updates", "schema_id", e.schemaID, "batch_kind", batchKind, "batch_size", len(batchIDs))
 		return nil
-	}
-
-	if e.manifestStore != nil {
-		// Rows are already marked flushed, so a re-run will not re-export
-		// them: a delta file missing from the manifest stays invisible to
-		// manifest consumers (e.g. compaction) forever. Propagate so the run
-		// reports failure; the final key in the error is the operator's
-		// pointer to the orphaned file. Recovery: run
-		// `forma-tools manifest-reconcile --repair` (#203), which appends
-		// the orphaned delta with metadata recomputed from its contents.
-		if err := updateManifest(ctx, e.manifestStore, e.manifestResolver, e.schemaID, finalKey, "delta", updatedIDs, flushedAt, sizeBytes, e.logger); err != nil {
-			return fmt.Errorf("manifest update (%s) for %s: %w", batchKind, finalKey, err)
-		}
 	}
 
 	if len(updatedIDs) < len(batchIDs) {

--- a/internal/cdc/flush_batch.go
+++ b/internal/cdc/flush_batch.go
@@ -100,13 +100,21 @@ func (e *flushBatchExecutor) executeBatch(ctx context.Context, batchIDs []uuid.U
 	// heuristic; reconcile recomputes stats from parquet contents. A batch
 	// whose rows ALL changed concurrently leaves an LWW-inert junk delta
 	// listed — accepted, never rolled back.
-	flushedAt := time.Now().UnixMilli()
+	entryCreatedAt := time.Now().UnixMilli()
 	if e.manifestStore != nil {
-		if err := updateManifest(ctx, e.manifestStore, e.manifestResolver, e.schemaID, finalKey, "delta", batchIDs, flushedAt, sizeBytes, e.logger); err != nil {
+		if err := updateManifest(ctx, e.manifestStore, e.manifestResolver, e.schemaID, finalKey, "delta", batchIDs, entryCreatedAt, sizeBytes, e.logger); err != nil {
 			return fmt.Errorf("manifest update (%s) for %s: %w", batchKind, finalKey, err)
 		}
 	}
 
+	// The mark timestamp is sampled AFTER the append completes, separately
+	// from the manifest entry's CreatedMin/Max stamp: a reader that anchored
+	// its dirty-barrier cutoff and resolved its path set while the append was
+	// still in flight (its set lacks this delta) must observe
+	// flushed_at >= cutoff so the widened barrier keeps the rows hot-readable
+	// (#252 review P1). CreatedMin/Max only feed compaction ordering, so the
+	// two stamps diverging by the append latency is harmless.
+	flushedAt := time.Now().UnixMilli()
 	markFlushed := e.markFlushed
 	if markFlushed == nil {
 		markFlushed = MarkFlushedIDsAtSnapshot

--- a/internal/cdc/flush_batch_test.go
+++ b/internal/cdc/flush_batch_test.go
@@ -63,9 +63,11 @@ func TestExecuteFlush_SplitsBatchWhenByteTargetIsExceeded(t *testing.T) {
 
 // executeBatch must not swallow manifest failures: a delta file absent from
 // the manifest is invisible to manifest consumers (e.g. compaction) while
-// the run would otherwise report success. Rows are already marked flushed
-// by this point, so the flush state persists even though the pass fails —
-// the returned error carries the final key for manual reconciliation.
+// the run would otherwise report success. Under the #252 ordering the
+// manifest append runs BEFORE mark-flushed, so an append failure leaves the
+// rows dirty: the retry re-selects them and self-heals with a fresh key,
+// and the old copied final is an unlisted orphan for manifest-reconcile
+// --gc. The error still carries the final key for observability.
 func TestExecuteBatch_ReturnsErrorWhenManifestLoadFails(t *testing.T) {
 	db, err := sql.Open("duckdb", ":memory:")
 	require.NoError(t, err)
@@ -107,12 +109,12 @@ func TestExecuteBatch_ReturnsErrorWhenManifestLoadFails(t *testing.T) {
 	require.Contains(t, err.Error(), "manifest update")
 	require.Contains(t, err.Error(), "cdc/7/delta-file.parquet")
 
-	// The flush itself is durable: rows stay marked flushed even though the
-	// pass reports failure. A re-run will not re-export them.
+	// #252: mark-flushed runs after the append, so the failed append leaves
+	// the rows dirty — the retry re-selects and re-exports them.
 	var flushedAt int64
 	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
 	require.NoError(t, err)
-	require.NotZero(t, flushedAt)
+	require.Zero(t, flushedAt)
 	require.Zero(t, store.saved)
 }
 
@@ -159,6 +161,70 @@ func TestExecuteBatch_ReturnsErrorWhenManifestSaveFails(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, saveErr)
 	require.Contains(t, err.Error(), "cdc/7/delta-file.parquet")
+
+	// #252: the failed save precedes mark-flushed, so the rows stay dirty.
+	var flushedAt int64
+	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
+	require.NoError(t, err)
+	require.Zero(t, flushedAt)
+}
+
+// TestExecuteBatch_MarkFailsAfterManifestAppend pins the #252 failure
+// contract's second leg: mark-flushed failing after a successful append
+// leaves a LISTED delta with dirty rows. The retry then produces a second
+// listed delta whose duplicate (row_id, ver_ts) copies are LWW-deduped at
+// read time — the write path must only propagate the error, not attempt to
+// roll the manifest entry back.
+func TestExecuteBatch_MarkFailsAfterManifestAppend(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
+	snapshot := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
+	require.NoError(t, err)
+
+	store := newInMemoryManifestStore()
+	resolver := manifest.PathResolver{Prefix: "cdc", PathTemplate: "manifest/{{.SchemaID}}.json"}
+	markErr := errors.New("pg connection reset")
+
+	executor := &flushBatchExecutor{
+		db:               db,
+		duck:             &DuckExporter{Logger: zap.NewNop()},
+		s3Client:         &objectOnlyS3Client{},
+		cfg:              CDCConfig{S3Bucket: "test-bucket", S3Prefix: "cdc"},
+		tableName:        "change_log",
+		schemaID:         7,
+		snapshot:         snapshot,
+		pgConnForDuck:    "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
+		logger:           zap.NewNop(),
+		manifestStore:    store,
+		manifestResolver: resolver,
+		exportSnapshot: func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error {
+			return nil
+		},
+		markFlushed: func(context.Context, *sql.DB, string, int16, []uuid.UUID, int64, int64) ([]uuid.UUID, error) {
+			return nil, markErr
+		},
+	}
+
+	err = executor.executeBatch(ctx, []uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single")
+	require.Error(t, err)
+	require.ErrorIs(t, err, markErr)
+	require.Contains(t, err.Error(), "mark flushed at snapshot")
+
+	// The manifest entry stays: the delta is listed while the rows stay dirty.
+	require.Equal(t, 1, store.saved)
+	var flushedAt int64
+	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
+	require.NoError(t, err)
+	require.Zero(t, flushedAt)
 }
 
 func TestExecuteBatch_ReturnsErrorWhenExportFailsAndDoesNotAdvanceState(t *testing.T) {

--- a/internal/cdc/flush_batch_test.go
+++ b/internal/cdc/flush_batch_test.go
@@ -169,6 +169,58 @@ func TestExecuteBatch_ReturnsErrorWhenManifestSaveFails(t *testing.T) {
 	require.Zero(t, flushedAt)
 }
 
+// TestExecuteBatch_MarkStampSampledAfterManifestAppend pins the #252 review-P1
+// fix: the flushed_at stamp must be sampled AFTER the manifest append
+// completes. A reader that anchored its cutoff and resolved its path set
+// while the append was in flight has cutoff >= append-start; sampling the
+// stamp before the append could write flushed_at < cutoff and hide the rows
+// from the widened barrier. The store's Save is slowed so a pre-append stamp
+// is strictly older than the append completion at millisecond resolution.
+func TestExecuteBatch_MarkStampSampledAfterManifestAppend(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, "CREATE TABLE change_log (schema_id SMALLINT, row_id UUID, changed_at BIGINT, flushed_at BIGINT)")
+	require.NoError(t, err)
+	rowID := uuid.MustParse("018f05c0-0000-7000-8000-000000000001")
+	snapshot := time.Now().UnixMilli()
+	_, err = db.ExecContext(ctx, "INSERT INTO change_log VALUES (7, ?, ?, 0)", rowID, snapshot-1000)
+	require.NoError(t, err)
+
+	store := newInMemoryManifestStore()
+	store.saveDelay = 5 * time.Millisecond
+	resolver := manifest.PathResolver{Prefix: "cdc", PathTemplate: "manifest/{{.SchemaID}}.json"}
+
+	executor := &flushBatchExecutor{
+		db:               db,
+		duck:             &DuckExporter{Logger: zap.NewNop()},
+		s3Client:         &objectOnlyS3Client{},
+		cfg:              CDCConfig{S3Bucket: "test-bucket", S3Prefix: "cdc"},
+		tableName:        "change_log",
+		schemaID:         7,
+		snapshot:         snapshot,
+		pgConnForDuck:    "host=pg port=5432 user=pguser password=secret dbname=forma sslmode=disable",
+		logger:           zap.NewNop(),
+		manifestStore:    store,
+		manifestResolver: resolver,
+		exportSnapshot: func(*DuckExporter, context.Context, CDCConfig, string, string, int16, int64, []uuid.UUID, forma.SchemaAttributeCache) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, executor.executeBatch(ctx, []uuid.UUID{rowID}, "cdc/7/_tmp/file.parquet", "cdc/7/delta-file.parquet", "single"))
+
+	var flushedAt int64
+	err = db.QueryRowContext(ctx, "SELECT flushed_at FROM change_log WHERE schema_id = 7 AND row_id = ?", rowID).Scan(&flushedAt)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, flushedAt, store.lastSaveDoneMs,
+		"flushed_at must be sampled after the manifest append completes")
+}
+
 // TestExecuteBatch_MarkFailsAfterManifestAppend pins the #252 failure
 // contract's second leg: mark-flushed failing after a successful append
 // leaves a LISTED delta with dirty rows. The retry then produces a second

--- a/internal/cdc/mocks_test.go
+++ b/internal/cdc/mocks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -82,6 +83,11 @@ type inMemoryManifestStore struct {
 	loadErr error
 	saveErr error
 	saved   int
+	// saveDelay slows Save so tests can order the manifest append against
+	// timestamps sampled around it at millisecond resolution (#252 review P1);
+	// lastSaveDoneMs records when the slowed Save completed.
+	saveDelay      time.Duration
+	lastSaveDoneMs int64
 }
 
 type objectOnlyS3Client struct{}
@@ -173,6 +179,10 @@ func (s *inMemoryManifestStore) Save(_ context.Context, path string, data []byte
 	if s.saveErr != nil {
 		return "", s.saveErr
 	}
+	if s.saveDelay > 0 {
+		time.Sleep(s.saveDelay)
+	}
+	s.lastSaveDoneMs = time.Now().UnixMilli()
 	s.saved++
 	etag := fmt.Sprintf("etag-%d", s.saved)
 	s.data[path] = append([]byte(nil), data...)

--- a/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
@@ -4,7 +4,6 @@ package production
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -63,42 +62,12 @@ type flushOutcome struct {
 // invokes mutate on the test goroutine while the flush is suspended, then
 // resumes the flush and returns its outcome. The seeds stay small and no
 // chunking config is set, so the single batch issues exactly one CopyObject
-// and the pause fires deterministically once.
+// and the pause fires deterministically once. The goroutine/cleanup core
+// lives in runFlushPausedOn (cdc_flush_window_e2e_test.go), which #252 also
+// drives with a manifest-PutObject pause point.
 func runPausedFlush(ctx context.Context, t *testing.T, env *Env, mutate func()) (*FlushReport, error) {
 	t.Helper()
-	pauser := NewPausingS3(env.Cluster.S3, S3OpCopy)
-	ctx, cancel := context.WithTimeout(ctx, pausedFlushTimeout)
-
-	// The flush goroutine must not touch t; it reports through done (buffered
-	// so it never leaks even when the test dies before reading it).
-	done := make(chan flushOutcome, 1)
-	finished := make(chan struct{})
-	go func() {
-		defer close(finished)
-		report, err := env.RunFlushWith(ctx, FlushOverrides{S3: pauser})
-		done <- flushOutcome{report: report, err: err}
-	}()
-	// Registered after NewEnv's cleanups, so this runs first: any early
-	// t.Fatal (including inside mutate) releases the paused flush and waits
-	// for it to exit while the Env's resources are still alive.
-	t.Cleanup(func() {
-		pauser.Resume()
-		cancel()
-		<-finished
-	})
-
-	select {
-	case <-pauser.Reached():
-	case out := <-done:
-		t.Fatalf("flush finished before reaching the CopyObject pause: err=%v", out.err)
-	}
-	mutate()
-	pauser.Resume()
-	out := <-done
-	if out.err != nil {
-		return out.report, fmt.Errorf("flush under CopyObject pause: %w", out.err)
-	}
-	return out.report, nil
+	return runFlushPausedOn(ctx, t, env, NewPausingS3(env.Cluster.S3, S3OpCopy), mutate)
 }
 
 // runCleanRetry re-runs the flush without any pause and asserts it drains

--- a/internal/e2e_harness/production/cdc_fault_postmark_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_postmark_e2e_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 )
 
-// TestFlushFaultMarkFlushed breaks step 5 (UPDATE change_log SET flushed_at)
-// via a poison trigger, after the final S3 object already landed. Retry
-// re-exports the same rows into a second final object; LWW must dedup the
-// identical (row_id, ver_ts) copies so the federated result has no
-// duplicates (#179 known risky boundary 1). The first final object stays
-// outside the manifest forever (its manifest step never ran; retry appends
-// only its own key) — inventory drift owned by #203, invisible to reads.
+// TestFlushFaultMarkFlushed breaks the mark-flushed UPDATE via a poison
+// trigger. Under the #252 ordering mark runs LAST, so the final S3 object
+// landed AND its manifest entry was appended before the failure: the first
+// delta is listed with all its rows still dirty (the dirty anti-join keeps
+// serving the hot versions). Retry re-exports the same rows into a second
+// listed delta; LWW must dedup the identical (row_id, ver_ts) copies across
+// the two listed files so the federated result has no duplicates (#179
+// known risky boundary 1, relaxed to crash-free runs by #252).
 func TestFlushFaultMarkFlushed(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -37,7 +38,9 @@ func TestFlushFaultMarkFlushed(t *testing.T) {
 	if report.UnflushedAfter != 3 {
 		t.Errorf("rows must stay dirty, unflushed = %d, want 3", report.UnflushedAfter)
 	}
-	assertManifestDeltaPaths(t, report.Manifests, simple, nil)
+	// #252: the manifest append preceded the failed mark, so the first delta
+	// is already listed while its rows stay dirty.
+	assertManifestDeltaPaths(t, report.Manifests, simple, firstFinals)
 
 	healMarkFlushed(ctx, t, env)
 	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
@@ -51,22 +54,23 @@ func TestFlushFaultMarkFlushed(t *testing.T) {
 	if len(secondFinals) != 1 {
 		t.Fatalf("retry must create exactly one more final object, got %v", secondFinals)
 	}
-	// Two physical copies of the same rows exist; only the retry's object is
-	// tracked by the manifest.
-	assertManifestDeltaPaths(t, retry.Manifests, simple, secondFinals)
-	// The oracle knows 3 rows; duplicates across the two parquet copies would
+	// Two physical copies of the same rows exist and BOTH are listed; LWW is
+	// the only thing keeping the duplicates invisible.
+	assertManifestDeltaPaths(t, retry.Manifests, simple,
+		append(append([]string(nil), firstFinals...), secondFinals...))
+	// The oracle knows 3 rows; duplicates across the two listed copies would
 	// surface as extra result rows here.
 	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
 }
 
-// TestFlushFaultManifestLoad breaks step 6 (manifest GetObject) and
-// TestFlushFaultManifestSave breaks step 7 (manifest PutObject). Both land
-// after mark-flushed, pinning the corrected #197 contract: the run fails
-// with the final key embedded in the error, the retry is a strict no-op
-// (rows are flushed; no re-export, no manifest self-repair — a blind
-// AppendFile retry would duplicate entries), the delta file stays outside
-// the manifest (reconciliation is #203's scope), and federated reads are
-// unaffected because the read path never consults the manifest.
+// TestFlushFaultManifestLoad breaks the manifest GetObject and
+// TestFlushFaultManifestSave breaks the manifest PutObject. Under the #252
+// ordering both land BEFORE mark-flushed, pinning the contract that
+// superseded #197: the run fails with the final key embedded in the error
+// (observability, not a --repair pointer), the rows stay dirty and fully
+// hot-visible, and the retry self-heals — it re-exports the same rows to a
+// fresh UUIDv7 key and appends that. The first copied final stays an
+// unlisted orphan for manifest-reconcile --gc (ClassDelta covered leftover).
 func TestFlushFaultManifestLoad(t *testing.T) {
 	t.Parallel()
 	testFlushFaultManifest(t, S3OpGet)
@@ -95,27 +99,38 @@ func testFlushFaultManifest(t *testing.T, op S3Op) {
 	if len(finals) != 1 {
 		t.Fatalf("the final object must exist when the manifest step fails, got %v", finals)
 	}
-	// #197 contract: the error names the orphaned final key for the operator.
+	// The error still names the copied final key for observability.
 	if !strings.Contains(err.Error(), "manifest update") || !strings.Contains(err.Error(), finals[0]) {
-		t.Errorf("error must point at the orphaned final key %q, got: %v", finals[0], err)
+		t.Errorf("error must point at the copied final key %q, got: %v", finals[0], err)
 	}
-	// Rows are already marked flushed — the partial commit this matrix exists
-	// to pin.
-	if report.UnflushedAfter != 0 {
-		t.Errorf("rows must be marked flushed before the manifest step, unflushed = %d", report.UnflushedAfter)
+	// #252: the manifest append precedes mark-flushed, so the failed append
+	// leaves every row dirty — nothing was partially committed to Postgres.
+	if report.UnflushedAfter != 3 {
+		t.Errorf("rows must stay dirty when the manifest step fails, unflushed = %d, want 3", report.UnflushedAfter)
 	}
 	assertManifestDeltaPaths(t, report.Manifests, simple, nil)
+	// Mid-failure visibility: the rows never left the hot tier.
+	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
 
-	// Retry is a strict no-op and does NOT self-repair the manifest.
+	// Retry self-heals: it re-exports the same rows to a fresh key and appends
+	// only that key. The first copied final stays an unlisted orphan.
 	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
 	if err != nil {
 		t.Fatalf("clean retry flush: %v", err)
 	}
-	if retry.UnflushedBefore != 0 || len(retry.NewObjects) != 0 {
-		t.Errorf("retry must be a no-op: unflushed %d, new objects %v", retry.UnflushedBefore, retry.NewObjects)
+	if retry.UnflushedBefore != 3 || retry.UnflushedAfter != 0 {
+		t.Errorf("retry must drain the dirty rows: unflushed before/after = %d/%d, want 3/0",
+			retry.UnflushedBefore, retry.UnflushedAfter)
 	}
-	assertManifestDeltaPaths(t, retry.Manifests, simple, nil)
+	retryFinals, _ := splitKeys(retry.NewObjects)
+	if len(retryFinals) != 1 {
+		t.Fatalf("retry must promote exactly one new final object, got %v", retryFinals)
+	}
+	if retryFinals[0] == finals[0] {
+		t.Errorf("retry must use a fresh key, reused %q", finals[0])
+	}
+	assertManifestDeltaPaths(t, retry.Manifests, simple, retryFinals)
 
-	// Reads never consult the manifest; the flushed data stays fully visible.
+	// Converged: the listed delta serves the rows, the orphan stays invisible.
 	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
 }

--- a/internal/e2e_harness/production/cdc_flush_grace_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_flush_grace_e2e_test.go
@@ -1,0 +1,97 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// TestFlushGraceBackstopServesStaleManifestSnapshot pins the #252 read-side
+// grace: even with the append-before-mark ordering, a reader that resolved
+// its parquet path set BEFORE a flush's manifest append but runs its dirty
+// scan AFTER the mark would see the batch in neither tier. The grace widens
+// the dirty barrier to (flushed_at = 0 OR flushed_at > now-GRACE), so
+// just-flushed rows stay hot-readable until the reader's path snapshot
+// catches up.
+//
+// The stale snapshot is simulated with an explicit S3ParquetPathTemplate
+// hint (an explicit hint wins over the manifest source, #184/#187) listing
+// only the FIRST flush's delta while the second flush has already marked and
+// appended. The disabled-grace probe is the red anchor proving the grace is
+// the serving mechanism, not some other path.
+func TestFlushGraceBackstopServesStaleManifestSnapshot(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	seedTwoFlushedGenerations := func(t *testing.T, env *Env) (staleHint string) {
+		t.Helper()
+		wide := DefaultSchemaFixtures()[1] // e2e_wide
+		gen1 := buildOpenCreates(wide, 4)
+		mustApplyEvents(ctx, t, env, "seed generation 1", gen1...)
+		first, err := env.RunFlushWith(ctx, FlushOverrides{})
+		if err != nil {
+			t.Fatalf("first flush: %v", err)
+		}
+		firstFinals, _ := splitKeys(first.NewObjects)
+		if len(firstFinals) != 1 {
+			t.Fatalf("first flush must promote exactly one final delta, got %v", firstFinals)
+		}
+		gen2 := make([]*Event, 0, 4)
+		for i := 0; i < 4; i++ {
+			gen2 = append(gen2, CreateEvent(wide, map[string]any{
+				"title": fmt.Sprintf("fresh-%02d", i),
+				"count": float64(300000 + i),
+			}))
+		}
+		mustApplyEvents(ctx, t, env, "seed generation 2", gen2...)
+		if _, err := env.RunFlushWith(ctx, FlushOverrides{}); err != nil {
+			t.Fatalf("second flush: %v", err)
+		}
+		// The stale reader's path set: only the first delta, as if the second
+		// flush's manifest append had not been observed yet.
+		return fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, firstFinals[0])
+	}
+
+	queryStale := func(t *testing.T, env *Env, staleHint string) int {
+		t.Helper()
+		wide := DefaultSchemaFixtures()[1]
+		res, err := env.Query(ctx, Query{
+			Schema: wide, Limit: 10, S3ParquetPathTemplate: staleHint,
+		})
+		if err != nil {
+			t.Fatalf("stale-snapshot query: %v", err)
+		}
+		if !res.Plan.Routing.UseDuckDB {
+			t.Errorf("stale-snapshot query did not route to duckdb: %+v", res.Plan.Routing)
+		}
+		return len(res.Records)
+	}
+
+	t.Run("GraceServesJustFlushedRows", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, SharedCluster(t))
+		staleHint := seedTwoFlushedGenerations(t, env)
+		// Default grace (60s): both generations were flushed within the grace,
+		// so the widened barrier serves ALL rows from the hot tier even though
+		// the stale path set lists only the first delta.
+		if got := queryStale(t, env, staleHint); got != 8 {
+			t.Errorf("graced stale-snapshot query saw %d rows, want 8 — just-flushed rows must stay hot-readable (#252)", got)
+		}
+	})
+
+	t.Run("DisabledGraceExposesTheGap", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, SharedCluster(t))
+		// Restore the exact pre-#252 barrier before the engine is built.
+		env.DuckCfg.FlushVisibilityGraceMs = -1
+		staleHint := seedTwoFlushedGenerations(t, env)
+		// Red anchor: without the grace the second generation is invisible —
+		// marked flushed, absent from the stale path set. This documents that
+		// the grace is the mechanism serving the rows above.
+		if got := queryStale(t, env, staleHint); got != 4 {
+			t.Errorf("disabled-grace stale-snapshot query saw %d rows, want 4 (the pre-#252 gap)", got)
+		}
+	})
+}

--- a/internal/e2e_harness/production/cdc_flush_grace_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_flush_grace_e2e_test.go
@@ -11,16 +11,20 @@ import (
 // TestFlushGraceBackstopServesStaleManifestSnapshot pins the #252 read-side
 // grace: even with the append-before-mark ordering, a reader that resolved
 // its parquet path set BEFORE a flush's manifest append but runs its dirty
-// scan AFTER the mark would see the batch in neither tier. The grace widens
-// the dirty barrier to (flushed_at = 0 OR flushed_at > now-GRACE), so
-// just-flushed rows stay hot-readable until the reader's path snapshot
-// catches up.
+// scan AFTER the mark would see the batch in neither tier. The dirty-barrier
+// cutoff anchors at the query's own path-resolution instant (minus the
+// configured clock-skew margin), so rows marked after that instant stay
+// hot-readable while the resolved path set may predate their delta.
 //
-// The stale snapshot is simulated with an explicit S3ParquetPathTemplate
-// hint (an explicit hint wins over the manifest source, #184/#187) listing
-// only the FIRST flush's delta while the second flush has already marked and
-// appended. The disabled-grace probe is the red anchor proving the grace is
-// the serving mechanism, not some other path.
+// The e2e cannot pause a query between its path resolution and its dirty
+// scan, so the race is emulated from the other side: an explicit
+// S3ParquetPathTemplate hint (an explicit hint wins over the manifest
+// source, #184/#187) lists only the FIRST flush's delta while the second
+// flush has already marked and appended, and a large margin stands in for
+// "the path set was resolved before that flush". The default-margin probe is
+// the counterpart pin: in the steady state (flush completed before the
+// query) the exact anchor must NOT widen, so results keep their flushed
+// parquet semantics with zero drift.
 func TestFlushGraceBackstopServesStaleManifestSnapshot(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -69,29 +73,31 @@ func TestFlushGraceBackstopServesStaleManifestSnapshot(t *testing.T) {
 		return len(res.Records)
 	}
 
-	t.Run("GraceServesJustFlushedRows", func(t *testing.T) {
+	t.Run("MarginServesRowsFlushedAfterSnapshot", func(t *testing.T) {
 		t.Parallel()
 		env := NewEnv(t, SharedCluster(t))
-		staleHint := seedTwoFlushedGenerations(t, env)
-		// Default grace (60s): both generations were flushed within the grace,
+		// A 60s margin emulates a path set resolved before the recent flushes:
+		// both generations' flushed_at land after cutoff = resolution - 60s,
 		// so the widened barrier serves ALL rows from the hot tier even though
 		// the stale path set lists only the first delta.
+		env.DuckCfg.FlushVisibilityGraceMs = 60_000
+		staleHint := seedTwoFlushedGenerations(t, env)
 		if got := queryStale(t, env, staleHint); got != 8 {
-			t.Errorf("graced stale-snapshot query saw %d rows, want 8 — just-flushed rows must stay hot-readable (#252)", got)
+			t.Errorf("margined stale-snapshot query saw %d rows, want 8 — rows flushed after the emulated snapshot must stay hot-readable (#252)", got)
 		}
 	})
 
-	t.Run("DisabledGraceExposesTheGap", func(t *testing.T) {
+	t.Run("ExactAnchorNeverWidensSteadyState", func(t *testing.T) {
 		t.Parallel()
 		env := NewEnv(t, SharedCluster(t))
-		// Restore the exact pre-#252 barrier before the engine is built.
-		env.DuckCfg.FlushVisibilityGraceMs = -1
 		staleHint := seedTwoFlushedGenerations(t, env)
-		// Red anchor: without the grace the second generation is invisible —
-		// marked flushed, absent from the stale path set. This documents that
-		// the grace is the mechanism serving the rows above.
+		// Default (zero margin): both flushes completed before this query
+		// resolved its paths, so nothing is widened — the second generation is
+		// invisible through the stale hint exactly as pre-#252. This pins both
+		// the zero-drift steady state and that the margin is the serving
+		// mechanism in the subtest above.
 		if got := queryStale(t, env, staleHint); got != 4 {
-			t.Errorf("disabled-grace stale-snapshot query saw %d rows, want 4 (the pre-#252 gap)", got)
+			t.Errorf("exact-anchor stale-snapshot query saw %d rows, want 4 (steady state must not widen)", got)
 		}
 	})
 }

--- a/internal/e2e_harness/production/cdc_flush_grace_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_flush_grace_e2e_test.go
@@ -5,7 +5,11 @@ package production
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
+
+	fedengine "github.com/lychee-technology/forma/internal/federated"
 )
 
 // TestFlushGraceBackstopServesStaleManifestSnapshot pins the #252 read-side
@@ -91,6 +95,11 @@ func TestFlushGraceBackstopServesStaleManifestSnapshot(t *testing.T) {
 		t.Parallel()
 		env := NewEnv(t, SharedCluster(t))
 		staleHint := seedTwoFlushedGenerations(t, env)
+		// The inclusive cutoff comparison deliberately widens a mark landing
+		// in the SAME millisecond as the query's path stamp; let the clock
+		// tick past the flush so this probe pins the steady state, not the
+		// boundary.
+		waitWallClockTick(t)
 		// Default (zero margin): both flushes completed before this query
 		// resolved its paths, so nothing is widened — the second generation is
 		// invisible through the stale hint exactly as pre-#252. This pins both
@@ -98,6 +107,154 @@ func TestFlushGraceBackstopServesStaleManifestSnapshot(t *testing.T) {
 		// mechanism in the subtest above.
 		if got := queryStale(t, env, staleHint); got != 4 {
 			t.Errorf("exact-anchor stale-snapshot query saw %d rows, want 4 (steady state must not widen)", got)
+		}
+	})
+}
+
+// waitWallClockTick blocks until UnixMilli advances, so a subsequent
+// timestamp is strictly greater than any stamp taken before the call.
+func waitWallClockTick(t *testing.T) {
+	t.Helper()
+	start := time.Now().UnixMilli()
+	for time.Now().UnixMilli() <= start {
+		time.Sleep(200 * time.Microsecond)
+	}
+}
+
+// pausingParquetSource decorates the manifest-driven parquet source: the
+// FIRST Paths call resolves the real list, signals Reached, then blocks until
+// Release (or ctx cancellation). The caller can therefore run a full flush
+// strictly between a query's path resolution and its execution — the #252
+// reader race that no S3-level pause can reach.
+type pausingParquetSource struct {
+	inner       fedengine.ParquetSource
+	reached     chan struct{}
+	release     chan struct{}
+	reachOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newPausingParquetSource() *pausingParquetSource {
+	return &pausingParquetSource{reached: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (p *pausingParquetSource) Reached() <-chan struct{} { return p.reached }
+
+func (p *pausingParquetSource) Release() {
+	p.releaseOnce.Do(func() { close(p.release) })
+}
+
+func (p *pausingParquetSource) Paths(ctx context.Context, schemaID int16) ([]string, error) {
+	paths, err := p.inner.Paths(ctx, schemaID)
+	first := false
+	p.reachOnce.Do(func() { first = true })
+	if first {
+		close(p.reached)
+		select {
+		case <-p.release:
+		case <-ctx.Done():
+		}
+	}
+	return paths, err
+}
+
+func (p *pausingParquetSource) MissingIn(ctx context.Context, scanned []string) ([]string, error) {
+	return p.inner.MissingIn(ctx, scanned)
+}
+
+// TestFlushGraceExactAnchorCoversInFlightFlush pins the actual #252 reader
+// race end to end (review P2): a query stamps its cutoff and resolves its
+// parquet path set, THEN a full flush appends and marks a generation the
+// resolved set does not list, then the query's dirty scan executes. The
+// default exact anchor must keep the raced generation hot-readable; the
+// disabled-widening probe proves the anchor is the serving mechanism. This
+// also exercises the review-P1 fix — the mark stamp is sampled after the
+// append, so it lands at-or-after the paused query's cutoff.
+func TestFlushGraceExactAnchorCoversInFlightFlush(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	runRacedQuery := func(t *testing.T, env *Env) int {
+		t.Helper()
+		// Installed before ANY event: seeding goes through the EntityManager,
+		// which assembles the engine on first use — a wrapper set later would
+		// be ignored. The wrapper only pauses the first Paths call, and
+		// neither writes nor flushes resolve paths, so that first call is
+		// exactly the raced query below.
+		pauser := newPausingParquetSource()
+		env.ParquetSourceWrap = func(src fedengine.ParquetSource) fedengine.ParquetSource {
+			pauser.inner = src
+			return pauser
+		}
+
+		wide := DefaultSchemaFixtures()[1] // e2e_wide
+		gen1 := buildOpenCreates(wide, 4)
+		mustApplyEvents(ctx, t, env, "seed generation 1", gen1...)
+		if _, err := env.RunFlushWith(ctx, FlushOverrides{}); err != nil {
+			t.Fatalf("first flush: %v", err)
+		}
+		gen2 := make([]*Event, 0, 4)
+		for i := 0; i < 4; i++ {
+			gen2 = append(gen2, CreateEvent(wide, map[string]any{
+				"title": fmt.Sprintf("raced-%02d", i),
+				"count": float64(500000 + i),
+			}))
+		}
+		mustApplyEvents(ctx, t, env, "seed generation 2", gen2...)
+
+		type outcome struct {
+			res *QueryResult
+			err error
+		}
+		qctx, cancel := context.WithTimeout(ctx, pausedFlushTimeout)
+		done := make(chan outcome, 1)
+		finished := make(chan struct{})
+		go func() {
+			defer close(finished)
+			res, err := env.Query(qctx, Query{Schema: wide, Limit: 10})
+			done <- outcome{res: res, err: err}
+		}()
+		t.Cleanup(func() {
+			pauser.Release()
+			cancel()
+			<-finished
+		})
+
+		select {
+		case <-pauser.Reached():
+		case out := <-done:
+			t.Fatalf("query finished before pausing at path resolution: err=%v", out.err)
+		}
+		// The query holds a path set WITHOUT generation 2's delta and a cutoff
+		// stamped before this flush: append + mark race the suspended query.
+		if _, err := env.RunFlushWith(ctx, FlushOverrides{}); err != nil {
+			t.Fatalf("racing flush: %v", err)
+		}
+		pauser.Release()
+		out := <-done
+		if out.err != nil {
+			t.Fatalf("query racing the flush: %v", out.err)
+		}
+		if !out.res.Plan.Routing.UseDuckDB {
+			t.Errorf("raced query did not route to duckdb: %+v", out.res.Plan.Routing)
+		}
+		return len(out.res.Records)
+	}
+
+	t.Run("ExactAnchorServesRacedRows", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, SharedCluster(t))
+		if got := runRacedQuery(t, env); got != 8 {
+			t.Errorf("raced query saw %d rows, want 8 — rows marked after the query's path snapshot must stay hot-readable (#252)", got)
+		}
+	})
+
+	t.Run("DisabledWideningExposesRace", func(t *testing.T) {
+		t.Parallel()
+		env := NewEnv(t, SharedCluster(t))
+		env.DuckCfg.FlushVisibilityGraceMs = -1
+		if got := runRacedQuery(t, env); got != 4 {
+			t.Errorf("disabled-widening raced query saw %d rows, want 4 (the uncovered race)", got)
 		}
 	})
 }

--- a/internal/e2e_harness/production/cdc_flush_window_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_flush_window_e2e_test.go
@@ -24,6 +24,10 @@ func TestFlushManifestWindowVisibility(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := NewEnv(t, SharedCluster(t))
+	// The #252 read-side grace would also serve the window (see
+	// cdc_flush_grace_e2e_test.go); disable it so this test pins the
+	// write-side ordering fix in isolation.
+	env.DuckCfg.FlushVisibilityGraceMs = -1
 	wide := DefaultSchemaFixtures()[1] // e2e_wide
 
 	gen1 := buildOpenCreates(wide, 4)

--- a/internal/e2e_harness/production/cdc_flush_window_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_flush_window_e2e_test.go
@@ -1,0 +1,132 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// TestFlushManifestWindowVisibility pins issue #252: a federated query landing
+// between a flush's mark-flushed and its manifest-append must still see the
+// batch's rows. Under the pre-#252 ordering (copy -> mark -> append) the batch
+// was transiently invisible in every tier: the rows had left the hot tier
+// (flushed_at != 0 excludes them from dirty_ids and pg_source) while the delta
+// was not yet listed in the manifest the reader resolves paths from.
+//
+// The probe needs a NON-EMPTY manifest: a never-flushed schema falls back to
+// the legacy glob (QuerySource.Fallback), which sees the copied final object
+// regardless of manifest state — the window only exists for manifest-driven
+// reads. So generation 1 flushes cleanly first, then generation 2's flush is
+// held open at its manifest PutObject while the query probes the window.
+func TestFlushManifestWindowVisibility(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	gen1 := buildOpenCreates(wide, 4)
+	mustApplyEvents(ctx, t, env, "seed generation 1", gen1...)
+	first, err := env.RunFlushWith(ctx, FlushOverrides{})
+	if err != nil {
+		t.Fatalf("first clean flush: %v", err)
+	}
+	firstFinals, _ := splitKeys(first.NewObjects)
+	if len(firstFinals) != 1 {
+		t.Fatalf("first flush must promote exactly one final delta, got %v", firstFinals)
+	}
+	assertManifestDeltaPaths(t, first.Manifests, wide, firstFinals)
+	assertFederatedRowCount(ctx, t, env, "post-first-flush rows",
+		Query{Schema: wide, Limit: 10}, 4)
+
+	gen2 := make([]*Event, 0, 4)
+	for i := 0; i < 4; i++ {
+		gen2 = append(gen2, CreateEvent(wide, map[string]any{
+			"title": fmt.Sprintf("fresh-%02d", i),
+			"count": float64(300000 + i),
+		}))
+	}
+	mustApplyEvents(ctx, t, env, "seed generation 2", gen2...)
+	assertFederatedRowCount(ctx, t, env, "pre-pause rows",
+		Query{Schema: wide, Limit: 10}, 8)
+
+	// Hold the flush open at its manifest PutObject. The reader must keep
+	// seeing all 8 rows through the whole pipeline, including this window.
+	pauser := NewPausingS3OnKey(env.Cluster.S3, S3OpPut, "manifest/")
+	report, err := runFlushPausedOn(ctx, t, env, pauser, func() {
+		// The probe bypasses the oracle helper on purpose: the red signal is
+		// a crisp row count, not an artifact-dumping diff. It must route to
+		// DuckDB — the PG-only path reads the main table directly and has no
+		// window to expose.
+		res, qerr := env.Query(ctx, Query{Schema: wide, Limit: 10})
+		if qerr != nil {
+			t.Fatalf("mid-window query: %v", qerr)
+		}
+		if !res.Plan.Routing.UseDuckDB {
+			t.Errorf("mid-window query did not route to duckdb: %+v", res.Plan.Routing)
+		}
+		if got := len(res.Records); got != 8 {
+			t.Errorf("mid-flush window: query saw %d rows, want 8 — the in-flight batch is visible in neither tier (#252)", got)
+		}
+	})
+	if err != nil {
+		t.Fatalf("flush under manifest-append pause: %v", err)
+	}
+	if report.UnflushedAfter != 0 {
+		t.Errorf("flush must drain all dirty rows, unflushed = %d", report.UnflushedAfter)
+	}
+	secondFinals, _ := splitKeys(report.NewObjects)
+	if len(secondFinals) != 1 {
+		t.Fatalf("paused flush must promote exactly one final delta, got %v", secondFinals)
+	}
+	assertManifestDeltaPaths(t, report.Manifests, wide,
+		append(append([]string(nil), firstFinals...), secondFinals...))
+
+	// Converged: both deltas listed, nothing hot, oracle agrees on all 8.
+	assertFederatedRowCount(ctx, t, env, "converged rows",
+		Query{Schema: wide, Limit: 10}, 8)
+	assertRowCount(ctx, t, env, "generation 2 reachable",
+		Query{Schema: wide, Filters: []Filter{{Attr: "title", Value: "fresh-00"}}, Limit: 10}, 1)
+}
+
+// runFlushPausedOn starts one real flush with the given pauser installed as
+// its S3 client, invokes during on the test goroutine while the flush is
+// suspended at the pauser's first matching call, then resumes the flush and
+// returns its outcome. The generic core of runPausedFlush (which pins the
+// CopyObject pause point for #182); #252 pauses at the manifest PutObject.
+func runFlushPausedOn(ctx context.Context, t *testing.T, env *Env, pauser *PausingS3, during func()) (*FlushReport, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(ctx, pausedFlushTimeout)
+
+	// The flush goroutine must not touch t; it reports through done (buffered
+	// so it never leaks even when the test dies before reading it).
+	done := make(chan flushOutcome, 1)
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		report, err := env.RunFlushWith(ctx, FlushOverrides{S3: pauser})
+		done <- flushOutcome{report: report, err: err}
+	}()
+	// Registered after NewEnv's cleanups, so this runs first: any early
+	// t.Fatal (including inside during) releases the paused flush and waits
+	// for it to exit while the Env's resources are still alive.
+	t.Cleanup(func() {
+		pauser.Resume()
+		cancel()
+		<-finished
+	})
+
+	select {
+	case <-pauser.Reached():
+	case out := <-done:
+		t.Fatalf("flush finished before reaching the pause: err=%v", out.err)
+	}
+	during()
+	pauser.Resume()
+	out := <-done
+	if out.err != nil {
+		return out.report, fmt.Errorf("flush under pause: %w", out.err)
+	}
+	return out.report, nil
+}

--- a/internal/e2e_harness/production/cdc_flush_window_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_flush_window_e2e_test.go
@@ -24,9 +24,9 @@ func TestFlushManifestWindowVisibility(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	env := NewEnv(t, SharedCluster(t))
-	// The #252 read-side grace would also serve the window (see
-	// cdc_flush_grace_e2e_test.go); disable it so this test pins the
-	// write-side ordering fix in isolation.
+	// A configured #252 clock-skew margin could also serve the window (see
+	// cdc_flush_grace_e2e_test.go); disable the read-side widening so this
+	// test pins the write-side ordering fix in isolation.
 	env.DuckCfg.FlushVisibilityGraceMs = -1
 	wide := DefaultSchemaFixtures()[1] // e2e_wide
 

--- a/internal/e2e_harness/production/doc.go
+++ b/internal/e2e_harness/production/doc.go
@@ -36,6 +36,7 @@
 //	#246 breaker single-probe      -> WithBreaker, Duck.Close, ReopenDuckDB
 //	#186 multi-schema isolation    -> schemas/e2e_simple + e2e_second, per-test DB
 //	#260 nested dotted attributes  -> schemas/e2e_nested, nested_attrs_e2e_test.go
+//	#252 flush-window visibility   -> runFlushPausedOn, PausingS3 on manifest PUT, DuckCfg.FlushVisibilityGraceMs
 //
 // Environment variables: KEEP_E2E_ENV, E2E_SEED, E2E_ARTIFACTS_DIR,
 // E2E_VERBOSE, and PRODUCTION_E2E_EXTERNAL_* (see README.md).

--- a/internal/e2e_harness/production/engine.go
+++ b/internal/e2e_harness/production/engine.go
@@ -36,6 +36,9 @@ func (e *Env) Engine() *fedengine.DBFederatedQueryEngine {
 
 	var opts []fedengine.EngineOption
 	if src := e.parquetSource(); src != nil {
+		if e.ParquetSourceWrap != nil {
+			src = e.ParquetSourceWrap(src)
+		}
 		opts = append(opts, fedengine.WithParquetSource(src))
 	}
 	e.engine = fedengine.NewDBFederatedQueryEngine(

--- a/internal/e2e_harness/production/env.go
+++ b/internal/e2e_harness/production/env.go
@@ -42,6 +42,12 @@ type Env struct {
 	S3Prefix string
 	CDC      cdc.CDCConfig
 
+	// ParquetSourceWrap, when set before the Env's first query, decorates the
+	// manifest-driven parquet source the engine is built with — the seam for
+	// observing/pausing path resolution mid-query (#252). Mirrors the DuckCfg
+	// mutate-before-first-use pattern; nil leaves the source untouched.
+	ParquetSourceWrap func(fedengine.ParquetSource) fedengine.ParquetSource
+
 	logger *zap.Logger
 	opts   envOptions
 

--- a/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+++ b/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
@@ -109,9 +109,11 @@ func testMultiSchemaCopyFault(ctx context.Context, t *testing.T) {
 }
 
 // testMultiSchemaManifestSaveFault breaks the manifest PutObject for one
-// schema only. The faulted schema lands in the #197 partial-commit state
-// (rows flushed, final promoted, manifest missing, no self-repair on retry)
-// while the sibling schema's manifest and data are untouched by the failure.
+// schema only. Under the #252 ordering the faulted schema's append fails
+// BEFORE mark-flushed, so its rows stay dirty and the healed retry
+// self-heals them into a fresh listed delta (the first copied final stays an
+// unlisted orphan for reconcile --gc) — while the sibling schema's manifest
+// and data are untouched by the failure.
 func testMultiSchemaManifestSaveFault(ctx context.Context, t *testing.T) {
 	env := NewEnv(t, SharedCluster(t))
 	simple, second := seedTwoSchemas(ctx, t, env)
@@ -131,12 +133,12 @@ func testMultiSchemaManifestSaveFault(ctx context.Context, t *testing.T) {
 	// Healthy schema: complete commit including its manifest entry.
 	assertSchemaFullyFlushed(ctx, t, env, report.NewObjects, report.Manifests, simple, 3)
 
-	// Faulted schema: the #197 partial commit, scoped to this schema. Rows
-	// are marked flushed and the final exists, so the error must point the
-	// operator at the orphaned key; the manifest tracks nothing.
+	// Faulted schema: the failed append precedes mark-flushed (#252), so its
+	// rows stay dirty; the copied final exists and the error names it for
+	// observability, but the manifest tracks nothing.
 	flushed, dirty := fetchChangeLogRowIDs(ctx, t, env, second)
-	if len(flushed) != 3 || len(dirty) != 0 {
-		t.Fatalf("schema %d rows must be marked flushed before the manifest step: flushed=%v dirty=%v",
+	if len(flushed) != 0 || len(dirty) != 3 {
+		t.Fatalf("schema %d rows must stay dirty when its manifest append fails: flushed=%v dirty=%v",
 			second.ID, flushed, dirty)
 	}
 	finals := finalsForSchema(env, report.NewObjects, second)
@@ -144,22 +146,31 @@ func testMultiSchemaManifestSaveFault(ctx context.Context, t *testing.T) {
 		t.Fatalf("schema %d final must exist when its manifest save fails, got %v", second.ID, finals)
 	}
 	if !strings.Contains(err.Error(), "manifest update") || !strings.Contains(err.Error(), finals[0]) {
-		t.Errorf("error must point at the orphaned final key %q, got: %v", finals[0], err)
+		t.Errorf("error must point at the copied final key %q, got: %v", finals[0], err)
 	}
 	assertManifestDeltaPaths(t, report.Manifests, second, nil)
 
-	// Retry is a strict no-op for BOTH schemas: nothing dirty anywhere, no
-	// re-export, and no manifest self-repair for the faulted schema (#197).
+	// Retry self-heals ONLY the faulted schema: the healthy schema has
+	// nothing dirty and gains no objects; the faulted schema re-exports to a
+	// fresh listed delta (#252 supersedes the #197 no-op-retry contract).
 	retry, err := env.RunFlushWith(ctx, FlushOverrides{})
 	if err != nil {
 		t.Fatalf("clean retry flush: %v", err)
 	}
-	if retry.UnflushedBefore != 0 || len(retry.NewObjects) != 0 {
-		t.Errorf("retry must be a no-op: unflushed %d, new objects %v", retry.UnflushedBefore, retry.NewObjects)
+	if retry.UnflushedBefore != 3 || retry.UnflushedAfter != 0 {
+		t.Errorf("retry must drain only the faulted schema: unflushed before/after = %d/%d, want 3/0",
+			retry.UnflushedBefore, retry.UnflushedAfter)
 	}
-	assertManifestDeltaPaths(t, retry.Manifests, second, nil)
+	retryFinals := finalsForSchema(env, retry.NewObjects, second)
+	if len(retryFinals) != 1 {
+		t.Fatalf("retry must promote exactly one new final for the faulted schema, got %v", retry.NewObjects)
+	}
+	if healthy := finalsForSchema(env, retry.NewObjects, simple); len(healthy) != 0 {
+		t.Errorf("healthy schema must gain no new objects on retry, got %v", healthy)
+	}
+	assertManifestDeltaPaths(t, retry.Manifests, second, retryFinals)
 
-	// Reads never consult the manifest: both schemas stay fully visible.
+	// Both schemas fully visible after convergence.
 	env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 100})
 	env.AssertQueryMatches(ctx, Query{Schema: second, Limit: 100})
 }

--- a/internal/federated/design_doc_sql_test.go
+++ b/internal/federated/design_doc_sql_test.go
@@ -163,6 +163,9 @@ func rewriteDocSQLForLocalExecution(t *testing.T, sqlText, parquetPath string) s
 		{"$PG_WHERE_CLAUSE", "1 = 1"},
 		{"$PAGE_SIZE", "100"},
 		{"$OFFSET", "0"},
+		// Grace disabled (MaxInt64) so the seed's flushed s3 row keeps its
+		// #173 out-of-dirty-set semantics (#252).
+		{"$FLUSH_GRACE_CUTOFF_MS", "9223372036854775807"},
 		// Scan calls collapse to local relations above; this only clears the
 		// parameter-legend comment lines.
 		{"$PG_CONN", "(local)"},

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -99,46 +99,21 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 		return 0, fmt.Errorf("duckdb circuit breaker open, query rejected: %w", ErrDuckDBUnavailable)
 	}
 
-	// Resolve the parquet path set once (#187): explicit render hints win,
-	// otherwise the manifest-driven source authors the list. Provenance
-	// gates the read-error classification below. The flush-grace cutoff is
-	// stamped BEFORE resolution (#252): any row marked flushed after this
-	// instant may belong to a delta this path set does not list yet, so the
-	// dirty barrier keeps it hot-readable for this query.
-	graceCutoffMs := e.flushGraceCutoffMs(time.Now().UnixMilli())
-	parquetPaths, pathsFromSource, err := e.resolveParquetPaths(ctx, q)
+	parquetPaths, pathsFromSource, graceCutoffMs, err := e.resolveScanSources(ctx, q)
 	if err != nil {
-		return 0, fmt.Errorf("resolve parquet paths: %w", err)
-	}
-
-	// Pre-read schema-invariant validation (#189): the scan's union_by_name
-	// tolerates attribute-column drift across parquet generations, which
-	// would let a wrong-schema object's rows silently vanish (NULL row_id
-	// drops out of the dirty anti-join) instead of failing loudly (#187).
-	// Schema violations fail here, classified and degradable; unreadable
-	// footers are inconclusive and stay with the execution-path classifier.
-	// No recordQueryFailure: the query never started, and its timing fields
-	// would read from an unset start time. Benchmark schemas (100-102) are
-	// exempt: their parquet is the legacy CSV-sniffed harness shape (row_id
-	// VARCHAR, cast by the hardcoded benchmark projections) — the
-	// parquetcheck invariant codifies the PRODUCTION exporters, which never
-	// write those IDs (ValidateFixtureSchemaID reserves the range).
-	if !isBenchmarkSchemaID(q.SchemaID) {
-		if err := e.schemaValidator.Validate(ctx, e.duck, parquetPaths); err != nil {
-			return 0, fmt.Errorf("pre-read parquet schema validation: %w", err)
-		}
+		return 0, err
 	}
 
 	// Fetch dirty IDs and record in execution plan
 	dirtyIDs, err := e.fetchAndRecordDirtyIDs(ctx, tables, q, planCtx)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("fetch dirty row ids: %w", err)
 	}
 
 	// Build and execute the query
 	sqlStr, args, translateMs, err := e.buildDuckDBQueryWithPlan(ctx, tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, planCtx)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("build duckdb federated query: %w", err)
 	}
 
 	// Record translation in plan
@@ -173,7 +148,7 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 				return 0, fmt.Errorf("%w: %w", classified, err)
 			}
 		}
-		return 0, err
+		return 0, fmt.Errorf("stream duckdb federated rows: %w", err)
 	}
 
 	// Record success in circuit breaker
@@ -185,6 +160,44 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 	e.finalizeDuckDBExecutionPlan(ctx, planCtx, dirtyIDs, totalRecords, rowCount)
 
 	return totalRecords, nil
+}
+
+// resolveScanSources is the storage-facing pre-flight of a DuckDB federated
+// query: it stamps the #252 flush-grace cutoff, resolves the parquet path
+// set, and validates the parquet system-column invariant.
+func (e *DBFederatedQueryEngine) resolveScanSources(ctx context.Context, q *model.FederatedAttributeQuery) (paths []string, fromSource bool, graceCutoffMs int64, err error) {
+	// The flush-grace cutoff is stamped BEFORE resolution (#252): any row
+	// marked flushed at or after this instant may belong to a delta this
+	// path set does not list yet, so the dirty barrier keeps it hot-readable
+	// for this query.
+	graceCutoffMs = e.flushGraceCutoffMs(time.Now().UnixMilli())
+
+	// Resolve the parquet path set once (#187): explicit render hints win,
+	// otherwise the manifest-driven source authors the list. Provenance
+	// gates the read-error classification.
+	paths, fromSource, err = e.resolveParquetPaths(ctx, q)
+	if err != nil {
+		return nil, false, 0, fmt.Errorf("resolve parquet paths: %w", err)
+	}
+
+	// Pre-read schema-invariant validation (#189): the scan's union_by_name
+	// tolerates attribute-column drift across parquet generations, which
+	// would let a wrong-schema object's rows silently vanish (NULL row_id
+	// drops out of the dirty anti-join) instead of failing loudly (#187).
+	// Schema violations fail here, classified and degradable; unreadable
+	// footers are inconclusive and stay with the execution-path classifier.
+	// No recordQueryFailure: the query never started, and its timing fields
+	// would read from an unset start time. Benchmark schemas (100-102) are
+	// exempt: their parquet is the legacy CSV-sniffed harness shape (row_id
+	// VARCHAR, cast by the hardcoded benchmark projections) — the
+	// parquetcheck invariant codifies the PRODUCTION exporters, which never
+	// write those IDs (ValidateFixtureSchemaID reserves the range).
+	if !isBenchmarkSchemaID(q.SchemaID) {
+		if err := e.schemaValidator.Validate(ctx, e.duck, paths); err != nil {
+			return nil, false, 0, fmt.Errorf("pre-read parquet schema validation: %w", err)
+		}
+	}
+	return paths, fromSource, graceCutoffMs, nil
 }
 
 // fetchAndRecordDirtyIDs fetches dirty row IDs from Postgres and records in execution plan.

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -101,7 +101,11 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 
 	// Resolve the parquet path set once (#187): explicit render hints win,
 	// otherwise the manifest-driven source authors the list. Provenance
-	// gates the read-error classification below.
+	// gates the read-error classification below. The flush-grace cutoff is
+	// stamped BEFORE resolution (#252): any row marked flushed after this
+	// instant may belong to a delta this path set does not list yet, so the
+	// dirty barrier keeps it hot-readable for this query.
+	graceCutoffMs := e.flushGraceCutoffMs(time.Now().UnixMilli())
 	parquetPaths, pathsFromSource, err := e.resolveParquetPaths(ctx, q)
 	if err != nil {
 		return 0, fmt.Errorf("resolve parquet paths: %w", err)
@@ -132,7 +136,7 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 	}
 
 	// Build and execute the query
-	sqlStr, args, translateMs, err := e.buildDuckDBQueryWithPlan(ctx, tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, planCtx)
+	sqlStr, args, translateMs, err := e.buildDuckDBQueryWithPlan(ctx, tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, planCtx)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/federated/duckdb_query_build.go
+++ b/internal/federated/duckdb_query_build.go
@@ -147,6 +147,10 @@ func (e *DBFederatedQueryEngine) buildDuckDBTemplateBaseParams(
 	if len(parquetPaths) > 0 {
 		sqlParams["DuckDBS3Paths"] = parquetPaths
 	}
+	// Per-request dirty-barrier cutoff (#252). The direct builder renders it
+	// as a literal; the compiled path overwrites it with the splice sentinel
+	// so the cached skeleton stays cutoff-independent.
+	sqlParams["FlushGraceCutoffMs"] = e.flushGraceCutoffMs()
 	return sqlParams
 }
 
@@ -236,7 +240,7 @@ func (e *DBFederatedQueryEngine) serveFromPlanCache(
 		bound.PgMainClause = entry.dualPlan.PgMainClause
 		bound.DuckClause = entry.dualPlan.DuckClause
 	}
-	sqlStr, args := entry.compiled.Bind(q, bound, dirtyIDs)
+	sqlStr, args := entry.compiled.Bind(q, bound, dirtyIDs, e.flushGraceCutoffMs())
 	return sqlStr, args, true
 }
 

--- a/internal/federated/duckdb_query_build.go
+++ b/internal/federated/duckdb_query_build.go
@@ -30,9 +30,10 @@ func (e *DBFederatedQueryEngine) buildDuckDBQueryWithPlan(
 	attributeOrders []model.AttributeOrder,
 	limit, offset int,
 	parquetPaths []string,
+	graceCutoffMs int64,
 	planCtx *duckDBExecutionPlanContext,
 ) (string, []any, int64, error) {
-	sqlParams := e.buildDuckDBTemplateBaseParams(tables, q, attributeOrders, limit, offset, parquetPaths)
+	sqlParams := e.buildDuckDBTemplateBaseParams(tables, q, attributeOrders, limit, offset, parquetPaths, graceCutoffMs)
 
 	startTranslate := time.Now()
 
@@ -90,7 +91,7 @@ func (e *DBFederatedQueryEngine) buildDuckDBQueryWithPlan(
 	// Compiled-plan cache (#142): skeleton + template args are reused per
 	// (fingerprint, shape, scope); condition/keyset/dirty operands bind per
 	// request. Test hooks and non-advanced templates bypass the cache.
-	if sqlStr, args, ok := e.serveFromPlanCache(tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, sqlParams, &dc, cache, planCtx); ok {
+	if sqlStr, args, ok := e.serveFromPlanCache(tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, sqlParams, &dc, cache, planCtx); ok {
 		translateMs := time.Since(startTranslate).Milliseconds()
 		telemetry.EmitLatency(ctx, "translation", translateMs)
 		return sqlStr, args, translateMs, nil
@@ -115,6 +116,7 @@ func (e *DBFederatedQueryEngine) buildDuckDBTemplateBaseParams(
 	attributeOrders []model.AttributeOrder,
 	limit, offset int,
 	parquetPaths []string,
+	graceCutoffMs int64,
 ) map[string]any {
 	changeLogSchema, changeLogScanTable := duckDBPostgresScanLocation(tables.ChangeLog)
 	mainSchema, mainScanTable := duckDBPostgresScanLocation(tables.EntityMain)
@@ -147,10 +149,11 @@ func (e *DBFederatedQueryEngine) buildDuckDBTemplateBaseParams(
 	if len(parquetPaths) > 0 {
 		sqlParams["DuckDBS3Paths"] = parquetPaths
 	}
-	// Per-request dirty-barrier cutoff (#252). The direct builder renders it
-	// as a literal; the compiled path overwrites it with the splice sentinel
-	// so the cached skeleton stays cutoff-independent.
-	sqlParams["FlushGraceCutoffMs"] = e.flushGraceCutoffMs()
+	// Per-request dirty-barrier cutoff (#252), anchored at the query's
+	// path-resolution instant. The direct builder renders it as a literal;
+	// the compiled path overwrites it with the splice sentinel so the cached
+	// skeleton stays cutoff-independent.
+	sqlParams["FlushGraceCutoffMs"] = graceCutoffMs
 	return sqlParams
 }
 
@@ -173,6 +176,7 @@ func (e *DBFederatedQueryEngine) serveFromPlanCache(
 	attributeOrders []model.AttributeOrder,
 	limit, offset int,
 	parquetPaths []string,
+	graceCutoffMs int64,
 	sqlParams map[string]any,
 	dc *sqlgen.DualClauses,
 	cache forma.SchemaAttributeCache,
@@ -240,7 +244,7 @@ func (e *DBFederatedQueryEngine) serveFromPlanCache(
 		bound.PgMainClause = entry.dualPlan.PgMainClause
 		bound.DuckClause = entry.dualPlan.DuckClause
 	}
-	sqlStr, args := entry.compiled.Bind(q, bound, dirtyIDs, e.flushGraceCutoffMs())
+	sqlStr, args := entry.compiled.Bind(q, bound, dirtyIDs, graceCutoffMs)
 	return sqlStr, args, true
 }
 

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"text/template"
+	"time"
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/queryplan"
@@ -67,6 +68,10 @@ type DBFederatedQueryEngine struct {
 	// parquetSource resolves manifest-listed parquet paths (#187); nil keeps
 	// the legacy hint-only path resolution. See WithParquetSource.
 	parquetSource ParquetSource
+	// flushVisibilityGraceMs widens the dirty barrier by this many ms of
+	// flushed_at recency (#252); negative disables the grace. Resolved from
+	// DuckDBConfig.FlushVisibilityGraceMs at construction (zero -> default).
+	flushVisibilityGraceMs int64
 	// schemaValidator enforces the parquet system-column invariant before
 	// each scan (#189): union_by_name tolerates attribute-column evolution,
 	// so schema corruption must be caught by probing instead of by the
@@ -82,21 +87,59 @@ func WithPlanCache(c *queryplan.Cache) EngineOption {
 	return func(e *DBFederatedQueryEngine) { e.planCache = c }
 }
 
+// defaultFlushVisibilityGraceMs covers the reader-side manifest-load-to-scan
+// latency plus cross-host clock skew (flushed_at is stamped on the CDC host,
+// the cutoff on the query host) with wide margin.
+const defaultFlushVisibilityGraceMs int64 = 60_000
+
+// WithFlushVisibilityGrace overrides the #252 flush-visibility grace: rows
+// flushed within d of query start stay hot-readable. d <= 0 disables the
+// grace entirely (the exact flushed_at = 0 barrier — the pre-#252 behavior),
+// unlike the zero config value, which selects the built-in default.
+func WithFlushVisibilityGrace(d time.Duration) EngineOption {
+	return func(e *DBFederatedQueryEngine) {
+		if d <= 0 {
+			e.flushVisibilityGraceMs = -1
+			return
+		}
+		e.flushVisibilityGraceMs = d.Milliseconds()
+	}
+}
+
+// resolveFlushVisibilityGraceMs maps the config value to the engine field:
+// zero -> built-in default, negative -> disabled, positive -> as configured.
+func resolveFlushVisibilityGraceMs(ms int64) int64 {
+	if ms == 0 {
+		return defaultFlushVisibilityGraceMs
+	}
+	return ms
+}
+
+// flushGraceCutoffMs computes the per-request dirty-barrier cutoff: rows with
+// flushed_at strictly after it count as dirty (#252).
+func (e *DBFederatedQueryEngine) flushGraceCutoffMs() int64 {
+	if e.flushVisibilityGraceMs < 0 {
+		return sqlgen.FlushGraceCutoffDisabled
+	}
+	return time.Now().UnixMilli() - e.flushVisibilityGraceMs
+}
+
 // NewDBFederatedQueryEngine assembles the engine from its injected seams.
 // duck and breaker may be nil: a nil duck marks DuckDB as unavailable and a
 // nil breaker disables circuit breaking.
 func NewDBFederatedQueryEngine(pgSource PostgresFederatedSource, dirtyIDFetcher DirtyIDFetcher, duck DuckDBQueryExecutor, breaker *CircuitBreaker, cfg forma.DuckDBConfig, metadataCache *schemameta.MetadataCache, pgConnString string, opts ...EngineOption) *DBFederatedQueryEngine {
 	e := &DBFederatedQueryEngine{
-		pgSource:        pgSource,
-		dirtyIDFetcher:  dirtyIDFetcher,
-		duck:            duck,
-		breaker:         breaker,
-		cfg:             cfg,
-		metadataCache:   metadataCache,
-		pgConnString:    pgConnString,
-		duckTemplate:    sqlgen.AdvancedQueryTemplateDuckDB,
-		projections:     sqlgen.NewProjectionCache(),
-		schemaValidator: newParquetSchemaValidator(),
+		pgSource:               pgSource,
+		dirtyIDFetcher:         dirtyIDFetcher,
+		duck:                   duck,
+		breaker:                breaker,
+		cfg:                    cfg,
+		metadataCache:          metadataCache,
+		pgConnString:           pgConnString,
+		duckTemplate:           sqlgen.AdvancedQueryTemplateDuckDB,
+		projections:            sqlgen.NewProjectionCache(),
+		schemaValidator:        newParquetSchemaValidator(),
+		flushVisibilityGraceMs: resolveFlushVisibilityGraceMs(cfg.FlushVisibilityGraceMs),
 	}
 	for _, opt := range opts {
 		opt(e)

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -68,9 +68,10 @@ type DBFederatedQueryEngine struct {
 	// parquetSource resolves manifest-listed parquet paths (#187); nil keeps
 	// the legacy hint-only path resolution. See WithParquetSource.
 	parquetSource ParquetSource
-	// flushVisibilityGraceMs widens the dirty barrier by this many ms of
-	// flushed_at recency (#252); negative disables the grace. Resolved from
-	// DuckDBConfig.FlushVisibilityGraceMs at construction (zero -> default).
+	// flushVisibilityGraceMs is the #252 clock-skew margin subtracted from
+	// the query's path-resolution timestamp to form the dirty-barrier
+	// cutoff; zero = exact anchor (default), negative = widening disabled.
+	// Copied from DuckDBConfig.FlushVisibilityGraceMs at construction.
 	flushVisibilityGraceMs int64
 	// schemaValidator enforces the parquet system-column invariant before
 	// each scan (#189): union_by_name tolerates attribute-column evolution,
@@ -87,18 +88,15 @@ func WithPlanCache(c *queryplan.Cache) EngineOption {
 	return func(e *DBFederatedQueryEngine) { e.planCache = c }
 }
 
-// defaultFlushVisibilityGraceMs covers the reader-side manifest-load-to-scan
-// latency plus cross-host clock skew (flushed_at is stamped on the CDC host,
-// the cutoff on the query host) with wide margin.
-const defaultFlushVisibilityGraceMs int64 = 60_000
-
-// WithFlushVisibilityGrace overrides the #252 flush-visibility grace: rows
-// flushed within d of query start stay hot-readable. d <= 0 disables the
-// grace entirely (the exact flushed_at = 0 barrier — the pre-#252 behavior),
-// unlike the zero config value, which selects the built-in default.
+// WithFlushVisibilityGrace overrides the #252 clock-skew margin subtracted
+// from the query's path-resolution timestamp when computing the dirty-barrier
+// cutoff. d == 0 is the exact anchor (the default); d > 0 hardens against
+// cross-host clock skew (flushed_at is stamped on the CDC host, the cutoff on
+// the query host) at the cost of hot-serving rows flushed up to d before the
+// query; d < 0 disables the widening entirely (the pre-#252 barrier).
 func WithFlushVisibilityGrace(d time.Duration) EngineOption {
 	return func(e *DBFederatedQueryEngine) {
-		if d <= 0 {
+		if d < 0 {
 			e.flushVisibilityGraceMs = -1
 			return
 		}
@@ -106,22 +104,18 @@ func WithFlushVisibilityGrace(d time.Duration) EngineOption {
 	}
 }
 
-// resolveFlushVisibilityGraceMs maps the config value to the engine field:
-// zero -> built-in default, negative -> disabled, positive -> as configured.
-func resolveFlushVisibilityGraceMs(ms int64) int64 {
-	if ms == 0 {
-		return defaultFlushVisibilityGraceMs
-	}
-	return ms
-}
-
-// flushGraceCutoffMs computes the per-request dirty-barrier cutoff: rows with
-// flushed_at strictly after it count as dirty (#252).
-func (e *DBFederatedQueryEngine) flushGraceCutoffMs() int64 {
+// flushGraceCutoffMs computes the per-request dirty-barrier cutoff from the
+// instant the query resolved its parquet path set (#252): rows with
+// flushed_at strictly after the cutoff count as dirty. Because the flush
+// appends the manifest BEFORE marking, any row flushed before path
+// resolution already has its delta listed in the resolved set — so the
+// steady state is never widened; only rows racing this query stay
+// hot-readable. The configured grace is a clock-skew margin, not a window.
+func (e *DBFederatedQueryEngine) flushGraceCutoffMs(pathsResolvedAtMs int64) int64 {
 	if e.flushVisibilityGraceMs < 0 {
 		return sqlgen.FlushGraceCutoffDisabled
 	}
-	return time.Now().UnixMilli() - e.flushVisibilityGraceMs
+	return pathsResolvedAtMs - e.flushVisibilityGraceMs
 }
 
 // NewDBFederatedQueryEngine assembles the engine from its injected seams.
@@ -139,7 +133,7 @@ func NewDBFederatedQueryEngine(pgSource PostgresFederatedSource, dirtyIDFetcher 
 		duckTemplate:           sqlgen.AdvancedQueryTemplateDuckDB,
 		projections:            sqlgen.NewProjectionCache(),
 		schemaValidator:        newParquetSchemaValidator(),
-		flushVisibilityGraceMs: resolveFlushVisibilityGraceMs(cfg.FlushVisibilityGraceMs),
+		flushVisibilityGraceMs: cfg.FlushVisibilityGraceMs,
 	}
 	for _, opt := range opts {
 		opt(e)

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -106,8 +106,10 @@ func WithFlushVisibilityGrace(d time.Duration) EngineOption {
 
 // flushGraceCutoffMs computes the per-request dirty-barrier cutoff from the
 // instant the query resolved its parquet path set (#252): rows with
-// flushed_at strictly after the cutoff count as dirty. Because the flush
-// appends the manifest BEFORE marking, any row flushed before path
+// flushed_at at or after the cutoff count as dirty (inclusive, because
+// millisecond stamps cannot order a mark and a path resolution landing in
+// the same tick). Because the flush appends the manifest BEFORE marking and
+// samples the mark stamp after the append, any row flushed before path
 // resolution already has its delta listed in the resolved set — so the
 // steady state is never widened; only rows racing this query stay
 // hot-readable. The configured grace is a clock-skew margin, not a window.

--- a/internal/federated/engine_flush_grace_test.go
+++ b/internal/federated/engine_flush_grace_test.go
@@ -9,35 +9,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Pins the #252 grace-knob semantics: config zero selects the built-in
-// default, config negative disables, and the disabled engine emits the
-// FlushGraceCutoffDisabled cutoff (the exact pre-#252 barrier) instead of a
-// time-derived one.
+// Pins the #252 grace-knob semantics: the cutoff anchors at the query's
+// path-resolution timestamp minus the configured clock-skew margin (zero =
+// exact anchor, the default), and a negative margin disables the widening
+// entirely (the always-false FlushGraceCutoffDisabled cutoff).
 func TestFlushVisibilityGraceResolution(t *testing.T) {
-	require.Equal(t, defaultFlushVisibilityGraceMs, resolveFlushVisibilityGraceMs(0),
-		"config zero must select the built-in default")
-	require.Equal(t, int64(1234), resolveFlushVisibilityGraceMs(1234))
-	require.Equal(t, int64(-1), resolveFlushVisibilityGraceMs(-1),
-		"negative config must stay disabled")
-
 	newEngine := func(cfg forma.DuckDBConfig, opts ...EngineOption) *DBFederatedQueryEngine {
 		return NewDBFederatedQueryEngine(nil, nil, nil, nil, cfg, nil, "", opts...)
 	}
+	const resolvedAt = int64(1_752_900_000_000)
+
+	exact := newEngine(forma.DuckDBConfig{})
+	require.Equal(t, resolvedAt, exact.flushGraceCutoffMs(resolvedAt),
+		"zero margin must anchor the cutoff exactly at path resolution")
+
+	margined := newEngine(forma.DuckDBConfig{FlushVisibilityGraceMs: 5000})
+	require.Equal(t, resolvedAt-5000, margined.flushGraceCutoffMs(resolvedAt),
+		"a positive margin subtracts from the path-resolution anchor")
 
 	disabled := newEngine(forma.DuckDBConfig{FlushVisibilityGraceMs: -1})
-	require.Equal(t, sqlgen.FlushGraceCutoffDisabled, disabled.flushGraceCutoffMs(),
-		"disabled grace must emit the always-false cutoff, not now-minus-anything")
+	require.Equal(t, sqlgen.FlushGraceCutoffDisabled, disabled.flushGraceCutoffMs(resolvedAt),
+		"disabled widening must emit the always-false cutoff")
 
-	graced := newEngine(forma.DuckDBConfig{FlushVisibilityGraceMs: 5000})
-	cutoff := graced.flushGraceCutoffMs()
-	now := time.Now().UnixMilli()
-	require.InDelta(t, now-5000, cutoff, 1000,
-		"cutoff must be query-start now minus the configured grace")
-
-	// The option overrides the config, and d <= 0 disables (unlike config 0).
+	// The option overrides the config; a negative duration disables.
 	overridden := newEngine(forma.DuckDBConfig{FlushVisibilityGraceMs: 5000},
-		WithFlushVisibilityGrace(0))
-	require.Equal(t, sqlgen.FlushGraceCutoffDisabled, overridden.flushGraceCutoffMs())
+		WithFlushVisibilityGrace(-time.Second))
+	require.Equal(t, sqlgen.FlushGraceCutoffDisabled, overridden.flushGraceCutoffMs(resolvedAt))
 	widened := newEngine(forma.DuckDBConfig{}, WithFlushVisibilityGrace(2*time.Minute))
 	require.Equal(t, int64(120_000), widened.flushVisibilityGraceMs)
 }

--- a/internal/federated/engine_flush_grace_test.go
+++ b/internal/federated/engine_flush_grace_test.go
@@ -1,0 +1,43 @@
+package federated
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the #252 grace-knob semantics: config zero selects the built-in
+// default, config negative disables, and the disabled engine emits the
+// FlushGraceCutoffDisabled cutoff (the exact pre-#252 barrier) instead of a
+// time-derived one.
+func TestFlushVisibilityGraceResolution(t *testing.T) {
+	require.Equal(t, defaultFlushVisibilityGraceMs, resolveFlushVisibilityGraceMs(0),
+		"config zero must select the built-in default")
+	require.Equal(t, int64(1234), resolveFlushVisibilityGraceMs(1234))
+	require.Equal(t, int64(-1), resolveFlushVisibilityGraceMs(-1),
+		"negative config must stay disabled")
+
+	newEngine := func(cfg forma.DuckDBConfig, opts ...EngineOption) *DBFederatedQueryEngine {
+		return NewDBFederatedQueryEngine(nil, nil, nil, nil, cfg, nil, "", opts...)
+	}
+
+	disabled := newEngine(forma.DuckDBConfig{FlushVisibilityGraceMs: -1})
+	require.Equal(t, sqlgen.FlushGraceCutoffDisabled, disabled.flushGraceCutoffMs(),
+		"disabled grace must emit the always-false cutoff, not now-minus-anything")
+
+	graced := newEngine(forma.DuckDBConfig{FlushVisibilityGraceMs: 5000})
+	cutoff := graced.flushGraceCutoffMs()
+	now := time.Now().UnixMilli()
+	require.InDelta(t, now-5000, cutoff, 1000,
+		"cutoff must be query-start now minus the configured grace")
+
+	// The option overrides the config, and d <= 0 disables (unlike config 0).
+	overridden := newEngine(forma.DuckDBConfig{FlushVisibilityGraceMs: 5000},
+		WithFlushVisibilityGrace(0))
+	require.Equal(t, sqlgen.FlushGraceCutoffDisabled, overridden.flushGraceCutoffMs())
+	widened := newEngine(forma.DuckDBConfig{}, WithFlushVisibilityGrace(2*time.Minute))
+	require.Equal(t, int64(120_000), widened.flushVisibilityGraceMs)
+}

--- a/internal/federated/engine_flush_grace_test.go
+++ b/internal/federated/engine_flush_grace_test.go
@@ -1,6 +1,7 @@
 package federated
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -8,6 +9,17 @@ import (
 	"github.com/lychee-technology/forma/internal/sqlgen"
 	"github.com/stretchr/testify/require"
 )
+
+// flushGraceCutoffLiteral matches the #252 per-request cutoff spliced into
+// bound SQL. Tests comparing SQL across separate engine requests must
+// normalize it: each request stamps its own millisecond cutoff, so two
+// otherwise-identical builds legitimately differ in exactly this literal
+// (review P0 — the raw comparison was flaky across a millisecond boundary).
+var flushGraceCutoffLiteral = regexp.MustCompile(`flushed_at >= \d+`)
+
+func normalizeFlushGraceCutoff(sql string) string {
+	return flushGraceCutoffLiteral.ReplaceAllString(sql, "flushed_at >= <cutoff>")
+}
 
 // Pins the #252 grace-knob semantics: the cutoff anchors at the query's
 // path-resolution timestamp minus the configured clock-skew margin (zero =

--- a/internal/federated/engine_test.go
+++ b/internal/federated/engine_test.go
@@ -378,7 +378,10 @@ func TestEngineCompiledPlanCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, optsB.ExecutionPlan.Notes, "plan_cache=hit")
 	require.Equal(t, int64(1), optsB.ExecutionPlan.Timings["plan_cache_hit"])
-	require.Equal(t, duckA.lastSQL, duckB.lastSQL, "same shape must reuse the rendered skeleton")
+	// The per-request #252 cutoff is the only legitimate difference between
+	// the two bound SQLs; normalize it so the skeleton-reuse pin is exact.
+	require.Equal(t, normalizeFlushGraceCutoff(duckA.lastSQL), normalizeFlushGraceCutoff(duckB.lastSQL),
+		"same shape must reuse the rendered skeleton")
 	require.Contains(t, duckB.lastArgs, int64(77), "hit must bind the second request's operand")
 	require.NotContains(t, duckB.lastArgs, int64(10))
 

--- a/internal/federated/plan_cache_parity_test.go
+++ b/internal/federated/plan_cache_parity_test.go
@@ -44,7 +44,9 @@ func TestEnginePlanCachePathParity(t *testing.T) {
 	directSQL, directArgs := capturePlanPathSQL(t, false, 100, mc)
 	cachedSQL, cachedArgs := capturePlanPathSQL(t, true, 100, mc)
 
-	require.Equal(t, directSQL, cachedSQL,
+	// Each request stamps its own #252 cutoff, the sole legitimate byte
+	// difference between the two paths; normalize it before comparing.
+	require.Equal(t, normalizeFlushGraceCutoff(directSQL), normalizeFlushGraceCutoff(cachedSQL),
 		"engine cache path must produce byte-identical SQL to the direct builder")
 	require.Equal(t, directArgs, cachedArgs)
 }

--- a/internal/sqlgen/advanced_query_template_duckdb.go
+++ b/internal/sqlgen/advanced_query_template_duckdb.go
@@ -16,6 +16,14 @@ import "text/template"
 // stay consistently invisible instead of resurfacing as stale parquet
 // versions. Callers must always set HasHot (a missing map key renders as
 // false and would silently prune pg_source).
+// FlushGraceCutoffMs widens the dirty barrier (#252): rows flushed after the
+// cutoff (query-start now minus the visibility grace) count as dirty even
+// though flushed_at != 0, keeping just-flushed rows hot-readable while the
+// reader's manifest snapshot catches up to the append. Widening is a safe
+// over-approximation — it only shifts rows from parquet-served to PG-served.
+// The cutoff is a server-generated int64 (or the compile-time sentinel that
+// Bind splices); callers must always set it — FlushGraceCutoffDisabled
+// (MaxInt64) restores the exact flushed_at = 0 barrier.
 var AdvancedQueryTemplateDuckDB = template.Must(template.New("optimizedQueryDuckDB").Funcs(template.FuncMap{
 	"add": func(a, b int) int { return a + b },
 }).Parse(`
@@ -24,7 +32,7 @@ dirty_ids AS (
   SELECT row_id
   FROM postgres_scan('{{.PG_CONN}}', '{{.ChangeLogSchema}}', '{{.ChangeLogScanTable}}')
   WHERE schema_id = {{.SCHEMA_ID}}
-    AND flushed_at = 0
+    AND (flushed_at = 0 OR flushed_at > {{.FlushGraceCutoffMs}})
 ),
 
 s3_source AS (
@@ -74,7 +82,7 @@ pg_source AS (
   ) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id::VARCHAR
   {{end}}
   WHERE cl.schema_id = {{.SCHEMA_ID}}
-    AND cl.flushed_at = 0
+    AND (cl.flushed_at = 0 OR cl.flushed_at > {{.FlushGraceCutoffMs}})
     AND m.ltbase_schema_id = {{.SCHEMA_ID}}
     AND ({{.PG_WHERE_CLAUSE}})
   GROUP BY {{.PGGroupBy}}

--- a/internal/sqlgen/advanced_query_template_duckdb.go
+++ b/internal/sqlgen/advanced_query_template_duckdb.go
@@ -16,9 +16,12 @@ import "text/template"
 // stay consistently invisible instead of resurfacing as stale parquet
 // versions. Callers must always set HasHot (a missing map key renders as
 // false and would silently prune pg_source).
-// FlushGraceCutoffMs widens the dirty barrier (#252): rows flushed after the
-// cutoff (the instant this query resolved its parquet path set, minus the
-// configured clock-skew margin) count as dirty even though flushed_at != 0.
+// FlushGraceCutoffMs widens the dirty barrier (#252): rows flushed at or
+// after the cutoff (the instant this query resolved its parquet path set,
+// minus the configured clock-skew margin) count as dirty even though
+// flushed_at != 0. The comparison is inclusive because millisecond stamps
+// cannot order a mark and a path resolution landing in the same tick — the
+// ambiguous tick must resolve toward visibility (review P1).
 // The flush appends the manifest before marking, so a row flushed before
 // path resolution already has its delta listed — the widening therefore
 // catches exactly the rows racing this query, keeping them hot-readable
@@ -37,7 +40,7 @@ dirty_ids AS (
   SELECT row_id
   FROM postgres_scan('{{.PG_CONN}}', '{{.ChangeLogSchema}}', '{{.ChangeLogScanTable}}')
   WHERE schema_id = {{.SCHEMA_ID}}
-    AND (flushed_at = 0{{if .HasHot}} OR flushed_at > {{.FlushGraceCutoffMs}}{{end}})
+    AND (flushed_at = 0{{if .HasHot}} OR flushed_at >= {{.FlushGraceCutoffMs}}{{end}})
 ),
 
 s3_source AS (
@@ -87,7 +90,7 @@ pg_source AS (
   ) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id::VARCHAR
   {{end}}
   WHERE cl.schema_id = {{.SCHEMA_ID}}
-    AND (cl.flushed_at = 0 OR cl.flushed_at > {{.FlushGraceCutoffMs}})
+    AND (cl.flushed_at = 0 OR cl.flushed_at >= {{.FlushGraceCutoffMs}})
     AND m.ltbase_schema_id = {{.SCHEMA_ID}}
     AND ({{.PG_WHERE_CLAUSE}})
   GROUP BY {{.PGGroupBy}}

--- a/internal/sqlgen/advanced_query_template_duckdb.go
+++ b/internal/sqlgen/advanced_query_template_duckdb.go
@@ -17,13 +17,18 @@ import "text/template"
 // versions. Callers must always set HasHot (a missing map key renders as
 // false and would silently prune pg_source).
 // FlushGraceCutoffMs widens the dirty barrier (#252): rows flushed after the
-// cutoff (query-start now minus the visibility grace) count as dirty even
-// though flushed_at != 0, keeping just-flushed rows hot-readable while the
-// reader's manifest snapshot catches up to the append. Widening is a safe
-// over-approximation — it only shifts rows from parquet-served to PG-served.
-// The cutoff is a server-generated int64 (or the compile-time sentinel that
-// Bind splices); callers must always set it — FlushGraceCutoffDisabled
-// (MaxInt64) restores the exact flushed_at = 0 barrier.
+// cutoff (the instant this query resolved its parquet path set, minus the
+// configured clock-skew margin) count as dirty even though flushed_at != 0.
+// The flush appends the manifest before marking, so a row flushed before
+// path resolution already has its delta listed — the widening therefore
+// catches exactly the rows racing this query, keeping them hot-readable
+// instead of invisible. It renders only in the HasHot form: widening is safe
+// solely because pg_source serves the discarded rows, so hot-excluded
+// shapes keep the strict flushed_at = 0 barrier (their contract is
+// flushed-data-only, and discarding without a hot server would drop rows
+// whose delta IS listed). The cutoff is a server-generated int64 (or the
+// compile-time sentinel that Bind splices); callers must always set it —
+// FlushGraceCutoffDisabled (MaxInt64) restores the exact strict barrier.
 var AdvancedQueryTemplateDuckDB = template.Must(template.New("optimizedQueryDuckDB").Funcs(template.FuncMap{
 	"add": func(a, b int) int { return a + b },
 }).Parse(`
@@ -32,7 +37,7 @@ dirty_ids AS (
   SELECT row_id
   FROM postgres_scan('{{.PG_CONN}}', '{{.ChangeLogSchema}}', '{{.ChangeLogScanTable}}')
   WHERE schema_id = {{.SCHEMA_ID}}
-    AND (flushed_at = 0 OR flushed_at > {{.FlushGraceCutoffMs}})
+    AND (flushed_at = 0{{if .HasHot}} OR flushed_at > {{.FlushGraceCutoffMs}}{{end}})
 ),
 
 s3_source AS (

--- a/internal/sqlgen/duckdb_compiled_query.go
+++ b/internal/sqlgen/duckdb_compiled_query.go
@@ -24,12 +24,12 @@ const dirtyIDsSentinel = "__FORMA_DIRTY_IDS_SENTINEL__"
 // of the HasHot-sensitive arg interleave).
 const flushGraceCutoffSentinel = "__FORMA_FLUSH_GRACE_CUTOFF__"
 
-// FlushGraceCutoffDisabled renders the pre-#252 dirty barrier: no BIGINT
-// flushed_at can exceed MaxInt64, so `flushed_at > cutoff` is always false
-// and only flushed_at = 0 rows count as dirty. It is also the defensive
-// default when a render path fails to supply the cutoff — rendering 0 would
-// pull every flushed row back to hot (bypassing the parquet tiers), and an
-// absent key would render invalid SQL.
+// FlushGraceCutoffDisabled renders the pre-#252 dirty barrier: real
+// flushed_at stamps are epoch milliseconds, so `flushed_at >= MaxInt64` is
+// never true and only flushed_at = 0 rows count as dirty. It is also the
+// defensive default when a render path fails to supply the cutoff —
+// rendering 0 would pull every flushed row back to hot (bypassing the
+// parquet tiers), and an absent key would render invalid SQL.
 const FlushGraceCutoffDisabled int64 = math.MaxInt64
 
 // DuckDBCompiledQuery is the shape/scope-stable half of BuildDuckDBQuery for

--- a/internal/sqlgen/duckdb_compiled_query.go
+++ b/internal/sqlgen/duckdb_compiled_query.go
@@ -2,6 +2,8 @@ package sqlgen
 
 import (
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -13,6 +15,22 @@ import (
 // the per-request dirty-ID VALUES list belongs. UUID CSV output can never
 // contain this text, so a plain string splice is unambiguous.
 const dirtyIDsSentinel = "__FORMA_DIRTY_IDS_SENTINEL__"
+
+// flushGraceCutoffSentinel is the placeholder rendered into a compiled
+// skeleton where the per-request flush-visibility cutoff (#252) belongs. The
+// cutoff is a server-generated epoch-ms int64, never user input, so a literal
+// splice at Bind is injection-free and keeps the plan-cache key independent
+// of the per-request value (a bind ? would slot into two different positions
+// of the HasHot-sensitive arg interleave).
+const flushGraceCutoffSentinel = "__FORMA_FLUSH_GRACE_CUTOFF__"
+
+// FlushGraceCutoffDisabled renders the pre-#252 dirty barrier: no BIGINT
+// flushed_at can exceed MaxInt64, so `flushed_at > cutoff` is always false
+// and only flushed_at = 0 rows count as dirty. It is also the defensive
+// default when a render path fails to supply the cutoff — rendering 0 would
+// pull every flushed row back to hot (bypassing the parquet tiers), and an
+// absent key would render invalid SQL.
+const FlushGraceCutoffDisabled int64 = math.MaxInt64
 
 // DuckDBCompiledQuery is the shape/scope-stable half of BuildDuckDBQuery for
 // the production path (advanced template + dual clauses): the rendered SQL
@@ -82,6 +100,9 @@ func CompileDuckDBQuery(tpl *template.Template, params map[string]any, q *model.
 	} else {
 		m["DirtyIDsCSV"] = ""
 	}
+	// The cutoff is per-request: the skeleton carries the sentinel (keeping
+	// the cache key cutoff-independent) and Bind splices the real value.
+	m["FlushGraceCutoffMs"] = flushGraceCutoffSentinel
 
 	sql, tplArgs, err := RenderSQLTemplate(tpl, m)
 	if err != nil {
@@ -91,14 +112,15 @@ func CompileDuckDBQuery(tpl *template.Template, params map[string]any, q *model.
 }
 
 // Bind produces the executable SQL and full argument list for a request whose
-// shape matches the compiled skeleton: dirty CSV spliced, condition args in
-// the advanced-template interleave (DuckArgs, PgMainArgs, DuckArgs), keyset
-// cursor values, then the cached template args.
-func (c *DuckDBCompiledQuery) Bind(q *model.FederatedAttributeQuery, dual DualClauses, dirtyIDs []uuid.UUID) (string, []any) {
+// shape matches the compiled skeleton: dirty CSV and flush-grace cutoff
+// spliced, condition args in the advanced-template interleave (DuckArgs,
+// PgMainArgs, DuckArgs), keyset cursor values, then the cached template args.
+func (c *DuckDBCompiledQuery) Bind(q *model.FederatedAttributeQuery, dual DualClauses, dirtyIDs []uuid.UUID, graceCutoffMs int64) (string, []any) {
 	sql := c.Skeleton
 	if c.HasDirty {
 		sql = strings.ReplaceAll(sql, dirtyIDsSentinel, RenderDirtyIDsValuesCSV(dirtyIDs))
 	}
+	sql = strings.ReplaceAll(sql, flushGraceCutoffSentinel, strconv.FormatInt(graceCutoffMs, 10))
 
 	args := make([]any, 0, 2*len(dual.DuckArgs)+len(dual.PgMainArgs)+len(c.TplArgs)+4)
 	args = append(args, dual.DuckArgs...)

--- a/internal/sqlgen/duckdb_compiled_query_test.go
+++ b/internal/sqlgen/duckdb_compiled_query_test.go
@@ -37,7 +37,7 @@ func requireCompiledParity(t *testing.T, q *model.FederatedAttributeQuery, dual 
 	require.NoError(t, err)
 	require.NotNil(t, compiled)
 
-	gotSQL, gotArgs := compiled.Bind(q, dual, dirtyIDs)
+	gotSQL, gotArgs := compiled.Bind(q, dual, dirtyIDs, FlushGraceCutoffDisabled)
 	require.Equal(t, wantSQL, gotSQL)
 	require.Equal(t, wantArgs, gotArgs)
 }
@@ -110,7 +110,7 @@ func TestCompiledQueryColdOnlyParityOmitsPgSource(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, compiled)
 
-	gotSQL, gotArgs := compiled.Bind(q, dual, nil)
+	gotSQL, gotArgs := compiled.Bind(q, dual, nil, FlushGraceCutoffDisabled)
 	require.NotContains(t, gotSQL, "pg_source",
 		"hot excluded: the compiled skeleton must omit the pg_source CTE")
 	wantArgs := append(append([]any{}, dual.DuckArgs...), dual.DuckArgs...)
@@ -144,7 +144,7 @@ func TestCompiledQueryReuseAcrossRequests(t *testing.T) {
 	dualB, err := plan.Bind(qB.Condition, cache, nil)
 	require.NoError(t, err)
 
-	gotSQL, gotArgs := compiled.Bind(qB, dualB, dirtyB)
+	gotSQL, gotArgs := compiled.Bind(qB, dualB, dirtyB, FlushGraceCutoffDisabled)
 	wantSQL, wantArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), qB, dirtyB, &dualB)
 	require.NoError(t, err)
 	require.Equal(t, wantSQL, gotSQL, "request B served from request A's skeleton must equal the direct build")

--- a/internal/sqlgen/duckdb_flush_grace_test.go
+++ b/internal/sqlgen/duckdb_flush_grace_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Pins for the #252 read-side grace: the flushed_at barrier widens to
-// (flushed_at = 0 OR flushed_at > cutoff) at BOTH change_log scan sites, the
+// Pins for the #252 read-side grace: in the HasHot form the flushed_at
+// barrier widens to (flushed_at = 0 OR flushed_at > cutoff) at BOTH
+// change_log scan sites (cutoff = the query's path-resolution instant minus
+// the clock-skew margin), hot-excluded shapes keep the strict barrier, the
 // cutoff stays out of the compiled skeleton (sentinel splice, cache-key
 // stable), and every render path supplies a value — a missing cutoff must
 // fall back to FlushGraceCutoffDisabled, never to 0 (which would pull the
@@ -63,6 +65,19 @@ func TestFlushGraceCutoffRendersAtBothSites(t *testing.T) {
 		flushGraceParams(t, cutoff), flushGraceQuery(), nil, dual)
 	require.NoError(t, err)
 	requireGraceSites(t, sqlText, strconv.FormatInt(cutoff, 10))
+}
+
+// TestFlushGraceHotExcludedKeepsStrictBarrier pins the HasHot gate: with
+// pg_source pruned there is no hot server for grace-discarded rows, so the
+// dirty CTE must keep the strict flushed_at = 0 predicate.
+func TestFlushGraceHotExcludedKeepsStrictBarrier(t *testing.T) {
+	q := flushGraceQuery()
+	q.PreferredTiers = []model.DataTier{model.DataTierWarm, model.DataTierCold}
+	sqlText, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB,
+		flushGraceParams(t, int64(1_752_900_000_000)), q, nil, &DualClauses{DuckClause: "1=1"})
+	require.NoError(t, err)
+	require.Contains(t, sqlText, "AND (flushed_at = 0)")
+	require.NotContains(t, sqlText, "OR flushed_at > ")
 }
 
 // TestFlushGraceCutoffDefaultsToDisabled pins the defensive default on both

--- a/internal/sqlgen/duckdb_flush_grace_test.go
+++ b/internal/sqlgen/duckdb_flush_grace_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Pins for the #252 read-side grace: in the HasHot form the flushed_at
-// barrier widens to (flushed_at = 0 OR flushed_at > cutoff) at BOTH
+// barrier widens to (flushed_at = 0 OR flushed_at >= cutoff) at BOTH
 // change_log scan sites (cutoff = the query's path-resolution instant minus
 // the clock-skew margin), hot-excluded shapes keep the strict barrier, the
 // cutoff stays out of the compiled skeleton (sentinel splice, cache-key
@@ -48,9 +48,9 @@ func flushGraceQuery() *model.FederatedAttributeQuery {
 // change_log sites with the given cutoff literal.
 func requireGraceSites(t *testing.T, sqlText, cutoff string) {
 	t.Helper()
-	require.Contains(t, sqlText, "AND (flushed_at = 0 OR flushed_at > "+cutoff+")",
+	require.Contains(t, sqlText, "AND (flushed_at = 0 OR flushed_at >= "+cutoff+")",
 		"dirty_ids must render the widened barrier with the cutoff")
-	require.Contains(t, sqlText, "AND (cl.flushed_at = 0 OR cl.flushed_at > "+cutoff+")",
+	require.Contains(t, sqlText, "AND (cl.flushed_at = 0 OR cl.flushed_at >= "+cutoff+")",
 		"pg_source must render the widened barrier with the cutoff")
 	require.Equal(t, 2, strings.Count(sqlText, "flushed_at = 0 OR"),
 		"the widened barrier must appear at exactly the two change_log sites")
@@ -77,7 +77,7 @@ func TestFlushGraceHotExcludedKeepsStrictBarrier(t *testing.T) {
 		flushGraceParams(t, int64(1_752_900_000_000)), q, nil, &DualClauses{DuckClause: "1=1"})
 	require.NoError(t, err)
 	require.Contains(t, sqlText, "AND (flushed_at = 0)")
-	require.NotContains(t, sqlText, "OR flushed_at > ")
+	require.NotContains(t, sqlText, "OR flushed_at >= ")
 }
 
 // TestFlushGraceCutoffDefaultsToDisabled pins the defensive default on both
@@ -134,7 +134,7 @@ func TestFlushGraceCompiledSkeletonIsCutoffIndependent(t *testing.T) {
 	require.NotNil(t, compiled)
 	require.Contains(t, compiled.Skeleton, flushGraceCutoffSentinel,
 		"the skeleton must carry the sentinel so the cache key is cutoff-independent")
-	require.NotContains(t, compiled.Skeleton, "flushed_at > 111",
+	require.NotContains(t, compiled.Skeleton, "flushed_at >= 111",
 		"a per-request cutoff must never bake into the skeleton")
 
 	sqlA, argsA := compiled.Bind(q, dual, nil, 1000)

--- a/internal/sqlgen/duckdb_flush_grace_test.go
+++ b/internal/sqlgen/duckdb_flush_grace_test.go
@@ -1,0 +1,133 @@
+package sqlgen
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins for the #252 read-side grace: the flushed_at barrier widens to
+// (flushed_at = 0 OR flushed_at > cutoff) at BOTH change_log scan sites, the
+// cutoff stays out of the compiled skeleton (sentinel splice, cache-key
+// stable), and every render path supplies a value — a missing cutoff must
+// fall back to FlushGraceCutoffDisabled, never to 0 (which would pull the
+// whole flushed history back to hot) or to empty (invalid SQL).
+
+func flushGraceParams(t *testing.T, cutoff any) map[string]any {
+	t.Helper()
+	m := map[string]any{
+		"PG_CONN":              "dbname=forma host=localhost",
+		"ChangeLogSchema":      "public",
+		"ChangeLogScanTable":   "change_log",
+		"MainSchema":           "public",
+		"MainScanTable":        "entity_main_dev",
+		"EAVSchema":            "public",
+		"EAVScanTable":         "eav_data_dev",
+		"S3_PATHS":             "['s3://bucket/base/*.parquet']",
+		"LOGICAL_WHERE_CLAUSE": "1=1",
+	}
+	if cutoff != nil {
+		m["FlushGraceCutoffMs"] = cutoff
+	}
+	return injectTestProjection(t, m, 1)
+}
+
+func flushGraceQuery() *model.FederatedAttributeQuery {
+	return &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0},
+	}
+}
+
+// requireGraceSites asserts the widened predicate renders at exactly the two
+// change_log sites with the given cutoff literal.
+func requireGraceSites(t *testing.T, sqlText, cutoff string) {
+	t.Helper()
+	require.Contains(t, sqlText, "AND (flushed_at = 0 OR flushed_at > "+cutoff+")",
+		"dirty_ids must render the widened barrier with the cutoff")
+	require.Contains(t, sqlText, "AND (cl.flushed_at = 0 OR cl.flushed_at > "+cutoff+")",
+		"pg_source must render the widened barrier with the cutoff")
+	require.Equal(t, 2, strings.Count(sqlText, "flushed_at = 0 OR"),
+		"the widened barrier must appear at exactly the two change_log sites")
+}
+
+// TestFlushGraceCutoffRendersAtBothSites pins the direct (dual-clause) path
+// with an engine-supplied cutoff.
+func TestFlushGraceCutoffRendersAtBothSites(t *testing.T) {
+	const cutoff = int64(1_752_900_000_000)
+	dual := &DualClauses{DuckClause: "1=1"}
+	sqlText, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB,
+		flushGraceParams(t, cutoff), flushGraceQuery(), nil, dual)
+	require.NoError(t, err)
+	requireGraceSites(t, sqlText, strconv.FormatInt(cutoff, 10))
+}
+
+// TestFlushGraceCutoffDefaultsToDisabled pins the defensive default on both
+// the dual and the legacy (dual == nil) render paths: an absent cutoff must
+// render FlushGraceCutoffDisabled.
+func TestFlushGraceCutoffDefaultsToDisabled(t *testing.T) {
+	disabled := strconv.FormatInt(FlushGraceCutoffDisabled, 10)
+
+	dualSQL, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB,
+		flushGraceParams(t, nil), flushGraceQuery(), nil, &DualClauses{DuckClause: "1=1"})
+	require.NoError(t, err)
+	requireGraceSites(t, dualSQL, disabled)
+
+	legacySQL, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB,
+		flushGraceParams(t, nil), flushGraceQuery(), nil, nil)
+	require.NoError(t, err)
+	requireGraceSites(t, legacySQL, disabled)
+}
+
+// TestFlushGraceCompiledSkeletonIsCutoffIndependent pins the plan-cache
+// contract: the skeleton carries the sentinel (identical across requests with
+// different cutoffs), and Bind splices the per-request value at both sites.
+func TestFlushGraceCompiledSkeletonIsCutoffIndependent(t *testing.T) {
+	cache := dualPlanTestCache()
+	q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{
+		SchemaID: 7,
+		Condition: &forma.KvCondition{Attr: "age", Value: "gt:10"},
+	}}
+	idx := 0
+	dual, err := ToDualClauses(q.Condition, "eav_t", 7, cache, &idx)
+	require.NoError(t, err)
+
+	// The engine's per-request param map carries a real cutoff; Compile must
+	// still bake the sentinel, not the value.
+	params := injectTestProjection(t, map[string]any{
+		"EAVTable":           "eav_t",
+		"MainTable":          "main_t",
+		"ChangeLogTable":     "cl_t",
+		"ChangeLogSchema":    "public",
+		"ChangeLogScanTable": "cl_t",
+		"MainSchema":         "public",
+		"MainScanTable":      "main_t",
+		"EAVSchema":          "public",
+		"EAVScanTable":       "eav_t",
+		"SchemaID":           int16(7),
+		"Anchor":             map[string]any{"Condition": "1=1"},
+		"Limit":              25,
+		"Offset":             0,
+		"PageSize":           25,
+		"FlushGraceCutoffMs": int64(111),
+	}, 7)
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, params, q, &dual, false)
+	require.NoError(t, err)
+	require.NotNil(t, compiled)
+	require.Contains(t, compiled.Skeleton, flushGraceCutoffSentinel,
+		"the skeleton must carry the sentinel so the cache key is cutoff-independent")
+	require.NotContains(t, compiled.Skeleton, "flushed_at > 111",
+		"a per-request cutoff must never bake into the skeleton")
+
+	sqlA, argsA := compiled.Bind(q, dual, nil, 1000)
+	sqlB, argsB := compiled.Bind(q, dual, nil, 2000)
+	requireGraceSites(t, sqlA, "1000")
+	requireGraceSites(t, sqlB, "2000")
+	require.NotContains(t, sqlA, flushGraceCutoffSentinel)
+	require.NotContains(t, sqlB, flushGraceCutoffSentinel)
+	require.Equal(t, argsA, argsB,
+		"the cutoff is a splice, not a bind arg: the interleave must not change")
+}

--- a/internal/sqlgen/duckdb_namespace_render_test.go
+++ b/internal/sqlgen/duckdb_namespace_render_test.go
@@ -68,7 +68,7 @@ func TestDuckDBNamespace_RenderPaths_AttributeAliasedClause(t *testing.T) {
 	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, nonBenchmarkNamespaceParams(t, cache), q, &dc, true)
 	require.NoError(t, err)
 	require.NotNil(t, compiled, "non-benchmark column-bound composite must be cacheable")
-	boundSQL, boundArgs := compiled.Bind(q, dc, dirty)
+	boundSQL, boundArgs := compiled.Bind(q, dc, dirty, FlushGraceCutoffDisabled)
 
 	for name, sql := range map[string]string{"direct": builtSQL, "compiled": boundSQL} {
 		// The attribute-aliased clause flows into the DuckDB CTE WHERE clauses.

--- a/internal/sqlgen/duckdb_scan_contract_test.go
+++ b/internal/sqlgen/duckdb_scan_contract_test.go
@@ -99,8 +99,11 @@ func TestAdvancedTemplate_ColdOnlyOmitsPgSource(t *testing.T) {
 		"hot excluded: unified must read from s3_source alone")
 	require.Contains(t, sqlText, "read_parquet",
 		"warm/cold requested: the parquet source must render")
-	require.Contains(t, sqlText, "AND (flushed_at = 0 OR flushed_at > ",
-		"the dirty_ids barrier must survive tier pruning")
+	require.Contains(t, sqlText, "AND (flushed_at = 0)",
+		"the dirty_ids barrier must survive tier pruning UNWIDENED: with "+
+			"pg_source pruned there is no hot server for grace-discarded rows (#252)")
+	require.NotContains(t, sqlText, "OR flushed_at > ",
+		"hot-excluded shapes must keep the strict flushed_at = 0 barrier")
 	require.Equal(t, []any{int64(10), int64(10)}, args,
 		"PgMainArgs must be dropped with the pg_source CTE: "+
 			"binds are the s3 semijoin and visible occurrences of DuckArgs only")

--- a/internal/sqlgen/duckdb_scan_contract_test.go
+++ b/internal/sqlgen/duckdb_scan_contract_test.go
@@ -52,9 +52,9 @@ func TestAdvancedTemplate_PostgresScanContract(t *testing.T) {
 			"flushed_at = 0 is a WHERE predicate, not a scan argument")
 	}
 
-	require.Contains(t, sqlText, "AND (flushed_at = 0 OR flushed_at > ",
+	require.Contains(t, sqlText, "AND (flushed_at = 0 OR flushed_at >= ",
 		"dirty_ids must restrict to unflushed-or-grace rows via a WHERE predicate (#252)")
-	require.Contains(t, sqlText, "AND (cl.flushed_at = 0 OR cl.flushed_at > ",
+	require.Contains(t, sqlText, "AND (cl.flushed_at = 0 OR cl.flushed_at >= ",
 		"pg_source must restrict to unflushed-or-grace rows via a WHERE predicate (#252)")
 }
 
@@ -102,7 +102,7 @@ func TestAdvancedTemplate_ColdOnlyOmitsPgSource(t *testing.T) {
 	require.Contains(t, sqlText, "AND (flushed_at = 0)",
 		"the dirty_ids barrier must survive tier pruning UNWIDENED: with "+
 			"pg_source pruned there is no hot server for grace-discarded rows (#252)")
-	require.NotContains(t, sqlText, "OR flushed_at > ",
+	require.NotContains(t, sqlText, "OR flushed_at >= ",
 		"hot-excluded shapes must keep the strict flushed_at = 0 barrier")
 	require.Equal(t, []any{int64(10), int64(10)}, args,
 		"PgMainArgs must be dropped with the pg_source CTE: "+

--- a/internal/sqlgen/duckdb_scan_contract_test.go
+++ b/internal/sqlgen/duckdb_scan_contract_test.go
@@ -52,10 +52,10 @@ func TestAdvancedTemplate_PostgresScanContract(t *testing.T) {
 			"flushed_at = 0 is a WHERE predicate, not a scan argument")
 	}
 
-	require.Contains(t, sqlText, "AND flushed_at = 0",
-		"dirty_ids must restrict to unflushed rows via a WHERE predicate")
-	require.Contains(t, sqlText, "AND cl.flushed_at = 0",
-		"pg_source must restrict to unflushed rows via a WHERE predicate")
+	require.Contains(t, sqlText, "AND (flushed_at = 0 OR flushed_at > ",
+		"dirty_ids must restrict to unflushed-or-grace rows via a WHERE predicate (#252)")
+	require.Contains(t, sqlText, "AND (cl.flushed_at = 0 OR cl.flushed_at > ",
+		"pg_source must restrict to unflushed-or-grace rows via a WHERE predicate (#252)")
 }
 
 // TestAdvancedTemplate_ColdOnlyOmitsPgSource pins the #184 tier-hint contract:
@@ -99,7 +99,7 @@ func TestAdvancedTemplate_ColdOnlyOmitsPgSource(t *testing.T) {
 		"hot excluded: unified must read from s3_source alone")
 	require.Contains(t, sqlText, "read_parquet",
 		"warm/cold requested: the parquet source must render")
-	require.Contains(t, sqlText, "AND flushed_at = 0",
+	require.Contains(t, sqlText, "AND (flushed_at = 0 OR flushed_at > ",
 		"the dirty_ids barrier must survive tier pruning")
 	require.Equal(t, []any{int64(10), int64(10)}, args,
 		"PgMainArgs must be dropped with the pg_source CTE: "+

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -203,6 +203,12 @@ func FederatedQueryHasHot(q *model.FederatedAttributeQuery) bool {
 }
 
 func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttributeQuery, dual *DualClauses) {
+	// Defensive default for the #252 flush-grace cutoff, set before the nil-q
+	// return so every render path (dual, legacy, nil query) produces valid
+	// SQL with the pre-#252 barrier when the engine did not supply a cutoff.
+	if _, ok := params["FlushGraceCutoffMs"]; !ok {
+		params["FlushGraceCutoffMs"] = FlushGraceCutoffDisabled
+	}
 	if q == nil {
 		return
 	}


### PR DESCRIPTION
Closes #252.

## Problem

`executeBatch` committed **copy → mark-flushed → manifest-append**. Under manifest-driven reads (#187), a federated query landing between mark and append saw the batch's rows in *neither* tier: no longer hot (`flushed_at != 0` leaves the dirty set and the pg_source gate), not yet in the listed delta. Reproduced red by `TestFlushManifestWindowVisibility` (4 of 8 rows visible mid-flush).

## Fix (adjudicated: (a)+(c) belt-and-braces)

**(a) Write-side reorder (primary):** `copy → manifest-append → mark-flushed`. The middle state — delta listed, rows still `flushed_at = 0` — is safe by construction: the dirty anti-join discards the S3 copies and hot pg_source serves them (the exact scenario the anti-join was designed for). The manifest entry is built from `batchIDs` (mark hasn't run); RowCount/bounds may overcount concurrently-changed rows, feeding only compaction's promotion heuristic (reconcile recomputes from parquet).

**(c) Read-side grace (backstop):** the residual reader race — path set resolved before the append, dirty scan after the mark — is covered by widening the dirty barrier to `(flushed_at = 0 OR flushed_at > cutoff)`, where **cutoff = the instant this query resolved its parquet path set** minus a configurable clock-skew margin (`DuckDBConfig.FlushVisibilityGraceMs`, default 0 = exact anchor, negative = disabled). Because (a) appends before marking, rows flushed before path resolution already have their delta listed → **the steady state is never widened** (zero semantic drift); only rows racing the in-flight query stay hot-readable. The widening renders only in the HasHot form (hot-excluded shapes keep the strict barrier — no hot server exists for discarded rows). The cutoff splices via a compile-sentinel mirroring `dirtyIDsSentinel`, keeping the plan-cache key cutoff-independent; every render path defaults an absent cutoff to `MaxInt64` (never `0`, which would bypass the parquet tiers; never empty, which is invalid SQL).

> Design note: the first-cut wall-clock grace (`now − 60s`) failed full-suite verification — it flipped `created_at` semantics for recently-flushed rows (s3 `changed_at` proxy vs PG creation time; broke the #212 keyset pins and the oracle), dropped rows in hot-excluded tier forms, and defeated the reconcile e2e's stripped-manifest premise. The path-resolution anchor eliminates all three while covering the actual race.

## Contract re-adjudications (superseding prior pins)

- **#197 orphan contract superseded:** manifest-append failure now leaves rows dirty → retry self-heals with a fresh UUIDv7 key; the old copied final is an unlisted orphan for `manifest-reconcile --gc` (ClassDelta covered leftover). Recovery improves from "data loss until operator `--repair`" to "self-heal + junk". The final key stays in the error for observability.
- **#179 "no row exported twice" relaxes to crash-free runs:** mark failing after append → retry produces a second *listed* delta with identical `(row_id, ver_ts)` rows; LWW rn=1 + #183 tie-break dedups, compaction collapses later.
- **#187 direction contract unchanged:** copy still precedes append (manifest ⊆ live objects).
- `updatedIDs == 0` batches leave an LWW-inert junk delta listed — accepted, not rolled back.
- **Preserved invariants:** keys stay random UUIDv7 (bare-UUID → ClassDelta), so #226 tmp self-heal reasoning, the #290 advisory-lock/init-GC proofs, and the reconcile classifier are untouched.

## Tests

- Red-first e2e `TestFlushManifestWindowVisibility` (pauses the flush at its manifest PUT; grace disabled so it pins the reorder in isolation): red pre-fix, green post-fix.
- `TestFlushGraceBackstopServesStaleManifestSnapshot`: margin emulates a pre-flush path snapshot → rows hot-served; exact-anchor default → steady state not widened (zero drift pin).
- #179 matrix re-adjudicated: `TestFlushFaultManifestLoad/Save` (rows stay dirty, retry self-heals, old final = unlisted orphan), `TestFlushFaultMarkFlushed` (first delta LISTED, retry adds second listed delta, LWW dedup), multi-schema `ManifestSaveFault` (faulted schema self-heals, sibling untouched).
- Unit: flipped `TestExecuteBatch_ReturnsErrorWhenManifestLoad/SaveFails`, new `TestExecuteBatch_MarkFailsAfterManifestAppend` (via new `markFlushed` seam); sqlgen pins for both widened render sites, HasHot gating, sentinel splice, skeleton cutoff-independence, defensive defaults; `TestFlushVisibilityGraceResolution` for knob semantics. §5 executable-doc updated and still executes.

## Verification

- `make lint` clean; `make test` (full unit) green.
- Full `internal/e2e_harness/production` suite green (was 6 failures under the wall-clock design — all resolved by the anchor revision, no oracle/#212 pin changes needed).
- Infra smoke + `-tags=e2e -short` federated suite + benchmark package green.
- Docs updated: `docs/federated-query/design.md` (DirtySet definition, §5 template + params), `docs/manifest-reconcile.md` (delta-orphan provenance), production harness `doc.go` consumer map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)