### PR TITLE
fix(cdc): #329 session token rides the pair source; unify cmd/tools onto the single credential rule; honest exporter cache keys

### DIFF
--- a/cmd/tools/compactor.go
+++ b/cmd/tools/compactor.go
@@ -120,7 +120,7 @@ func openMergeEngine(ctx context.Context, opts *compactorOptions, logger *zap.Lo
 		S3UsePath:               opts.s3.usePath,
 		S3SessionToken:          token,
 	}
-	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, logger)
+	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, token, logger)
 	if err != nil {
 		return nil, fmt.Errorf("open merge duckdb: %w", err)
 	}

--- a/cmd/tools/compactor.go
+++ b/cmd/tools/compactor.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
 	"time"
 
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/lychee-technology/forma/internal/cdc"
 	"github.com/lychee-technology/forma/internal/compaction"
 	"go.uber.org/zap"
@@ -85,27 +83,28 @@ func parseCompactorFlags(args []string) (*compactorOptions, error) {
 	return opts, nil
 }
 
-// resolveMergeCredentials resolves the FULL default AWS credential chain
-// (env, shared profiles, assumed roles, web identity, IMDS) so DuckDB signs
-// with the same identity as the SDK S3 client — including the session token
-// temporary credentials require. Falls back to raw env vars when the chain
-// yields nothing (e.g. anonymous local object stores).
-func resolveMergeCredentials(ctx context.Context, region string, logger *zap.Logger) (key, secret, token string) {
-	awsCfg, err := toolLoadAWSConfigFn(ctx, awsconfig.WithRegion(region))
-	if err == nil {
-		if creds, retrieveErr := awsCfg.Credentials.Retrieve(ctx); retrieveErr == nil {
-			return creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken
-		} else {
-			err = retrieveErr
-		}
-	}
-	logger.Warn("could not resolve AWS credential chain for the merge engine; falling back to env vars", zap.Error(err))
-	return os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN")
-}
-
 // openMergeEngine builds the CDC DuckDB exporter the rewrite merges through.
+// Credentials come from the single shared rule cdc.ResolveStaticS3Credentials
+// (#329): explicit config wins, otherwise the AWS_ACCESS_KEY_ID /
+// AWS_SECRET_ACCESS_KEY pair, with AWS_SESSION_TOKEN riding whichever source
+// supplied that pair.
+//
+// WARNING — this is a deliberate narrowing. The merge engine previously
+// resolved the FULL AWS default credential chain, so chain-only sources
+// (shared profiles, assumed roles, web identity, IMDS/container roles) reached
+// the DuckDB httpfs SET statements. They no longer do: an operator whose
+// credentials live only in ~/.aws/config or an instance role now gets an
+// engine with no S3 credentials at all, and DuckDB falls back to whatever its
+// own environment chain provides. The compactor exposes no credential flags,
+// so in practice the contract is env-pair-or-nothing.
+//
+// Lambda and container deployments that already export the environment triple
+// are unaffected — the environment is exactly what the shared rule reads. The
+// correct way to restore chain support is to add explicit credential flags
+// feeding cdc.CDCConfig.S3AccessKeyID/S3SecretAccessKey/S3SessionToken, not to
+// reintroduce a second private resolver: two credential rules signing the same
+// bucket differently is the failure mode #329 retires.
 func openMergeEngine(ctx context.Context, opts *compactorOptions, logger *zap.Logger) (*cdc.DuckExporter, error) {
-	key, secret, token := resolveMergeCredentials(ctx, opts.s3.region, logger)
 	duckCfg := cdc.CDCConfig{
 		DuckDBPath:              opts.duck.duckDBPath,
 		DuckThreads:             opts.duck.duckThreads,
@@ -118,8 +117,8 @@ func openMergeEngine(ctx context.Context, opts *compactorOptions, logger *zap.Lo
 		S3Region:                opts.s3.region,
 		S3UseSSL:                opts.s3.useSSL,
 		S3UsePath:               opts.s3.usePath,
-		S3SessionToken:          token,
 	}
+	key, secret, token := cdc.ResolveStaticS3Credentials(duckCfg)
 	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, token, logger)
 	if err != nil {
 		return nil, fmt.Errorf("open merge duckdb: %w", err)

--- a/cmd/tools/compactor.go
+++ b/cmd/tools/compactor.go
@@ -91,12 +91,14 @@ func parseCompactorFlags(args []string) (*compactorOptions, error) {
 //
 // WARNING — this is a deliberate narrowing. The merge engine previously
 // resolved the FULL AWS default credential chain, so chain-only sources
-// (shared profiles, assumed roles, web identity, IMDS/container roles) reached
-// the DuckDB httpfs SET statements. They no longer do: an operator whose
-// credentials live only in ~/.aws/config or an instance role now gets an
-// engine with no S3 credentials at all, and DuckDB falls back to whatever its
-// own environment chain provides. The compactor exposes no credential flags,
-// so in practice the contract is env-pair-or-nothing.
+// (IMDS/instance and container roles, SSO, assumed roles, web identity, shared
+// profiles) reached the DuckDB httpfs SET statements. They no longer do: an
+// operator whose credentials live only in an SSO session, ~/.aws/config, or an
+// instance role now gets an engine with no S3 credentials at all, and DuckDB
+// falls back to whatever its own environment chain provides — the warn log
+// below is the only early signal before an opaque httpfs 403. The compactor
+// exposes no credential flags, so in practice the contract is
+// env-pair-or-nothing.
 //
 // Lambda and container deployments that already export the environment triple
 // are unaffected — the environment is exactly what the shared rule reads. The
@@ -119,6 +121,9 @@ func openMergeEngine(ctx context.Context, opts *compactorOptions, logger *zap.Lo
 		S3UsePath:               opts.s3.usePath,
 	}
 	key, secret, token := cdc.ResolveStaticS3Credentials(duckCfg)
+	if key == "" {
+		logger.Warn("no static S3 credentials resolved for the DuckDB engine; httpfs will read s3:// unsigned (#329)")
+	}
 	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, token, logger)
 	if err != nil {
 		return nil, fmt.Errorf("open merge duckdb: %w", err)

--- a/cmd/tools/compactor_test.go
+++ b/cmd/tools/compactor_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
+	"go.uber.org/zap"
+)
+
+// stubToolAWSChainLoader replaces the shared AWS config loader seam with a
+// recorder. The stub returns a *usable* static provider rather than a bare
+// aws.Config: a nil Credentials provider would make any caller that reaches
+// Retrieve panic, which would mask the assertion these tests actually make.
+func stubToolAWSChainLoader(t *testing.T, called *bool) {
+	t.Helper()
+	old := toolLoadAWSConfigFn
+	t.Cleanup(func() { toolLoadAWSConfigFn = old })
+	toolLoadAWSConfigFn = func(ctx context.Context, optFns ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		*called = true
+		return aws.Config{
+			Region:      "us-east-1",
+			Credentials: awscreds.NewStaticCredentialsProvider("chain-key", "chain-secret", "chain-token"),
+		}, nil
+	}
+}
+
+// setStaticS3Env supplies the environment triple that
+// cdc.ResolveStaticS3Credentials is expected to read, so the engines have a
+// credential source that does not involve the default chain.
+func setStaticS3Env(t *testing.T) {
+	t.Helper()
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "env-token")
+}
+
+// TestOpenMergeEngine_DoesNotConsultCredentialChain pins the deliberate
+// narrowing of #329: the merge engine resolves credentials through the shared
+// cdc.ResolveStaticS3Credentials rule (explicit config, else the environment
+// pair) and never through the AWS default credential chain. Chain-only
+// sources — shared profiles, assumed roles, web identity, IMDS — are
+// intentionally disconnected from the DuckDB httpfs session; see the WARNING
+// on openMergeEngine.
+func TestOpenMergeEngine_DoesNotConsultCredentialChain(t *testing.T) {
+	called := false
+	stubToolAWSChainLoader(t, &called)
+	setStaticS3Env(t)
+
+	opts := &compactorOptions{s3: s3Flags{region: "us-east-1"}}
+	exporter, err := openMergeEngine(context.Background(), opts, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = exporter.DB.Close() }()
+
+	if called {
+		t.Fatal("merge engine must not load the AWS default credential chain (#329)")
+	}
+}
+
+// TestOpenReconcileStatsEngine_DoesNotConsultCredentialChain holds the
+// reconcile stats engine to the same rule as the merge engine, so the two
+// DuckDB constructors in cmd/tools cannot drift apart again.
+func TestOpenReconcileStatsEngine_DoesNotConsultCredentialChain(t *testing.T) {
+	called := false
+	stubToolAWSChainLoader(t, &called)
+	setStaticS3Env(t)
+
+	opts := &reconcileOptions{s3: s3Flags{region: "us-east-1"}}
+	exporter, err := openReconcileStatsEngine(context.Background(), opts, zap.NewNop())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = exporter.DB.Close() }()
+
+	if called {
+		t.Fatal("reconcile stats engine must not load the AWS default credential chain (#329)")
+	}
+}

--- a/cmd/tools/compactor_test.go
+++ b/cmd/tools/compactor_test.go
@@ -80,3 +80,30 @@ func TestOpenReconcileStatsEngine_DoesNotConsultCredentialChain(t *testing.T) {
 		t.Fatal("reconcile stats engine must not load the AWS default credential chain (#329)")
 	}
 }
+
+// TestOpenMergeEngine_EnvCredentialsReachEngineValidation is the positive
+// counterpart to the chain assertions above: those alone stay green if the
+// cdc.ResolveStaticS3Credentials call is deleted and empty strings are passed
+// through. Here the environment pair carries an access key containing a space,
+// which duckdbinit.ValidateS3Credential rejects while building the httpfs SET
+// statements — so a non-nil construction error is only possible if the
+// resolved environment credentials genuinely reach that builder.
+func TestOpenMergeEngine_EnvCredentialsReachEngineValidation(t *testing.T) {
+	called := false
+	stubToolAWSChainLoader(t, &called)
+	t.Setenv("AWS_ACCESS_KEY_ID", "bad key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+
+	opts := &compactorOptions{s3: s3Flags{region: "us-east-1"}}
+	exporter, err := openMergeEngine(context.Background(), opts, zap.NewNop())
+	if err == nil {
+		_ = exporter.DB.Close()
+		t.Fatal("expected the env access key to reach httpfs credential validation and be rejected (#329)")
+	}
+	if exporter != nil {
+		t.Fatal("expected a nil exporter alongside the construction error")
+	}
+	if called {
+		t.Fatal("merge engine must not load the AWS default credential chain (#329)")
+	}
+}

--- a/cmd/tools/manifest_reconcile.go
+++ b/cmd/tools/manifest_reconcile.go
@@ -250,6 +250,9 @@ func openReconcileStatsEngine(ctx context.Context, opts *reconcileOptions, logge
 		S3UsePath:               opts.s3.usePath,
 	}
 	key, secret, token := cdc.ResolveStaticS3Credentials(duckCfg)
+	if key == "" {
+		logger.Warn("no static S3 credentials resolved for the DuckDB engine; httpfs will read s3:// unsigned (#329)")
+	}
 	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, token, logger)
 	if err != nil {
 		return nil, fmt.Errorf("open stats duckdb: %w", err)

--- a/cmd/tools/manifest_reconcile.go
+++ b/cmd/tools/manifest_reconcile.go
@@ -246,7 +246,7 @@ func openReconcileStatsEngine(ctx context.Context, opts *reconcileOptions, logge
 		S3UsePath:               opts.s3.usePath,
 		S3SessionToken:          token,
 	}
-	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, logger)
+	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, token, logger)
 	if err != nil {
 		return nil, fmt.Errorf("open stats duckdb: %w", err)
 	}

--- a/cmd/tools/manifest_reconcile.go
+++ b/cmd/tools/manifest_reconcile.go
@@ -230,8 +230,12 @@ func reconcileExitError(report reconcile.Report) error {
 // compactor's merge engine uses. The pool is pinned to one connection: the
 // exporter's S3 session settings apply per connection, and a second pooled
 // connection would read s3:// without credentials (#285).
+//
+// Credentials come from the same shared rule the merge engine uses,
+// cdc.ResolveStaticS3Credentials (#329). See the WARNING on openMergeEngine
+// for the deliberate narrowing that rule implies: chain-only credential
+// sources no longer reach the DuckDB httpfs session.
 func openReconcileStatsEngine(ctx context.Context, opts *reconcileOptions, logger *zap.Logger) (*cdc.DuckExporter, error) {
-	key, secret, token := resolveMergeCredentials(ctx, opts.s3.region, logger)
 	duckCfg := cdc.CDCConfig{
 		DuckDBPath:              opts.duck.duckDBPath,
 		DuckThreads:             opts.duck.duckThreads,
@@ -244,8 +248,8 @@ func openReconcileStatsEngine(ctx context.Context, opts *reconcileOptions, logge
 		S3Region:                opts.s3.region,
 		S3UseSSL:                opts.s3.useSSL,
 		S3UsePath:               opts.s3.usePath,
-		S3SessionToken:          token,
 	}
+	key, secret, token := cdc.ResolveStaticS3Credentials(duckCfg)
 	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, token, logger)
 	if err != nil {
 		return nil, fmt.Errorf("open stats duckdb: %w", err)

--- a/docs/superpowers/plans/2026-07-27-issue-329-credential-stragglers.md
+++ b/docs/superpowers/plans/2026-07-27-issue-329-credential-stragglers.md
@@ -1,0 +1,269 @@
+# Issue #329 — 凭据解析收尾（session token / compactor / exporter region key）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> 执行时先按 AGENTS.md 惯例建 worktree（先清已合并分支、FF main），并将本计划落盘为 `docs/superpowers/plans/2026-07-27-issue-329-credential-stragglers.md`。
+
+## Context
+
+#326（PR #330）把 cdc 包的静态 S3 凭据统一到 `resolveStaticS3Credentials` 的 config-wins/both-halves 规则，但评审台账留下三个相邻分歧点（issue #329）：① session token 仍独立走 config→env 直落，config pair 可与环境的 `AWS_SESSION_TOKEN` 跨源混合；② `cmd/tools` 的 `resolveMergeCredentials` 是全仓最后一个逐变量 env 读取点，可返回半套三元组；③ `duckExporterKey.region` 用 chain-resolved region 而实际配置 exporter 的是 raw `cfg.S3Region`。另有 4 条 cosmetic 项（#330 评审 comment 追加 2 条）。
+
+**用户裁决（已定）**：① token 随提供 pair 的来源走，DuckDB SET + SDK 静态 provider 一起修（顺带修掉 env-pair STS 临时凭据在 SDK 侧丢 token 的 latent bug）；② compactor **完全统一**进单一规则，chain-first 移除；③ key 改用 `cfg.S3Region`；④ cosmetic 全收（含 breaker 测试拆分）。
+
+**⚠️ 裁决②的行为后果（须写入代码注释与 PR 描述）**：IMDS/instance-role、SSO、assumed-role、shared-profile 等仅 chain 可见的凭据源不再喂给 merge/reconcile 引擎的 DuckDB SET。`cmd/tools` 没有 `--s3-access-key` flag（`tool_flags.go:97-104` 已核实），故工具侧实际是 **env-pair-or-nothing**。Lambda 场景 env 三元组齐全且 token 现在随 env pair 走，不受影响；SDK 侧 `buildToolS3Client` 仍走完整 chain。若未来需恢复 chain 支持，正解是加凭据 flag 而非恢复第二套解析规则。
+
+**Goal:** 全仓凭据解析收敛到唯一导出规则 `cdc.ResolveStaticS3Credentials(cfg) (key, secret, token)`，token 永不跨源；exporter 缓存 key 如实反映配置输入。
+
+**Tech Stack:** Go, aws-sdk-go-v2, DuckDB httpfs SET, testify（cdc/factory）/ 纯 stdlib testing（cmd/tools，须匹配包内风格）。
+
+## Global Constraints
+
+- 文件 ≤500 行、函数 ≤100 行；错误一律 `fmt.Errorf("...: %w", err)`；early return。
+- TDD 红先行（arity 变化的"红"= 编译错误，须确认报错点名正确符号）。
+- 单测：`GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test <pkg> -run <Name> -v`；收尾 `make test` + `make lint`（钉 v1.64.8）。
+- **e2e build tag 藏了一个调用点**：`internal/e2e_harness/production/manifest_reconcile_e2e_test.go:56` 在 `//go:build e2e` 后，`make test` 抓不到——每次签名变更后必须跑 `go vet -tags e2e ./internal/e2e_harness/production/`。
+- 纯移动用 sed 机械搬运，禁手写重打；commit 尾加 `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`。
+- `internal/bootstrap/s3.go`（第 4 个 both-halves 站点，不同包）**不在范围**。
+- PR 关联 #329（Closes #329），**不自动合并**。
+
+## 探索核实的关键事实（@ 67a777d）
+
+- 规则本体：`internal/cdc/aws_credentials.go`（23 行）；内部调用点 `runner.go:180`、`flusher.go:99`、`flusher.go:152`、`init.go:101`。
+- `resolveExporterSessionToken`：`duckdb_exporter_init.go:73-78`，在 `buildExporterS3Steps` SET 表 :43 被调；删除后该文件 `os` import 孤立。
+- `NewDuckExporter` 调用点 ×6：flusher.go:100、init.go:102、runner.go `newDuckExporterFn`(:28)+:252、compactor.go:123、manifest_reconcile.go:249、e2e_harness/production/cdc.go:199（+ e2e-tag 的 manifest_reconcile_e2e_test.go:56）。
+- SDK 空 token provider：`flusher.go:153`、`runner.go:210`。
+- `resolveMergeCredentials`：`compactor.go:88-104`（chain-first + 逐变量 env 回落）；调用点 compactor.go:108、manifest_reconcile.go:234；两处都把 token 写进 `duckCfg.S3SessionToken` 后调 `NewDuckExporter`——统一后该赋值成自引用死写，必须删除。删函数后 compactor.go 的 `awsconfig`、`os` import 孤立（manifest_reconcile.go 的 `os` 因 :199 `report.Render(os.Stdout)` 保留）。
+- `internal/cdc/config.go:56` `S3SessionToken` 注释（"overrides environment variable AWS_SESSION_TOKEN"）将失真，须改。
+- runner 缓存：`cachedS3Runtime`/`s3RuntimeKey`/`duckExporterKey` 均无 token 字段；`duckExporterKey.region` 用 `s3Runtime.region`(:236)。
+- 测试现状：`aws_credentials_test.go` 7-case 二元组表测试；`duckdb_exporter_init_test.go` 的 `_SessionTokenEnvFallback`(:90) 钉旧跨源行为须重写、`_FullConfigStatementSet`(:65) 的 `S3SessionToken:"tok123"` 无 pair，须移到参数；`runner_test.go` 5 处手工 save/restore `newS3ClientFn`；`cmd/tools` 测试全 stdlib 无 testify；`resolveMergeCredentials` 零覆盖。
+- 改名影响 22 处引用/4 文件；breaker 4 测试在 `factory_entity_manager_unit_test.go:293-341`，移出后老文件 `time`/`require`/`zap`/`observer` 4 个 import 孤立。
+- `flusher_aws_test.go:65` `return aws.Config{}, err` 未包装（runner 孪生 ca99945 已修）；该文件无 `fmt` import。
+
+## 依赖图
+
+```
+T1 (resolver 三元组+导出)
+ ├─> T2 (SDK provider 接 token)
+ └─> T3 (exporter token 显式参数) ──> T4 (cmd/tools 统一)
+        └─> T5 (region key) ──> T6 (token 进缓存 key)
+T7-T10 cosmetic 独立（T9 须在 T8 后：同文件）──> T11 全支验证
+```
+
+---
+
+## Task 1 — 共享 resolver 返回三元组并导出
+
+**Files:** modify `internal/cdc/aws_credentials.go`、`aws_credentials_test.go`、`config.go:56`（仅注释）、四个内部调用点（机械 arity，token 先弃元）。
+
+**Interfaces:** produces `func ResolveStaticS3Credentials(cfg CDCConfig) (accessKeyID, secretAccessKey, sessionToken string)`；retires 未导出旧签名。直接改名导出而非包 wrapper：一条规则两个名字正是 #326 要消灭的重复；`CDCConfig` 已导出，无新类型面。
+
+- [ ] **1.1 (red)** 重写 `aws_credentials_test.go` 表测试：保留原 7 case（补 token 列，期望 `""`），新增 6 个 token 纪律 case：
+
+```go
+// #329 token discipline: the token rides the source that supplied the pair.
+{name: "config pair carries the config token", cfgKey: "ck", cfgSecret: "cs", cfgToken: "ct",
+	wantKey: "ck", wantSecret: "cs", wantToken: "ct"},
+{name: "config pair does not adopt an ambient env token", cfgKey: "ck", cfgSecret: "cs", envToken: "et",
+	wantKey: "ck", wantSecret: "cs", wantToken: ""},
+{name: "env pair carries the env token", envKey: "ek", envSecret: "es", envToken: "et",
+	wantKey: "ek", wantSecret: "es", wantToken: "et"},
+{name: "env pair does not adopt the config token", cfgToken: "ct", envKey: "ek", envSecret: "es", envToken: "et",
+	wantKey: "ek", wantSecret: "es", wantToken: "et"},
+{name: "half env pair drops the env token too", envKey: "ek", envToken: "et",
+	wantKey: "", wantSecret: "", wantToken: ""},
+{name: "config token alone is not a credential source", cfgToken: "ct",
+	wantKey: "", wantSecret: "", wantToken: ""},
+```
+
+  循环体加 `t.Setenv("AWS_SESSION_TOKEN", tc.envToken)`，调用改三返回值 `ResolveStaticS3Credentials(CDCConfig{S3AccessKeyID: tc.cfgKey, S3SecretAccessKey: tc.cfgSecret, S3SessionToken: tc.cfgToken})`。
+
+- [ ] **1.2 (run red)** `go test ./internal/cdc -run TestResolveStaticS3Credentials -v` → 编译错 `undefined: ResolveStaticS3Credentials`（确认点名该符号）。
+- [ ] **1.3 (green)** 重写 `aws_credentials.go`：
+
+```go
+func ResolveStaticS3Credentials(cfg CDCConfig) (accessKeyID, secretAccessKey, sessionToken string) {
+	if cfg.S3AccessKeyID != "" {
+		return cfg.S3AccessKeyID, cfg.S3SecretAccessKey, cfg.S3SessionToken
+	}
+	envKey, envSecret := os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if envKey != "" && envSecret != "" {
+		return envKey, envSecret, os.Getenv("AWS_SESSION_TOKEN")
+	}
+	return "", "", ""
+}
+```
+
+  doc comment 保留 #326 both-halves 说明，追加 #329 段：token 随提供 pair 的来源走且永不跨源（长期 key 配外来临时 token 会产生存储端只报 opaque 签名失败的组合）；无 pair 的孤 token 不是凭据源，丢弃。
+- [ ] **1.4 (green)** 四内部调用点机械改 `x, y, _ := ResolveStaticS3Credentials(cfg)`（flusher.go:152 处为 `if staticKey, staticSecret, _ := ...; staticKey != ""`）；flusher.go:150 注释同步改名。
+- [ ] **1.5 (green)** `config.go:56` 注释改为：token 仅随 `S3AccessKeyID/S3SecretAccessKey` 同源生效，见 `ResolveStaticS3Credentials`（#329）。
+- [ ] **1.6 (run green)** 13 subtests PASS；`go test ./internal/cdc` ok。
+- [ ] **1.7 (commit)** `fix(cdc): #329 session token rides the pair source in the shared static-credential rule`
+
+## Task 2 — SDK 静态 provider 接上 token
+
+**Files:** modify `flusher.go`(~152)、`runner.go`（struct :37-43、:180、:209-219）、`flusher_aws_test.go`、`runner_test.go`。
+
+**Interfaces:** `cachedS3Runtime` 增 `sessionToken string`。
+
+- [ ] **2.1 (red)** `flusher_aws_test.go` 追加两个测试（stdlib 风格、用现有 `stubLoadAWSConfig`+`retrieveCreds`）：
+  - `TestSetupAWSClient_EnvTripleCarriesSessionToken`：Setenv 三元组、`CDCConfig{}`，断言 `retrieveCreds(...).SessionToken == "env-token"`。
+  - `TestSetupAWSClient_ConfigPairRejectsAmbientEnvToken`：只 Setenv token、config pair，断言 SessionToken 为空。
+
+  `runner_test.go` 追加 `TestRunnerGetOrCreateS3Runtime_EnvTripleCarriesSessionToken`：stub 两个 seam、Setenv 三元组，断言 `runtime.sessionToken == "env-token"` 且 provider 取回同值。（seam 先用手工 save/restore，T7 统一清理。）
+- [ ] **2.2 (run red)** 编译错 `runtime.sessionToken undefined`；flusher 两测试行为红：`got ""`。
+- [ ] **2.3 (green)** flusher.go:149-154：`if staticKey, staticSecret, staticToken := ResolveStaticS3Credentials(cfg); staticKey != "" { awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(staticKey, staticSecret, staticToken) }`，注释补 #329。
+- [ ] **2.4 (green)** runner.go：struct 加 `sessionToken string`；:180 收三元组；:210 provider 传 `sessionToken`；runtime 字面量存 `sessionToken`。
+- [ ] **2.5 (run green)** 3 新测试 PASS + 包 ok。
+- [ ] **2.6 (commit)** `fix(cdc): #329 SDK static credential providers carry the resolved session token`
+
+## Task 3 — token 成为 exporter 显式入参，删 `resolveExporterSessionToken`
+
+**Files:** modify `duckdb_exporter_init.go`（两 builder 加参、删 :73-78、删 `os` import）、`duckdb_exporter.go:48-49`、`flusher.go:99-100`、`init.go:101-102`、`runner.go:252`、`duckdb_exporter_init_test.go`、`runner_test.go:90`（stub 签名）、`cmd/tools/compactor.go:123`、`manifest_reconcile.go:249`（过渡期传现有 `token`）、`internal/e2e_harness/production/cdc.go:199`、`manifest_reconcile_e2e_test.go:56`。
+
+**Interfaces:** produces `NewDuckExporter(ctx, cfg, s3AccessKey, s3Secret, s3SessionToken string, logger)`、`buildExporterInitSteps/buildExporterS3Steps(cfg, key, secret, token)`。**传播方式**：紧跟 `s3Secret` 的平参数——builder 内读 `cfg.S3SessionToken` 恰是 #329 要关的独立解析；struct 包装为一条三串返回值加转换成本、还动导出面。三个同型串的换位风险靠调用点固定写法 `key, secret, token := cdc.ResolveStaticS3Credentials(cfg)` 紧邻构造调用、顺序按构造对齐来压。
+
+- [ ] **3.1 (red)** `duckdb_exporter_init_test.go`：`_FullConfigStatementSet` 的 `S3SessionToken: "tok123"` 移出 cfg 字面量、作为第 4 参传入；`_SessionTokenEnvFallback`（钉旧行为）替换为：
+
+```go
+func TestBuildExporterInitSteps_IgnoresAmbientEnvSessionToken(t *testing.T) {
+	t.Setenv("AWS_SESSION_TOKEN", "envtok")
+	steps, err := buildExporterInitSteps(newExporterInitTestConfig(), "AKID", "secretvalue", "")
+	require.NoError(t, err)
+	for _, sql := range flattenStepSQL(steps) {
+		require.NotContains(t, sql, "s3_session_token")
+	}
+}
+
+func TestBuildExporterInitSteps_EmitsCallerResolvedSessionToken(t *testing.T) {
+	t.Setenv("AWS_SESSION_TOKEN", "envtok")
+	steps, err := buildExporterInitSteps(newExporterInitTestConfig(), "AKID", "secretvalue", "callertok")
+	require.NoError(t, err)
+	require.Contains(t, flattenStepSQL(steps), "SET s3_session_token='callertok';")
+}
+```
+
+  （若无 `newExporterInitTestConfig` helper 则内联最小 cfg。）其余调用点 :31/:51/:61/:99 补 `""` token 参。
+- [ ] **3.2 (run red)** 编译错 `too many arguments in call to buildExporterInitSteps`。
+- [ ] **3.3 (green)** 两 builder 加 `s3SessionToken string` 参；SET 表 `{"s3_session_token", s3SessionToken}`，注释改为「token 由调用方随 pair 一并解析传入，故只能来自提供 pair 的来源（#329），见 ResolveStaticS3Credentials」；删 :73-78 与 `os` import。
+- [ ] **3.4 (green)** `NewDuckExporter` 加参并透传；doc comment 补一句三元组由调用方解析的理由。
+- [ ] **3.5 (green)** cdc 包内调用点：flusher/init 改 `s3Key, s3Secret, s3Token := ResolveStaticS3Credentials(cfg)` + 6 参调用（注释补 #329）；runner.go:252 传 `s3Runtime.sessionToken`（用缓存值而非重解析：一次解析保证 SDK provider 与 DuckDB SET 恒同源）；runner_test.go:90 stub 签名同步。
+- [ ] **3.6 (green)** 包外调用点：compactor.go:123 / manifest_reconcile.go:249 过渡传现有 `token`；e2e_harness/production/cdc.go:199 与 manifest_reconcile_e2e_test.go:56 改 `s3Key, s3Secret, s3Token := cdc.ResolveStaticS3Credentials(...)` + 6 参。
+- [ ] **3.7 (run green)** `go test ./internal/cdc -run TestBuildExporterInitSteps -v`；`go test ./internal/cdc ./cmd/... ./internal/...`；**必跑** `go vet -tags e2e ./internal/e2e_harness/production/`（唯一能证 e2e-tag 调用点编译的闸门，不得推迟到 T11）。
+- [ ] **3.8 (commit)** `fix(cdc): #329 session token becomes an explicit DuckExporter input; retire resolveExporterSessionToken`
+
+## Task 4 — compactor / manifest-reconcile 完全统一
+
+**Files:** modify `cmd/tools/compactor.go`（删 :88-104、重写 `openMergeEngine`、删 `awsconfig`+`os` import）、`manifest_reconcile.go:233-254`；create `cmd/tools/compactor_test.go`（stdlib 风格）。
+
+- [ ] **4.1 (red)** 新建 `compactor_test.go`：`TestOpenMergeEngine_DoesNotConsultCredentialChain` + `TestOpenReconcileStatsEngine_DoesNotConsultCredentialChain`——stub `toolLoadAWSConfigFn` 置 `called=true` 并返回**非 nil provider**（`awscreds.NewStaticCredentialsProvider("chain-key",...)`；裸 `aws.Config{}` 会让旧代码在 `Credentials.Retrieve` 上 panic 而非红）；Setenv env 三元组；调 `openMergeEngine(ctx, &compactorOptions{...仅 s3.region...}, zap.NewNop())`，`defer exporter.DB.Close()`，断言 `!called`。注释写明 chain-only 源被有意断开。
+- [ ] **4.2 (run red)** 两测试 FAIL：`merge engine must not load the AWS default credential chain (#329)`。
+- [ ] **4.3 (green)** compactor.go：删 `resolveMergeCredentials`；`openMergeEngine` 改为先建 `duckCfg`（**删 `S3SessionToken: token` 行**——resolver 以 duckCfg 为输入，把自身输出写回是自引用死写），然后：
+
+```go
+	key, secret, token := cdc.ResolveStaticS3Credentials(duckCfg)
+	exporter, err := cdc.NewDuckExporter(ctx, duckCfg, key, secret, token, logger)
+```
+
+  doc comment 写入完整 WARNING（deliberate narrowing：chain-only 源不再进 httpfs SET；工具无凭据 flag 故 env-pair-or-nothing；Lambda env 三元组不受影响；恢复 chain 的正解是加 flag）。删 `awsconfig`、`os` import。
+- [ ] **4.4 (green)** manifest_reconcile.go 同构改造（`os` import 保留）；doc comment 指向 openMergeEngine 的 WARNING。
+- [ ] **4.5 (run green)** 两测试 PASS；`go test ./cmd/...` ok。（离线沙箱 `INSTALL httpfs` 失败不碍事：`duckdbinit.MakeConnInit` log-and-skip，构造仍成功。）
+- [ ] **4.6 (commit)** `fix(tools): #329 unify merge and reconcile engines onto cdc.ResolveStaticS3Credentials`
+
+## Task 5 — `duckExporterKey.region` 改用 raw `cfg.S3Region`
+
+**Files:** modify `runner.go:233-243`、`runner_test.go`。
+
+- [ ] **5.1 (red)** 红锚点测试 `TestRunnerDuckExporterCacheKeyIgnoresChainResolvedRegion`：stub `newDuckExporterFn` 计数；同一 `cfg`（`S3Region` 空）、两个手工构造的 `cachedS3Runtime` 仅 `.region` 不同（us-east-1 / eu-west-1），两次 `getOrCreateDuckExporter` 须 `require.Same` 且 `createCalls == 1`。
+- [ ] **5.2 (run red)** `Not same` + `expected: 1, actual: 2`。
+- [ ] **5.3 (green)** key 字面量 `region: cfg.S3Region` + 注释：exporter 由 cfg 配置、空 `S3Region` 完全抑制 `SET s3_region`，用 chain region 做 key 是声称 exporter 从未做出的区分（#329）；进程内 ambient region 稳定，纯 key 诚实性无行为变化。
+- [ ] **5.4 (run green)** `-run TestRunner` 全绿（既有 `TestRunnerCachesDuckExporter` cfg 设了 `S3Region: "us-east-1"` 与 runtime 一致，是天然对照）。
+- [ ] **5.5 (commit)** `fix(cdc): #329 key the DuckExporter cache on raw cfg.S3Region, not the chain-resolved region`
+
+## Task 6 — token 纳入两个缓存 key（与 T5 同类的 key 诚实性，**必做**）
+
+T2/T3 之后缓存的 provider 与 exporter SET 都嵌入了 token，但两个 key 都不含它：env pair 不变而 `AWS_SESSION_TOKEN` 轮换后会命中 stale-token 工件——正是 T5 修的那类问题，差一个字段。
+
+**Files:** modify `runner.go`（`s3RuntimeKey`、`duckExporterKey` 各加 `sessionToken string` + 两处 key 字面量）、`runner_test.go`。
+
+- [ ] **6.1 (red)** 两测试：`getOrCreateS3Runtime` 跨 `t.Setenv("AWS_SESSION_TOKEN", ...)` 变更（pair 不变）两次调用须 `require.NotSame` 且 load 计数 =2；`getOrCreateDuckExporter` 对仅 `sessionToken` 不同的两个 runtime 须构造两次。
+- [ ] **6.2 (run red)** `NotSame` 失败 / `expected: 2, actual: 1`。
+- [ ] **6.3 (green)** 两 struct 加字段、key 字面量分别填 `sessionToken` / `s3Runtime.sessionToken`，注释：token 是缓存工件烘焙进去的签名身份的一部分，缺席会在轮换后返回 stale-token 工件（#329）。
+- [ ] **6.4 (run green)** `go test ./internal/cdc` ok。
+- [ ] **6.5 (commit)** `fix(cdc): #329 include the session token in the S3 runtime and exporter cache keys`
+
+## Task 7 — `stubNewS3Client` 测试 helper（纯测试重构，无红步）
+
+**Files:** modify `runner_test.go`。
+
+- [ ] **7.1** 基线：`-run TestRunner -v | grep -c '^--- PASS'` 记数。
+- [ ] **7.2** 加 helper（`stubLoadAWSConfig` 的 t.Cleanup 孪生，注释注明 seam 进程全局、勿 t.Parallel）：
+
+```go
+func stubNewS3Client(t *testing.T, fn func(aws.Config, string, bool) *s3.Client) {
+	t.Helper()
+	previous := newS3ClientFn
+	newS3ClientFn = fn
+	t.Cleanup(func() { newS3ClientFn = previous })
+}
+```
+
+- [ ] **7.3** 清扫 6 处（原 5 处 + T2 新增那处）：块状/单行 save-restore 全部收敛为 `stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client { return &s3.Client{} })`（计数场景闭包内自增）。`newDuckExporterFn` 的手工 stub 不动（不同 seam，未被要求）。
+- [ ] **7.4** 复跑，PASS 计数与 7.1 一致。
+- [ ] **7.5 (commit)** `test(cdc): #329 add stubNewS3Client and unify the runner seam-restore idiom`
+
+## Task 8 — factory fixture verb-first 改名（22 处/4 文件）
+
+- [ ] **8.1** 基线 `go test ./factory`。
+- [ ] **8.2** 机械替换（`\b` 词边界防误伤）：
+
+```bash
+sed -i '' 's/\bunitEntityManagerDeps\b/buildUnitEntityManagerDeps/g; s/\bunitEntityManagerConfig\b/newUnitEntityManagerConfig/g' \
+  factory/factory_entity_manager_unit_test.go factory/factory_close_test.go \
+  factory/parquet_source_test.go factory/schema_validator_test.go
+```
+
+- [ ] **8.3** `grep -rn '\bunitEntityManagerDeps\b\|\bunitEntityManagerConfig\b' factory/` → 零输出。
+- [ ] **8.4** `go test ./factory` ok。
+- [ ] **8.5 (commit)** `test(factory): #329 rename entity-manager unit fixtures to build/new prefixes`
+
+## Task 9 — breaker 4 测试纯移动（T8 之后；sed 搬运，全计划风险最高的编辑）
+
+**Files:** create `factory/factory_circuit_breaker_unit_test.go`；modify `factory_entity_manager_unit_test.go`（删 :292-341 + 4 孤立 import）。
+
+- [ ] **9.1** 切割前核边界：`sed -n '291,293p;341p'` 应见 `}`/空行/`func TestNewDuckDBCircuitBreakerUsesDefaultParametersForZeroConfig...`/`}`；**不符则停下重算区间**。
+- [ ] **9.2** `printf` 头（package + import：testing/time/forma/assert/require/zap/observer + 移动注记）`+ sed -n '293,341p' >` 新文件。
+- [ ] **9.3** `sed -i '' '292,341d'` 老文件。
+- [ ] **9.4** 删孤立 import（`time`/`require`/`zap`/`observer`——移动后零使用已核实）：`sed -i '' '7d;15d;16d;17d'`（sed 按输入流编号，无级联）。
+- [ ] **9.5** 验证：`gofmt -l factory/` 空；`go test ./factory -run TestNewDuckDBCircuitBreaker -v` 4 PASS；包 ok；字节保真检查：
+
+```bash
+git show HEAD:factory/factory_entity_manager_unit_test.go | sed -n '293,341p' | diff - <(tail -n 49 factory/factory_circuit_breaker_unit_test.go)
+```
+
+  零 diff（这是抓搬运损坏的那道检查）。失败则 `git checkout -- factory/` 重来，勿手工缝补。
+- [ ] **9.6 (commit)** `test(factory): #329 split circuit-breaker unit tests into their own file (pure move)`
+
+## Task 10 — `flusher_aws_test.go` stub 补 error wrap
+
+- [ ] **10.1** :65 改 `return aws.Config{}, fmt.Errorf("apply AWS load option: %w", err)`（与 runner 孪生 ca99945 逐字一致）；import 块加 `"fmt"`。
+- [ ] **10.2** `gofmt -l internal/cdc/` 空；`-run TestSetupAWSClient` 全 PASS。
+- [ ] **10.3 (commit)** `test(cdc): #329 wrap the AWS load-option error in the flusher region stub`
+
+## Task 11 — 全支验证
+
+- [ ] `make test` 全 ok。
+- [ ] `go vet -tags e2e ./internal/e2e_harness/production/` 干净（**不可省**：唯一覆盖 e2e-tag 调用点的闸门）。
+- [ ] `make lint` 零 findings（重点盯孤立 import 与残留 `resolveExporterSessionToken`/`resolveMergeCredentials` 的 unused 告警）。
+- [ ] 残留扫描：`grep -rn 'resolveMergeCredentials\|resolveExporterSessionToken\|resolveStaticS3Credentials' --exclude-dir=.git .` 仅 `docs/superpowers/plans/` 历史文件命中。
+- [ ] `grep -n 'IMDS' cmd/tools/compactor.go` 命中 openMergeEngine doc comment——WARNING 落在代码而非仅计划里。
+- [ ] 行数抽查全部 ≤500（compactor.go ~188、runner_test.go ~240）。
+- [ ] Docker 可用时加跑 `go test -v ./internal/e2e_harness/... -timeout=5m`（infra smoke；本次动的是 CDC 凭据面，production harness 是历史上该类改动的真正闸门，PR CI 会跑）。
+- [ ] 建 PR：标题 `fix(cdc): #329 ...`，body 含 Closes #329、裁决②行为后果说明、`🤖 Generated with [Claude Code](https://claude.com/claude-code)`；**不自动合并**。
+
+## 已知风险与对策
+
+- **arity 变化无行为红**：T1/T3 以编译错为红，须确认报错点名目标符号。
+- **e2e tag 藏调用点**：3.7 就地 vet，不推迟。
+- **三个同型 string 换位无声**：调用点一律 `key, secret, token := cdc.ResolveStaticS3Credentials(cfg)` 紧邻构造、顺序对齐，肉眼可核。
+- **T9 sed 区间**：9.1 前核 + 9.5 字节 diff 双括号；失败整体回滚重算。
+- **加参致既有调用点默默变默认值**（#314 教训）：本次全部是编译期强制的新参，无默认值路径；e2e vet 兜底。

--- a/factory/factory_circuit_breaker_unit_test.go
+++ b/factory/factory_circuit_breaker_unit_test.go
@@ -1,0 +1,65 @@
+package factory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// Moved verbatim from factory_entity_manager_unit_test.go (#329): the DuckDB
+// circuit-breaker constructor tests now live in their own file.
+
+func TestNewDuckDBCircuitBreakerUsesDefaultParametersForZeroConfig(t *testing.T) {
+	t.Parallel()
+
+	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{})
+
+	for i := 0; i < 4; i++ {
+		breaker.RecordFailure()
+		assert.False(t, breaker.IsOpen())
+	}
+	breaker.RecordFailure()
+	assert.True(t, breaker.IsOpen())
+}
+
+func TestNewDuckDBCircuitBreakerUsesConfiguredParameters(t *testing.T) {
+	t.Parallel()
+
+	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{
+		CircuitBreakerFailureThreshold: 2,
+		CircuitBreakerWindow:           time.Minute,
+		CircuitBreakerOpenDuration:     time.Minute,
+	})
+
+	breaker.RecordFailure()
+	assert.False(t, breaker.IsOpen())
+	breaker.RecordFailure()
+	assert.True(t, breaker.IsOpen())
+}
+
+func TestNewDuckDBCircuitBreakerDoesNotWarnForDefaultThreshold(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	breaker := newDuckDBCircuitBreaker(forma.DefaultConfig(nil).DuckDB)
+
+	require.NotNil(t, breaker)
+	assert.Equal(t, 0, logs.FilterMessage("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead").Len())
+}
+
+func TestNewDuckDBCircuitBreakerWarnsForDeprecatedThreshold(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{CircuitBreakerThreshold: 0.5})
+
+	require.NotNil(t, breaker)
+	assert.Equal(t, 1, logs.FilterMessage("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead").Len())
+}

--- a/factory/factory_close_test.go
+++ b/factory/factory_close_test.go
@@ -20,13 +20,13 @@ func TestNewEntityManagerWithConfig_CloseReleasesDuckDBClient(t *testing.T) {
 	// TestNewEntityManagerWithConfig_Unit_Success, with DuckDB enabled and
 	// the client constructor capturing the real client it builds.
 	var captured *federated.DuckDBClient
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	deps.newDuckDBClient = func(ctx context.Context, cfg forma.DuckDBConfig) (*federated.DuckDBClient, error) {
 		c, err := federated.NewDuckDBClientContext(ctx, cfg)
 		captured = c
 		return c, err
 	}
-	config := unitEntityManagerConfig(t)
+	config := newUnitEntityManagerConfig(t)
 	config.DuckDB.Enabled = true
 	config.DuckDB.MaxConnections = 1
 

--- a/factory/factory_entity_manager_unit_test.go
+++ b/factory/factory_entity_manager_unit_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/lychee-technology/forma/internal/federated"
 	"github.com/lychee-technology/forma/internal/schemameta"
@@ -12,9 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lychee-technology/forma"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 // ---------------------------------------------------------------------------
@@ -288,54 +284,4 @@ func TestNewEntityManagerWithConfigContext_Unit_PropagatesContextToDuckDBFactory
 
 	assert.NotNil(t, em)
 	assert.NoError(t, err)
-}
-
-func TestNewDuckDBCircuitBreakerUsesDefaultParametersForZeroConfig(t *testing.T) {
-	t.Parallel()
-
-	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{})
-
-	for i := 0; i < 4; i++ {
-		breaker.RecordFailure()
-		assert.False(t, breaker.IsOpen())
-	}
-	breaker.RecordFailure()
-	assert.True(t, breaker.IsOpen())
-}
-
-func TestNewDuckDBCircuitBreakerUsesConfiguredParameters(t *testing.T) {
-	t.Parallel()
-
-	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{
-		CircuitBreakerFailureThreshold: 2,
-		CircuitBreakerWindow:           time.Minute,
-		CircuitBreakerOpenDuration:     time.Minute,
-	})
-
-	breaker.RecordFailure()
-	assert.False(t, breaker.IsOpen())
-	breaker.RecordFailure()
-	assert.True(t, breaker.IsOpen())
-}
-
-func TestNewDuckDBCircuitBreakerDoesNotWarnForDefaultThreshold(t *testing.T) {
-	core, logs := observer.New(zap.WarnLevel)
-	restore := zap.ReplaceGlobals(zap.New(core))
-	t.Cleanup(restore)
-
-	breaker := newDuckDBCircuitBreaker(forma.DefaultConfig(nil).DuckDB)
-
-	require.NotNil(t, breaker)
-	assert.Equal(t, 0, logs.FilterMessage("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead").Len())
-}
-
-func TestNewDuckDBCircuitBreakerWarnsForDeprecatedThreshold(t *testing.T) {
-	core, logs := observer.New(zap.WarnLevel)
-	restore := zap.ReplaceGlobals(zap.New(core))
-	t.Cleanup(restore)
-
-	breaker := newDuckDBCircuitBreaker(forma.DuckDBConfig{CircuitBreakerThreshold: 0.5})
-
-	require.NotNil(t, breaker)
-	assert.Equal(t, 1, logs.FilterMessage("circuitBreakerThreshold is deprecated and ignored; use circuitBreakerFailureThreshold instead").Len())
 }

--- a/factory/factory_entity_manager_unit_test.go
+++ b/factory/factory_entity_manager_unit_test.go
@@ -30,7 +30,7 @@ func (m *mockMetadataLoader) LoadMetadata(ctx context.Context) (*schemameta.Meta
 	return m.cache, m.err
 }
 
-func unitEntityManagerDeps(cache *schemameta.MetadataCache) entityManagerDependencies {
+func buildUnitEntityManagerDeps(cache *schemameta.MetadataCache) entityManagerDependencies {
 	deps := defaultEntityManagerDependencies()
 	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		return []string{"schema_registry", "eav_data", "entity_main"}, nil
@@ -41,10 +41,10 @@ func unitEntityManagerDeps(cache *schemameta.MetadataCache) entityManagerDepende
 	return deps
 }
 
-// unitEntityManagerConfig is the config half of the successful-construction
-// fixture: the table names unitEntityManagerDeps' collector reports, plus an
+// newUnitEntityManagerConfig is the config half of the successful-construction
+// fixture: the table names buildUnitEntityManagerDeps' collector reports, plus an
 // empty schema directory.
-func unitEntityManagerConfig(t *testing.T) *forma.Config {
+func newUnitEntityManagerConfig(t *testing.T) *forma.Config {
 	t.Helper()
 	config := forma.DefaultConfig(newMockSchemaRegistry())
 	config.Database.TableNames = forma.TableNames{
@@ -121,7 +121,7 @@ func TestNewEntityManagerWithConfig_Unit_MetadataLoaderError(t *testing.T) {
 	t.Parallel()
 
 	cache := schemameta.NewMetadataCache()
-	deps := unitEntityManagerDeps(cache)
+	deps := buildUnitEntityManagerDeps(cache)
 	deps.newMetadataLoader = func(pool *pgxpool.Pool, schemaTable, schemaDir string) metadataLoader {
 		return &mockMetadataLoader{cache: cache, err: fmt.Errorf("simulated loader error")}
 	}
@@ -145,7 +145,7 @@ func TestNewEntityManagerWithConfig_Unit_NilSchemaRegistry(t *testing.T) {
 	t.Parallel()
 
 	cache := schemameta.NewMetadataCache()
-	deps := unitEntityManagerDeps(cache)
+	deps := buildUnitEntityManagerDeps(cache)
 
 	config := forma.DefaultConfig(nil)
 	config.Database.TableNames = forma.TableNames{
@@ -166,9 +166,9 @@ func TestNewEntityManagerWithConfig_Unit_Success(t *testing.T) {
 	t.Parallel()
 
 	cache := schemameta.NewMetadataCache()
-	deps := unitEntityManagerDeps(cache)
+	deps := buildUnitEntityManagerDeps(cache)
 
-	config := unitEntityManagerConfig(t)
+	config := newUnitEntityManagerConfig(t)
 
 	em, err := newEntityManagerWithConfigContext(context.Background(), config, nil, deps)
 
@@ -180,7 +180,7 @@ func TestNewEntityManagerWithConfig_Unit_SchemaQualifiedTableNames(t *testing.T)
 	t.Parallel()
 
 	cache := schemameta.NewMetadataCache()
-	deps := unitEntityManagerDeps(cache)
+	deps := buildUnitEntityManagerDeps(cache)
 	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		assert.Equal(t, "tenant", schema)
 		return []string{"schema_registry", "eav_data", "entity_main"}, nil
@@ -209,7 +209,7 @@ func TestNewEntityManagerWithConfig_Unit_SchemaParamQualifiesUnqualifiedTableNam
 	t.Parallel()
 
 	cache := schemameta.NewMetadataCache()
-	deps := unitEntityManagerDeps(cache)
+	deps := buildUnitEntityManagerDeps(cache)
 	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		assert.Equal(t, "tenant", schema)
 		return []string{"schema_registry", "eav_data", "entity_main"}, nil
@@ -242,7 +242,7 @@ func TestNewEntityManagerWithConfigContext_Unit_PropagatesContextToTableCollecto
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	deps := unitEntityManagerDeps(cache)
+	deps := buildUnitEntityManagerDeps(cache)
 	deps.collectTables = func(ctx context.Context, pool queryPool, schema string) ([]string, error) {
 		assert.ErrorIs(t, ctx.Err(), context.Canceled)
 		return []string{"schema_registry", "eav_data", "entity_main"}, nil
@@ -269,7 +269,7 @@ func TestNewEntityManagerWithConfigContext_Unit_PropagatesContextToDuckDBFactory
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	deps := unitEntityManagerDeps(cache)
+	deps := buildUnitEntityManagerDeps(cache)
 	deps.newDuckDBClient = func(ctx context.Context, cfg forma.DuckDBConfig) (*federated.DuckDBClient, error) {
 		assert.ErrorIs(t, ctx.Err(), context.Canceled)
 		return nil, context.Canceled

--- a/factory/parquet_source_test.go
+++ b/factory/parquet_source_test.go
@@ -245,7 +245,7 @@ func parquetSourceTestConfig(t *testing.T) *forma.Config {
 func TestNewEntityManagerWithConfig_Unit_NoParquetSourceWhenManifestOff(t *testing.T) {
 	t.Parallel()
 
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	called := false
 	deps.newParquetSource = func(_ context.Context, cfg forma.DuckDBConfig) (federated.ParquetSource, error) {
 		called = true
@@ -262,7 +262,7 @@ func TestNewEntityManagerWithConfig_Unit_NoParquetSourceWhenManifestOff(t *testi
 func TestNewEntityManagerWithConfig_Unit_ParquetSourceFromConfig(t *testing.T) {
 	t.Parallel()
 
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	var gotCfg forma.DuckDBConfig
 	deps.newParquetSource = func(_ context.Context, cfg forma.DuckDBConfig) (federated.ParquetSource, error) {
 		gotCfg = cfg
@@ -285,7 +285,7 @@ func TestNewEntityManagerWithConfig_Unit_ParquetSourceFromConfig(t *testing.T) {
 func TestNewEntityManagerWithConfig_Unit_ParquetSourceErrorFailsFast(t *testing.T) {
 	t.Parallel()
 
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	deps.newParquetSource = func(context.Context, forma.DuckDBConfig) (federated.ParquetSource, error) {
 		return nil, errors.New("simulated s3 client failure")
 	}
@@ -313,7 +313,7 @@ func TestNewEntityManagerWithConfig_Unit_ParquetSourceErrorClosesDuckDBClient(t 
 	t.Parallel()
 
 	var built *federated.DuckDBClient
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	deps.newDuckDBClient = func(ctx context.Context, cfg forma.DuckDBConfig) (*federated.DuckDBClient, error) {
 		client, err := federated.NewDuckDBClientContext(ctx, cfg)
 		if err != nil {
@@ -350,7 +350,7 @@ func TestNewEntityManagerWithConfig_Unit_ParquetSourceErrorClosesDuckDBClient(t 
 func TestNewEntityManagerWithConfig_Unit_InvalidManifestConfigFailsFast(t *testing.T) {
 	t.Parallel()
 
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	// Any I/O reached before configuration validation is a contract breach:
 	// a malformed config must be rejected before the factory touches the DB.
 	deps.collectTables = func(context.Context, queryPool, string) ([]string, error) {

--- a/factory/schema_validator_test.go
+++ b/factory/schema_validator_test.go
@@ -39,7 +39,7 @@ func TestNewEntityManagerWithConfig_Unit_UnparseableSchemaFailsClosed(t *testing
 	registry := newMockSchemaRegistry()
 	registry.schemaBody = `{`
 
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	em, err := newEntityManagerWithConfigContext(
 		context.Background(), validatorTestConfig(t, registry), nil, deps)
 
@@ -68,7 +68,7 @@ func TestNewEntityManagerWithConfig_Unit_MissingSchemaDocumentFailsClosed(t *tes
 	registry := newMockSchemaRegistry()
 	registry.schemaDocMissing = true
 
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	em, err := newEntityManagerWithConfigContext(
 		context.Background(), validatorTestConfig(t, registry), nil, deps)
 
@@ -95,7 +95,7 @@ func TestNewEntityManagerWithConfig_Unit_ValidatorBuiltBeforeReadSurface(t *test
 	registry.schemaBody = `{`
 
 	duckDBFactoryCalled := false
-	deps := unitEntityManagerDeps(schemameta.NewMetadataCache())
+	deps := buildUnitEntityManagerDeps(schemameta.NewMetadataCache())
 	deps.newDuckDBClient = func(context.Context, forma.DuckDBConfig) (*federated.DuckDBClient, error) {
 		duckDBFactoryCalled = true
 		return nil, nil

--- a/internal/cdc/aws_credentials.go
+++ b/internal/cdc/aws_credentials.go
@@ -2,7 +2,7 @@ package cdc
 
 import "os"
 
-// resolveStaticS3Credentials resolves the static S3 credential pair shared by
+// ResolveStaticS3Credentials resolves the static S3 credential triple shared by
 // every CDC credential site — the SDK S3 client and the DuckDB httpfs
 // plumbing (#326). Explicit config wins as-is. Otherwise the environment pair
 // applies only when BOTH halves are non-empty: a lone AWS_ACCESS_KEY_ID would
@@ -10,13 +10,20 @@ import "os"
 // opaque signing failure (#302). With no fully-set pair it returns empty
 // strings — SDK callers then leave the default chain in place, and DuckDB
 // inherits its own environment chain.
-func resolveStaticS3Credentials(cfg CDCConfig) (accessKeyID, secretAccessKey string) {
+//
+// The session token rides the source that supplied the pair and never crosses
+// sources (#329): a config pair carries only the config token, an environment
+// pair carries only AWS_SESSION_TOKEN. Pairing a long-lived key with a foreign
+// temporary token yields a combination the storage endpoint can only report as
+// an opaque signing failure. A token with no accompanying pair is not a
+// credential source at all and is discarded with the rest.
+func ResolveStaticS3Credentials(cfg CDCConfig) (accessKeyID, secretAccessKey, sessionToken string) {
 	if cfg.S3AccessKeyID != "" {
-		return cfg.S3AccessKeyID, cfg.S3SecretAccessKey
+		return cfg.S3AccessKeyID, cfg.S3SecretAccessKey, cfg.S3SessionToken
 	}
 	envKey, envSecret := os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY")
 	if envKey != "" && envSecret != "" {
-		return envKey, envSecret
+		return envKey, envSecret, os.Getenv("AWS_SESSION_TOKEN")
 	}
-	return "", ""
+	return "", "", ""
 }

--- a/internal/cdc/aws_credentials_test.go
+++ b/internal/cdc/aws_credentials_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestResolveStaticS3Credentials(t *testing.T) {
 	cases := []struct {
-		name                string
-		cfgKey, cfgSecret   string
-		envKey, envSecret   string
-		wantKey, wantSecret string
+		name                           string
+		cfgKey, cfgSecret, cfgToken    string
+		envKey, envSecret, envToken    string
+		wantKey, wantSecret, wantToken string
 	}{
 		{name: "config pair wins over env", cfgKey: "ck", cfgSecret: "cs", envKey: "ek", envSecret: "es", wantKey: "ck", wantSecret: "cs"},
 		{name: "config key never cross-mixes with env secret", cfgKey: "ck", envSecret: "es", wantKey: "ck", wantSecret: ""},
@@ -20,14 +20,34 @@ func TestResolveStaticS3Credentials(t *testing.T) {
 		{name: "env secret alone falls to default chain", envSecret: "es", wantKey: "", wantSecret: ""},
 		{name: "config secret without key falls to default chain", cfgSecret: "cs", wantKey: "", wantSecret: ""},
 		{name: "nothing set falls to default chain", wantKey: "", wantSecret: ""},
+
+		// #329 token discipline: the token rides the source that supplied the pair.
+		{name: "config pair carries the config token", cfgKey: "ck", cfgSecret: "cs", cfgToken: "ct",
+			wantKey: "ck", wantSecret: "cs", wantToken: "ct"},
+		{name: "config pair does not adopt an ambient env token", cfgKey: "ck", cfgSecret: "cs", envToken: "et",
+			wantKey: "ck", wantSecret: "cs", wantToken: ""},
+		{name: "env pair carries the env token", envKey: "ek", envSecret: "es", envToken: "et",
+			wantKey: "ek", wantSecret: "es", wantToken: "et"},
+		{name: "env pair does not adopt the config token", cfgToken: "ct", envKey: "ek", envSecret: "es", envToken: "et",
+			wantKey: "ek", wantSecret: "es", wantToken: "et"},
+		{name: "half env pair drops the env token too", envKey: "ek", envToken: "et",
+			wantKey: "", wantSecret: "", wantToken: ""},
+		{name: "config token alone is not a credential source", cfgToken: "ct",
+			wantKey: "", wantSecret: "", wantToken: ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("AWS_ACCESS_KEY_ID", tc.envKey)
 			t.Setenv("AWS_SECRET_ACCESS_KEY", tc.envSecret)
-			key, secret := resolveStaticS3Credentials(CDCConfig{S3AccessKeyID: tc.cfgKey, S3SecretAccessKey: tc.cfgSecret})
+			t.Setenv("AWS_SESSION_TOKEN", tc.envToken)
+			key, secret, token := ResolveStaticS3Credentials(CDCConfig{
+				S3AccessKeyID:     tc.cfgKey,
+				S3SecretAccessKey: tc.cfgSecret,
+				S3SessionToken:    tc.cfgToken,
+			})
 			require.Equal(t, tc.wantKey, key)
 			require.Equal(t, tc.wantSecret, secret)
+			require.Equal(t, tc.wantToken, token)
 		})
 	}
 }

--- a/internal/cdc/aws_credentials_test.go
+++ b/internal/cdc/aws_credentials_test.go
@@ -30,6 +30,8 @@ func TestResolveStaticS3Credentials(t *testing.T) {
 			wantKey: "ek", wantSecret: "es", wantToken: "et"},
 		{name: "env pair does not adopt the config token", cfgToken: "ct", envKey: "ek", envSecret: "es", envToken: "et",
 			wantKey: "ek", wantSecret: "es", wantToken: "et"},
+		{name: "env pair with no env token does not fall back to the config token", cfgToken: "ct", envKey: "ek", envSecret: "es",
+			wantKey: "ek", wantSecret: "es", wantToken: ""},
 		{name: "half env pair drops the env token too", envKey: "ek", envToken: "et",
 			wantKey: "", wantSecret: "", wantToken: ""},
 		{name: "config token alone is not a credential source", cfgToken: "ct",

--- a/internal/cdc/config.go
+++ b/internal/cdc/config.go
@@ -53,7 +53,7 @@ type CDCConfig struct {
 	S3UsePath         bool   // path style addressing
 	S3AccessKeyID     string // AWS access key ID; overrides environment variable AWS_ACCESS_KEY_ID
 	S3SecretAccessKey string // AWS secret access key; overrides environment variable AWS_SECRET_ACCESS_KEY
-	S3SessionToken    string // AWS session token for temporary credentials (STS/roles); overrides environment variable AWS_SESSION_TOKEN
+	S3SessionToken    string // AWS session token for temporary credentials (STS/roles); effective only with same-source S3AccessKeyID/S3SecretAccessKey, see ResolveStaticS3Credentials (#329)
 
 	// Manifest (optional - when set, flush updates manifest after export)
 	ManifestPrefix   string // root prefix for manifests in S3

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -45,8 +45,13 @@ type exportSQLPlan struct {
 // one arbitrary connection (#285, same class as #245). Init statement
 // failures are logged and skipped, never blocking the connection;
 // construction fails only on credential validation or ping.
-func NewDuckExporter(ctx context.Context, cfg CDCConfig, s3AccessKey, s3Secret string, logger *zap.Logger) (*DuckExporter, error) {
-	steps, err := buildExporterInitSteps(cfg, s3AccessKey, s3Secret)
+//
+// The caller passes the whole key/secret/token triple because a session token
+// is only valid with the pair it was issued alongside; resolving it here would
+// let a token from one source pair with a key from another (#329, see
+// ResolveStaticS3Credentials).
+func NewDuckExporter(ctx context.Context, cfg CDCConfig, s3AccessKey, s3Secret, s3SessionToken string, logger *zap.Logger) (*DuckExporter, error) {
+	steps, err := buildExporterInitSteps(cfg, s3AccessKey, s3Secret, s3SessionToken)
 	if err != nil {
 		return nil, fmt.Errorf("build duckdb exporter init statements: %w", err)
 	}

--- a/internal/cdc/duckdb_exporter_init.go
+++ b/internal/cdc/duckdb_exporter_init.go
@@ -2,7 +2,6 @@ package cdc
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/lychee-technology/forma/internal/duckdbinit"
@@ -13,7 +12,7 @@ import (
 // statement set and order NewDuckExporter previously issued through the pool
 // (#285). Credential validation happens here, so construction fails fast
 // before any connection is opened.
-func buildExporterInitSteps(cfg CDCConfig, s3AccessKey, s3Secret string) ([]duckdbinit.Step, error) {
+func buildExporterInitSteps(cfg CDCConfig, s3AccessKey, s3Secret, s3SessionToken string) ([]duckdbinit.Step, error) {
 	var steps []duckdbinit.Step
 	if cfg.DuckMemLimit != "" {
 		steps = append(steps, duckdbinit.SingleStmtStep(fmt.Sprintf("PRAGMA memory_limit='%s';", cfg.DuckMemLimit), "set memory_limit"))
@@ -25,22 +24,26 @@ func buildExporterInitSteps(cfg CDCConfig, s3AccessKey, s3Secret string) ([]duck
 	for _, ext := range []string{"postgres_scanner", "httpfs", "parquet"} {
 		steps = append(steps, duckdbinit.ExtensionStep(ext))
 	}
-	s3Steps, err := buildExporterS3Steps(cfg, s3AccessKey, s3Secret)
+	s3Steps, err := buildExporterS3Steps(cfg, s3AccessKey, s3Secret, s3SessionToken)
 	if err != nil {
 		return nil, fmt.Errorf("build cdc duckdb s3 statements: %w", err)
 	}
 	return append(steps, s3Steps...), nil
 }
 
-func buildExporterS3Steps(cfg CDCConfig, s3AccessKey, s3Secret string) ([]duckdbinit.Step, error) {
+func buildExporterS3Steps(cfg CDCConfig, s3AccessKey, s3Secret, s3SessionToken string) ([]duckdbinit.Step, error) {
 	var steps []duckdbinit.Step
 	credentials := []struct{ name, value string }{
 		{"s3_access_key_id", s3AccessKey},
 		{"s3_secret_access_key", s3Secret},
 		// Temporary credentials (STS/assumed roles) are a key+secret+token
 		// triple; without the token httpfs signs requests the store rejects
-		// even though the SDK client on the same credentials works.
-		{"s3_session_token", resolveExporterSessionToken(cfg)},
+		// even though the SDK client on the same credentials works. The token
+		// arrives from the caller alongside the pair, so it can only come from
+		// the source that supplied that pair (#329) — resolving it here
+		// independently is exactly the cross-source mix that fails opaquely.
+		// See ResolveStaticS3Credentials.
+		{"s3_session_token", s3SessionToken},
 		{"s3_region", cfg.S3Region},
 	}
 	for _, c := range credentials {
@@ -68,11 +71,4 @@ func buildExporterS3Steps(cfg CDCConfig, s3AccessKey, s3Secret string) ([]duckdb
 		steps = append(steps, duckdbinit.SingleStmtStep("SET s3_url_style='path';", "set s3_url_style"))
 	}
 	return steps, nil
-}
-
-func resolveExporterSessionToken(cfg CDCConfig) string {
-	if cfg.S3SessionToken != "" {
-		return cfg.S3SessionToken
-	}
-	return os.Getenv("AWS_SESSION_TOKEN")
 }

--- a/internal/cdc/duckdb_exporter_init_test.go
+++ b/internal/cdc/duckdb_exporter_init_test.go
@@ -28,7 +28,7 @@ func newExporterInitTestConfig() CDCConfig {
 func TestNewDuckExporter_FreshConnectionsConfigured(t *testing.T) {
 	t.Setenv("AWS_SESSION_TOKEN", "")
 	ctx := context.Background()
-	exp, err := NewDuckExporter(ctx, newExporterInitTestConfig(), "AKIDEXAMPLE", "testsecretvalue", zap.NewNop())
+	exp, err := NewDuckExporter(ctx, newExporterInitTestConfig(), "AKIDEXAMPLE", "testsecretvalue", "", zap.NewNop())
 	require.NoError(t, err)
 	defer exp.DB.Close()
 
@@ -48,7 +48,7 @@ func TestNewDuckExporter_FreshConnectionsConfigured(t *testing.T) {
 // The exporter pool must be bounded (#285: sql.Open default is unlimited).
 func TestNewDuckExporter_PoolBoundedToSingleConnection(t *testing.T) {
 	t.Setenv("AWS_SESSION_TOKEN", "")
-	exp, err := NewDuckExporter(context.Background(), newExporterInitTestConfig(), "AKIDEXAMPLE", "testsecretvalue", zap.NewNop())
+	exp, err := NewDuckExporter(context.Background(), newExporterInitTestConfig(), "AKIDEXAMPLE", "testsecretvalue", "", zap.NewNop())
 	require.NoError(t, err)
 	defer exp.DB.Close()
 	require.Equal(t, 1, exp.DB.Stats().MaxOpenConnections)
@@ -58,7 +58,7 @@ func TestNewDuckExporter_PoolBoundedToSingleConnection(t *testing.T) {
 // holds pre-fix; post-fix it fails before any connection is opened).
 func TestNewDuckExporter_InvalidCredentialFailsFast(t *testing.T) {
 	t.Setenv("AWS_SESSION_TOKEN", "")
-	_, err := NewDuckExporter(context.Background(), newExporterInitTestConfig(), "bad'key", "testsecretvalue", zap.NewNop())
+	_, err := NewDuckExporter(context.Background(), newExporterInitTestConfig(), "bad'key", "testsecretvalue", "", zap.NewNop())
 	require.Error(t, err)
 }
 
@@ -67,9 +67,9 @@ func TestBuildExporterInitSteps_FullConfigStatementSet(t *testing.T) {
 	cfg := CDCConfig{
 		DuckMemLimit: "1GB", DuckThreads: 2,
 		S3Region: "us-test-1", S3Endpoint: "https://s3.example.com",
-		S3UseSSL: true, S3UsePath: true, S3SessionToken: "tok123",
+		S3UseSSL: true, S3UsePath: true,
 	}
-	steps, err := buildExporterInitSteps(cfg, "AKID", "secretvalue")
+	steps, err := buildExporterInitSteps(cfg, "AKID", "secretvalue", "tok123")
 	require.NoError(t, err)
 	require.Equal(t, []string{
 		"PRAGMA memory_limit='1GB';",
@@ -87,16 +87,30 @@ func TestBuildExporterInitSteps_FullConfigStatementSet(t *testing.T) {
 	}, flattenStepSQL(steps))
 }
 
-func TestBuildExporterInitSteps_SessionTokenEnvFallback(t *testing.T) {
+// The exporter must never reach for an ambient AWS_SESSION_TOKEN of its own:
+// the token is resolved once by the caller alongside the key/secret pair, so a
+// caller that supplies no token means no token applies (#329).
+func TestBuildExporterInitSteps_IgnoresAmbientEnvSessionToken(t *testing.T) {
 	t.Setenv("AWS_SESSION_TOKEN", "envtok")
-	steps, err := buildExporterInitSteps(newExporterInitTestConfig(), "AKID", "secretvalue")
+	steps, err := buildExporterInitSteps(newExporterInitTestConfig(), "AKID", "secretvalue", "")
 	require.NoError(t, err)
-	require.Contains(t, flattenStepSQL(steps), "SET s3_session_token='envtok';")
+	for _, sql := range flattenStepSQL(steps) {
+		require.NotContains(t, sql, "s3_session_token")
+	}
+}
+
+// The caller-resolved token is what reaches DuckDB, even when the environment
+// offers a competing one (#329).
+func TestBuildExporterInitSteps_EmitsCallerResolvedSessionToken(t *testing.T) {
+	t.Setenv("AWS_SESSION_TOKEN", "envtok")
+	steps, err := buildExporterInitSteps(newExporterInitTestConfig(), "AKID", "secretvalue", "callertok")
+	require.NoError(t, err)
+	require.Contains(t, flattenStepSQL(steps), "SET s3_session_token='callertok';")
 }
 
 func TestBuildExporterInitSteps_MinimalConfigOmitsOptionalStatements(t *testing.T) {
 	t.Setenv("AWS_SESSION_TOKEN", "")
-	steps, err := buildExporterInitSteps(CDCConfig{}, "", "")
+	steps, err := buildExporterInitSteps(CDCConfig{}, "", "", "")
 	require.NoError(t, err)
 	// no pragmas, no SETs except the unconditional s3_use_ssl
 	require.Equal(t, []string{

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -148,9 +148,12 @@ func setupAWSClient(ctx context.Context, cfg CDCConfig) (string, aws.Credentials
 	}
 	// Both-halves rule and config-wins precedence live in
 	// ResolveStaticS3Credentials — the shared rule for every cdc credential
-	// site (#326). Empty pair leaves the default chain in place.
-	if staticKey, staticSecret, _ := ResolveStaticS3Credentials(cfg); staticKey != "" {
-		awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(staticKey, staticSecret, "")
+	// site (#326). Empty pair leaves the default chain in place. The session
+	// token rides the source that supplied the pair (#329): dropping it here
+	// signed temporary STS credentials as if they were long-lived keys, which
+	// the storage endpoint can only report as an opaque signing failure.
+	if staticKey, staticSecret, staticToken := ResolveStaticS3Credentials(cfg); staticKey != "" {
+		awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(staticKey, staticSecret, staticToken)
 	}
 
 	// Build S3 client options

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -95,9 +95,12 @@ func RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectClient, dryRun
 	// DuckDB httpfs credentials follow the same both-halves rule as the SDK
 	// client (#326): with no fully-set static pair NewDuckExporter receives
 	// empty strings and DuckDB inherits its own environment chain, so the SDK
-	// client and httpfs never diverge under a half-set env pair.
-	s3Key, s3Secret, _ := ResolveStaticS3Credentials(cfg)
-	duck, err := NewDuckExporter(ctx, cfg, s3Key, s3Secret, logger)
+	// client and httpfs never diverge under a half-set env pair. The session
+	// token rides the source that supplied the pair (#329) — resolved once
+	// here and handed to the exporter, so httpfs signs with the same triple
+	// the SDK client does.
+	s3Key, s3Secret, s3Token := ResolveStaticS3Credentials(cfg)
+	duck, err := NewDuckExporter(ctx, cfg, s3Key, s3Secret, s3Token, logger)
 	if err != nil {
 		return fmt.Errorf("new duck exporter: %w", err)
 	}

--- a/internal/cdc/flusher.go
+++ b/internal/cdc/flusher.go
@@ -96,7 +96,7 @@ func RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectClient, dryRun
 	// client (#326): with no fully-set static pair NewDuckExporter receives
 	// empty strings and DuckDB inherits its own environment chain, so the SDK
 	// client and httpfs never diverge under a half-set env pair.
-	s3Key, s3Secret := resolveStaticS3Credentials(cfg)
+	s3Key, s3Secret, _ := ResolveStaticS3Credentials(cfg)
 	duck, err := NewDuckExporter(ctx, cfg, s3Key, s3Secret, logger)
 	if err != nil {
 		return fmt.Errorf("new duck exporter: %w", err)
@@ -147,9 +147,9 @@ func setupAWSClient(ctx context.Context, cfg CDCConfig) (string, aws.Credentials
 		return "", nil, nil, fmt.Errorf("load aws config: %w", err)
 	}
 	// Both-halves rule and config-wins precedence live in
-	// resolveStaticS3Credentials — the shared rule for every cdc credential
+	// ResolveStaticS3Credentials — the shared rule for every cdc credential
 	// site (#326). Empty pair leaves the default chain in place.
-	if staticKey, staticSecret := resolveStaticS3Credentials(cfg); staticKey != "" {
+	if staticKey, staticSecret, _ := ResolveStaticS3Credentials(cfg); staticKey != "" {
 		awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(staticKey, staticSecret, "")
 	}
 

--- a/internal/cdc/flusher_aws_test.go
+++ b/internal/cdc/flusher_aws_test.go
@@ -2,6 +2,7 @@ package cdc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -62,7 +63,7 @@ func TestSetupAWSClient_RegionPassedAtLoad(t *testing.T) {
 		lo := &config.LoadOptions{}
 		for _, fn := range optFns {
 			if err := fn(lo); err != nil {
-				return aws.Config{}, err
+				return aws.Config{}, fmt.Errorf("apply AWS load option: %w", err)
 			}
 		}
 		loadedRegion = lo.Region

--- a/internal/cdc/flusher_aws_test.go
+++ b/internal/cdc/flusher_aws_test.go
@@ -98,3 +98,53 @@ func TestSetupAWSClient_ConfigCredentialsStillWin(t *testing.T) {
 		t.Fatalf("config credentials must win over env, got %+v", creds)
 	}
 }
+
+// TestSetupAWSClient_EnvTripleCarriesSessionToken pins that a fully-set
+// environment triple reaches the SDK static provider with its token: without
+// it, temporary STS credentials sign every request as if they were long-lived
+// keys and the endpoint can only report an opaque signing failure (#329).
+func TestSetupAWSClient_EnvTripleCarriesSessionToken(t *testing.T) {
+	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	})
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "env-token")
+
+	_, credProvider, _, err := setupAWSClient(context.Background(), CDCConfig{})
+	if err != nil {
+		t.Fatalf("setupAWSClient: %v", err)
+	}
+	creds := retrieveCreds(t, credProvider)
+	if creds.AccessKeyID != "env-key" || creds.SecretAccessKey != "env-secret" {
+		t.Fatalf("env triple must become the static provider, got %+v", creds)
+	}
+	if creds.SessionToken != "env-token" {
+		t.Fatalf("expected session token %q, got %q", "env-token", creds.SessionToken)
+	}
+}
+
+// TestSetupAWSClient_ConfigPairRejectsAmbientEnvToken pins that the token
+// never crosses sources: a config pair carries only the config token, so an
+// ambient AWS_SESSION_TOKEN left over from an unrelated session must not be
+// stapled onto explicitly configured long-lived keys (#329).
+func TestSetupAWSClient_ConfigPairRejectsAmbientEnvToken(t *testing.T) {
+	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	})
+	t.Setenv("AWS_SESSION_TOKEN", "env-token")
+
+	_, credProvider, _, err := setupAWSClient(context.Background(), CDCConfig{
+		S3AccessKeyID: "cfg-key", S3SecretAccessKey: "cfg-secret",
+	})
+	if err != nil {
+		t.Fatalf("setupAWSClient: %v", err)
+	}
+	creds := retrieveCreds(t, credProvider)
+	if creds.AccessKeyID != "cfg-key" || creds.SecretAccessKey != "cfg-secret" {
+		t.Fatalf("config credentials must win over env, got %+v", creds)
+	}
+	if creds.SessionToken != "" {
+		t.Fatalf("config pair must not adopt the ambient env token, got %q", creds.SessionToken)
+	}
+}

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -98,7 +98,7 @@ func newInitRunContext(ctx context.Context, opts InitOptions) (*initRunContext, 
 	// other cdc credential site (#326): with no fully-set static pair the
 	// exporter receives empty strings and DuckDB inherits its own
 	// environment chain.
-	s3Key, s3Secret := resolveStaticS3Credentials(cfg)
+	s3Key, s3Secret, _ := ResolveStaticS3Credentials(cfg)
 	duck, err := NewDuckExporter(ctx, cfg, s3Key, s3Secret, opts.Logger)
 	if err != nil {
 		_ = db.Close()

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -97,9 +97,11 @@ func newInitRunContext(ctx context.Context, opts InitOptions) (*initRunContext, 
 	// DuckDB httpfs credentials follow the same both-halves rule as every
 	// other cdc credential site (#326): with no fully-set static pair the
 	// exporter receives empty strings and DuckDB inherits its own
-	// environment chain.
-	s3Key, s3Secret, _ := ResolveStaticS3Credentials(cfg)
-	duck, err := NewDuckExporter(ctx, cfg, s3Key, s3Secret, opts.Logger)
+	// environment chain. The session token rides the source that supplied the
+	// pair (#329), so it is resolved together with the pair and passed on
+	// rather than looked up again inside the exporter.
+	s3Key, s3Secret, s3Token := ResolveStaticS3Credentials(cfg)
+	duck, err := NewDuckExporter(ctx, cfg, s3Key, s3Secret, s3Token, opts.Logger)
 	if err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("new duck exporter: %w", err)

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -40,6 +40,7 @@ type cachedS3Runtime struct {
 	client          *s3.Client
 	accessKeyID     string
 	secretAccessKey string
+	sessionToken    string
 }
 
 type s3RuntimeKey struct {
@@ -177,7 +178,7 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 }
 
 func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cachedS3Runtime, error) {
-	accessKeyID, secretAccessKey, _ := ResolveStaticS3Credentials(cfg)
+	accessKeyID, secretAccessKey, sessionToken := ResolveStaticS3Credentials(cfg)
 
 	key := s3RuntimeKey{
 		region:          cfg.S3Region,
@@ -207,7 +208,9 @@ func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cach
 		return nil, fmt.Errorf("load aws config: %w", err)
 	}
 	if accessKeyID != "" {
-		awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")
+		// The session token rides the source that supplied the pair (#329) —
+		// dropping it signed temporary STS credentials as long-lived keys.
+		awsCfg.Credentials = awsCreds.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken)
 	}
 
 	runtime := &cachedS3Runtime{
@@ -216,6 +219,7 @@ func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cach
 		client:          newS3ClientFn(awsCfg, cfg.S3Endpoint, cfg.S3UsePath),
 		accessKeyID:     accessKeyID,
 		secretAccessKey: secretAccessKey,
+		sessionToken:    sessionToken,
 	}
 
 	r.mu.Lock()

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -253,7 +253,9 @@ func (r *Runner) getOrCreateDuckExporter(ctx context.Context, cfg CDCConfig, s3R
 		return cached, nil
 	}
 
-	exporter, err := newDuckExporterFn(ctx, cfg, s3Runtime.accessKeyID, s3Runtime.secretAccessKey, r.logger)
+	// The cached triple, not a fresh resolve: one resolution keeps the SDK
+	// provider and the DuckDB SET statements on the same credentials (#329).
+	exporter, err := newDuckExporterFn(ctx, cfg, s3Runtime.accessKeyID, s3Runtime.secretAccessKey, s3Runtime.sessionToken, r.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -177,7 +177,7 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 }
 
 func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cachedS3Runtime, error) {
-	accessKeyID, secretAccessKey := resolveStaticS3Credentials(cfg)
+	accessKeyID, secretAccessKey, _ := ResolveStaticS3Credentials(cfg)
 
 	key := s3RuntimeKey{
 		region:          cfg.S3Region,

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -44,23 +44,32 @@ type cachedS3Runtime struct {
 }
 
 type s3RuntimeKey struct {
-	region          string
-	endpoint        string
-	usePath         bool
-	accessKeyID     string
+	region      string
+	endpoint    string
+	usePath     bool
+	accessKeyID string
+	// The token is part of the signing identity the cached provider bakes in,
+	// so it belongs in the key alongside the pair: omit it and a rotated
+	// AWS_SESSION_TOKEN under an unchanged pair keeps hitting the cached
+	// runtime, handing every caller a stale-token artifact (#329).
 	secretAccessKey string
+	sessionToken    string
 }
 
 type duckExporterKey struct {
-	dbPath          string
-	threads         int
-	memLimit        string
-	region          string
-	endpoint        string
-	useSSL          bool
-	usePath         bool
-	accessKeyID     string
+	dbPath      string
+	threads     int
+	memLimit    string
+	region      string
+	endpoint    string
+	useSSL      bool
+	usePath     bool
+	accessKeyID string
+	// Same rule as s3RuntimeKey: the exporter bakes the token into
+	// SET s3_session_token at construction, so a key without it returns a
+	// stale-token exporter after a rotation (#329).
 	secretAccessKey string
+	sessionToken    string
 }
 
 func NewRunner(logger *zap.Logger) *Runner {
@@ -142,7 +151,7 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 
 	duck, err := r.getOrCreateDuckExporter(ctx, cfg, s3Runtime)
 	if err != nil {
-		// getOrCreateDuckExporter now wraps with "new duck exporter:" itself;
+		// getOrCreateDuckExporter wraps its own error with "new duck exporter:";
 		// re-wrapping here would double the prefix. Same pass-through shape as
 		// the other already-wrapped callees above.
 		return err
@@ -189,6 +198,7 @@ func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cach
 		usePath:         cfg.S3UsePath,
 		accessKeyID:     accessKeyID,
 		secretAccessKey: secretAccessKey,
+		sessionToken:    sessionToken,
 	}
 
 	r.mu.Lock()
@@ -245,14 +255,20 @@ func (r *Runner) getOrCreateDuckExporter(ctx context.Context, cfg CDCConfig, s3R
 		// from cfg alone, and an empty cfg.S3Region suppresses SET s3_region
 		// entirely. Keying on the chain-resolved region claims a distinction
 		// the exporter never makes, so two runs producing byte-identical
-		// exporters would miss the cache (#329). The ambient region is stable
-		// within a process, so this is key honesty with no behavior change.
-		region:          cfg.S3Region,
-		endpoint:        cfg.S3Endpoint,
-		useSSL:          cfg.S3UseSSL,
-		usePath:         cfg.S3UsePath,
-		accessKeyID:     s3Runtime.accessKeyID,
+		// exporters would miss the cache (#329). It also cut the other way: an
+		// empty-region cfg whose chain resolved to some region could collide
+		// with an explicitly-configured cfg of that same region, two configs
+		// that build *different* exporters, so the second silently reused the
+		// first's — a latent wrong cache hit the raw cfg region rules out.
+		region:      cfg.S3Region,
+		endpoint:    cfg.S3Endpoint,
+		useSSL:      cfg.S3UseSSL,
+		usePath:     cfg.S3UsePath,
+		accessKeyID: s3Runtime.accessKeyID,
+		// The cached runtime's token, matching the triple handed to
+		// newDuckExporterFn below (#329).
 		secretAccessKey: s3Runtime.secretAccessKey,
+		sessionToken:    s3Runtime.sessionToken,
 	}
 
 	r.mu.Lock()

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -142,7 +142,10 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 
 	duck, err := r.getOrCreateDuckExporter(ctx, cfg, s3Runtime)
 	if err != nil {
-		return fmt.Errorf("new duck exporter: %w", err)
+		// getOrCreateDuckExporter now wraps with "new duck exporter:" itself;
+		// re-wrapping here would double the prefix. Same pass-through shape as
+		// the other already-wrapped callees above.
+		return err
 	}
 
 	tableName := cfg.ChangeLogTable
@@ -235,10 +238,16 @@ func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cach
 
 func (r *Runner) getOrCreateDuckExporter(ctx context.Context, cfg CDCConfig, s3Runtime *cachedS3Runtime) (*DuckExporter, error) {
 	key := duckExporterKey{
-		dbPath:          cfg.DuckDBPath,
-		threads:         cfg.DuckThreads,
-		memLimit:        cfg.DuckMemLimit,
-		region:          s3Runtime.region,
+		dbPath:   cfg.DuckDBPath,
+		threads:  cfg.DuckThreads,
+		memLimit: cfg.DuckMemLimit,
+		// The raw cfg region, not s3Runtime.region: the exporter is configured
+		// from cfg alone, and an empty cfg.S3Region suppresses SET s3_region
+		// entirely. Keying on the chain-resolved region claims a distinction
+		// the exporter never makes, so two runs producing byte-identical
+		// exporters would miss the cache (#329). The ambient region is stable
+		// within a process, so this is key honesty with no behavior change.
+		region:          cfg.S3Region,
 		endpoint:        cfg.S3Endpoint,
 		useSSL:          cfg.S3UseSSL,
 		usePath:         cfg.S3UsePath,
@@ -257,7 +266,7 @@ func (r *Runner) getOrCreateDuckExporter(ctx context.Context, cfg CDCConfig, s3R
 	// provider and the DuckDB SET statements on the same credentials (#329).
 	exporter, err := newDuckExporterFn(ctx, cfg, s3Runtime.accessKeyID, s3Runtime.secretAccessKey, s3Runtime.sessionToken, r.logger)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new duck exporter: %w", err)
 	}
 
 	r.mu.Lock()

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -121,13 +121,13 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 
 	s3Runtime, err := r.getOrCreateS3Runtime(ctx, cfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("prepare s3 runtime: %w", err)
 	}
 
 	requireFullS3 := cfg.ManifestTemplate != ""
 	activeS3Client, activeFullS3Client, err := resolveS3Clients(s3Client, s3Runtime.client, requireFullS3)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve s3 clients: %w", err)
 	}
 
 	var manifestStore manifest.Store
@@ -145,16 +145,15 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 
 	db, pgPassword, err := setupPostgresConnection(ctx, cfg, s3Runtime.region, s3Runtime.credProvider, r.logger)
 	if err != nil {
-		return err
+		return fmt.Errorf("setup postgres connection: %w", err)
 	}
 	defer db.Close()
 
 	duck, err := r.getOrCreateDuckExporter(ctx, cfg, s3Runtime)
 	if err != nil {
-		// getOrCreateDuckExporter wraps its own error with "new duck exporter:";
-		// re-wrapping here would double the prefix. Same pass-through shape as
-		// the other already-wrapped callees above.
-		return err
+		// getOrCreateDuckExporter carries the "new duck exporter:" prefix; this
+		// layer adds the run-level step so the two never duplicate.
+		return fmt.Errorf("prepare duck exporter: %w", err)
 	}
 
 	tableName := cfg.ChangeLogTable

--- a/internal/cdc/runner_test.go
+++ b/internal/cdc/runner_test.go
@@ -80,6 +80,31 @@ func TestRunnerGetOrCreateS3Runtime_EnvPairBecomesStaticProvider(t *testing.T) {
 	require.Equal(t, "env-secret", creds.SecretAccessKey)
 }
 
+// TestRunnerGetOrCreateS3Runtime_EnvTripleCarriesSessionToken pins the third
+// credential site: the cached runtime must both remember the resolved session
+// token and hand it to the static provider, or every long-lived Runner signs
+// temporary credentials as if they were permanent keys (#329).
+func TestRunnerGetOrCreateS3Runtime_EnvTripleCarriesSessionToken(t *testing.T) {
+	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-west-2"}, nil
+	})
+	origNewS3ClientFn := newS3ClientFn
+	defer func() { newS3ClientFn = origNewS3ClientFn }()
+	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client { return &s3.Client{} }
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "env-token")
+
+	runtime, err := NewRunner(zap.NewNop()).getOrCreateS3Runtime(context.Background(), CDCConfig{})
+	require.NoError(t, err)
+	require.Equal(t, "env-token", runtime.sessionToken)
+	creds := retrieveCreds(t, runtime.credProvider)
+	require.Equal(t, "env-key", creds.AccessKeyID)
+	require.Equal(t, "env-secret", creds.SecretAccessKey)
+	require.Equal(t, "env-token", creds.SessionToken)
+}
+
 func TestRunnerCachesDuckExporter(t *testing.T) {
 	origNewDuckExporterFn := newDuckExporterFn
 	defer func() {

--- a/internal/cdc/runner_test.go
+++ b/internal/cdc/runner_test.go
@@ -105,6 +105,42 @@ func TestRunnerGetOrCreateS3Runtime_EnvTripleCarriesSessionToken(t *testing.T) {
 	require.Equal(t, "env-token", creds.SessionToken)
 }
 
+// TestRunnerS3RuntimeCacheKeyIncludesSessionToken pins that the cached runtime
+// is keyed on the whole credential triple. The provider bakes the token in, so
+// a rotated AWS_SESSION_TOKEN under an unchanged access-key pair describes a
+// different signing identity — key on the pair alone and the Runner keeps
+// serving the expired token until the process restarts (#329).
+func TestRunnerS3RuntimeCacheKeyIncludesSessionToken(t *testing.T) {
+	loadCalls := 0
+	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		loadCalls++
+		return aws.Config{Region: "us-west-2"}, nil
+	})
+	origNewS3ClientFn := newS3ClientFn
+	defer func() { newS3ClientFn = origNewS3ClientFn }()
+	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client { return &s3.Client{} }
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "token-1")
+
+	runner := NewRunner(zap.NewNop())
+	first, err := runner.getOrCreateS3Runtime(context.Background(), CDCConfig{})
+	require.NoError(t, err)
+	require.Equal(t, "token-1", first.sessionToken)
+
+	// Same access-key pair, rotated token.
+	t.Setenv("AWS_SESSION_TOKEN", "token-2")
+
+	second, err := runner.getOrCreateS3Runtime(context.Background(), CDCConfig{})
+	require.NoError(t, err)
+	require.NotSame(t, first, second)
+	require.Equal(t, 2, loadCalls)
+	require.Equal(t, "token-2", second.sessionToken)
+	creds := retrieveCreds(t, second.credProvider)
+	require.Equal(t, "token-2", creds.SessionToken)
+}
+
 func TestRunnerCachesDuckExporter(t *testing.T) {
 	origNewDuckExporterFn := newDuckExporterFn
 	defer func() {
@@ -186,6 +222,55 @@ func TestRunnerDuckExporterCacheKeyIgnoresChainResolvedRegion(t *testing.T) {
 
 	require.Same(t, exporter1, exporter2)
 	require.Equal(t, 1, createCalls)
+}
+
+// TestRunnerDuckExporterCacheKeyIncludesSessionToken pins the other half of the
+// same rule: the exporter bakes the token into SET s3_session_token at
+// construction, so two runtimes differing only in their token configure
+// different exporters and must not share a cache slot (#329).
+func TestRunnerDuckExporterCacheKeyIncludesSessionToken(t *testing.T) {
+	origNewDuckExporterFn := newDuckExporterFn
+	defer func() {
+		newDuckExporterFn = origNewDuckExporterFn
+	}()
+
+	createCalls := 0
+	var seenTokens []string
+	newDuckExporterFn = func(ctx context.Context, cfg CDCConfig, s3AccessKey, s3Secret, s3SessionToken string, logger *zap.Logger) (*DuckExporter, error) {
+		createCalls++
+		seenTokens = append(seenTokens, s3SessionToken)
+		return &DuckExporter{Logger: logger}, nil
+	}
+
+	runner := NewRunner(zap.NewNop())
+	cfg := CDCConfig{
+		DuckDBPath:   ":memory:",
+		DuckThreads:  4,
+		DuckMemLimit: "4GB",
+		S3Region:     "us-east-1",
+		S3UseSSL:     true,
+	}
+	runtimeOld := &cachedS3Runtime{
+		region:          "us-east-1",
+		accessKeyID:     "key",
+		secretAccessKey: "secret",
+		sessionToken:    "token-1",
+	}
+	runtimeRotated := &cachedS3Runtime{
+		region:          "us-east-1",
+		accessKeyID:     "key",
+		secretAccessKey: "secret",
+		sessionToken:    "token-2",
+	}
+
+	exporter1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeOld)
+	require.NoError(t, err)
+	exporter2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeRotated)
+	require.NoError(t, err)
+
+	require.NotSame(t, exporter1, exporter2)
+	require.Equal(t, 2, createCalls)
+	require.Equal(t, []string{"token-1", "token-2"}, seenTokens)
 }
 
 func TestRunnerClose_ClearsCachesAndClosesExporters(t *testing.T) {

--- a/internal/cdc/runner_test.go
+++ b/internal/cdc/runner_test.go
@@ -140,6 +140,54 @@ func TestRunnerCachesDuckExporter(t *testing.T) {
 	require.Equal(t, 1, createCalls)
 }
 
+// TestRunnerDuckExporterCacheKeyIgnoresChainResolvedRegion pins that the
+// exporter cache key describes the exporter that was actually built. The
+// exporter is configured from the raw cfg — an empty cfg.S3Region suppresses
+// SET s3_region entirely — so two runs whose only difference is the region the
+// AWS default chain happened to resolve produce byte-identical exporters. Key
+// on the chain region and the cache claims a distinction the exporter never
+// made, building (and leaking) a second identical DuckDB instance (#329).
+func TestRunnerDuckExporterCacheKeyIgnoresChainResolvedRegion(t *testing.T) {
+	origNewDuckExporterFn := newDuckExporterFn
+	defer func() {
+		newDuckExporterFn = origNewDuckExporterFn
+	}()
+
+	createCalls := 0
+	newDuckExporterFn = func(ctx context.Context, cfg CDCConfig, s3AccessKey, s3Secret, s3SessionToken string, logger *zap.Logger) (*DuckExporter, error) {
+		createCalls++
+		return &DuckExporter{Logger: logger}, nil
+	}
+
+	runner := NewRunner(zap.NewNop())
+	// cfg.S3Region is empty: the exporter never issues SET s3_region, so both
+	// runtimes below configure the exact same exporter.
+	cfg := CDCConfig{
+		DuckDBPath:   ":memory:",
+		DuckThreads:  4,
+		DuckMemLimit: "4GB",
+		S3UseSSL:     true,
+	}
+	runtimeEast := &cachedS3Runtime{
+		region:          "us-east-1",
+		accessKeyID:     "key",
+		secretAccessKey: "secret",
+	}
+	runtimeWest := &cachedS3Runtime{
+		region:          "eu-west-1",
+		accessKeyID:     "key",
+		secretAccessKey: "secret",
+	}
+
+	exporter1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeEast)
+	require.NoError(t, err)
+	exporter2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeWest)
+	require.NoError(t, err)
+
+	require.Same(t, exporter1, exporter2)
+	require.Equal(t, 1, createCalls)
+}
+
 func TestRunnerClose_ClearsCachesAndClosesExporters(t *testing.T) {
 	db, err := sql.Open("duckdb", ":memory:")
 	require.NoError(t, err)

--- a/internal/cdc/runner_test.go
+++ b/internal/cdc/runner_test.go
@@ -14,6 +14,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// stubNewS3Client swaps the package seam for one test, the t.Cleanup twin of
+// stubLoadAWSConfig in flusher_aws_test.go. No t.Parallel: the seam is
+// process-global (same pattern as internal/bootstrap).
+func stubNewS3Client(t *testing.T, fn func(aws.Config, string, bool) *s3.Client) {
+	t.Helper()
+	previous := newS3ClientFn
+	newS3ClientFn = fn
+	t.Cleanup(func() { newS3ClientFn = previous })
+}
+
 func TestNewRunner_UsesNopLoggerWhenNil(t *testing.T) {
 	runner := NewRunner(nil)
 	require.NotNil(t, runner)
@@ -28,21 +38,16 @@ func TestRunnerRunOnce_RequiresSchemaRegistry(t *testing.T) {
 }
 
 func TestRunnerCachesS3Runtime(t *testing.T) {
-	origNewS3ClientFn := newS3ClientFn
-	defer func() {
-		newS3ClientFn = origNewS3ClientFn
-	}()
-
 	loadCalls := 0
 	clientCalls := 0
 	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
 		loadCalls++
 		return aws.Config{}, nil
 	})
-	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client {
+	stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client {
 		clientCalls++
 		return &s3.Client{}
-	}
+	})
 
 	runner := NewRunner(zap.NewNop())
 	cfg := CDCConfig{S3Region: "us-east-1"}
@@ -63,9 +68,7 @@ func TestRunnerGetOrCreateS3Runtime_EnvPairBecomesStaticProvider(t *testing.T) {
 	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{Region: "us-west-2"}, nil
 	})
-	origNewS3ClientFn := newS3ClientFn
-	defer func() { newS3ClientFn = origNewS3ClientFn }()
-	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client { return &s3.Client{} }
+	stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client { return &s3.Client{} })
 
 	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
@@ -88,9 +91,7 @@ func TestRunnerGetOrCreateS3Runtime_EnvTripleCarriesSessionToken(t *testing.T) {
 	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{Region: "us-west-2"}, nil
 	})
-	origNewS3ClientFn := newS3ClientFn
-	defer func() { newS3ClientFn = origNewS3ClientFn }()
-	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client { return &s3.Client{} }
+	stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client { return &s3.Client{} })
 
 	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
@@ -116,9 +117,7 @@ func TestRunnerS3RuntimeCacheKeyIncludesSessionToken(t *testing.T) {
 		loadCalls++
 		return aws.Config{Region: "us-west-2"}, nil
 	})
-	origNewS3ClientFn := newS3ClientFn
-	defer func() { newS3ClientFn = origNewS3ClientFn }()
-	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client { return &s3.Client{} }
+	stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client { return &s3.Client{} })
 
 	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
@@ -300,9 +299,7 @@ func TestRunnerGetOrCreateS3Runtime_EnvHalfPairPreservesDefaultChain(t *testing.
 	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{Region: "us-east-1", Credentials: chain}, nil
 	})
-	origNewS3ClientFn := newS3ClientFn
-	defer func() { newS3ClientFn = origNewS3ClientFn }()
-	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client { return &s3.Client{} }
+	stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client { return &s3.Client{} })
 
 	t.Setenv("AWS_ACCESS_KEY_ID", "env-key")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
@@ -331,9 +328,7 @@ func TestRunnerGetOrCreateS3Runtime_RegionPassedAtLoad(t *testing.T) {
 		loadedRegion = lo.Region
 		return aws.Config{Region: lo.Region}, nil
 	})
-	origNewS3ClientFn := newS3ClientFn
-	defer func() { newS3ClientFn = origNewS3ClientFn }()
-	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client { return &s3.Client{} }
+	stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client { return &s3.Client{} })
 
 	runtime, err := NewRunner(zap.NewNop()).getOrCreateS3Runtime(context.Background(), CDCConfig{S3Region: "eu-central-1"})
 	require.NoError(t, err)
@@ -348,9 +343,7 @@ func TestRunnerGetOrCreateS3Runtime_UnconfiguredRegionPreservesChainRegion(t *te
 	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{Region: "ap-southeast-2"}, nil
 	})
-	origNewS3ClientFn := newS3ClientFn
-	defer func() { newS3ClientFn = origNewS3ClientFn }()
-	newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Client { return &s3.Client{} }
+	stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client { return &s3.Client{} })
 
 	runtime, err := NewRunner(zap.NewNop()).getOrCreateS3Runtime(context.Background(), CDCConfig{})
 	require.NoError(t, err)

--- a/internal/cdc/runner_test.go
+++ b/internal/cdc/runner_test.go
@@ -112,7 +112,7 @@ func TestRunnerCachesDuckExporter(t *testing.T) {
 	}()
 
 	createCalls := 0
-	newDuckExporterFn = func(ctx context.Context, cfg CDCConfig, s3AccessKey, s3Secret string, logger *zap.Logger) (*DuckExporter, error) {
+	newDuckExporterFn = func(ctx context.Context, cfg CDCConfig, s3AccessKey, s3Secret, s3SessionToken string, logger *zap.Logger) (*DuckExporter, error) {
 		createCalls++
 		return &DuckExporter{Logger: logger}, nil
 	}

--- a/internal/e2e_harness/production/cdc.go
+++ b/internal/e2e_harness/production/cdc.go
@@ -196,7 +196,8 @@ func (e *Env) RunCompactionWith(ctx context.Context, schema SchemaRef, ov Compac
 		PathTemplate: e.CDC.ManifestTemplate,
 	}, s3Client)
 
-	exporter, err := cdc.NewDuckExporter(ctx, e.CDC, e.CDC.S3AccessKeyID, e.CDC.S3SecretAccessKey, e.logger)
+	s3Key, s3Secret, s3Token := cdc.ResolveStaticS3Credentials(e.CDC)
+	exporter, err := cdc.NewDuckExporter(ctx, e.CDC, s3Key, s3Secret, s3Token, e.logger)
 	if err != nil {
 		return compaction.CompactionResult{}, fmt.Errorf("open merge duckdb: %w", err)
 	}

--- a/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
+++ b/internal/e2e_harness/production/manifest_reconcile_e2e_test.go
@@ -53,7 +53,8 @@ func newReconcileHarness(t *testing.T, ctx context.Context, env *Env, schema Sch
 
 	cleanup := func() { _ = db.Close() }
 	if withStats {
-		exporter, err := cdc.NewDuckExporter(ctx, env.CDC, env.CDC.S3AccessKeyID, env.CDC.S3SecretAccessKey, env.logger)
+		s3Key, s3Secret, s3Token := cdc.ResolveStaticS3Credentials(env.CDC)
+		exporter, err := cdc.NewDuckExporter(ctx, env.CDC, s3Key, s3Secret, s3Token, env.logger)
 		if err != nil {
 			_ = db.Close()
 			t.Fatalf("open stats duckdb: %v", err)


### PR DESCRIPTION
Closes #329.

## What this does

Finishes the credential-resolution stragglers left after #326 (PR #330), per the issue's three items plus the ledger/comment cosmetics:

1. **Session token rides the pair source** (`internal/cdc/aws_credentials.go`). `ResolveStaticS3Credentials` (now exported) returns a `(key, secret, token)` triple: a config pair carries `cfg.S3SessionToken`, an env pair carries `AWS_SESSION_TOKEN`, and the token never crosses sources — a config pair no longer adopts an ambient env token (the cross-source mixing class #326 eliminated for the pair itself). A token with no pair is not a credential source. `resolveExporterSessionToken` is retired; the token is now an explicit `NewDuckExporter` parameter so the DuckDB `SET s3_session_token` can only ever come from the same resolution as the pair.
   - This also fixes a latent SDK-side bug: all static providers previously hard-coded an empty token (`NewStaticCredentialsProvider(key, secret, "")`), so env-pair STS temporary credentials signed without their session token. Both SDK sites (flusher `setupAWSClient`, runner `getOrCreateS3Runtime`) now carry the resolved token.

2. **`cmd/tools` fully unified onto the single rule** (user ruling). `resolveMergeCredentials` (the last per-variable env-var resolution site, able to return a half-set triple) is deleted; the compactor merge engine and the manifest-reconcile stats engine now call `cdc.ResolveStaticS3Credentials`.
   - ⚠️ **Deliberate behavior narrowing**: chain-only credential sources (IMDS/instance and container roles, SSO, assumed roles, web identity, shared profiles) no longer feed the engines' DuckDB httpfs `SET` statements. The tools expose no `--s3-access-key` flags, so the engines are env-pair-or-nothing in practice. Lambda-style env triples are unaffected — the token now rides the env pair. The failure shape on e.g. instance-role hosts is asymmetric: `buildToolS3Client` still walks the full chain, so manifest reads succeed while httpfs parquet IO goes unsigned (reads like an S3 permission error). A WARNING doc comment on `openMergeEngine` records all of this, and both engines now `logger.Warn` when they come up with no static credentials. Restoring chain support later means adding credential flags, not reinstating a second resolution rule.

3. **Honest exporter cache keys** (`internal/cdc/runner.go`). `duckExporterKey.region` now uses raw `cfg.S3Region` (what actually configures the exporter — empty suppresses `SET s3_region`) instead of the chain-resolved SDK region; the old key could produce a latent wrong cache hit (empty-region cfg colliding with an explicit-region cfg). Both `s3RuntimeKey` and `duckExporterKey` now include the resolved `sessionToken`, so an `AWS_SESSION_TOKEN` rotation under an unchanged pair no longer returns stale-token artifacts.

4. **Cosmetics from the #326 ledger / #330 review comments**: `stubNewS3Client(t, fn)` helper unifies 7 manual seam save/restores in `runner_test.go`; `unitEntityManagerDeps`/`unitEntityManagerConfig` → `buildUnitEntityManagerDeps`/`newUnitEntityManagerConfig` across all 4 factory test files (22 refs); the 4 `TestNewDuckDBCircuitBreaker*` tests moved byte-faithfully into `factory/factory_circuit_breaker_unit_test.go`; the flusher region-stub error now wraps identically to its runner twin (ca99945).

## Verification

- `make test` green across all packages; new/updated coverage: 14-case resolver table (mutation-verified — each token-discipline direction kills a distinct injected mutant), SDK-provider token tests (flusher + runner), exporter-builder discipline tests, `cmd/tools` chain-not-consulted + positive credential-wiring tests, cache-key red anchors (region + token, both s3Runtime and exporter).
- `go vet -tags e2e ./internal/e2e_harness/production/` clean — the only gate that compiles the e2e-tagged `NewDuckExporter` caller.
- `make lint` (golangci-lint v1.64.8) exit 0; `grep` shows zero residue of `resolveMergeCredentials`/`resolveExporterSessionToken`/the old unexported resolver.
- T9 move verified byte-faithful (`git show` range diff = zero).

## Follow-up

- #331 — Runner S3-runtime/exporter caches never evict; with the token now in the keys, credential rotation strands open DuckDB instances in long-lived runners (pre-existing class, aggravated by the honest keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)