### PR TITLE
fix(federated): #306 scrub PG_CONN credentials from engine error strings

### DIFF
--- a/internal/entity_query_service.go
+++ b/internal/entity_query_service.go
@@ -141,10 +141,12 @@ func toExecutionPlan(plan *model.ExecutionPlan) *forma.ExecutionPlan {
 	}
 
 	// SECURITY: do not project src.SQL / src.Params or plan.Notes / merge.Notes.
-	// The DuckDB source SQL embeds the postgres_scan connection string (with the
-	// DB password) and notes can echo raw engine errors — surfacing them on the
-	// HTTP response would leak credentials to any advanced_query caller. Only
-	// safe routing/tier metadata crosses into the public projection.
+	// Since #306, the database password is redacted at the source (plan SQL and
+	// failure notes carry password=***REDACTED***), but the rendered DuckDB SQL
+	// still embeds host/user/dbname, table internals; Params carry query arguments;
+	// notes carry storage keys and engine internals — surfacing them on the HTTP
+	// response would leak internals to any advanced_query caller. Only safe
+	// routing/tier metadata crosses into the public projection.
 	out := &forma.ExecutionPlan{
 		Routing: forma.ExecutionRouting{
 			UsedDuckDB: plan.Routing.UseDuckDB,

--- a/internal/federated/credential_scrub_test.go
+++ b/internal/federated/credential_scrub_test.go
@@ -1,0 +1,102 @@
+package federated
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/redact"
+	"github.com/stretchr/testify/require"
+)
+
+// #306: the credential DuckDB quotes back on a postgres_scan attach failure
+// must be scrubbed before the text enters the engine's error chain — asserted
+// on the error string returned from the engine, not on any HTTP body (#301
+// already gates that boundary). Canary construction follows
+// internal/httpapi/canaries_test.go: the ';' makes truncation regressions
+// visible as a surviving tail, so all fragments are asserted separately.
+const (
+	scrubCanaryHead = "SUPERSECRET"
+	scrubCanaryTail = "CANARY-TAIL"
+	scrubCanary     = scrubCanaryHead + ";" + scrubCanaryTail
+)
+
+// attachFailureErr reproduces the DuckDB attach-failure prose shape (verified
+// against duckdb-go in #301): the whole given conn string echoed back, quoted.
+func attachFailureErr() error {
+	return fmt.Errorf(
+		`IO Error: Unable to connect to Postgres at "host=h port=5432 user=u password='%s' dbname=d": connection refused`,
+		scrubCanary)
+}
+
+func requireNoCanary(t *testing.T, s, surface string) {
+	t.Helper()
+	for _, frag := range []string{"password='" + scrubCanary + "'", scrubCanary, scrubCanaryHead, scrubCanaryTail} {
+		require.NotContains(t, s, frag, "credential fragment leaked into %s", surface)
+	}
+}
+
+func TestCredentialScrub_ExecuteFailureErrorString(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &fakeDuckDBExecutor{err: attachFailureErr()}
+	engine := newSentinelTestEngine(t, duck, nil)
+
+	_, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		coldTierQuery(), nil)
+
+	require.Error(t, err)
+	msg := err.Error()
+	// Positive preconditions: diagnosis prose and the redaction placeholder
+	// must be present, so the NotContains checks below cannot pass vacuously.
+	require.Contains(t, msg, "Unable to connect to Postgres")
+	require.Contains(t, msg, "password="+redact.Placeholder)
+	requireNoCanary(t, msg, "engine error string (execute branch)")
+	// Classification must survive the scrub wrapper.
+	require.ErrorIs(t, err, ErrFederatedReadFailed)
+}
+
+func TestCredentialScrub_StreamFailureErrorString(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	// Lazy attach: DuckDB can surface the connect failure mid-stream instead
+	// of at Query (see executeAndStreamDuckDB's stream-branch comment).
+	duck := &fakeDuckDBExecutor{rows: &erroringRowsIterator{err: attachFailureErr()}}
+	engine := newSentinelTestEngine(t, duck, nil)
+
+	_, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		coldTierQuery(), nil)
+
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "iterate duckdb rows")
+	require.Contains(t, msg, "password="+redact.Placeholder)
+	requireNoCanary(t, msg, "engine error string (stream branch)")
+	require.ErrorIs(t, err, ErrFederatedReadFailed)
+}
+
+func TestCredentialScrub_ExecutionPlanFailureNotes(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &fakeDuckDBExecutor{err: attachFailureErr()}
+	engine := newSentinelTestEngine(t, duck, nil)
+
+	opts := &model.FederatedQueryOptions{IncludeExecutionPlan: true}
+	_, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		coldTierQuery(), opts)
+
+	require.Error(t, err)
+	require.NotNil(t, opts.ExecutionPlan)
+	notes := strings.Join(opts.ExecutionPlan.Notes, "\n")
+	require.Contains(t, notes, "duckdb query failed",
+		"precondition: the failure note must have been recorded")
+	requireNoCanary(t, notes, "internal execution plan notes")
+}

--- a/internal/federated/credential_scrub_test.go
+++ b/internal/federated/credential_scrub_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/redact"
 	"github.com/stretchr/testify/require"
@@ -99,4 +101,49 @@ func TestCredentialScrub_ExecutionPlanFailureNotes(t *testing.T) {
 	require.Contains(t, notes, "duckdb query failed",
 		"precondition: the failure note must have been recorded")
 	requireNoCanary(t, notes, "internal execution plan notes")
+}
+
+// The success path leaks too: recordTranslation stores the rendered SQL —
+// which embeds postgres_scan('…password=…') — verbatim on the internal plan
+// that attachExecutionPlan stitches onto the returned page. The public HTTP
+// projection already omits SQL (types.go SECURITY comment); this closes the
+// same credential for Go embedders, the audience #306 names.
+func TestCredentialScrub_PlanRenderedSQL(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: uuid.New()}}
+	engine := NewDBFederatedQueryEngine(&fakePostgresFederatedSource{}, &fakeDirtyIDFetcher{}, duck, nil,
+		forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}},
+		testMetadataCacheSchema7(t),
+		"host=h port=5432 user=u password='"+scrubCanary+"' dbname=d",
+		withTestParquetPath())
+
+	opts := &model.FederatedQueryOptions{IncludeExecutionPlan: true}
+	_, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		coldTierQuery(), opts)
+	require.NoError(t, err)
+	require.NotNil(t, opts.ExecutionPlan)
+
+	var duckSQL string
+	for _, src := range opts.ExecutionPlan.Sources {
+		if src.Engine == "duckdb" && src.SQL != "" {
+			duckSQL = src.SQL
+		}
+	}
+	require.NotEmpty(t, duckSQL, "plan must record the rendered duckdb SQL")
+	// Positive precondition: the DSN really rendered into this SQL (hot tier
+	// present in coldTierQuery keeps the postgres_scan sections, #184), so the
+	// NotContains checks cannot pass vacuously.
+	require.Contains(t, duckSQL, "postgres_scan")
+	require.Contains(t, duckSQL, "password="+redact.Placeholder)
+	requireNoCanary(t, duckSQL, "internal execution plan rendered SQL")
+
+	// Regression guard: the engine must execute the unscrubbed SQL. If someone
+	// later moves the scrub upstream (into the query builder or plan-cache
+	// compile), this test fails while production would emit
+	// postgres_scan('…password=***REDACTED***…') and fail at runtime.
+	require.Contains(t, duck.lastSQL, scrubCanary,
+		"the engine must execute the unscrubbed SQL; only the plan copy is scrubbed")
 }

--- a/internal/federated/duckdb_query_execute.go
+++ b/internal/federated/duckdb_query_execute.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/redact"
 )
 
 // Execute-and-stream half of the DuckDB federated read path: running the
@@ -42,6 +43,12 @@ func (e *DBFederatedQueryEngine) executeAndStreamDuckDB(
 	planCtx.recordQueryStart()
 	rows, err := e.duck.Query(ctx, sqlStr, args...)
 	if err != nil {
+		// #306: a postgres_scan attach failure echoes the whole conn string,
+		// password included, in DuckDB's own prose. Scrub before the text
+		// enters any chain or the execution-plan failure note — this is the
+		// source, so every consumer (embedder logs, future transports) is
+		// covered without repeating #301's boundary redaction.
+		err = redact.Error(err)
 		planCtx.recordQueryFailure(err)
 		if e.breaker != nil {
 			e.breaker.RecordFailure()
@@ -53,6 +60,9 @@ func (e *DBFederatedQueryEngine) executeAndStreamDuckDB(
 
 	totalRecords, rowCount, err := e.streamDuckDBRows(ctx, rows, rowHandler)
 	if err != nil {
+		// #306: lazy object opens mean the attach failure can surface here
+		// instead of at Query; same scrub, same reason as above.
+		err = redact.Error(err)
 		if e.breaker != nil {
 			e.breaker.RecordFailure()
 		}

--- a/internal/federated/duckdb_query_helpers.go
+++ b/internal/federated/duckdb_query_helpers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/redact"
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma/internal/sqlutil"
@@ -329,7 +330,11 @@ func (c *duckDBExecutionPlanContext) recordTranslation(sqlStr string, args []any
 	dp := model.DataSourcePlan{
 		Tier:   served[0],
 		Engine: "duckdb",
-		SQL:    sqlStr,
+		// #306: the rendered SQL embeds postgres_scan('…password=…'); the
+		// internal plan reaches Go embedders via attachExecutionPlan, so the
+		// credential is scrubbed here while the rest of the query shape stays
+		// diagnosable. The engine still executes the unscrubbed sqlStr.
+		SQL:    redact.ConnStringPassword(sqlStr),
 		Params: formatPlanParams(args),
 		// The anchor hint is a no-op in the advanced template, so it must not
 		// masquerade as actual pushdown here (#184); real pushdown facts live

--- a/internal/redact/connstring.go
+++ b/internal/redact/connstring.go
@@ -1,17 +1,18 @@
 // Package redact removes credential material from strings before they leave the
 // process — into a log sink, or into an HTTP response body.
 //
-// It exists because the same connection-string password has to be scrubbed in two
-// unrelated places, and the matcher is subtle enough that two copies would drift:
+// It exists because the same connection-string password has to be scrubbed in three
+// unrelated places, and the matcher is subtle enough that multiple copies would drift:
 //
 //   - internal/cdc logs DuckDB ATTACH statements and DSNs (#290).
 //   - internal/httpapi logs error chains, and DuckDB quotes the whole postgres_scan
 //     connection string back inside its own attach-failure prose, so the password
 //     arrives as driver-authored text no Forma wrap site can intercept (#301).
 //   - internal/federated scrubs driver errors at the source (#306): the engine
-//     wraps duck.Query failures through redact.Error before the text enters an
-//     error chain or the internal execution plan, so embedders that log the
-//     engine's errors never capture the credential.
+//     scrubs DuckDB read failures at both emergence points (execute and
+//     mid-stream), the plan failure note built from them, and the plan's
+//     rendered SQL — so embedders that log the engine's errors or dump the
+//     internal plan never capture the credential.
 //
 // A weaker matcher is not a smaller version of this one, it is a leak: a naive
 // `'[^']*'` branch mistakes libpq's escaped `\'` for the closing quote and emits

--- a/internal/redact/connstring.go
+++ b/internal/redact/connstring.go
@@ -8,6 +8,10 @@
 //   - internal/httpapi logs error chains, and DuckDB quotes the whole postgres_scan
 //     connection string back inside its own attach-failure prose, so the password
 //     arrives as driver-authored text no Forma wrap site can intercept (#301).
+//   - internal/federated scrubs driver errors at the source (#306): the engine
+//     wraps duck.Query failures through redact.Error before the text enters an
+//     error chain or the internal execution plan, so embedders that log the
+//     engine's errors never capture the credential.
 //
 // A weaker matcher is not a smaller version of this one, it is a leak: a naive
 // `'[^']*'` branch mistakes libpq's escaped `\'` for the closing quote and emits

--- a/internal/redact/error.go
+++ b/internal/redact/error.go
@@ -2,7 +2,9 @@ package redact
 
 // Error returns err with any connection-string password in its message replaced
 // by Placeholder. A nil error, or one whose message carries no credential, is
-// returned unchanged — the scrub allocates only when it actually matched.
+// returned unchanged — the no-match path returns the error unchanged with no
+// wrapper allocated, preserving the caller's error identity (the regex scan
+// itself may still allocate).
 //
 // The wrapper rewrites only the composed message. It Unwraps to the original
 // error, so errors.Is/errors.As classification (sentinels, typed carriers,
@@ -23,6 +25,8 @@ func Error(err error) error {
 	return &redactedError{msg: scrubbed, err: err}
 }
 
+// redactedError stores the rewritten message alongside the original error so
+// composed messages are scrubbed while errors.Is/errors.As still walk the real chain.
 type redactedError struct {
 	msg string
 	err error

--- a/internal/redact/error.go
+++ b/internal/redact/error.go
@@ -1,0 +1,32 @@
+package redact
+
+// Error returns err with any connection-string password in its message replaced
+// by Placeholder. A nil error, or one whose message carries no credential, is
+// returned unchanged — the scrub allocates only when it actually matched.
+//
+// The wrapper rewrites only the composed message. It Unwraps to the original
+// error, so errors.Is/errors.As classification (sentinels, typed carriers,
+// context.Canceled) is unaffected, and any later fmt.Errorf("…: %w", err) wrap
+// builds its message from the scrubbed text. Residual, deliberate: the raw
+// message stays reachable by explicitly unwrapping to the leaf and calling
+// Error() on it — no composed message ever contains it, which is the boundary
+// #306 requires (the credential must not enter an error chain's text).
+func Error(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	scrubbed := ConnStringPassword(msg)
+	if scrubbed == msg {
+		return err
+	}
+	return &redactedError{msg: scrubbed, err: err}
+}
+
+type redactedError struct {
+	msg string
+	err error
+}
+
+func (e *redactedError) Error() string { return e.msg }
+func (e *redactedError) Unwrap() error { return e.err }

--- a/internal/redact/error_test.go
+++ b/internal/redact/error_test.go
@@ -9,7 +9,7 @@ import (
 
 // The canary follows #301's construction (internal/httpapi/canaries_test.go):
 // the value carries a ';' so a truncation regression leaves a distinct tail,
-// and every fragment — assignment, value, head, tail — is asserted separately.
+// and the value, head, and tail are asserted separately.
 const (
 	errCanaryHead = "SUPERSECRET"
 	errCanaryTail = "CANARY-TAIL"

--- a/internal/redact/error_test.go
+++ b/internal/redact/error_test.go
@@ -1,0 +1,61 @@
+package redact
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The canary follows #301's construction (internal/httpapi/canaries_test.go):
+// the value carries a ';' so a truncation regression leaves a distinct tail,
+// and every fragment — assignment, value, head, tail — is asserted separately.
+const (
+	errCanaryHead = "SUPERSECRET"
+	errCanaryTail = "CANARY-TAIL"
+	errCanary     = errCanaryHead + ";" + errCanaryTail
+)
+
+func TestError_NilAndCleanErrorsPassThroughUnchanged(t *testing.T) {
+	if got := Error(nil); got != nil {
+		t.Fatalf("Error(nil) = %v, want nil", got)
+	}
+	clean := errors.New("IO Error: read_parquet failed on base/schema_7/x.parquet")
+	if got := Error(clean); got != clean {
+		t.Fatalf("clean error must be returned as the same instance, got %v", got)
+	}
+}
+
+func TestError_ScrubsPasswordFromMessage(t *testing.T) {
+	orig := fmt.Errorf(
+		`IO Error: Unable to connect to Postgres at "host=h port=5432 user=u password='%s' dbname=d": connection refused`,
+		errCanary)
+	got := Error(orig)
+
+	msg := got.Error()
+	// Positive precondition: the scrub must not have eaten the diagnosis.
+	if !strings.Contains(msg, "Unable to connect to Postgres") || !strings.Contains(msg, "host=h") {
+		t.Fatalf("diagnosis prose must survive redaction: %q", msg)
+	}
+	if !strings.Contains(msg, "password="+Placeholder) {
+		t.Fatalf("password value must be replaced by placeholder: %q", msg)
+	}
+	for _, frag := range []string{errCanary, errCanaryHead, errCanaryTail} {
+		if strings.Contains(msg, frag) {
+			t.Fatalf("fragment %q survived redaction: %q", frag, msg)
+		}
+	}
+}
+
+func TestError_PreservesWrappedChainIdentity(t *testing.T) {
+	sentinel := errors.New("sentinel: federated read failed")
+	orig := fmt.Errorf(`attach failed: "host=h user=u password='%s' dbname=d": %w`, errCanary, sentinel)
+	got := Error(orig)
+
+	if !errors.Is(got, sentinel) {
+		t.Fatal("errors.Is must resolve the wrapped sentinel through the scrub wrapper")
+	}
+	if unwrapped := errors.Unwrap(got); unwrapped != orig {
+		t.Fatalf("Unwrap must return the original error, got %v", unwrapped)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -285,11 +285,13 @@ type QueryResult struct {
 // metadata an external caller needs to understand the route.
 //
 // SECURITY: the internal plan's SQL, bind params, and free-text notes are
-// deliberately NOT projected here. The rendered DuckDB SQL embeds the
-// postgres_scan(...) connection string — including the database password — and
-// notes can echo raw engine errors, so exposing them on the HTTP API would leak
-// credentials to any caller of advanced_query. Only enum/numeric/static-string
-// fields are surfaced. It also imports nothing so it can live in the public API.
+// deliberately NOT projected here. Since #306, the database password is
+// redacted at the source (plan SQL and failure notes carry password=***REDACTED***),
+// but the rendered DuckDB SQL still embeds host/user/dbname and table internals;
+// Params carry query arguments, and notes carry storage keys and engine internals.
+// Exposing them on the HTTP API would leak internals to any caller of
+// advanced_query. Only enum/numeric/static-string fields are surfaced. It also
+// imports nothing so it can live in the public API.
 type ExecutionPlan struct {
 	Routing ExecutionRouting  `json:"routing"`
 	Sources []ExecutionSource `json:"sources,omitempty"`


### PR DESCRIPTION
Closes #306.

Scrubs the Postgres password at the source — the federated engine's two DuckDB
driver-error emergence points (`executeAndStreamDuckDB`, execute + mid-stream
branches) — instead of at each consumer, plus the internal execution plan's
failure Notes and rendered SQL (the same embedder-facing surface reached via
`attachExecutionPlan`). `redact.Error` rewrites only the composed message and
Unwraps to the original chain, so `errors.Is`/`errors.As` classification
(`ErrFederatedReadFailed`, degradation gating, httpapi carriers) is untouched.

Commits:
- `redact.Error`: message-scrubbing wrapper on the shared #290/#301 matcher (no new regex); identity path for clean errors.
- Engine scrub at both emergence points + `TestCredentialScrub_*` canary suite (#301 canary shape: `;` in the value so truncation regressions surface; assignment/value/head/tail asserted; every NotContains paired with a positive precondition).
- Plan rendered-SQL scrub in `recordTranslation`, with a mutation-verified guard that the engine still **executes** the unscrubbed SQL (`duck.lastSQL` keeps the raw DSN) — only the plan copy is redacted.
- Refresh of the two plan-projection SECURITY comments (`types.go`, `entity_query_service.go`): password now redacted at source, but host/user/dbname, Params, and note internals remain — the public-projection restriction stands.

Deliberately not changed:
- `queryPostgresOnly` (the issue's `engine.go:382` candidate): pgx error prose carries no password and the DuckDB DSN never enters that path.
- `parquet_schema_validation.go` probes: their SQL (`glob`/`DESCRIBE read_parquet`) never embeds the DSN, and both callers discard the errors.
- The public HTTP plan projection already omits SQL/Notes (#301); this PR closes the internal/embedder surface the projection cannot reach. httpapi's boundary redaction stays as belt-and-braces.

Audit notes (full disposition tables in the branch workspace reports):
- All 6 `pgConnString`/`PG_CONN` flows in `internal/federated` either never leave the process (plan-cache scope key is a digest) or pass through a scrub.
- `recordDegradedFallbackPlan` — a third output surface — is clean transitively with zero edits, evidence the source placement is right.
- Plan `Params` cannot carry the DSN: it renders as a SQL literal, never a bind arg.
- Scrub-before-`recordQueryFailure` ordering is pinned by `TestCredentialScrub_ExecutionPlanFailureNotes` (a reorder leaks the note and fails it).

Verified with the #301 canary shape at the engine boundary: the error string
returned from `engine.Query` — not just the HTTP body — carries no
`password=` value, no bare value, and no truncation tail.

Gate: `go build ./... && go vet ./... && go test ./...` green (30 pkgs), plus
the docker e2e suite explicitly (`go test ./internal/e2e_harness/production/
-tags=e2e`, 127.8s, real containers — note plain `go test ./...` does NOT run
it), and pinned golangci-lint v1.64.8 clean on the touched packages.

Known deferred minor: `TestCredentialScrub_PlanRenderedSQL` asserts the last
duckdb plan source only — equivalent today since exactly one exists per query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)