### PR TITLE
docs: #309 "message text unchanged" is imprecise — prefix preserved, sentinel suffix appended

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -441,7 +441,8 @@ errors that wrapped no sentinel. It was removed for two reasons:
 The consequence is that a genuine client error earns its 4xx only by wrapping a
 sentinel. Removing the heuristic therefore required a sweep of the sites that had
 been relying on it — every one of them now wraps `forma.ErrInvalidInput`, with
-message text unchanged:
+the human-authored message prefix unchanged (the rendered string gains a
+sentinel suffix — see below):
 
 | site | caller mistake |
 | --- | --- |
@@ -456,6 +457,19 @@ attribute would answer `500` with an opaque body instead of naming the attribute
 The `sqlgen`/`conditionexpr` group is reachable through `POST
 /api/v1/advanced_query`, whose `condition` payload is entirely caller-supplied.
 
+**The rendered body is the prefix plus a sentinel suffix, and the suffix is
+deliberate (#309).** Wrapping with `%w` renders the sentinel's own text, so a
+verbatim 4xx body ends in `: invalid input` (likewise `: not found` and
+`: conflict` for the other two sentinels) — e.g.
+`unsupported operator: equals: invalid input`, or the
+`…: schema not found: nosuchschema: not found` body in the worked example under
+"Accepted disclosures inside the allowlist" below. What the sweep preserved is
+the human-authored prefix, not the exact full string. The suffix is kept as part
+of the body contract: clients must not assert on the exact full message — match
+the prefix (this repo's tests use `Contains`) or, better, key on the status
+code. Stripping the suffix would be a message-construction change to every wrap
+site, and #309 decided against it.
+
 Since #314 there is a **second** write-path validator on the same footing,
 `internal/schemavalidate`'s `Validator.Validate`, which wraps
 `forma.ErrInvalidInput` for a JSON Schema violation — `enum`, `pattern`, `type`,
@@ -468,8 +482,8 @@ enforcement on write" for the split.
 `normalizePgEavPayload`'s operator whitelist — the two rejections that pair an
 operator with an attribute type it does not accept — so `starts_with` on a UUID
 column answered an opaque `500` while the "condition-DSL errors stay 400" claim
-below said otherwise. Both now wrap the sentinel, message text unchanged, and are
-pinned by the `clientError` column of
+below said otherwise. Both now wrap the sentinel — prefix unchanged, same
+appended suffix as the sweep above — and are pinned by the `clientError` column of
 `TestToDualClauses_Characterization_Errors` plus
 `TestAdvancedQueryOperatorWhitelistIs400AndVerbatim`.
 

--- a/docs/superpowers/plans/2026-07-25-issue-301-redact-http-error-bodies.md
+++ b/docs/superpowers/plans/2026-07-25-issue-301-redact-http-error-bodies.md
@@ -24,7 +24,8 @@
 >    that #296 was the only affected site was disproved — six sites across four
 >    packages depended on the heuristic, including the write-path
 >    `missing required attribute` check. All now wrap `forma.ErrInvalidInput`
->    with their message text unchanged.
+>    with the human-authored message prefix unchanged; the `%w` rendering
+>    appends `: invalid input` to the full string (#309).
 >
 > A third change has no counterpart here at all: credentials are scrubbed
 > (`internal/redact`) before anything is logged or returned, and

--- a/internal/entity_query_sort.go
+++ b/internal/entity_query_sort.go
@@ -85,8 +85,9 @@ func buildAttributeOrders(req *forma.QueryRequest, schemaCache forma.SchemaAttri
 			// does not define is caller fault, and the HTTP boundary now classifies
 			// on sentinel evidence alone (#301). Without the sentinel this would
 			// answer 500 with a redacted body instead of 400 with the guidance the
-			// caller needs. The message text is unchanged on purpose — it is what
-			// callers and tests already read.
+			// caller needs. The human-authored prefix is unchanged on purpose — it
+			// is what callers and tests match on — while the %w rendering appends
+			// ": invalid input" to the full string (#309).
 			return nil, fmt.Errorf("cannot sort by unknown attribute '%s' in schema '%s': %w",
 				key.attr, req.SchemaName, forma.ErrInvalidInput)
 		}

--- a/internal/httpapi/error_response.go
+++ b/internal/httpapi/error_response.go
@@ -165,8 +165,10 @@ func writeError(w http.ResponseWriter, statusCode int, message string) error {
 //
 // The cost is that a genuine client error only earns its 4xx by wrapping a
 // sentinel, and removing the heuristic therefore required a sweep. Six sites
-// across four packages had been relying on it and now wrap forma.ErrInvalidInput,
-// message text unchanged:
+// across four packages had been relying on it and now wrap forma.ErrInvalidInput.
+// The human-authored message prefix is unchanged; the %w rendering appends
+// ": invalid input" to the full string, and that suffix is a kept part of the
+// body contract (#309):
 //
 //   - internal/entity_query_sort.go — unknown sort attribute (#296)
 //   - internal/transform/transformer.go — create or update body omitting a


### PR DESCRIPTION
Closes #309.

## What

#307 recorded in three places that the `forma.ErrInvalidInput` sweep left "message text unchanged". That is imprecise: `%w` wrapping appends the sentinel's own text, so the rendered string is the human-authored **prefix** plus `: invalid input` (observed as `unsupported operator: equals: invalid input` in #307's characterization tests). `docs/error-handling.md`'s own worked example (`…schema not found: nosuchschema: not found`) already showed the effect, so the document contradicted itself.

## Changes (doc/comment only, zero behavior change)

Five claim sites corrected — the issue lists three; a fourth with the same wording landed after it was filed (in #307's operator-whitelist underreach fix), and a fifth was caught by review round 1:

- `internal/httpapi/error_response.go` (`classifyManagerError` comment)
- `internal/entity_query_sort.go` (`buildAttributeOrders` comment)
- `docs/error-handling.md` — sweep-table intro
- `docs/error-handling.md` — operator-whitelist underreach paragraph
- `docs/superpowers/plans/2026-07-25-issue-301-redact-http-error-bodies.md` — the "Superseded by code review" preface, which describes shipped state, not plan history (review round 1, P2)

All now say the human-authored message prefix is preserved and the `%w` rendering appends the sentinel suffix.

## Decision recorded

The issue asked for a separate decision on whether the appended `: invalid input` is wanted in public bodies at all. **Decision: keep the suffix** (owner ruling, 2026-07-27). A new paragraph in `docs/error-handling.md` records it as part of the body contract: clients must not assert on the exact full message — match the prefix (this repo's tests use `Contains`) or key on the status code. Stripping it would be a message-construction change to every wrap site and is explicitly not pursued.

## Verification

- `grep -rn -i "message text unchanged\|text is unchanged" --include="*.go" --include="*.md" .` with **no path exclusions** → zero matches (round 1 of this check wrongly excluded `docs/superpowers/`, which is what let the plan-preface claim through)
- `make lint` clean; `make test` 31 packages ok, zero FAIL
- The new paragraph's cross-reference ("Accepted disclosures inside the allowlist") verified against the actual section heading above the `nosuchschema` example

🤖 Generated with [Claude Code](https://claude.com/claude-code)