### PR TITLE
refactor: #310 consolidate the three SQL quote-doubler copies into sqlutil.EscapeLiteral

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -604,7 +604,7 @@ the password tail past the placeholder. That was a real bug fixed in #290, and
 its regression tests (`internal/cdc/redact_test.go`) exercise the shared matcher
 through `redactConnStr`, and `internal/redact/connstring_test.go` gates the
 pattern in the package that owns it. Three forms are covered — the
-`escapeLiteral`-doubled `password=''…''` used inside DuckDB `ATTACH` literals,
+`sqlutil.EscapeLiteral`-doubled `password=''…''` used inside DuckDB `ATTACH` literals,
 the libpq-quoted `password='…'`, and the bare `password=value` of legacy or
 third-party text.
 
@@ -626,8 +626,8 @@ exposure this whole section exists to prevent. Two changes closed it:
 
 Because the DSN is interpolated into a single-quoted SQL literal
 (`postgres_scan('{{.PG_CONN}}', …)`), the renderer escapes it —
-`escapeSQLLiteral` in `internal/sqlgen/duckdb_template_renderer.go`, mirroring
-CDC's `escapeLiteral`. Without that, the newly-added quotes would terminate the
+`sqlutil.EscapeLiteral` in `internal/sqlgen/duckdb_template_renderer.go`, mirroring
+CDC's `sqlutil.EscapeLiteral`. Without that, the newly-added quotes would terminate the
 literal early. It also closes a hole that predates the quoting: a Postgres
 password containing a single quote used to be interpolated raw into query
 structure.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -626,10 +626,12 @@ exposure this whole section exists to prevent. Two changes closed it:
 
 Because the DSN is interpolated into a single-quoted SQL literal
 (`postgres_scan('{{.PG_CONN}}', …)`), the renderer escapes it —
-`sqlutil.EscapeLiteral`, called from `internal/sqlgen/duckdb_template_renderer.go` — the same shared helper `internal/cdc` uses, consolidated in #310. Without that, the newly-added quotes would terminate the
-literal early. It also closes a hole that predates the quoting: a Postgres
-password containing a single quote used to be interpolated raw into query
-structure.
+`sqlutil.EscapeLiteral`, called from
+`internal/sqlgen/duckdb_template_renderer.go` — the same shared helper
+`internal/cdc` uses, consolidated in #310. Without that, the newly-added
+quotes would terminate the literal early. It also closes a hole that
+predates the quoting: a Postgres password containing a single quote used to
+be interpolated raw into query structure.
 
 One shape is deliberately **not** matched, recorded in
 `TestRedactCredentialsKnownGaps` and `TestConnStringPassword_KnownGaps`:

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -626,8 +626,7 @@ exposure this whole section exists to prevent. Two changes closed it:
 
 Because the DSN is interpolated into a single-quoted SQL literal
 (`postgres_scan('{{.PG_CONN}}', …)`), the renderer escapes it —
-`sqlutil.EscapeLiteral` in `internal/sqlgen/duckdb_template_renderer.go`, mirroring
-CDC's `sqlutil.EscapeLiteral`. Without that, the newly-added quotes would terminate the
+`sqlutil.EscapeLiteral`, called from `internal/sqlgen/duckdb_template_renderer.go` — the same shared helper `internal/cdc` uses, consolidated in #310. Without that, the newly-added quotes would terminate the
 literal early. It also closes a hole that predates the quoting: a Postgres
 password containing a single quote used to be interpolated raw into query
 structure.

--- a/docs/superpowers/plans/2026-07-28-issue-310-consolidate-sql-quote-doubler.md
+++ b/docs/superpowers/plans/2026-07-28-issue-310-consolidate-sql-quote-doubler.md
@@ -1,0 +1,385 @@
+# Issue #310: Consolidate the Three SQL Quote-Doubler Copies — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the three independent copies of `strings.ReplaceAll(s, "'", "''")` with one tested helper `sqlutil.EscapeLiteral`, consumed by `internal/cdc`, `internal/sqlgen`, and the federated e2e harness.
+
+**Architecture:** Add `EscapeLiteral` to the existing `internal/sqlutil` package (currently home of `SanitizeIdentifier` — literal escaping is its natural sibling). Delete the three local copies and point every call site at the shared helper. The load-bearing doc comment on `escapeSQLLiteral` (just corrected by PR #333, issue #311) is relocated verbatim-in-substance to its only call site, not discarded. A final sweep renames every comment/test-case mention of the old function names so no stale references survive.
+
+**Tech Stack:** Go, testify. No new dependencies.
+
+## Global Constraints
+
+- Source files ≤500 lines, functions ≤100 lines (coding-standard.md).
+- Always wrap errors with context — not applicable here (helper is infallible), but no bare `return err` anywhere touched.
+- Single-test invocations must mirror the Makefile env: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ...` (avoids sandbox cache/VCS errors).
+- `make lint` is pinned to golangci-lint v1.64.8 — do not upgrade the pin.
+- Execution happens in a worktree created via superpowers:using-git-worktrees (per workspace AGENTS.md: clean merged branches + update local main first). Branch name suggestion: `issue-310-consolidate-quote-doubler`.
+- PR must reference the issue: body includes `Closes #310`. 请不要自动合并 PR.
+
+## Decisions Locked In (record these in the PR body)
+
+1. **Helper location/name:** `internal/sqlutil.EscapeLiteral` — the issue itself points at `sqlutil` ("that package already exists"); verb-first name matches repo review convention and mirrors cdc's `escapeLiteral`.
+2. **The e2e harness consumes the shared helper too.** The issue allowed keeping the harness copy "if importing production code there is undesirable — decide explicitly rather than by omission." Decision: consolidate. `internal/e2e_harness/federated` already imports `internal/cdc`, `internal/model`, and `internal/federated` (see `query_build.go` sibling files), so importing `internal/sqlutil` sets no new precedent.
+3. **The inline `strings.ReplaceAll` copies in `internal/cdc/duckdb_exporter_test.go:11-12` stay.** They are a test oracle re-deriving the expected escaped form independently of production code; pointing them at the helper would make the assertion tautological.
+4. **`escapeSQLLiteral`'s doc comment survives.** PR #333 (merged 2026-07-28, b70867f) just spent a review cycle making this comment precise. Its content moves to the single call site in `duckdb_template_renderer.go` with only the grammatical reframing needed (function-doc → call-site comment). Do not paraphrase away the #301/#307 substance.
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `internal/sqlutil/literal.go` | Create | The one escaping rule: `EscapeLiteral` |
+| `internal/sqlutil/literal_test.go` | Create | Table-driven tests for the rule |
+| `internal/cdc/duckdb_exporter.go` | Modify | Delete `escapeLiteral` (L88-90); 5 call sites → `sqlutil.EscapeLiteral` |
+| `internal/cdc/redact_test.go` | Modify | 3 call sites + 2 comments → `sqlutil.EscapeLiteral` |
+| `internal/sqlgen/duckdb_template_renderer.go` | Modify | Delete `escapeSQLLiteral` (L351-370); comment moves to PG_CONN call site (L259-263) |
+| `internal/federated/connstring.go` | Modify | Cross-reference comment (L31-33) → new helper name |
+| `internal/e2e_harness/federated/query_build.go` | Modify | `benchmarkSQLLiteral` string case (L341) → helper |
+| `internal/redact/connstring.go` | Modify | Comments (L35, L43) rename `escapeLiteral` mentions |
+| `internal/redact/connstring_test.go` | Modify | Test-case name (L41) rename |
+| `internal/httpapi/credential_redaction_test.go` | Modify | Comment + test-case name (L47-49) rename |
+
+---
+
+### Task 1: `sqlutil.EscapeLiteral` (TDD)
+
+**Files:**
+- Create: `internal/sqlutil/literal.go`
+- Test: `internal/sqlutil/literal_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `func EscapeLiteral(s string) string` in package `sqlutil` (`github.com/lychee-technology/forma/internal/sqlutil`). Doubles every `'`; adds no surrounding quotes. Tasks 2–4 depend on exactly this signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/sqlutil/literal_test.go`:
+
+```go
+package sqlutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty", input: "", expected: ""},
+		{name: "no quotes unchanged", input: "host=h port=5432", expected: "host=h port=5432"},
+		{name: "single quote doubled", input: "O'Brien", expected: "O''Brien"},
+		{name: "every quote doubled", input: "a'b'c", expected: "a''b''c"},
+		{name: "adjacent quotes each doubled", input: "x''y", expected: "x''''y"},
+		{name: "quote-only string", input: "'", expected: "''"},
+		// Backslash is an ordinary character in a plain '…' literal (PG
+		// standard_conforming_strings and DuckDB agree): it must pass through
+		// untouched while the quote beside it is still doubled.
+		{name: "backslash passes through", input: `a\'b`, expected: `a\''b`},
+		// The real payload shape: a pgdsn-quoted DSN embedded in
+		// postgres_scan('…') / ATTACH '…' (#301, #290).
+		{
+			name:     "quoted DSN",
+			input:    `host='h' password='p''w' dbname='d'`,
+			expected: `host=''h'' password=''p''''w'' dbname=''d''`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, EscapeLiteral(tt.input))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/sqlutil -run TestEscapeLiteral -v`
+Expected: FAIL to compile with `undefined: EscapeLiteral`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/sqlutil/literal.go`:
+
+```go
+package sqlutil
+
+import "strings"
+
+// EscapeLiteral doubles single quotes so a value can be embedded inside a
+// single-quoted SQL string literal. PostgreSQL and DuckDB share the doubling
+// rule, and both treat backslashes in a plain '…' literal as ordinary
+// characters, so doubling quotes is the entire rule. It does not add the
+// surrounding quotes, and it is only correct for string-literal context —
+// use SanitizeIdentifier for identifiers.
+//
+// This is the single home of the rule; #307 showed it is load-bearing (an
+// unescaped credential in postgres_scan('…') put deployment-configured text
+// into SQL structure), and #310 consolidated the copies that previously
+// lived in internal/cdc, internal/sqlgen, and the federated e2e harness.
+func EscapeLiteral(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/sqlutil -v`
+Expected: PASS (all `TestEscapeLiteral` cases plus existing `TestSanitizeIdentifier`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/sqlutil/literal.go internal/sqlutil/literal_test.go
+git commit -m "feat(sqlutil): #310 add EscapeLiteral, the single home of the SQL quote-doubling rule"
+```
+
+---
+
+### Task 2: Migrate `internal/cdc`
+
+**Files:**
+- Modify: `internal/cdc/duckdb_exporter.go` (delete L88-90 func; call sites L133-134, L192-193, L199; add import)
+- Modify: `internal/cdc/redact_test.go` (call sites L62, L91, L103; comments L60, L98-99)
+
+**Interfaces:**
+- Consumes: `sqlutil.EscapeLiteral(s string) string` from Task 1.
+- Produces: nothing new — behavior-preserving refactor; existing cdc tests are the gate.
+
+- [ ] **Step 1: Delete the local helper and repoint call sites**
+
+In `internal/cdc/duckdb_exporter.go`:
+
+1. Add `"github.com/lychee-technology/forma/internal/sqlutil"` to the import block (it already imports `internal/duckdbinit` and `internal/sqlgen`, so grouping is established).
+2. Delete:
+
+```go
+// escapeLiteral doubles single quotes for safe embedding in SQL string literals.
+func escapeLiteral(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+```
+
+3. Replace all five call sites (`pgEsc := escapeLiteral(pgConnStr)`, `s3Esc := escapeLiteral(s3TmpPath)`, `mQueryEsc := escapeLiteral(mQuery)`, `eQueryEsc := escapeLiteral(eQuery)`, `clQueryEsc := escapeLiteral(clQuery)`) with `sqlutil.EscapeLiteral(...)`, e.g.:
+
+```go
+	pgEsc := sqlutil.EscapeLiteral(pgConnStr)
+	s3Esc := sqlutil.EscapeLiteral(s3TmpPath)
+```
+
+4. Check whether `"strings"` is still used elsewhere in the file (it is — e.g. other helpers); leave the import if so, drop it only if the compiler complains.
+
+- [ ] **Step 2: Repoint the test callers in `redact_test.go`**
+
+In `internal/cdc/redact_test.go`, add the `sqlutil` import and change the three call sites:
+
+```go
+	sqlLiteral := sqlutil.EscapeLiteral(BuildPGDSN(redactHostileParams()))
+```
+
+```go
+	redacted := redactConnStr(sqlutil.EscapeLiteral(BuildPGDSN(p)))
+```
+
+```go
+	sqlLiteral := sqlutil.EscapeLiteral(BuildPGDSN(redactTestParams()))
+```
+
+Update the two comments that name the old function — `// through the escapeLiteral'd (doubled-quote) form embedded in a DuckDB literal.` becomes `// through the sqlutil.EscapeLiteral'd (doubled-quote) form embedded in a DuckDB literal.`, and `// feed BuildPGDSN's quoted DSN through escapeLiteral (doubling single quotes)` becomes `// feed BuildPGDSN's quoted DSN through sqlutil.EscapeLiteral (doubling single quotes)`.
+
+**Do NOT touch** `internal/cdc/duckdb_exporter_test.go:11-12` — those inline `strings.ReplaceAll` calls are the independent test oracle (Decision 3).
+
+- [ ] **Step 3: Run the cdc test suite**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/cdc -count=1`
+Expected: PASS. Also verify no stragglers in production code: `grep -rn "escapeLiteral" internal/cdc/ --include="*.go"` should return only `duckdb_exporter_test.go`'s oracle lines (which say `strings.ReplaceAll`, not `escapeLiteral`) — i.e. **zero** hits for the name `escapeLiteral`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cdc/duckdb_exporter.go internal/cdc/redact_test.go
+git commit -m "refactor(cdc): #310 consume sqlutil.EscapeLiteral, delete local escapeLiteral"
+```
+
+---
+
+### Task 3: Migrate `internal/sqlgen` (+ cross-reference in `internal/federated`)
+
+**Files:**
+- Modify: `internal/sqlgen/duckdb_template_renderer.go` (delete L351-370; relocate comment to the PG_CONN block at L259-263; add import)
+- Modify: `internal/federated/connstring.go` (comment L31-33)
+
+**Interfaces:**
+- Consumes: `sqlutil.EscapeLiteral(s string) string` from Task 1.
+- Produces: nothing new — behavior-preserving; sqlgen render tests are the gate.
+
+- [ ] **Step 1: Delete `escapeSQLLiteral`, relocate its comment to the call site**
+
+In `internal/sqlgen/duckdb_template_renderer.go`:
+
+1. Add `"github.com/lychee-technology/forma/internal/sqlutil"` to the imports.
+2. Delete the entire function **and** its doc comment (L351-370, starting `// escapeSQLLiteral doubles single quotes...` through the closing brace).
+3. Replace the PG_CONN injection block (currently ~L259-263) with the comment content reframed for the call site — the #301/#307 substance from PR #333 must survive verbatim-in-substance (Decision 4):
+
+```go
+	// PG_CONN is escaped because the templates interpolate it as
+	// postgres_scan('{{.PG_CONN}}', …). Since #301 the DSN produced by
+	// federated.DuckDBPostgresConnStringFromPool quotes its values, so it
+	// legitimately contains single quotes; without escaping the rendered SQL
+	// would terminate the literal early and fail to parse.
+	//
+	// Escaping also closes the pre-existing hole that made quoting unsafe to
+	// add: before #301 a Postgres password containing a single quote was
+	// interpolated raw, which broke the query and put deployment-configured
+	// text into SQL structure. PG_CONN comes from the pgx pool configuration,
+	// not from any HTTP caller, so this was never a caller-reachable injection
+	// vector — but escaping is still required so credential characters can
+	// never alter the rendered SQL. The same rule guards the CDC ATTACH path
+	// (#290); both sites consume sqlutil.EscapeLiteral (#310).
+	if _, ok := params["PG_CONN"]; !ok {
+		if raw, ok := params["DuckDBPGConnString"].(string); ok && raw != "" {
+			params["PG_CONN"] = sqlutil.EscapeLiteral(raw)
+		}
+	}
+```
+
+4. If `"strings"` becomes unused in this file, remove it from the imports (check with the compiler, don't guess).
+
+- [ ] **Step 2: Update the cross-reference comment in `internal/federated/connstring.go`**
+
+The `DuckDBPostgresConnStringFromPool` doc comment currently ends:
+
+```go
+// The result is embedded in a single-quoted DuckDB SQL literal
+// (postgres_scan('{{.PG_CONN}}', …)), so the renderer escapes it; see
+// escapeSQLLiteral in internal/sqlgen/duckdb_template_renderer.go.
+```
+
+Change the last line to:
+
+```go
+// (postgres_scan('{{.PG_CONN}}', …)), so the renderer escapes it with
+// sqlutil.EscapeLiteral (internal/sqlgen/duckdb_template_renderer.go).
+```
+
+- [ ] **Step 3: Run the sqlgen and federated test suites**
+
+Run: `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/sqlgen ./internal/federated -count=1`
+Expected: PASS. Then `grep -rn "escapeSQLLiteral" internal/ --include="*.go"` — expected: zero hits.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/sqlgen/duckdb_template_renderer.go internal/federated/connstring.go
+git commit -m "refactor(sqlgen): #310 consume sqlutil.EscapeLiteral; #333 comment moves to the PG_CONN call site"
+```
+
+---
+
+### Task 4: Migrate the federated e2e harness
+
+**Files:**
+- Modify: `internal/e2e_harness/federated/query_build.go` (string case of `benchmarkSQLLiteral`, L338-342; add import)
+
+**Interfaces:**
+- Consumes: `sqlutil.EscapeLiteral(s string) string` from Task 1.
+- Produces: nothing new. This package builds only under `-tags=e2e`, so the compile gate must pass that tag.
+
+- [ ] **Step 1: Repoint the string case**
+
+In `internal/e2e_harness/federated/query_build.go`, add the `sqlutil` import and change only the `string` case of `benchmarkSQLLiteral` (the `int`/`int64`/`float64`/`default` cases don't quote-escape and are out of scope):
+
+```go
+func benchmarkSQLLiteral(value any) string {
+	switch v := value.(type) {
+	case string:
+		return fmt.Sprintf("'%s'", sqlutil.EscapeLiteral(v))
+	case int:
+```
+
+If `"strings"` becomes unused in the file, remove the import (compiler will say).
+
+- [ ] **Step 2: Verify the e2e-tagged package still compiles**
+
+The harness is behind a build tag, so a plain `go build ./...` won't touch it. Run:
+
+`GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go vet -tags=e2e ./internal/e2e_harness/federated`
+Expected: exit 0, no output. (Do not run the full federated e2e suite here — it needs Docker and 30 minutes; CI runs the `-short` variant.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/e2e_harness/federated/query_build.go
+git commit -m "refactor(e2e): #310 harness consumes sqlutil.EscapeLiteral — decided against keeping the copy"
+```
+
+---
+
+### Task 5: Stale-name sweep + full verification
+
+**Files:**
+- Modify: `internal/redact/connstring.go` (comments L35, L43)
+- Modify: `internal/redact/connstring_test.go` (test-case name L41)
+- Modify: `internal/httpapi/credential_redaction_test.go` (comment + test-case name L47-49)
+
+**Interfaces:**
+- Consumes: nothing — comment/test-name-only changes.
+- Produces: a codebase where `grep -rn "escapeLiteral\|escapeSQLLiteral"` returns zero hits.
+
+- [ ] **Step 1: Rename the mentions in `internal/redact/connstring.go`**
+
+Two comment lines name the old cdc function. **Caution from the file itself:** its comment block warns that gofmt rewrites bare `''` pairs in comment prose into typographic quotes — change ONLY the function-name tokens, do not retype or reflow the quote sequences around them.
+
+`// (pgdsn.Quote), and escapeLiteral additionally doubles every single quote when the` → `// (pgdsn.Quote), and sqlutil.EscapeLiteral additionally doubles every single quote when the`
+
+`//	Branch 1  password=''VALUE''   the escapeLiteral'd doubled form, tried first.` → `//	Branch 1  password=''VALUE''   the EscapeLiteral'd doubled form, tried first.`
+
+- [ ] **Step 2: Rename the test-case names/comments**
+
+`internal/redact/connstring_test.go` L41: `name: "escapeLiteral doubled-quote form inside a SQL literal",` → `name: "EscapeLiteral doubled-quote form inside a SQL literal",`
+
+`internal/httpapi/credential_redaction_test.go` L47-49:
+
+```go
+		{
+			// sqlutil.EscapeLiteral doubles every quote when a DSN is embedded in a
+			// DuckDB SQL literal.
+			name: "EscapeLiteral doubled-quote form",
+```
+
+- [ ] **Step 3: Confirm the sweep is exhaustive**
+
+Run: `grep -rn "escapeLiteral\|escapeSQLLiteral" --include="*.go" . | grep -v "\.gocache"`
+Expected: zero hits. If anything surfaces (docs, other comments), fix it in this step.
+
+Also check non-Go references: `grep -rn "escapeSQLLiteral\|escapeLiteral" docs/ 2>/dev/null` — historical plan/spec docs under `docs/superpowers/` are records of past work and stay untouched; only living docs (e.g. `docs/federated-query/`) would need updating if hit.
+
+- [ ] **Step 4: Full gates**
+
+```bash
+make test
+make lint
+GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go vet -tags=e2e ./internal/e2e_harness/federated
+```
+
+Expected: all pass. (`make test` covers `./cdc` wrapper, `./internal/...` including sqlutil, sqlgen, federated, redact, httpapi.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/redact/connstring.go internal/redact/connstring_test.go internal/httpapi/credential_redaction_test.go
+git commit -m "docs: #310 rename stale escapeLiteral/escapeSQLLiteral mentions to sqlutil.EscapeLiteral"
+```
+
+---
+
+## PR
+
+Title: `refactor: #310 consolidate the three SQL quote-doubler copies into sqlutil.EscapeLiteral`
+
+Body must include: `Closes #310`, the four locked decisions (helper location, harness consolidates + why the "keep the copy" option was rejected, test-oracle copies stay, #333 comment relocation), and the verification evidence (test/lint/vet output). Per repo rules: 请不要自动合并 PR — leave it open for review.

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/duckdbinit"
 	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/lychee-technology/forma/internal/sqlutil"
 	"go.uber.org/zap"
 )
 
@@ -85,11 +86,6 @@ func (e *DuckExporter) ExportSnapshotToTmp(ctx context.Context, cfg CDCConfig, p
 	return e.executeExportSQL(ctx, cfg, "duckdb export sql", "duckdb copy exec", sql, clQuery, mQuery, eQuery)
 }
 
-// escapeLiteral doubles single quotes for safe embedding in SQL string literals.
-func escapeLiteral(s string) string {
-	return strings.ReplaceAll(s, "'", "''")
-}
-
 func buildExportSQL(pgConnStr string, s3TmpPath string, cfg CDCConfig, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) (string, string, string, string, error) {
 	plan, err := buildExportSQLPlan(exportModeSpec{
 		defaultMemoryLimit: "4GB",
@@ -130,8 +126,8 @@ func buildExportSQLPlan(spec exportModeSpec, pgConnStr string, s3TmpPath string,
 		return exportSQLPlan{}, fmt.Errorf("export %s: no row ids provided", modeName)
 	}
 
-	pgEsc := escapeLiteral(pgConnStr)
-	s3Esc := escapeLiteral(s3TmpPath)
+	pgEsc := sqlutil.EscapeLiteral(pgConnStr)
+	s3Esc := sqlutil.EscapeLiteral(s3TmpPath)
 	entityMain, eavData := resolveMainAndEAVTableNames(cfg)
 	rowList := quoteUUIDList(rowIDs)
 	mFilter := fmt.Sprintf("ltbase_row_id IN (%s)", rowList)
@@ -189,14 +185,14 @@ func (spec exportModeSpec) baseSelectColumns() []string {
 }
 
 func buildProjectedExportSQL(spec exportModeSpec, opts exportSQLOptions, copyOptions, pgEsc, s3Esc, clQuery, mQuery, eQuery string, mainSelectCols, eavAgg []string) string {
-	mQueryEsc := escapeLiteral(mQuery)
-	eQueryEsc := escapeLiteral(eQuery)
+	mQueryEsc := sqlutil.EscapeLiteral(mQuery)
+	eQueryEsc := sqlutil.EscapeLiteral(eQuery)
 	eAggSQL := buildEAVAggregationSQL(eQueryEsc, eavAgg)
 
 	if spec.useChangeLog {
 		// LEFT JOIN to entity_main so change_log tombstones of hard-deleted
 		// rows are exported instead of silently dropped (#173).
-		clQueryEsc := escapeLiteral(clQuery)
+		clQueryEsc := sqlutil.EscapeLiteral(clQuery)
 		return fmt.Sprintf(`PRAGMA memory_limit='%s';
 ATTACH IF NOT EXISTS '%s' AS pg_db (TYPE postgres, READ_ONLY);
 

--- a/internal/cdc/duckdb_exporter_sql_test.go
+++ b/internal/cdc/duckdb_exporter_sql_test.go
@@ -92,6 +92,70 @@ func TestBuildExportSQL_WithSchemaCacheProjectsColumns(t *testing.T) {
 	}
 }
 
+// TestExportSQLEscapesQuotedPGConn pins the CDC half of the #310 consolidation.
+//
+// Both export builders embed the Postgres DSN inside a single-quoted SQL literal
+// — ATTACH IF NOT EXISTS '<dsn>' AS pg_db (…) — so the DSN must pass through
+// sqlutil.EscapeLiteral first. Without that, a quoted DSN (the form
+// federated.DuckDBPostgresConnStringFromPool emits, and any password containing
+// a quote) terminates the literal early and turns deployment-controlled text
+// into SQL structure. No other cdc test passes a DSN containing a quote, so
+// nothing else would catch a regression here.
+func TestExportSQLEscapesQuotedPGConn(t *testing.T) {
+	const hostileDSN = `host='h' password='p''w' dbname=forma`
+	const wantDSNLiteralBody = `host=''h'' password=''p''''w'' dbname=forma`
+	const wantAttach = `ATTACH IF NOT EXISTS '` + wantDSNLiteralBody + `' AS pg_db (TYPE postgres, READ_ONLY);`
+
+	rowID := uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")
+
+	builders := []struct {
+		name  string
+		build func() (string, error)
+	}{
+		{
+			name: "snapshot export",
+			build: func() (string, error) {
+				sql, _, _, _, err := buildExportSQL(hostileDSN, "s3://bucket/prefix/1/_tmp/tmp.parquet", CDCConfig{}, 1, 1700000000000, []uuid.UUID{rowID}, testAttrCache())
+				return sql, err
+			},
+		},
+		{
+			name: "base export",
+			build: func() (string, error) {
+				sql, _, _, err := buildBaseExportSQL(hostileDSN, "s3://bucket/base/1/_tmp/tmp.parquet", CDCConfig{}, 1, []uuid.UUID{rowID}, testAttrCache())
+				return sql, err
+			},
+		},
+	}
+
+	for _, b := range builders {
+		t.Run(b.name, func(t *testing.T) {
+			sql, err := b.build()
+			require.NoError(t, err)
+			require.Contains(t, sql, wantAttach)
+
+			// The raw DSN must never be embedded verbatim: its bare quotes
+			// would close the outer literal early.
+			require.NotContains(t, sql, "ATTACH IF NOT EXISTS '"+hostileDSN+"'")
+
+			// Structural check: the ATTACH literal is delimited by exactly one
+			// outer quote pair, and undoubling its body round-trips back to the
+			// original DSN.
+			const openMarker = "ATTACH IF NOT EXISTS '"
+			const closeMarker = "' AS pg_db"
+			start := strings.Index(sql, openMarker)
+			require.NotEqual(t, -1, start, "ATTACH statement not found: %s", sql)
+			body := sql[start+len(openMarker):]
+			end := strings.Index(body, closeMarker)
+			require.NotEqual(t, -1, end, "ATTACH literal not terminated: %s", sql)
+			body = body[:end]
+
+			require.Equal(t, wantDSNLiteralBody, body)
+			require.Equal(t, hostileDSN, strings.ReplaceAll(body, "''", "'"))
+		})
+	}
+}
+
 func TestBuildExportSQL_UsesCustomTableNames(t *testing.T) {
 	cfg := CDCConfig{
 		ChangeLogTable:  "change_log_dev",

--- a/internal/cdc/redact_test.go
+++ b/internal/cdc/redact_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lychee-technology/forma/internal/sqlutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,9 +58,9 @@ func TestRedactConnStr_HostilePasswordRawQuoted(t *testing.T) {
 }
 
 // TestRedactConnStr_HostilePasswordEscapedQuoted feeds the same hostile password
-// through the escapeLiteral'd (doubled-quote) form embedded in a DuckDB literal.
+// through the sqlutil.EscapeLiteral'd (doubled-quote) form embedded in a DuckDB literal.
 func TestRedactConnStr_HostilePasswordEscapedQuoted(t *testing.T) {
-	sqlLiteral := escapeLiteral(BuildPGDSN(redactHostileParams()))
+	sqlLiteral := sqlutil.EscapeLiteral(BuildPGDSN(redactHostileParams()))
 	redacted := redactConnStr(sqlLiteral)
 	t.Logf("escaped literal:  %q", sqlLiteral)
 	t.Logf("escaped redacted: %q", redacted)
@@ -88,19 +89,19 @@ func TestRedactConnStr_EmptyPasswordRawQuoted(t *testing.T) {
 func TestRedactConnStr_EmptyPasswordEscapedQuoted(t *testing.T) {
 	p := redactTestParams()
 	p.Password = ""
-	redacted := redactConnStr(escapeLiteral(BuildPGDSN(p)))
+	redacted := redactConnStr(sqlutil.EscapeLiteral(BuildPGDSN(p)))
 	require.Contains(t, redacted, "***REDACTED***")
 	require.Contains(t, redacted, "dbname=''")
 	require.Contains(t, redacted, "sslmode=''")
 }
 
 // TestRedactConnStr_EscapedQuotedDSN pins the #290 regression: the flusher/init
-// feed BuildPGDSN's quoted DSN through escapeLiteral (doubling single quotes)
+// feed BuildPGDSN's quoted DSN through sqlutil.EscapeLiteral (doubling single quotes)
 // into a DuckDB ATTACH literal, then log it via redactConnStr. The doubled-quote
 // form (password=''secret'') must still be fully redacted — the old regex
 // matched the empty string between the doubled quotes and leaked the password.
 func TestRedactConnStr_EscapedQuotedDSN(t *testing.T) {
-	sqlLiteral := escapeLiteral(BuildPGDSN(redactTestParams()))
+	sqlLiteral := sqlutil.EscapeLiteral(BuildPGDSN(redactTestParams()))
 	require.Contains(t, sqlLiteral, "password=''"+redactSecret+"''",
 		"precondition: escaped DSN must carry the doubled-quote form")
 

--- a/internal/e2e_harness/federated/query_build.go
+++ b/internal/e2e_harness/federated/query_build.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/lychee-technology/forma/internal/sqlutil"
 )
 
 // Federated multi-tier SQL assembly: the dynamic entry points, the UNION ALL
@@ -338,7 +340,7 @@ func benchmarkQueryColumn(attribute string) string {
 func benchmarkSQLLiteral(value any) string {
 	switch v := value.(type) {
 	case string:
-		return fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''"))
+		return fmt.Sprintf("'%s'", sqlutil.EscapeLiteral(v))
 	case int:
 		return fmt.Sprintf("%d", v)
 	case int64:

--- a/internal/federated/connstring.go
+++ b/internal/federated/connstring.go
@@ -29,8 +29,8 @@ import (
 // rejected by libpq.
 //
 // The result is embedded in a single-quoted DuckDB SQL literal
-// (postgres_scan('{{.PG_CONN}}', …)), so the renderer escapes it; see
-// escapeSQLLiteral in internal/sqlgen/duckdb_template_renderer.go.
+// (postgres_scan('{{.PG_CONN}}', …)), so the renderer escapes it with
+// sqlutil.EscapeLiteral (internal/sqlgen/duckdb_template_renderer.go).
 func DuckDBPostgresConnStringFromPool(pool *pgxpool.Pool) string {
 	if pool == nil {
 		return ""

--- a/internal/httpapi/credential_redaction_test.go
+++ b/internal/httpapi/credential_redaction_test.go
@@ -44,9 +44,9 @@ func TestRedactCredentialsRemovesPasswordValues(t *testing.T) {
 			want: "host=h password=***REDACTED*** dbname=forma",
 		},
 		{
-			// escapeLiteral doubles every quote when a DSN is embedded in a DuckDB
+			// sqlutil.EscapeLiteral doubles every quote when a DSN is embedded in a DuckDB
 			// SQL literal.
-			name: "escapeLiteral doubled-quote form",
+			name: "EscapeLiteral doubled-quote form",
 			in:   `ATTACH 'host=h password=''s3cr3t'' dbname=forma'`,
 			want: `ATTACH 'host=h password=***REDACTED*** dbname=forma'`,
 		},

--- a/internal/redact/connstring.go
+++ b/internal/redact/connstring.go
@@ -32,7 +32,7 @@ const Placeholder = "***REDACTED***"
 // placeholder.
 //
 // libpq quoting escapes both a single quote and a backslash with a backslash
-// (pgdsn.Quote), and escapeLiteral additionally doubles every single quote when the
+// (pgdsn.Quote), and sqlutil.EscapeLiteral additionally doubles every single quote when the
 // DSN is embedded in a DuckDB SQL literal — so the matcher must understand
 // backslash escapes, not just balanced quotes.
 //
@@ -40,7 +40,7 @@ const Placeholder = "***REDACTED***"
 // bare pair of single quotes in comment prose into a typographic quote, which
 // would silently corrupt the very sequences being described.
 //
-//	Branch 1  password=''VALUE''   the escapeLiteral'd doubled form, tried first.
+//	Branch 1  password=''VALUE''   the EscapeLiteral'd doubled form, tried first.
 //	          content atoms:  \''  a libpq escaped quote whose ' was doubled
 //	                          \[^'] any other backslash escape, incl. \\
 //	                          [^'\] a plain character

--- a/internal/redact/connstring_test.go
+++ b/internal/redact/connstring_test.go
@@ -38,7 +38,7 @@ func TestConnStringPassword_Forms(t *testing.T) {
 			want: "host='h' password=***REDACTED*** dbname='d'",
 		},
 		{
-			name: "escapeLiteral doubled-quote form inside a SQL literal",
+			name: "EscapeLiteral doubled-quote form inside a SQL literal",
 			in:   `ATTACH 'host=''h'' password=''s3cr3t'' dbname=''d''' AS pg`,
 			want: `ATTACH 'host=''h'' password=***REDACTED*** dbname=''d''' AS pg`,
 		},

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/sqlutil"
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
@@ -256,9 +257,23 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 		}
 	}
 
+	// PG_CONN is escaped because the templates interpolate it as
+	// postgres_scan('{{.PG_CONN}}', …). Since #301 the DSN produced by
+	// federated.DuckDBPostgresConnStringFromPool quotes its values, so it
+	// legitimately contains single quotes; without escaping the rendered SQL
+	// would terminate the literal early and fail to parse.
+	//
+	// Escaping also closes the pre-existing hole that made quoting unsafe to
+	// add: before #301 a Postgres password containing a single quote was
+	// interpolated raw, which broke the query and put deployment-configured
+	// text into SQL structure. PG_CONN comes from the pgx pool configuration,
+	// not from any HTTP caller, so this was never a caller-reachable injection
+	// vector — but escaping is still required so credential characters can
+	// never alter the rendered SQL. The same rule guards the CDC ATTACH path
+	// (#290); both sites consume sqlutil.EscapeLiteral (#310).
 	if _, ok := params["PG_CONN"]; !ok {
 		if raw, ok := params["DuckDBPGConnString"].(string); ok && raw != "" {
-			params["PG_CONN"] = escapeSQLLiteral(raw)
+			params["PG_CONN"] = sqlutil.EscapeLiteral(raw)
 		}
 	}
 
@@ -346,25 +361,4 @@ func appendKeysetArgs(params map[string]any, args []any) []any {
 	}
 	delete(params, "KEYSET_ARGS")
 	return append(args, keysetArgs...)
-}
-
-// escapeSQLLiteral doubles single quotes so a value can be embedded inside a
-// single-quoted DuckDB SQL literal.
-//
-// It exists for PG_CONN, which the templates interpolate as
-// postgres_scan('{{.PG_CONN}}', …). Since #301 the DSN produced by
-// federated.DuckDBPostgresConnStringFromPool quotes its values, so it now
-// legitimately contains single quotes; without this the rendered SQL would
-// terminate the literal early and fail to parse.
-//
-// It also closes the pre-existing hole that made quoting unsafe to add: before
-// #301 a Postgres password containing a single quote was interpolated raw, which
-// broke the query and put deployment-configured text into SQL structure. PG_CONN
-// comes from the pgx pool configuration, not from any HTTP caller, so this was
-// never a caller-reachable injection vector — but escaping is still required so
-// credential characters can never alter the rendered SQL. The mechanism mirrors
-// internal/cdc's escapeLiteral, which has done the same for the ATTACH path
-// since #290.
-func escapeSQLLiteral(s string) string {
-	return strings.ReplaceAll(s, "'", "''")
 }

--- a/internal/sqlutil/literal.go
+++ b/internal/sqlutil/literal.go
@@ -3,11 +3,14 @@ package sqlutil
 import "strings"
 
 // EscapeLiteral doubles single quotes so a value can be embedded inside a
-// single-quoted SQL string literal. PostgreSQL and DuckDB share the doubling
-// rule, and both treat backslashes in a plain '…' literal as ordinary
-// characters, so doubling quotes is the entire rule. It does not add the
-// surrounding quotes, and it is only correct for string-literal context —
-// use SanitizeIdentifier for identifiers.
+// single-quoted SQL string literal. Every current consumer renders DuckDB
+// SQL, where backslashes in a plain '…' literal are always ordinary
+// characters, so doubling quotes is the entire rule. PostgreSQL matches
+// that behavior under standard_conforming_strings=on (the default since
+// 9.1) — a consumer targeting a PostgreSQL literal with that setting off
+// would need backslash handling this helper deliberately does not do. It
+// does not add the surrounding quotes, and it is only correct for
+// string-literal context — use SanitizeIdentifier for identifiers.
 //
 // This is the single home of the rule; #307 showed it is load-bearing (an
 // unescaped credential in postgres_scan('…') put deployment-configured text

--- a/internal/sqlutil/literal.go
+++ b/internal/sqlutil/literal.go
@@ -1,0 +1,18 @@
+package sqlutil
+
+import "strings"
+
+// EscapeLiteral doubles single quotes so a value can be embedded inside a
+// single-quoted SQL string literal. PostgreSQL and DuckDB share the doubling
+// rule, and both treat backslashes in a plain '…' literal as ordinary
+// characters, so doubling quotes is the entire rule. It does not add the
+// surrounding quotes, and it is only correct for string-literal context —
+// use SanitizeIdentifier for identifiers.
+//
+// This is the single home of the rule; #307 showed it is load-bearing (an
+// unescaped credential in postgres_scan('…') put deployment-configured text
+// into SQL structure), and #310 consolidated the copies that previously
+// lived in internal/cdc, internal/sqlgen, and the federated e2e harness.
+func EscapeLiteral(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}

--- a/internal/sqlutil/literal_test.go
+++ b/internal/sqlutil/literal_test.go
@@ -1,0 +1,39 @@
+package sqlutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty", input: "", expected: ""},
+		{name: "no quotes unchanged", input: "host=h port=5432", expected: "host=h port=5432"},
+		{name: "single quote doubled", input: "O'Brien", expected: "O''Brien"},
+		{name: "every quote doubled", input: "a'b'c", expected: "a''b''c"},
+		{name: "adjacent quotes each doubled", input: "x''y", expected: "x''''y"},
+		{name: "quote-only string", input: "'", expected: "''"},
+		// Backslash is an ordinary character in a plain '…' literal (PG
+		// standard_conforming_strings and DuckDB agree): it must pass through
+		// untouched while the quote beside it is still doubled.
+		{name: "backslash passes through", input: `a\'b`, expected: `a\''b`},
+		// The real payload shape: a pgdsn-quoted DSN embedded in
+		// postgres_scan('…') / ATTACH '…' (#301, #290).
+		{
+			name:     "quoted DSN",
+			input:    `host='h' password='p''w' dbname='d'`,
+			expected: `host=''h'' password=''p''''w'' dbname=''d''`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, EscapeLiteral(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
Closes #310.

## What

`strings.ReplaceAll(s, "'", "''")` — escaping a value for a single-quoted SQL literal — existed in three independent copies. This PR consolidates the rule into one tested helper, `sqlutil.EscapeLiteral` (`internal/sqlutil/literal.go`), consumed by all three former sites:

- `internal/cdc/duckdb_exporter.go` (was `escapeLiteral`; 5 call sites — ATTACH DSN, S3 path, subqueries)
- `internal/sqlgen/duckdb_template_renderer.go` (was `escapeSQLLiteral`, added by #307; the `postgres_scan('{{.PG_CONN}}', …)` credential path)
- `internal/e2e_harness/federated/query_build.go` (`benchmarkSQLLiteral` string case; the issue cites `query.go:616`, which #220's slicing moved here)

Plus a sweep: every comment/test-case mention of the deleted function names now says `sqlutil.EscapeLiteral` (internal/redact, internal/httpapi, and living doc `docs/error-handling.md` — the latter absent from the plan's file table but authorized by its living-docs clause).

## Decisions (the issue asked for explicit ones)

1. **Helper location**: `internal/sqlutil` — the issue itself pointed there; sits beside `SanitizeIdentifier`.
2. **The e2e harness consumes the shared helper** rather than keeping its copy. The issue allowed keeping it "if importing production code there is undesirable" — that concern is moot: `internal/e2e_harness/federated` already imports `internal/cdc`, `internal/model`, and `internal/federated`, so no new coupling precedent.
3. **#333's carefully-corrected comment survives**: the `escapeSQLLiteral` doc comment moved verbatim-in-substance to its only call site (the PG_CONN injection block), keeping the #301 quoted-DSN rationale, the pre-#301 hole description, the "deployment-configured, not caller-reachable" framing, and the #290 ATTACH cross-reference. Reviewed byte-for-byte against the plan's mandated text.
4. **Correction to the plan's Decision 3** (surfaced by final review): the plan kept `TestEscapePgConnAndS3`'s inline `ReplaceAll` lines as an "independent test oracle" — that framing was wrong. The test is tautological (asserts on its own `strings.ReplaceAll` output, never calls production code), and no cdc test passed a quoted DSN at all: the credential-load-bearing ATTACH path had **zero** real escaping assertions (pre-existing gap, not introduced here). Fixed by adding `TestExportSQLEscapesQuotedPGConn`, which drives a hostile quoted DSN (`host='h' password='p''w'`) through **both** real builders (`buildExportSQL` and `buildBaseExportSQL` — `pgEsc` feeds two separate format strings) and pins the doubled form inside the ATTACH literal. Mutation-verified: substituting the raw string for `sqlutil.EscapeLiteral(pgConnStr)` fails the test. The tautological test was left in place (plan-protected); deleting it is a candidate follow-up now that the real pin exists.

## Verification

- TDD on the helper: red (`undefined: EscapeLiteral`) → green; 8 discriminating cases incl. adjacent-quote doubling (`x''y` → `x''''y`), backslash passthrough, and the real pgdsn-quoted-DSN payload shape.
- Behavior preservation is provable by inspection: the helper body is byte-identical to all three deleted expressions; every migrated call site keeps the same argument in the same position.
- `make test` (31 packages ok), `make lint` (pinned v1.64.8, clean), `go vet -tags=e2e ./internal/e2e_harness/federated` (clean — the harness package is behind the build tag, so plain builds don't compile it).
- Zero-hit sweep: `grep -rn "escapeLiteral\|escapeSQLLiteral" --include="*.go" .` returns nothing; only sanctioned `ReplaceAll` occurrences are the helper itself and the plan-protected test lines.
- The gofmt-sensitive doubled-quote prose in `internal/redact/connstring.go` was verified byte-identical around the renamed tokens (non-ASCII scan; only pre-existing em dashes).

## Review observations (recorded, not blocking)

- `internal/federated/connstring.go:33`: the parenthetical after `sqlutil.EscapeLiteral` names the renderer file (the call site), not the helper's home — plan-mandated wording; reads as a location claim. One-line clarification candidate.
- `internal/sqlutil/literal.go` doc states the PG backslash rule unconditionally; exact only under `standard_conforming_strings=on` (default since PG 9.1; always true for DuckDB, which is the actual consumer).
- `internal/cdc/redact_test.go` is gofmt-unclean on **main** too (newer gofmt rewrites `''` in comment prose into typographic quotes — the exact corruption `redact/connstring.go` warns about and dodges with an indented block). CI's pinned linter doesn't run gofmt, so CI stays green; same indented-block defense there is a candidate follow-up.
- Only the ATTACH DSN escape site is pinned by the new test; the S3-path and subquery `EscapeLiteral` sites remain assertion-free (values are internally generated, lower stakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)