### PR TITLE
refactor(cdc): #308 remove dead quotePGConnValue shim

### DIFF
--- a/internal/cdc/pgdsn.go
+++ b/internal/cdc/pgdsn.go
@@ -17,7 +17,3 @@ type PGDSNParams = pgdsn.Params
 func BuildPGDSN(p PGDSNParams) string {
 	return pgdsn.Build(p)
 }
-
-func quotePGConnValue(v string) string {
-	return pgdsn.Quote(v)
-}

--- a/internal/cdc/pgdsn_test.go
+++ b/internal/cdc/pgdsn_test.go
@@ -11,18 +11,3 @@ func TestBuildPGDSN_QuotesValues(t *testing.T) {
 		t.Fatalf("BuildPGDSN = %s, want %s", got, want)
 	}
 }
-
-func TestQuotePGConnValue(t *testing.T) {
-	tests := []struct{ in, want string }{
-		{"plain", "'plain'"},
-		{"pa ss", "'pa ss'"},
-		{"it's", `'it\'s'`},
-		{`back\slash`, `'back\\slash'`},
-		{"", "''"},
-	}
-	for _, tt := range tests {
-		if got := quotePGConnValue(tt.in); got != tt.want {
-			t.Fatalf("quotePGConnValue(%q) = %s, want %s", tt.in, got, tt.want)
-		}
-	}
-}

--- a/internal/cdc/redact_test.go
+++ b/internal/cdc/redact_test.go
@@ -17,7 +17,7 @@ const redactSecret = "secret123"
 const redactHostileSecret = "p'w\\d"
 
 // redactHostileFragment is the leaking password tail as it appears *after*
-// quoting: quotePGConnValue doubles the backslash, so the tail that a naive
+// quoting: pgdsn.Quote doubles the backslash, so the tail that a naive
 // matcher leaks is w\\d (Go literal for w, backslash, backslash, d). This is
 // the exact material the buggy '[^']*' branch surfaced past ***REDACTED***; it
 // must never survive redaction in any DSN form.


### PR DESCRIPTION
Closes #308. Follow-up from #307 (issue #301). Spec: approved approach A — verify coverage, then delete.

## What

- Delete `internal/cdc/pgdsn.go` `quotePGConnValue`: a dead pass-through to `pgdsn.Quote` whose only callers were its own same-package test, which is exactly why the `unused` linter could not flag it.
- Delete `TestQuotePGConnValue` rather than moving it: every equivalence class it pinned already exists in `internal/pgdsn/pgdsn_test.go` `TestQuote` (a strict superset — it additionally pins the escaping order and libpq non-delimiter separators). Mapping:

| deleted cdc case | existing `pgdsn.TestQuote` case |
|---|---|
| `"plain"` | `plain` |
| `"pa ss"` (space) | `space` |
| `"it's"` (single quote) | `single quote` |
| `` `back\slash` `` | `backslash` + `both, quote after backslash` |
| `""` (empty) | `empty` |

- Reword the comment at `internal/cdc/redact_test.go:20` that named the deleted function (now says `pgdsn.Quote`).

## Out of scope (per issue)

`PGDSNParams` and `BuildPGDSN` stay: four production call sites (`cmd/tools/manifest_reconcile.go:261`, `internal/cdc/flusher.go:206,361`, `internal/cdc/init.go:91`) make them a legitimate re-export, not dead code.

## Verification

`make lint` + `make test` green; `grep -rn quotePGConnValue --include='*.go' .` returns nothing. Pure deletion + comment reword — no behaviour change, no e2e needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
