### PR TITLE
feat: #302 harness parquetSource dedup, EntityManager Close hook, AWS config parity, TS e2e manifest reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,14 @@ jobs:
           S3_ENDPOINT: http://localhost:9000
           S3_ACCESS_KEY: minio
           S3_SECRET_KEY: minio_password
+          # Manifest-driven reads (#302): the flush step below writes
+          # manifests (cdc-flush passes --manifest-template); these vars make
+          # the server resolve parquet paths from them instead of relying on
+          # per-request hints. S3_BUCKET/S3_PREFIX mirror the tests/e2e
+          # defaults (forma-cdc / delta) the writers use.
+          DUCKDB_MANIFEST_TEMPLATE: "manifest/{{.SchemaID}}.json"
+          S3_BUCKET: forma-cdc
+          S3_PREFIX: delta
         run: |
           ./build/server &
           for i in $(seq 1 30); do
@@ -177,6 +185,10 @@ jobs:
           # flat schema; lead/visit have nested dotted attributes that currently
           # hit a federated-projection binder bug (tracked separately).
           bun run federated-check -- --schema log --require-duckdb
+          # Same route proof without the client-side path hint: an explicit
+          # hint always wins over the manifest source, so only a hint-free
+          # request exercises the server's manifest-driven read path (#302).
+          bun run federated-check -- --schema log --require-duckdb --manifest-reads
 
       # OLTP-path load smoke. The DuckDB route is proven above by
       # federated-check --require-duckdb; the k6 latency SLA deliberately does

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -104,7 +104,12 @@ func bootstrapLambda(ctx context.Context, sugar *zap.SugaredLogger) (*lambdaRunt
 
 	formaConfig := lambdaFormaConfig(registry, schemaDir, tableNames)
 
-	// Initialize EntityManager using factory
+	// Initialize EntityManager using factory. Deliberately never Closed (#302):
+	// the manager is process-lifetime — bootstrapLambda runs once per execution
+	// environment — and the Go Lambda runtime has no shutdown hook to run
+	// cleanup from (SIGTERM reaches the function process only when an external
+	// extension is registered; otherwise the frozen sandbox is reclaimed with
+	// the process, DuckDB instance included).
 	manager, err := factory.NewEntityManagerWithConfigContext(startupCtx, formaConfig, dbPool)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create entity manager: %w", err)

--- a/cmd/sample/main.go
+++ b/cmd/sample/main.go
@@ -137,7 +137,11 @@ func main() {
 		sugar.Fatalf("Failed to create entity manager: %v", err)
 	}
 	// Defers run LIFO, so the manager is released before the pool (#302).
-	defer func() { _ = entityManager.Close() }()
+	defer func() {
+		if err := entityManager.Close(); err != nil {
+			sugar.Warnf("Failed to close entity manager: %v", err)
+		}
+	}()
 
 	// Create importer
 	importer := NewCSVImporter(entityManager, mapper, *batchSize)

--- a/cmd/sample/main.go
+++ b/cmd/sample/main.go
@@ -136,6 +136,8 @@ func main() {
 	if err != nil {
 		sugar.Fatalf("Failed to create entity manager: %v", err)
 	}
+	// Defers run LIFO, so the manager is released before the pool (#302).
+	defer func() { _ = entityManager.Close() }()
 
 	// Create importer
 	importer := NewCSVImporter(entityManager, mapper, *batchSize)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,8 +22,9 @@ import (
 )
 
 type serverRuntime struct {
-	pool   *pgxpool.Pool
-	server *httpapi.Server
+	pool    *pgxpool.Pool
+	manager forma.EntityManager
+	server  *httpapi.Server
 }
 
 func main() {
@@ -44,6 +45,13 @@ func main() {
 		sugar.Fatalf("failed to bootstrap server: %v", err)
 	}
 	defer runtime.pool.Close()
+	// Defers run LIFO, so the manager — whose DuckDB holds a Postgres
+	// attachment DSN — is released before the pool it points at (#302).
+	defer func() {
+		if err := runtime.manager.Close(); err != nil {
+			sugar.Warnw("failed to close entity manager", "err", err)
+		}
+	}()
 
 	port := bootstrap.Env("PORT", "8080")
 	zap.S().Infow("starting server", "port", port)
@@ -198,8 +206,9 @@ func bootstrapServer(ctx context.Context, sugar *zap.SugaredLogger) (*serverRunt
 	}
 
 	return &serverRuntime{
-		pool:   pool,
-		server: httpapi.NewServer(manager, httpapi.Options{EnableHealth: true}),
+		pool:    pool,
+		manager: manager,
+		server:  httpapi.NewServer(manager, httpapi.Options{EnableHealth: true}),
 	}, nil
 }
 

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -184,9 +184,17 @@ func newEntityManagerWithConfigContext(ctx context.Context, config *forma.Config
 		federated.DuckDBPostgresConnStringFromPool(pool),
 		engineOpts...,
 	)
+	// The DuckDB client has no owner other than the manager being built:
+	// register it so EntityManager.Close releases it (#302). Guarded on nil
+	// because a typed-nil *DuckDBClient boxed into io.Closer would defeat
+	// WithCloser's nil check.
+	var managerOpts []internal.EntityManagerOption
+	if duckClient != nil {
+		managerOpts = append(managerOpts, internal.WithCloser(duckClient))
+	}
 	// Create and return entity manager
 	return internal.NewEntityManager(
-		transformer, repository, federatedEngine, registry, effectiveConfig, schemaValidator), nil
+		transformer, repository, federatedEngine, registry, effectiveConfig, schemaValidator, managerOpts...), nil
 }
 
 // newFederatedReadSurface opens the DuckDB client and the manifest parquet source

--- a/factory/factory_close_test.go
+++ b/factory/factory_close_test.go
@@ -1,0 +1,53 @@
+package factory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/federated"
+	"github.com/lychee-technology/forma/internal/schemameta"
+)
+
+// TestNewEntityManagerWithConfig_CloseReleasesDuckDBClient pins the #302
+// lifecycle fix: the DuckDB client the factory constructs is owned by the
+// returned manager and released by Close — previously it leaked until
+// process exit (mitigated in e2e only via MaxConnections=1).
+func TestNewEntityManagerWithConfig_CloseReleasesDuckDBClient(t *testing.T) {
+	t.Parallel()
+
+	// Base fixture: same stubbed deps + config as
+	// TestNewEntityManagerWithConfig_Unit_Success, with DuckDB enabled and
+	// the client constructor capturing the real client it builds.
+	var captured *federated.DuckDBClient
+	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps.newDuckDBClient = func(ctx context.Context, cfg forma.DuckDBConfig) (*federated.DuckDBClient, error) {
+		c, err := federated.NewDuckDBClientContext(ctx, cfg)
+		captured = c
+		return c, err
+	}
+	config := unitEntityManagerConfig(t)
+	config.DuckDB.Enabled = true
+	config.DuckDB.MaxConnections = 1
+
+	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
+	if err != nil {
+		t.Fatalf("build entity manager: %v", err)
+	}
+	if captured == nil || captured.DB == nil {
+		t.Fatal("test wiring: DuckDB client was not constructed; the assertion below would be vacuous")
+	}
+	if err := captured.DB.Ping(); err != nil {
+		t.Fatalf("DuckDB client must be live before Close: %v", err)
+	}
+
+	if err := em.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := captured.DB.Ping(); err == nil {
+		t.Fatal("DuckDB client still answers Ping after manager Close; the factory did not register it")
+	}
+	if err := em.Close(); err != nil {
+		t.Fatalf("second Close must be a no-op: %v", err)
+	}
+}

--- a/factory/factory_test.go
+++ b/factory/factory_test.go
@@ -222,6 +222,21 @@ func unitEntityManagerDeps(cache *schemameta.MetadataCache) entityManagerDepende
 	return deps
 }
 
+// unitEntityManagerConfig is the config half of the successful-construction
+// fixture: the table names unitEntityManagerDeps' collector reports, plus an
+// empty schema directory.
+func unitEntityManagerConfig(t *testing.T) *forma.Config {
+	t.Helper()
+	config := forma.DefaultConfig(newMockSchemaRegistry())
+	config.Database.TableNames = forma.TableNames{
+		SchemaRegistry: "schema_registry",
+		EAVData:        "eav_data",
+		EntityMain:     "entity_main",
+	}
+	config.Entity.SchemaDirectory = t.TempDir()
+	return config
+}
+
 func TestNewEntityManagerWithConfig_Unit_TableCollectorError(t *testing.T) {
 	t.Parallel()
 
@@ -334,13 +349,7 @@ func TestNewEntityManagerWithConfig_Unit_Success(t *testing.T) {
 	cache := schemameta.NewMetadataCache()
 	deps := unitEntityManagerDeps(cache)
 
-	config := forma.DefaultConfig(newMockSchemaRegistry())
-	config.Database.TableNames = forma.TableNames{
-		SchemaRegistry: "schema_registry",
-		EAVData:        "eav_data",
-		EntityMain:     "entity_main",
-	}
-	config.Entity.SchemaDirectory = t.TempDir()
+	config := unitEntityManagerConfig(t)
 
 	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 

--- a/internal/bootstrap/s3.go
+++ b/internal/bootstrap/s3.go
@@ -32,17 +32,21 @@ type S3Options struct {
 //
 // Credential precedence mirrors internal/cdc/flusher.go setupAWSClient:
 // static credentials from opts win, then AWS_ACCESS_KEY_ID /
-// AWS_SECRET_ACCESS_KEY from the environment as a static provider, then
-// whatever the default chain resolved.
+// AWS_SECRET_ACCESS_KEY from the environment as a static provider (only when
+// both are non-empty), then whatever the default chain resolved.
 func NewS3Client(ctx context.Context, opts S3Options) (*s3.Client, error) {
-	awsCfg, err := loadAWSConfig(ctx)
+	var loadOpts []func(*awsconfig.LoadOptions) error
+	if opts.Region != "" {
+		// WithRegion at load time (not a post-load overwrite) so
+		// region-sensitive default-chain resolution — STS, SSO — runs
+		// against the configured region (#302).
+		loadOpts = append(loadOpts, awsconfig.WithRegion(opts.Region))
+	}
+	awsCfg, err := loadAWSConfig(ctx, loadOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load aws config for s3 client (region %q): %w", opts.Region, err)
 	}
 
-	if opts.Region != "" {
-		awsCfg.Region = opts.Region
-	}
 	applyCredentials(&awsCfg, opts)
 
 	if opts.Endpoint == "" {
@@ -69,7 +73,12 @@ func applyCredentials(awsCfg *aws.Config, opts S3Options) {
 		awsCfg.Credentials = awscreds.NewStaticCredentialsProvider(opts.AccessKey, opts.SecretKey, "")
 		return
 	}
-	if envKey := os.Getenv("AWS_ACCESS_KEY_ID"); envKey != "" {
-		awsCfg.Credentials = awscreds.NewStaticCredentialsProvider(envKey, os.Getenv("AWS_SECRET_ACCESS_KEY"), "")
+	// Both env halves are required: a lone AWS_ACCESS_KEY_ID would build an
+	// empty-secret static provider whose only observable behavior is an
+	// opaque signing failure. Half-set pairs fall through to whatever the
+	// default chain resolved (#302).
+	envKey, envSecret := os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if envKey != "" && envSecret != "" {
+		awsCfg.Credentials = awscreds.NewStaticCredentialsProvider(envKey, envSecret, "")
 	}
 }

--- a/internal/bootstrap/s3_test.go
+++ b/internal/bootstrap/s3_test.go
@@ -29,7 +29,16 @@ func stubLoadAWSConfig(
 // precedence logic.
 func stubBaseConfig(t *testing.T, region string) {
 	t.Helper()
-	stubLoadAWSConfig(t, func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+	stubLoadAWSConfig(t, func(ctx context.Context, optFns ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		lo := &awsconfig.LoadOptions{}
+		for _, fn := range optFns {
+			if err := fn(lo); err != nil {
+				return aws.Config{}, err
+			}
+		}
+		if lo.Region != "" {
+			return aws.Config{Region: lo.Region}, nil
+		}
 		return aws.Config{Region: region}, nil
 	})
 }
@@ -159,6 +168,53 @@ func TestNewS3Client_RegionOverride(t *testing.T) {
 	}
 	if got := inherited.Options().Region; got != "us-east-1" {
 		t.Errorf("expected loaded region to be preserved when S3Options.Region is empty, got %q", got)
+	}
+}
+
+// TestNewS3Client_EnvHalfPairPreservesDefaultChain pins the #302 fix: a
+// non-empty AWS_ACCESS_KEY_ID with an empty AWS_SECRET_ACCESS_KEY must NOT
+// build an empty-secret static provider (opaque signing failure); the
+// default chain's credentials stay in place.
+func TestNewS3Client_EnvHalfPairPreservesDefaultChain(t *testing.T) {
+	chainCreds := awscreds.NewStaticCredentialsProvider("chain-key", "chain-secret", "")
+	stubLoadAWSConfig(t, func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1", Credentials: chainCreds}, nil
+	})
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	client, err := NewS3Client(context.Background(), S3Options{Region: "us-east-1"})
+	if err != nil {
+		t.Fatalf("NewS3Client: %v", err)
+	}
+	creds := retrieveCredentials(t, client.Options().Credentials)
+	if creds.AccessKeyID != "chain-key" || creds.SecretAccessKey != "chain-secret" {
+		t.Fatalf("half-set env pair must preserve the default chain, got %+v", creds)
+	}
+}
+
+// TestNewS3Client_RegionPassedAtLoad pins that Region reaches
+// LoadDefaultConfig as a WithRegion load option rather than a post-load
+// overwrite — the distinction is invisible in the final Config.Region but
+// governs region-sensitive default-chain resolution (STS/SSO).
+func TestNewS3Client_RegionPassedAtLoad(t *testing.T) {
+	var loadedRegion string
+	stubLoadAWSConfig(t, func(ctx context.Context, optFns ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		lo := &awsconfig.LoadOptions{}
+		for _, fn := range optFns {
+			if err := fn(lo); err != nil {
+				return aws.Config{}, err
+			}
+		}
+		loadedRegion = lo.Region
+		return aws.Config{Region: lo.Region}, nil
+	})
+
+	if _, err := NewS3Client(context.Background(), S3Options{Region: "eu-central-1"}); err != nil {
+		t.Fatalf("NewS3Client: %v", err)
+	}
+	if loadedRegion != "eu-central-1" {
+		t.Fatalf("expected region to arrive as a load option, got %q", loadedRegion)
 	}
 }
 

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -21,6 +21,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// loadAWSConfig is the seam for loading the ambient AWS configuration,
+// mirroring internal/bootstrap.loadAWSConfig so the two S3 client sites
+// keep credential and region parity (#302). Tests swap it; production
+// always resolves the real chain.
+var loadAWSConfig = config.LoadDefaultConfig
+
 // generateIAMTokenFn is the function signature we use to generate IAM tokens.
 // We wrap the upstream function to keep a stable signature for tests.
 var generateIAMTokenFn = func(ctx context.Context, endpoint, region string, creds any) (string, error) {
@@ -131,20 +137,27 @@ func RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectClient, dryRun
 	return flushCtx.processSchemas(ctx, schemaIDs)
 }
 
-// setupAWSClient initializes the AWS credentials and S3 client.
+// setupAWSClient initializes the AWS credentials and S3 client. Credential
+// precedence and region handling deliberately mirror
+// internal/bootstrap.NewS3Client — the two sites must stay in parity (#302).
 func setupAWSClient(ctx context.Context, cfg CDCConfig) (string, aws.CredentialsProvider, *s3.Client, error) {
-	awsCfg, err := config.LoadDefaultConfig(ctx)
+	var loadOpts []func(*config.LoadOptions) error
+	if cfg.S3Region != "" {
+		// WithRegion at load time so region-sensitive default-chain
+		// resolution (STS, SSO) sees the configured region.
+		loadOpts = append(loadOpts, config.WithRegion(cfg.S3Region))
+	}
+	awsCfg, err := loadAWSConfig(ctx, loadOpts...)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("load aws config: %w", err)
 	}
-	if cfg.S3Region != "" {
-		awsCfg.Region = cfg.S3Region
-	}
 	if cfg.S3AccessKeyID != "" {
 		awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(cfg.S3AccessKeyID, cfg.S3SecretAccessKey, "")
-	} else if envKey := os.Getenv("AWS_ACCESS_KEY_ID"); envKey != "" {
-		// Fall back to environment variables when not set in config.
-		awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(envKey, os.Getenv("AWS_SECRET_ACCESS_KEY"), "")
+	} else if envKey, envSecret := os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"); envKey != "" && envSecret != "" {
+		// Both env halves required: a lone key would build an empty-secret
+		// static provider whose only observable behavior is an opaque
+		// signing failure; the half-pair falls through to the default chain.
+		awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(envKey, envSecret, "")
 	}
 
 	// Build S3 client options

--- a/internal/cdc/flusher_aws_test.go
+++ b/internal/cdc/flusher_aws_test.go
@@ -1,0 +1,100 @@
+package cdc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	awsCreds "github.com/aws/aws-sdk-go-v2/credentials"
+)
+
+// stubLoadAWSConfig swaps the package seam for one test. No t.Parallel:
+// the seam is process-global (same pattern as internal/bootstrap).
+func stubLoadAWSConfig(
+	t *testing.T,
+	fn func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error),
+) {
+	t.Helper()
+	previous := loadAWSConfig
+	loadAWSConfig = fn
+	t.Cleanup(func() { loadAWSConfig = previous })
+}
+
+func retrieveCreds(t *testing.T, p aws.CredentialsProvider) aws.Credentials {
+	t.Helper()
+	if p == nil {
+		t.Fatal("expected a credentials provider, got nil")
+	}
+	creds, err := p.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("retrieve credentials: %v", err)
+	}
+	return creds
+}
+
+// TestSetupAWSClient_EnvHalfPairPreservesDefaultChain mirrors the
+// internal/bootstrap test of the same intent: both sites must keep parity
+// (#302, #250 review T3/T4).
+func TestSetupAWSClient_EnvHalfPairPreservesDefaultChain(t *testing.T) {
+	chain := awsCreds.NewStaticCredentialsProvider("chain-key", "chain-secret", "")
+	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1", Credentials: chain}, nil
+	})
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	_, credProvider, _, err := setupAWSClient(context.Background(), CDCConfig{})
+	if err != nil {
+		t.Fatalf("setupAWSClient: %v", err)
+	}
+	creds := retrieveCreds(t, credProvider)
+	if creds.AccessKeyID != "chain-key" || creds.SecretAccessKey != "chain-secret" {
+		t.Fatalf("half-set env pair must preserve the default chain, got %+v", creds)
+	}
+}
+
+// TestSetupAWSClient_RegionPassedAtLoad pins WithRegion at load, mirroring
+// internal/bootstrap.
+func TestSetupAWSClient_RegionPassedAtLoad(t *testing.T) {
+	var loadedRegion string
+	stubLoadAWSConfig(t, func(ctx context.Context, optFns ...func(*config.LoadOptions) error) (aws.Config, error) {
+		lo := &config.LoadOptions{}
+		for _, fn := range optFns {
+			if err := fn(lo); err != nil {
+				return aws.Config{}, err
+			}
+		}
+		loadedRegion = lo.Region
+		return aws.Config{Region: lo.Region}, nil
+	})
+
+	region, _, _, err := setupAWSClient(context.Background(), CDCConfig{S3Region: "eu-central-1"})
+	if err != nil {
+		t.Fatalf("setupAWSClient: %v", err)
+	}
+	if loadedRegion != "eu-central-1" || region != "eu-central-1" {
+		t.Fatalf("expected region via load option, got loaded=%q returned=%q", loadedRegion, region)
+	}
+}
+
+// TestSetupAWSClient_ConfigCredentialsStillWin pins that explicit CDCConfig
+// credentials keep precedence over env, unchanged by #302.
+func TestSetupAWSClient_ConfigCredentialsStillWin(t *testing.T) {
+	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	})
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+
+	_, credProvider, _, err := setupAWSClient(context.Background(), CDCConfig{
+		S3AccessKeyID: "cfg-key", S3SecretAccessKey: "cfg-secret",
+	})
+	if err != nil {
+		t.Fatalf("setupAWSClient: %v", err)
+	}
+	creds := retrieveCreds(t, credProvider)
+	if creds.AccessKeyID != "cfg-key" || creds.SecretAccessKey != "cfg-secret" {
+		t.Fatalf("config credentials must win over env, got %+v", creds)
+	}
+}

--- a/internal/e2e_harness/production/engine.go
+++ b/internal/e2e_harness/production/engine.go
@@ -2,12 +2,8 @@ package production
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	forma "github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal"
 	fedengine "github.com/lychee-technology/forma/internal/federated"
@@ -55,40 +51,43 @@ func (e *Env) Engine() *fedengine.DBFederatedQueryEngine {
 	return e.engine
 }
 
-// parquetSource builds the manifest-driven parquet path resolver matching
-// the Env's CDC manifest wiring (#187): reads scan exactly the listed
+// clusterS3Client forwards every S3 call to the Cluster's *current* client at
+// call time, so a client rebuilt by RestartS3 (the host-mapped port can change)
+// is picked up without re-wiring. This is what lets parquetSource dedup onto
+// manifest.NewS3QuerySource without freezing the client at construction —
+// the naive dedup #250 plan decision D2 rejected (#302).
+type clusterS3Client struct{ cluster *Cluster }
+
+var _ manifest.S3ProbeClient = clusterS3Client{}
+
+func (f clusterS3Client) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return f.cluster.S3.GetObject(ctx, params, optFns...)
+}
+
+func (f clusterS3Client) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	return f.cluster.S3.PutObject(ctx, params, optFns...)
+}
+
+func (f clusterS3Client) HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	return f.cluster.S3.HeadObject(ctx, params, optFns...)
+}
+
+// parquetSource builds the manifest-driven parquet path resolver matching the
+// Env's CDC manifest wiring (#187) through the shared production assembly
+// (manifest.NewS3QuerySource, #250/#302). Reads scan exactly the listed
 // objects, missing listed keys classify as ErrParquetSetInconsistent, and
-// never-flushed schemas fall back to the legacy glob. Nil when the Env
-// opted out of manifests (WithoutManifest) — those Envs keep glob reads.
-// The closures read Cluster fields at call time, so an S3 client rebuilt by
-// RestartS3 is picked up without re-wiring.
+// never-flushed schemas fall back to the legacy glob. Nil when the Env opted
+// out of manifests (WithoutManifest) — those Envs keep glob reads.
 func (e *Env) parquetSource() fedengine.ParquetSource {
 	if e.CDC.ManifestTemplate == "" {
 		return nil
 	}
-	c := e.Cluster
-	return &manifest.QuerySource{
-		Store:    &manifest.S3Store{Client: c.S3, Bucket: c.Bucket},
-		Resolver: manifest.PathResolver{Prefix: e.CDC.ManifestPrefix, PathTemplate: e.CDC.ManifestTemplate},
-		Bucket:   c.Bucket,
-		Exists: func(ctx context.Context, key string) (bool, error) {
-			_, err := c.S3.HeadObject(ctx, &s3.HeadObjectInput{
-				Bucket: aws.String(c.Bucket),
-				Key:    aws.String(key),
-			})
-			if err != nil {
-				var notFound *types.NotFound
-				if errors.As(err, &notFound) {
-					return false, nil
-				}
-				return false, err
-			}
-			return true, nil
-		},
-		Fallback: func(schemaID int16) string {
-			return fmt.Sprintf("s3://%s/%s/%d/*.parquet", c.Bucket, e.S3Prefix, schemaID)
-		},
-	}
+	return manifest.NewS3QuerySource(clusterS3Client{e.Cluster}, manifest.S3QuerySourceConfig{
+		Bucket:           e.Cluster.Bucket,
+		ManifestPrefix:   e.CDC.ManifestPrefix,
+		ManifestTemplate: e.CDC.ManifestTemplate,
+		DataPrefix:       e.S3Prefix,
+	})
 }
 
 // EntityManager returns the Env's real production EntityManager, assembling

--- a/internal/e2e_harness/production/factory_manifest_e2e_test.go
+++ b/internal/e2e_harness/production/factory_manifest_e2e_test.go
@@ -260,6 +260,9 @@ func newFactoryManager(ctx context.Context, t *testing.T, env *Env, manifestOn b
 	}
 
 	duck := env.DuckCfg
+	// Pins #245: DuckDB session S3 settings land on a single pooled connection,
+	// so MaxConn > 1 against an in-memory database yields flaky 404s in
+	// concurrent reads. Not a leak mitigation — the managers are closed below.
 	duck.MaxConnections = 1
 	if manifestOn {
 		duck.S3Bucket = env.Cluster.Bucket
@@ -273,6 +276,11 @@ func newFactoryManager(ctx context.Context, t *testing.T, env *Env, manifestOn b
 	if err != nil {
 		t.Fatalf("build entity manager via factory (manifest=%t): %v", manifestOn, err)
 	}
+	t.Cleanup(func() {
+		if err := manager.Close(); err != nil {
+			t.Errorf("close factory-built manager (manifest=%t): %v", manifestOn, err)
+		}
+	})
 	return manager
 }
 

--- a/internal/entity_manager.go
+++ b/internal/entity_manager.go
@@ -2,7 +2,9 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemavalidate"
@@ -30,9 +32,42 @@ type entityManager struct {
 	query    *entityQueryService
 	batch    *entityBatchService
 	relation *entityRelationService
+
+	// closers holds resources the manager owns and must release on Close,
+	// registered at construction via WithCloser (#302). Directly-constructed
+	// managers (the e2e harness) register nothing: their resources are owned
+	// by the Env.
+	closers []io.Closer
 }
 
 var _ forma.EntityManager = (*entityManager)(nil)
+
+// EntityManagerOption customizes NewEntityManager construction.
+type EntityManagerOption func(*entityManager)
+
+// WithCloser registers a resource the manager owns and must release on Close.
+// Callers pass only non-nil resources; a typed-nil pointer boxed in io.Closer
+// would not compare equal to nil here, so the guard lives at the call site.
+func WithCloser(c io.Closer) EntityManagerOption {
+	return func(em *entityManager) {
+		if c != nil {
+			em.closers = append(em.closers, c)
+		}
+	}
+}
+
+// Close releases every registered resource. All closers run even when one
+// fails (errors.Join); a second Close is a no-op.
+func (em *entityManager) Close() error {
+	var errs []error
+	for _, c := range em.closers {
+		if err := c.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	em.closers = nil
+	return errors.Join(errs...)
+}
 
 // NewEntityManager creates a new EntityManager instance
 func NewEntityManager(
@@ -42,6 +77,7 @@ func NewEntityManager(
 	registry forma.SchemaRegistry,
 	config *forma.Config,
 	validator *schemavalidate.Validator,
+	opts ...EntityManagerOption,
 ) forma.EntityManager {
 	if config == nil {
 		config = forma.DefaultConfig(registry)
@@ -67,6 +103,9 @@ func NewEntityManager(
 
 		validator:             validator,
 		validateUpdatesStrict: config.Entity.ValidateUpdatesStrict,
+	}
+	for _, opt := range opts {
+		opt(em)
 	}
 	em.relation = newEntityRelationService(em)
 	em.crud = newEntityCRUDService(em)

--- a/internal/entity_manager.go
+++ b/internal/entity_manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemavalidate"
@@ -38,6 +39,13 @@ type entityManager struct {
 	// managers (the e2e harness) register nothing: their resources are owned
 	// by the Env.
 	closers []io.Closer
+	// closeOnce guards teardown: Close is public API surface, so concurrent
+	// callers must not double-close owned resources (#327 review). closeErr
+	// caches the joined result so every caller — first, repeated, or racing —
+	// observes the same outcome; sync.Once's happens-before edge makes the
+	// cached read safe.
+	closeOnce sync.Once
+	closeErr  error
 }
 
 var _ forma.EntityManager = (*entityManager)(nil)
@@ -56,17 +64,23 @@ func WithCloser(c io.Closer) EntityManagerOption {
 	}
 }
 
-// Close releases every registered resource. All closers run even when one
-// fails (errors.Join); a second Close is a no-op.
+// Close releases every registered resource exactly once. All closers run even
+// when one fails; each failure is wrapped with the resource's type before
+// joining (errors.Is still reaches the underlying error). Safe for concurrent
+// use: teardown is guarded by closeOnce and the joined result is cached, so
+// every call returns the same outcome.
 func (em *entityManager) Close() error {
-	var errs []error
-	for _, c := range em.closers {
-		if err := c.Close(); err != nil {
-			errs = append(errs, err)
+	em.closeOnce.Do(func() {
+		var errs []error
+		for _, c := range em.closers {
+			if err := c.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("close entity manager resource %T: %w", c, err))
+			}
 		}
-	}
-	em.closers = nil
-	return errors.Join(errs...)
+		em.closers = nil
+		em.closeErr = errors.Join(errs...)
+	})
+	return em.closeErr
 }
 
 // NewEntityManager creates a new EntityManager instance

--- a/internal/entity_manager_close_test.go
+++ b/internal/entity_manager_close_test.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"errors"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/lychee-technology/forma"
@@ -70,8 +72,44 @@ func TestEntityManagerClose_JoinsResourceErrors(t *testing.T) {
 	if !errors.Is(err, boom) {
 		t.Fatalf("expected Close error to wrap the resource failure, got %v", err)
 	}
+	if !strings.Contains(err.Error(), "close entity manager resource") {
+		t.Fatalf("close error must carry manager-level context (coding-standard §3), got %v", err)
+	}
 	if healthy.closed != 1 {
 		t.Fatalf("a sibling failure must not skip healthy closers, got %d", healthy.closed)
+	}
+}
+
+// TestEntityManagerClose_ConcurrentCallsCloseOnce pins that Close is safe for
+// concurrent use (#327 review round 2): the public EntityManager surface
+// invites concurrent teardown, teardown must run exactly once, and every
+// caller — including ones that lose the race after a failure — receives the
+// same cached result. Run under -race to catch unsynchronized teardown.
+func TestEntityManagerClose_ConcurrentCallsCloseOnce(t *testing.T) {
+	boom := errors.New("duckdb close failed")
+	failing := &recordingCloser{err: boom}
+	em := newTestEntityManagerForClose(t, WithCloser(failing))
+
+	const callers = 32
+	results := make(chan error, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- em.Close()
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	if failing.closed != 1 {
+		t.Fatalf("concurrent Close must run teardown exactly once, resource closed %d times", failing.closed)
+	}
+	for err := range results {
+		if !errors.Is(err, boom) {
+			t.Fatalf("every caller must receive the same cached close result, got %v", err)
+		}
 	}
 }
 

--- a/internal/entity_manager_close_test.go
+++ b/internal/entity_manager_close_test.go
@@ -1,0 +1,85 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/transform"
+)
+
+// recordingCloser counts Close calls and returns a configured error.
+type recordingCloser struct {
+	closed int
+	err    error
+}
+
+func (r *recordingCloser) Close() error {
+	r.closed++
+	return r.err
+}
+
+// newTestEntityManagerForClose builds a manager the same way
+// TestEntityManager_Create does (entity_manager_test.go): same registry,
+// transformer, mock repository, and default test config, with opts appended.
+func newTestEntityManagerForClose(t *testing.T, opts ...EntityManagerOption) forma.EntityManager {
+	t.Helper()
+
+	config := createTestConfig()
+	registry, err := newFileSchemaRegistryFromDir("../cmd/server/schemas")
+	if err != nil {
+		t.Fatalf("failed to create schema registry: %v", err)
+	}
+	transformer := transform.NewPersistentRecordTransformer(registry)
+	mockRepo := newMockPersistentRecordRepository()
+
+	return NewEntityManager(transformer, mockRepo, nil, registry, config, nil, opts...)
+}
+
+// TestEntityManagerClose_ClosesRegisteredResourcesOnce pins the lifecycle
+// contract #302 adds: Close releases every registered resource, and a second
+// Close is a no-op rather than a double-close.
+func TestEntityManagerClose_ClosesRegisteredResourcesOnce(t *testing.T) {
+	first := &recordingCloser{}
+	second := &recordingCloser{}
+	em := newTestEntityManagerForClose(t, WithCloser(first), WithCloser(second))
+
+	if err := em.Close(); err != nil {
+		t.Fatalf("Close with healthy resources: %v", err)
+	}
+	if first.closed != 1 || second.closed != 1 {
+		t.Fatalf("expected each closer called once, got first=%d second=%d", first.closed, second.closed)
+	}
+	if err := em.Close(); err != nil {
+		t.Fatalf("second Close must be a no-op, got %v", err)
+	}
+	if first.closed != 1 || second.closed != 1 {
+		t.Fatalf("second Close must not re-close resources, got first=%d second=%d", first.closed, second.closed)
+	}
+}
+
+// TestEntityManagerClose_JoinsResourceErrors pins that a failing resource
+// does not mask its siblings: every closer runs, and the error surfaces.
+func TestEntityManagerClose_JoinsResourceErrors(t *testing.T) {
+	boom := errors.New("duckdb close failed")
+	failing := &recordingCloser{err: boom}
+	healthy := &recordingCloser{}
+	em := newTestEntityManagerForClose(t, WithCloser(failing), WithCloser(healthy))
+
+	err := em.Close()
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected Close error to wrap the resource failure, got %v", err)
+	}
+	if healthy.closed != 1 {
+		t.Fatalf("a sibling failure must not skip healthy closers, got %d", healthy.closed)
+	}
+}
+
+// TestEntityManagerClose_NoResourcesIsNil pins that managers built without
+// owned resources (the harness path) Close to nil.
+func TestEntityManagerClose_NoResourcesIsNil(t *testing.T) {
+	em := newTestEntityManagerForClose(t)
+	if err := em.Close(); err != nil {
+		t.Fatalf("Close with no registered resources: %v", err)
+	}
+}

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -97,6 +97,8 @@ func (m *mockEntityManager) BatchDelete(ctx context.Context, req *forma.BatchOpe
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (m *mockEntityManager) Close() error { return nil }
+
 func TestHandleCreateRejectsNonObjectArrayElements(t *testing.T) {
 	server := &Server{
 		manager: &mockEntityManager{},

--- a/storage.go
+++ b/storage.go
@@ -29,10 +29,11 @@ type EntityBatchCreator interface {
 // EntityManager provides comprehensive entity and query operations.
 //
 // Close releases resources the manager owns — for factory-built managers
-// that is the embedded DuckDB client (#302). It is safe to call more than
-// once; managers constructed without owned resources return nil. Embedders
-// must Close the manager when done with it or the DuckDB instance lives
-// until process exit.
+// that is the embedded DuckDB client (#302). It is safe for concurrent use:
+// teardown runs exactly once and every call returns the same result, so a
+// failed close stays observable to late callers. Managers constructed
+// without owned resources return nil. Embedders must Close the manager when
+// done with it or the DuckDB instance lives until process exit.
 type EntityManager interface {
 	EntityWriter
 	EntityReader

--- a/storage.go
+++ b/storage.go
@@ -26,9 +26,16 @@ type EntityBatchCreator interface {
 	BatchCreate(ctx context.Context, req *BatchOperation) (*BatchResult, error)
 }
 
-// EntityManager provides comprehensive entity and query operations
+// EntityManager provides comprehensive entity and query operations.
+//
+// Close releases resources the manager owns — for factory-built managers
+// that is the embedded DuckDB client (#302). It is safe to call more than
+// once; managers constructed without owned resources return nil. Embedders
+// must Close the manager when done with it or the DuckDB instance lives
+// until process exit.
 type EntityManager interface {
 	EntityWriter
 	EntityReader
 	EntityBatchOperator
+	Close() error
 }

--- a/tests/e2e/scripts/federated-check.ts
+++ b/tests/e2e/scripts/federated-check.ts
@@ -45,6 +45,7 @@ interface Args {
   seed: string;
   fullScan: boolean;
   requireDuckDB: boolean;
+  manifestReads: boolean;
 }
 
 function parseArgs(): Args {
@@ -55,6 +56,8 @@ function parseArgs(): Args {
   let fullScan = false;
   // Also honor an env flag so CI can require the DuckDB route without args.
   let requireDuckDB = process.env.REQUIRE_DUCKDB === '1' || process.env.REQUIRE_DUCKDB === 'true';
+  // Same idea for the manifest-driven read mode (see queryFederated).
+  let manifestReads = process.env.MANIFEST_READS === '1' || process.env.MANIFEST_READS === 'true';
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--schema' && args[i + 1]) {
@@ -67,9 +70,11 @@ function parseArgs(): Args {
       fullScan = true;
     } else if (args[i] === '--require-duckdb') {
       requireDuckDB = true;
+    } else if (args[i] === '--manifest-reads') {
+      manifestReads = true;
     }
   }
-  return { schema, sampleSize, seed, fullScan, requireDuckDB };
+  return { schema, sampleSize, seed, fullScan, requireDuckDB, manifestReads };
 }
 
 interface DataRecord {
@@ -115,14 +120,20 @@ async function queryFederated(
   page: number,
   itemsPerPage: number,
   forceDuckDB: boolean,
+  manifestReads: boolean,
 ): Promise<FederatedQueryResult | null> {
   const federated: Record<string, unknown> = { enabled: true, include_execution_plan: true };
   if (forceDuckDB) {
     federated.preferred_tiers = ['warm', 'cold'];
-    // The DuckDB read needs to know where the parquet lives. Point read_parquet
-    // at the flushed delta layout (s3://<bucket>/<prefix>/<schemaID>/*.parquet),
-    // mirroring how the Go production harness supplies its glob.
-    federated.s3_parquet_path_template = `s3://${config.s3.bucket}/${config.s3.prefix}/{{.SchemaID}}/*.parquet`;
+    if (!manifestReads) {
+      // The DuckDB read needs to know where the parquet lives. Point read_parquet
+      // at the flushed delta layout (s3://<bucket>/<prefix>/<schemaID>/*.parquet),
+      // mirroring how the Go production harness supplies its glob. Skipped under
+      // --manifest-reads: an explicit hint always wins over the server's manifest
+      // source (duckdb_query_build.go), so sending it would leave the
+      // manifest-driven path untested (#302).
+      federated.s3_parquet_path_template = `s3://${config.s3.bucket}/${config.s3.prefix}/{{.SchemaID}}/*.parquet`;
+    }
   }
   const response = await post<FederatedQueryResult>('/api/v1/advanced_query', {
     schema_name: schemaName,
@@ -154,13 +165,14 @@ async function collectFederatedRowIds(
   targetSet: Set<string>,
   formaCount: number,
   forceDuckDB: boolean,
+  manifestReads: boolean,
 ): Promise<{ found: Set<string>; route: string }> {
   const found = new Set<string>();
   let route = 'unknown';
   const maxPages = Math.ceil(formaCount / API_PAGE_SIZE) + 2;
 
   for (let page = 1; page <= maxPages && found.size < targetSet.size; page++) {
-    const pageResult = await queryFederated(schemaName, page, API_PAGE_SIZE, forceDuckDB);
+    const pageResult = await queryFederated(schemaName, page, API_PAGE_SIZE, forceDuckDB, manifestReads);
     if (!pageResult) break;
     if (page === 1) route = routeLabel(pageResult.execution_plan);
     if (pageResult.data.length === 0) break;
@@ -199,7 +211,7 @@ async function compareSchema(
   }
 
   result.postgresCount = await getPostgresCount(sql, schemaId);
-  const countProbe = await queryFederated(schemaName, 1, 1, args.requireDuckDB);
+  const countProbe = await queryFederated(schemaName, 1, 1, args.requireDuckDB, args.manifestReads);
   if (countProbe) {
     result.formaCount = countProbe.total_records;
     result.route = routeLabel(countProbe.execution_plan);
@@ -222,7 +234,13 @@ async function compareSchema(
     return result;
   }
 
-  const { found, route } = await collectFederatedRowIds(schemaName, targetSet, result.formaCount, args.requireDuckDB);
+  const { found, route } = await collectFederatedRowIds(
+    schemaName,
+    targetSet,
+    result.formaCount,
+    args.requireDuckDB,
+    args.manifestReads,
+  );
   if (route !== 'unknown') result.route = route;
 
   for (const rowId of targetIds) {


### PR DESCRIPTION
Closes #302

Five commits, one per follow-up deferred from #250:

1. **`b95eb48` harness dedup** — `internal/e2e_harness/production/engine.go parquetSource()` now delegates to `manifest.NewS3QuerySource` through a `clusterS3Client` forwarder whose `GetObject`/`PutObject`/`HeadObject` read `Cluster.S3` at call time, satisfying #250 plan decision D2's condition (a client rebuilt by `RestartS3` is picked up without re-wiring). Strict improvement over the old inline copy: the manifest `S3Store` client was previously frozen at construction, and the harness now inherits `S3ExistsProbe`'s bodyless-HEAD-404 classification (RustFS) and `S3FallbackGlob`'s writer-parity trim.
2. **`bf12ee9` EntityManager Close** — `forma.EntityManager` gains `Close() error`. **Deliberate breaking change for external interface implementers, adjudicated 2026-07-26**: compile-time breakage was chosen over embedders silently leaking a DuckDB instance per manager. Resources register via a new variadic `internal.WithCloser` option (variadic specifically to avoid the #314 add-a-positional-param trap); Close runs every closer (`errors.Join`), second call is a no-op, no-resources managers return nil.
3. **`5265b3b` factory wiring** — the factory registers the DuckDB client it constructs (typed-nil guarded at the call site, since a boxed typed-nil passes `WithCloser`'s interface-nil check); `cmd/server` closes the manager on graceful shutdown before the pool; `cmd/sample` defers Close; the factory e2e closes both managers via `t.Cleanup` and **keeps `MaxConnections=1`** — no longer leak mitigation, still pins #245 single-connection S3 session config. **`cmd/lambda` is deliberately unchanged**: its manager is process-lifetime (Lambda freezes/kills the sandbox; there is no shutdown hook to run Close from).
4. **`90f0ab5` AWS config parity (both sites in one commit, as #302 mandates)** — a non-empty `AWS_ACCESS_KEY_ID` with an empty `AWS_SECRET_ACCESS_KEY` used to build an empty-secret static provider whose only observable behavior is an opaque signing failure ("static credentials are empty" — captured verbatim in the red test run); it now falls through to the default chain. Region reaches `LoadDefaultConfig` via `WithRegion` so region-sensitive chain resolution (STS/SSO) sees it; final `Config.Region` is unchanged, pinned by tests. Explicit config-credential branches untouched. New cdc test seam mirrors bootstrap's.
5. **`5e643ee` TS smoke manifest reads** — CI's server now starts with `DUCKDB_MANIFEST_TEMPLATE`/`S3_BUCKET`/`S3_PREFIX`, and `federated-check` gains `--manifest-reads`, which omits the client-side `s3_parquet_path_template` hint. The flag is load-bearing: an explicit hint always wins over the manifest source (`internal/federated/duckdb_query_build.go:251-284`), so only a hint-free request proves the manifest path at the HTTP layer. The existing hinted run is kept as hint-path coverage.

## Honest-scope note (Task 5)

With `S3_PREFIX` set (writer parity), a schema whose manifest went missing would still be served by the legacy fallback glob — the new CI check proves the manifest read surface is **wired and healthy**, not that the fallback never fires. Sharp missing-key failure modes remain pinned by the Go e2e (`TestFactoryWiring_ManifestDrivenReads`). Local falsification controls during implementation showed the check is non-vacuous: with a bogus `S3_PREFIX` (fallback can't match) the hint-free run still passed (paths came from the manifest), and with the template unset it failed loudly (HTTP 500, 0/2000).

## Third site deferred → #326

Review found `internal/cdc/runner.go` carries **both** bugs #302 fixed elsewhere, plus aggravators: `resolveS3Credentials` falls back to env per-variable (half-pair → empty-secret static provider, config-key/env-secret cross-mix), region is hardcoded-defaulted to `us-east-1` and clobbers the chain-resolved region unconditionally, and the broken runtime is memoized in `s3Runtimes` for the Runner's lifetime. Deliberately out of this PR's scope (#302 names two sites and mandates they move together); tracked with the seam-consolidation and doc follow-ups in #326.

## Verification

- Per-commit: `make lint` + `make test` green; TDD red/green evidence in the branch history for Tasks 2-4.
- Locally (Docker): `TestS3Restart_CleanRecovery` + `TestFactoryWiring_ManifestDrivenReads` per task, and a **full `-tags=e2e` production sweep at the head: PASS, 0 failures (121s; the known #276 flakes were green this run)**.
- Task 5 runtime proof in CI is the smoke job itself; the full stack was also run locally (register → gen-data 2000 → cdc-flush → both federated-check modes) — all green.
- Final whole-branch review: zero Critical/Important findings; all deferred minors triaged (doc/polish items folded into #326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
