### PR TITLE
docs(sqlgen): #311 correct escapeSQLLiteral comment — pre-#307 hole was not caller-reachable

### DIFF
--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -359,9 +359,12 @@ func appendKeysetArgs(params map[string]any, args []any) []any {
 //
 // It also closes the pre-existing hole that made quoting unsafe to add: before
 // #301 a Postgres password containing a single quote was interpolated raw, which
-// broke the query and put caller-influenced text into SQL structure. The
-// mechanism mirrors internal/cdc's escapeLiteral, which has done the same for the
-// ATTACH path since #290.
+// broke the query and put deployment-configured text into SQL structure. PG_CONN
+// comes from the pgx pool configuration, not from any HTTP caller, so this was
+// never a caller-reachable injection vector — but escaping is still required so
+// credential characters can never alter the rendered SQL. The mechanism mirrors
+// internal/cdc's escapeLiteral, which has done the same for the ATTACH path
+// since #290.
 func escapeSQLLiteral(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }


### PR DESCRIPTION
## Summary

Follow-up from #307 (issue #301). Fixes the doc comment on `escapeSQLLiteral` in `internal/sqlgen/duckdb_template_renderer.go`, which described the pre-#307 raw interpolation as putting **caller-influenced** text into SQL structure.

That overstates the hole: `PG_CONN` is derived from the pgx pool configuration (`federated.DuckDBPostgresConnStringFromPool`) — deployment configuration that no HTTP caller input reaches. The hole was real (a password containing `'` was interpolated raw into a single-quoted SQL literal), but it was never a caller-reachable injection vector. Sitting immediately beside a security fix in a credential-leak PR, the old wording was the sentence most likely to be quoted out of context as evidence of a reachable SQL injection.

## Change

Comment-only, single site (repo-wide `grep 'caller-influenced'` confirms this was the only occurrence):

- "caller-influenced" → "deployment-configured"
- states plainly that PG_CONN comes from pool configuration, not from any HTTP caller, and was never a caller-reachable injection vector
- keeps the explanation of why escaping is still required (credential characters must never alter the rendered SQL)

## Verification

- `go build ./internal/sqlgen` — clean
- `make lint` — clean
- `grep -rn "caller-influenced" --include="*.go" .` — zero matches

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)