### PR TITLE
feat(federated): #255 never-flushed column projection — NULL-augmented scan source, complete-union gate, plan-cache re-keying

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -331,6 +331,24 @@ a strict inequality on that key at the boundary, which silently skips every row
 tied there; the trailing `row_id` gives the composite key a unique tiebreak so
 each boundary tie is resolvable (#183).
 
+**Never-flushed columns (#255).** `union_by_name` can only union columns that
+exist in *some* file. An attribute added to the schema before its first flush is
+absent from the entire scan set, so the scan source (both `s3_source` and the
+semijoin) is wrapped as
+`(SELECT *, NULL::<type> AS <col> … FROM read_parquet(…)) AS cold_scan`,
+projecting each such column as a typed NULL — computed per query from the
+pre-read validator's footer-column union, and only when that union is complete
+(an incomplete union falls back to the unaugmented scan and today's loud
+classified failure). The missing-column set participates in the compiled-plan
+scope hash, so a skeleton compiled while a column was cold-absent is re-keyed the
+moment the first flush lands it (the plan-cache poisoning hazard the issue
+mandates addressing). With no missing columns the rendered SQL is byte-identical
+to this document's §5 sketch. One residual race is accepted: for glob-hint path
+sets the validator's listing and the scan's listing are separate S3 LISTs, so a
+flush landing between them can collide the NULL alias with the newly-landed real
+column — a one-time loud classified failure that self-heals on the next query,
+since the missing set is recomputed per query.
+
 ## **6. Optimization Strategies**
 
 ### **6.1 Predicate Pushdown (Critical)**

--- a/internal/cdc/duckdb_exporter_type_lockstep_test.go
+++ b/internal/cdc/duckdb_exporter_type_lockstep_test.go
@@ -1,0 +1,56 @@
+package cdc
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/stretchr/testify/require"
+)
+
+// eavExportFixture mimics the eav_data columns castEAVValue reads, at the
+// types the export query actually carries: value_numeric is DOUBLE (the
+// numeric-family column every scalar cast starts from) and value_text is
+// VARCHAR.
+const eavExportFixture = "(SELECT CAST(1 AS DOUBLE) AS value_numeric, CAST('x' AS VARCHAR) AS value_text)"
+
+// TestCastEAVValueMatchesNullScanTypeof is the #255 type-lockstep proof for
+// the CDC export leg, against a real DuckDB engine: the parquet column type
+// the exporter mints for an attribute must equal the type
+// sqlgen.DuckDBNullScanType names for the same attribute. The federated read
+// UNIONs a NULL-augmented parquet leg (for a column no generation carries
+// yet) with real parquet columns written by this exporter — divergence widens
+// the UNION ALL and re-opens #205.
+//
+// The comparison is on typeof() rather than on the rendered SQL text: bool
+// renders as `(value_numeric <> 0)`, which carries no type literal to
+// extract — only the engine knows the resulting type.
+func TestCastEAVValueMatchesNullScanTypeof(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	scalars := []forma.ValueType{
+		forma.ValueTypeBool, forma.ValueTypeBigInt, forma.ValueTypeDate,
+		forma.ValueTypeDateTime, forma.ValueTypeInteger, forma.ValueTypeSmallInt,
+		forma.ValueTypeNumeric, forma.ValueTypeText, forma.ValueTypeUUID,
+	}
+	for _, vt := range scalars {
+		t.Run(string(vt), func(t *testing.T) {
+			exportExpr := castEAVValue(forma.AttributeMetadata{ValueType: vt})
+
+			var exported string
+			require.NoError(t,
+				db.QueryRow("SELECT typeof(("+exportExpr+")) FROM "+eavExportFixture).Scan(&exported),
+				"export cast %q must evaluate", exportExpr)
+
+			var scan string
+			require.NoError(t,
+				db.QueryRow("SELECT typeof(NULL::"+sqlgen.DuckDBNullScanType(vt, "")+")").Scan(&scan))
+
+			require.Equal(t, exported, scan,
+				"cold NULL scan type must equal the exported parquet column type for %s (#205 no-widening)", vt)
+		})
+	}
+}

--- a/internal/e2e_harness/production/schema_evolution_never_flushed_e2e_test.go
+++ b/internal/e2e_harness/production/schema_evolution_never_flushed_e2e_test.go
@@ -1,0 +1,114 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// queryTierRestricted runs a parquet-only (warm+cold) read through the engine
+// alone and asserts its total. The oracle is deliberately tier-blind — it
+// folds the event log into the full logical set with no notion of what has
+// been flushed — so a tier-restricted read taken while unflushed hot rows
+// exist cannot be compared against it (that divergence would be a fixture
+// artifact, not a product defect). These assertions therefore pin the
+// engine's physical answer directly, the same way assertTierMatrixS3Only
+// does for #184.
+func queryTierRestricted(ctx context.Context, t *testing.T, env *Env, q Query, want int64, why string) *QueryResult {
+	t.Helper()
+	res, err := env.Query(ctx, q)
+	if err != nil {
+		t.Fatalf("tier-restricted query (%s): %v", why, err)
+	}
+	if res.Total != want {
+		t.Fatalf("tier-restricted total (%s) = %d, want %d", why, res.Total, want)
+	}
+	return res
+}
+
+// TestSchemaEvolutionNeverFlushedColumn covers #255: v2 adds `score` BEFORE
+// its first flush, so the base parquet (v1 generation) is the ENTIRE cold
+// set and physically lacks the column — union_by_name (#189) cannot invent
+// it. Contract: cold-inclusive reads succeed with score as a typed NULL on
+// every parquet-tier row (exact SQL NULL semantics for filters and sorts),
+// hot rows serve real values, and the compiled-plan cache does not keep
+// projecting NULL after the first flush lands the column (the #255
+// plan-cache poisoning hazard).
+func TestSchemaEvolutionNeverFlushedColumn(t *testing.T) {
+	ctx := context.Background()
+	cluster := SharedCluster(t)
+	v1 := writeSimpleSchemaDir(t, coreProps, coreAttrs)
+	v2 := writeSimpleSchemaDir(t, scoreIntProps, scoreIntAttrs)
+	env := NewEnv(t, cluster, WithSchemaDir(v1))
+	simple := DefaultSchemaFixtures()[0]
+
+	// 5 base rows under v1 (ordinals 0-4), exported as base; evolve to v2;
+	// 3 hot rows under v2 (ordinals 5-7, score 50/60/70) left UNFLUSHED.
+	seedGeneration(ctx, t, env, simple, 5, buildEvolutionProfile(buildLabeledExtras(nil)))
+	baseKey := runInitBase(ctx, t, env, simple)
+	if err := env.EvolveSchema(ctx, v2); err != nil {
+		t.Fatalf("evolve schema to v2: %v", err)
+	}
+	seedGeneration(ctx, t, env, simple, 3, buildEvolutionProfile(buildLabeledExtras(func(ordinal int) map[string]any {
+		return map[string]any{"score": float64(ordinal * 10)}
+	})))
+
+	// Shape precondition: the whole cold set lacks score.
+	forbidParquetCols(t, "base (v1)", describeParquetCols(ctx, t, env, baseKey), "score")
+
+	// Full scan across all tiers: 8 rows (5 base + 3 hot), no binder error.
+	full := env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 20})
+	assertUsesDuckDB(t, full)
+	if full != nil && full.Total != 8 {
+		t.Fatalf("full scan total = %d, want 8 (5 v1 base + 3 hot)", full.Total)
+	}
+
+	// Filter on the never-flushed attribute: hot rows only (score 50/60/70).
+	filtered := env.AssertQueryMatches(ctx, Query{
+		Schema:  simple,
+		Filters: []Filter{{Attr: "score", Op: "gte", Value: "50"}},
+		Limit:   20,
+	})
+	if filtered != nil && filtered.Total != 3 {
+		t.Fatalf("score >= 50 total = %d, want 3 (hot rows only; NULL excludes every base row)", filtered.Total)
+	}
+
+	// Sort on it: base rows (score NULL) land NULLS LAST.
+	env.AssertQueryMatches(ctx, Query{
+		Schema: simple,
+		Sorts:  []Sort{{Attr: "score"}},
+		Limit:  20,
+	})
+
+	// Hot-excluded (cold-only) read — the issue's title case: must succeed,
+	// serving the 5 base rows with score wholly absent/NULL. This is the
+	// positive query that makes the zero-row assertion below trustworthy.
+	coldTiers := []model.DataTier{model.DataTierWarm, model.DataTierCold}
+	coldOnly := queryTierRestricted(ctx, t, env, Query{
+		Schema: simple, PreferredTiers: coldTiers, Limit: 20,
+	}, 5, "base rows; unflushed hot invisible")
+	assertUsesDuckDB(t, coldOnly)
+
+	// Plan-transition (cache-poisoning) regression: compile & cache the
+	// cold-only filter shape while score is cold-absent...
+	coldFilter := Query{
+		Schema: simple, PreferredTiers: coldTiers,
+		Filters: []Filter{{Attr: "score", Op: "gte", Value: "50"}},
+		Limit:   20,
+	}
+	queryTierRestricted(ctx, t, env, coldFilter, 0, "pre-flush cold-only score filter")
+
+	// ...then land the FIRST flush carrying score and re-run the same shape.
+	// A poisoned plan (cached NULL projection) would keep the flushed rows
+	// invisible and return 0. Post-flush nothing is hot, so the parquet-only
+	// read is the whole logical set again and the oracle is authoritative.
+	mustFlush(ctx, t, env)
+	postFlush := env.AssertQueryMatches(ctx, coldFilter)
+	assertUsesDuckDB(t, postFlush)
+	if postFlush != nil && postFlush.Total != 3 {
+		t.Fatalf("post-flush cold-only score filter total = %d, want 3 — plan-cache poisoning (#255): the skeleton compiled while score was cold-absent is still projecting NULL", postFlush.Total)
+	}
+}

--- a/internal/e2e_harness/production/schema_evolution_never_flushed_e2e_test.go
+++ b/internal/e2e_harness/production/schema_evolution_never_flushed_e2e_test.go
@@ -34,9 +34,8 @@ func queryTierRestricted(ctx context.Context, t *testing.T, env *Env, q Query, w
 // set and physically lacks the column — union_by_name (#189) cannot invent
 // it. Contract: cold-inclusive reads succeed with score as a typed NULL on
 // every parquet-tier row (exact SQL NULL semantics for filters and sorts),
-// hot rows serve real values, and the compiled-plan cache does not keep
-// projecting NULL after the first flush lands the column (the #255
-// plan-cache poisoning hazard).
+// hot rows serve real values, and the same query shape flips from the NULL
+// projection to the real column once the first flush lands it.
 func TestSchemaEvolutionNeverFlushedColumn(t *testing.T) {
 	ctx := context.Background()
 	cluster := SharedCluster(t)
@@ -92,8 +91,20 @@ func TestSchemaEvolutionNeverFlushedColumn(t *testing.T) {
 	}, 5, "base rows; unflushed hot invisible")
 	assertUsesDuckDB(t, coldOnly)
 
-	// Plan-transition (cache-poisoning) regression: compile & cache the
-	// cold-only filter shape while score is cold-absent...
+	// Plan-transition regression: run the cold-only filter shape while score
+	// is cold-absent (the NULL projection excludes every base row)...
+	//
+	// Scope note: this pair proves end-to-end pre/post-flush CORRECTNESS —
+	// the missing set is recomputed per query, so the same shape answers from
+	// the augmented scan before the flush and from the real column after it.
+	// It is NOT a plan-cache proof: the harness engine (production/engine.go)
+	// is built without WithPlanCache, unlike factory.NewEntityManager, so
+	// serveFromPlanCache returns ok=false on every query here and no skeleton
+	// is ever reused. (The harness Env is also manifest-wired, so a flush
+	// changes the resolved path list, which would re-key the scope hash via
+	// parquetPaths regardless.) The genuine re-key proof — same shape, same
+	// paths, cache HIT in between, missing set alone forcing a recompile —
+	// lives in federated.TestEngineColdMissingSetRekeysPlanCache.
 	coldFilter := Query{
 		Schema: simple, PreferredTiers: coldTiers,
 		Filters: []Filter{{Attr: "score", Op: "gte", Value: "50"}},
@@ -102,13 +113,15 @@ func TestSchemaEvolutionNeverFlushedColumn(t *testing.T) {
 	queryTierRestricted(ctx, t, env, coldFilter, 0, "pre-flush cold-only score filter")
 
 	// ...then land the FIRST flush carrying score and re-run the same shape.
-	// A poisoned plan (cached NULL projection) would keep the flushed rows
-	// invisible and return 0. Post-flush nothing is hot, so the parquet-only
-	// read is the whole logical set again and the oracle is authoritative.
+	// A read still projecting NULL for score — because the missing set was
+	// computed once and reused rather than per query — would keep the flushed
+	// rows invisible and return 0. Post-flush nothing is hot, so the
+	// parquet-only read is the whole logical set again and the oracle is
+	// authoritative.
 	mustFlush(ctx, t, env)
 	postFlush := env.AssertQueryMatches(ctx, coldFilter)
 	assertUsesDuckDB(t, postFlush)
 	if postFlush != nil && postFlush.Total != 3 {
-		t.Fatalf("post-flush cold-only score filter total = %d, want 3 — plan-cache poisoning (#255): the skeleton compiled while score was cold-absent is still projecting NULL", postFlush.Total)
+		t.Fatalf("post-flush cold-only score filter total = %d, want 3 — stale NULL augmentation (#255): the read is still projecting NULL for score after the flush landed the real column", postFlush.Total)
 	}
 }

--- a/internal/federated/cold_columns.go
+++ b/internal/federated/cold_columns.go
@@ -1,0 +1,39 @@
+package federated
+
+import (
+	"sort"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+)
+
+// coldMissingColumns computes the #255 augmentation set: current-schema
+// attributes whose folded parquet column is absent from the ENTIRE resolved
+// scan set (an attribute added before its first flush). unionCols must be a
+// COMPLETE footer union (validator complete=true); passing nil — union
+// unknown — yields nil, which renders the unaugmented scan and preserves
+// today's loud classified failure. Sorted by column name so the rendered
+// SQL and the plan-cache scope key are deterministic.
+//
+// unionCols also carries the parquet system columns (row_id, changed_at,
+// deleted_at), which is harmless: only schema-attribute folded names are
+// ever probed against it, and those never collide with the system set (the
+// #260 reserved-column guard rejects such schemas at registration).
+func coldMissingColumns(cache forma.SchemaAttributeCache, unionCols map[string]string) []sqlgen.NullScanColumn {
+	if len(cache) == 0 || unionCols == nil {
+		return nil
+	}
+	var missing []sqlgen.NullScanColumn
+	for name, meta := range cache {
+		col := sqlgen.ParquetAttrColumn(name)
+		if _, ok := unionCols[col]; ok {
+			continue
+		}
+		missing = append(missing, sqlgen.NullScanColumn{
+			Name:       col,
+			DuckDBType: sqlgen.DuckDBNullScanType(meta.ValueType, meta.EffectiveItemsType()),
+		})
+	}
+	sort.Slice(missing, func(i, j int) bool { return missing[i].Name < missing[j].Name })
+	return missing
+}

--- a/internal/federated/cold_columns_plan_cache_test.go
+++ b/internal/federated/cold_columns_plan_cache_test.go
@@ -1,0 +1,119 @@
+package federated
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/queryplan"
+	"github.com/lychee-technology/forma/internal/schemameta"
+	"github.com/stretchr/testify/require"
+)
+
+// coldPlanCachePath is the query's ENTIRE scan set, held constant across every
+// run below so the path component of the plan-cache scope key cannot move: the
+// only thing that changes between runs is the cold-missing set. (In production
+// the path set is typically a glob string, which likewise does not change when
+// the first flush lands a column — that is exactly why the missing set has to
+// scope the key on its own.)
+const coldPlanCachePath = "s3://b/7/base.parquet"
+
+// coldPlanCacheFooter is a v1-generation footer: system columns plus the
+// already-flushed `age`. `score` — added to the schema before its first flush
+// — is absent, which is the #255 condition.
+func coldPlanCacheFooter(withScore bool) map[string]string {
+	cols := map[string]string{
+		"row_id": "UUID", "changed_at": "BIGINT", "deleted_at": "BIGINT",
+		"age": "INTEGER",
+	}
+	if withScore {
+		cols["score"] = "INTEGER"
+	}
+	return cols
+}
+
+func coldPlanCacheMetadata(t *testing.T) *schemameta.MetadataCache {
+	t.Helper()
+	mc := schemameta.NewMetadataCache()
+	require.NoError(t, mc.RegisterSchema("test", 7, forma.SchemaAttributeCache{
+		"age": {AttributeID: 6, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("integer_01")}},
+		"score": {AttributeID: 9, ValueType: forma.ValueTypeInteger},
+	}))
+	return mc
+}
+
+// runColdPlanCacheQuery drives one full engine request and returns the SQL
+// handed to DuckDB plus the execution-plan notes (which carry plan_cache=hit /
+// plan_cache=miss).
+func runColdPlanCacheQuery(t *testing.T, e *DBFederatedQueryEngine, duck *fakeDuckDBExecutor) (string, []string) {
+	t.Helper()
+	q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{
+		SchemaID:  7,
+		Condition: &forma.KvCondition{Attr: "score", Value: "gt:50"},
+		Limit:     2000,
+	}}
+	q.PreferredTiers = []model.DataTier{model.DataTierHot, model.DataTierCold}
+	opts := &model.FederatedQueryOptions{IncludeExecutionPlan: true,
+		ExecutionPlan: &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}}}
+	tables := model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"}
+
+	duck.rows = &singleDuckDBRow{rowID: uuid.New()}
+	_, _, err := e.ExecuteDuckDBFederatedQuery(context.Background(), tables, q, q.Limit, 0, nil, opts)
+	require.NoError(t, err)
+	return duck.lastSQL, opts.ExecutionPlan.Notes
+}
+
+// TestEngineColdMissingSetRekeysPlanCache is the engine-seam proof for the
+// #255 plan-cache poisoning hazard, at the one seam that can actually poison:
+// a real plan cache (as factory.go wires in production) serving repeated
+// requests of the SAME shape over the SAME path set.
+//
+// Run 1 compiles a skeleton while `score` is absent from the whole cold set,
+// so the scan source is NULL-augmented. Run 2 changes nothing and is a cache
+// HIT — that is what makes the hazard real: the skeleton is genuinely reused,
+// byte-for-byte, across requests. Run 3 lands the column in the footer union
+// (the first flush) with everything else identical; because the cold-missing
+// set participates in the scope key, it MISSES and recompiles without the NULL
+// alias. Drop the missing set from duckPlanScopeParts and run 3 turns into a
+// hit that keeps projecting NULL over real data.
+func TestEngineColdMissingSetRekeysPlanCache(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &fakeDuckDBExecutor{}
+	e := NewDBFederatedQueryEngine(&fakePostgresFederatedSource{}, &fakeDirtyIDFetcher{}, duck, nil,
+		forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}},
+		coldPlanCacheMetadata(t), "host=x",
+		WithPlanCache(queryplan.NewCache(64)),
+		WithParquetSource(&fakeParquetSource{paths: []string{coldPlanCachePath}}))
+
+	// Pre-flush: the validator's write-once cache holds the v1 footer, so the
+	// probe never reaches the fake executor and the union is complete.
+	e.schemaValidator.markValidated(coldPlanCachePath, coldPlanCacheFooter(false))
+
+	sql1, notes1 := runColdPlanCacheQuery(t, e, duck)
+	require.Contains(t, sql1, "NULL::INTEGER AS score",
+		"cold-absent attribute must render as a typed NULL in the scan source")
+	require.Contains(t, notes1, "plan_cache=miss", "first request compiles")
+
+	sql2, notes2 := runColdPlanCacheQuery(t, e, duck)
+	require.Contains(t, notes2, "plan_cache=hit",
+		"same shape, same paths, same missing set: the skeleton must be reused — this is the reuse that could poison")
+	require.Contains(t, sql2, "NULL::INTEGER AS score")
+
+	// The first flush lands `score`. markValidated overwrites the entry, so the
+	// union the next request computes carries the column; the path set, query
+	// shape, tables, limit and fingerprint are all unchanged.
+	e.schemaValidator.markValidated(coldPlanCachePath, coldPlanCacheFooter(true))
+
+	sql3, notes3 := runColdPlanCacheQuery(t, e, duck)
+	require.Contains(t, notes3, "plan_cache=miss",
+		"the missing set alone must re-key the plan cache (#255 poisoning guard)")
+	require.NotContains(t, sql3, "NULL::INTEGER AS score",
+		"post-flush the real column must be scanned, not a cached NULL projection")
+	require.NotContains(t, sql3, "AS cold_scan",
+		"no missing columns: the scan source reverts to the unaugmented read_parquet form")
+}

--- a/internal/federated/cold_columns_plan_cache_test.go
+++ b/internal/federated/cold_columns_plan_cache_test.go
@@ -50,12 +50,26 @@ func coldPlanCacheMetadata(t *testing.T) *schemameta.MetadataCache {
 // plan_cache=miss).
 func runColdPlanCacheQuery(t *testing.T, e *DBFederatedQueryEngine, duck *fakeDuckDBExecutor) (string, []string) {
 	t.Helper()
+	return runColdPlanCacheQueryWithHint(t, e, duck, "")
+}
+
+// runColdPlanCacheQueryWithHint is the same request with an optional explicit
+// S3ParquetPathTemplate hint (which always wins over the parquet source), so
+// the glob variant below can drive the identical query shape over a glob path
+// set.
+func runColdPlanCacheQueryWithHint(
+	t *testing.T, e *DBFederatedQueryEngine, duck *fakeDuckDBExecutor, pathHint string,
+) (string, []string) {
+	t.Helper()
 	q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{
 		SchemaID:  7,
 		Condition: &forma.KvCondition{Attr: "score", Value: "gt:50"},
 		Limit:     2000,
 	}}
 	q.PreferredTiers = []model.DataTier{model.DataTierHot, model.DataTierCold}
+	if pathHint != "" {
+		q.DuckDBHints = &model.DuckDBRenderHints{S3ParquetPathTemplate: pathHint}
+	}
 	opts := &model.FederatedQueryOptions{IncludeExecutionPlan: true,
 		ExecutionPlan: &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}}}
 	tables := model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"}
@@ -104,9 +118,14 @@ func TestEngineColdMissingSetRekeysPlanCache(t *testing.T) {
 		"same shape, same paths, same missing set: the skeleton must be reused — this is the reuse that could poison")
 	require.Contains(t, sql2, "NULL::INTEGER AS score")
 
-	// The first flush lands `score`. markValidated overwrites the entry, so the
-	// union the next request computes carries the column; the path set, query
-	// shape, tables, limit and fingerprint are all unchanged.
+	// The first flush lands `score`. Overwriting the cached footer is a TEST
+	// STAND-IN for "a new file's columns joined the union": production parquet
+	// objects are write-once, so a validated path's footer never actually
+	// changes under the validator's cache. The realistic production trigger —
+	// a glob expansion that gained a file — is the sibling test below; this
+	// one isolates the re-key with the path set held provably constant.
+	// Either way the union the next request computes carries the column, and
+	// the path set, query shape, tables, limit and fingerprint are unchanged.
 	e.schemaValidator.markValidated(coldPlanCachePath, coldPlanCacheFooter(true))
 
 	sql3, notes3 := runColdPlanCacheQuery(t, e, duck)
@@ -115,5 +134,74 @@ func TestEngineColdMissingSetRekeysPlanCache(t *testing.T) {
 	require.NotContains(t, sql3, "NULL::INTEGER AS score",
 		"post-flush the real column must be scanned, not a cached NULL projection")
 	require.NotContains(t, sql3, "AS cold_scan",
+		"no missing columns: the scan source reverts to the unaugmented read_parquet form")
+}
+
+// coldPlanCacheGlob is a glob path hint: it is the ENTIRE scan-set string the
+// plan-cache scope key sees, and — unlike a concrete manifest listing — it is
+// byte-identical before and after a flush lands a new object. That is what
+// makes it the production-realistic form of the #255 hazard.
+const coldPlanCacheGlob = "s3://b/7/*.parquet"
+
+// coldPlanCacheDescribeRows renders a footer in the DESCRIBE row shape the
+// validator scans. The system columns must be present or parquetcheck fails
+// the invariant before any of this is reached.
+func coldPlanCacheDescribeRows(withScore bool) [][2]string {
+	rows := [][2]string{
+		{"row_id", "UUID"}, {"changed_at", "BIGINT"}, {"deleted_at", "BIGINT"},
+		{"age", "INTEGER"},
+	}
+	if withScore {
+		rows = append(rows, [2]string{"score", "INTEGER"})
+	}
+	return rows
+}
+
+// TestEngineColdMissingSetRekeysPlanCacheViaGlobExpansion models the trigger
+// #255 actually fires on in production, which the sibling test above can only
+// stand in for: parquet objects are write-once, so an already-validated
+// footer never changes — the column union grows because the scan set's GLOB
+// EXPANSION GAINED A FILE (the first flush minting a new delta object).
+//
+// The glob string itself — the only path component the plan-cache scope key
+// sees — is byte-identical across both runs, and so are the query shape,
+// tables, limit, offset and fingerprint. Nothing but the cold-missing set can
+// therefore explain the run-2 miss: drop the missing set from
+// duckPlanScopeParts and run 2 becomes a hit that keeps projecting NULL over
+// the freshly flushed column.
+func TestEngineColdMissingSetRekeysPlanCacheViaGlobExpansion(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &fakeDuckDBExecutor{
+		globFiles: []string{"s3://b/7/base.parquet"},
+		describeCols: map[string][][2]string{
+			"base.parquet": coldPlanCacheDescribeRows(false),
+		},
+	}
+	e := NewDBFederatedQueryEngine(&fakePostgresFederatedSource{}, &fakeDirtyIDFetcher{}, duck, nil,
+		forma.DuckDBConfig{Enabled: true, Routing: forma.RoutingPolicy{Strategy: forma.RoutingStrategyHybrid}},
+		coldPlanCacheMetadata(t), "host=x",
+		WithPlanCache(queryplan.NewCache(64)))
+
+	// Run 1 — pre-flush: the glob expands to the single v1 base object, whose
+	// footer has no `score`.
+	sql1, notes1 := runColdPlanCacheQueryWithHint(t, e, duck, coldPlanCacheGlob)
+	require.Contains(t, sql1, "NULL::INTEGER AS score",
+		"cold-absent attribute must render as a typed NULL in the scan source")
+	require.Contains(t, notes1, "plan_cache=miss", "first request compiles")
+
+	// The first flush mints a NEW object carrying `score`. The already-probed
+	// base footer is untouched (write-once) and stays served from the
+	// validator's cache; only the expansion changed.
+	duck.globFiles = []string{"s3://b/7/base.parquet", "s3://b/7/delta1.parquet"}
+	duck.describeCols["delta1.parquet"] = coldPlanCacheDescribeRows(true)
+
+	sql2, notes2 := runColdPlanCacheQueryWithHint(t, e, duck, coldPlanCacheGlob)
+	require.Contains(t, notes2, "plan_cache=miss",
+		"the missing set ALONE must re-key the plan cache: the glob path string never changed (#255)")
+	require.NotContains(t, sql2, "NULL::INTEGER AS score",
+		"post-flush the real column must be scanned, not a cached NULL projection")
+	require.NotContains(t, sql2, "AS cold_scan",
 		"no missing columns: the scan source reverts to the unaugmented read_parquet form")
 }

--- a/internal/federated/cold_columns_test.go
+++ b/internal/federated/cold_columns_test.go
@@ -1,0 +1,61 @@
+package federated
+
+import (
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/queryplan"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/stretchr/testify/require"
+)
+
+func TestColdMissingColumnsDetectsAbsentAttributes(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"name":  {AttributeID: 1, ValueType: forma.ValueTypeText},
+		"score": {AttributeID: 3, ValueType: forma.ValueTypeInteger},
+		"tags":  {AttributeID: 4, ValueType: forma.ValueTypeList, ItemsType: forma.ValueTypeBigInt},
+	}
+	union := map[string]string{
+		"row_id": "UUID", "changed_at": "BIGINT", "deleted_at": "BIGINT",
+		"name": "VARCHAR",
+	}
+	got := coldMissingColumns(cache, union)
+	require.Equal(t, []sqlgen.NullScanColumn{
+		{Name: "score", DuckDBType: "INTEGER"},
+		{Name: "tags", DuckDBType: "BIGINT[]"},
+	}, got, "absent attrs detected, present ones skipped, sorted by name")
+}
+
+func TestColdMissingColumnsNilOnUnknownUnionOrEmptyCache(t *testing.T) {
+	cache := forma.SchemaAttributeCache{"score": {AttributeID: 3, ValueType: forma.ValueTypeInteger}}
+	require.Nil(t, coldMissingColumns(cache, nil), "unknown union must not augment")
+	require.Nil(t, coldMissingColumns(nil, map[string]string{}), "no metadata, nothing to augment")
+}
+
+// Dotted attribute names must probe the FOLDED parquet column (#260), not
+// the raw name — otherwise a flushed dotted attribute reads as missing and
+// gets shadow-augmented.
+func TestColdMissingColumnsUsesFoldedParquetColumnNames(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"user.name": {AttributeID: 7, ValueType: forma.ValueTypeText},
+	}
+	union := map[string]string{sqlgen.ParquetAttrColumn("user.name"): "VARCHAR"}
+	require.Nil(t, coldMissingColumns(cache, union))
+}
+
+// #255 plan-cache poisoning guard: the missing set participates in the
+// scope hash, so the same query shape over the same path STRING (a glob
+// hint does not change on flush) re-keys when the first flush lands the
+// column.
+func TestDuckPlanScopePartsIncludeColdMissingSet(t *testing.T) {
+	tables := model.StorageTables{EAVData: "eav_data", EntityMain: "entity_main", ChangeLog: "change_log"}
+	paths := []string{"s3://b/schema/1/**/*.parquet"}
+	absent := duckPlanScopeParts(tables, "conn", 10, 0, false, paths, nil,
+		[]sqlgen.NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}})
+	present := duckPlanScopeParts(tables, "conn", 10, 0, false, paths, nil, nil)
+	require.NotEqual(t,
+		queryplan.HashScopeParts(absent...),
+		queryplan.HashScopeParts(present...),
+		"cold-absent and cold-present shapes must occupy different plan-cache entries")
+}

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -116,7 +116,7 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 		}
 	}()
 
-	parquetPaths, pathsFromSource, graceCutoffMs, err := e.resolveScanSources(ctx, q)
+	parquetPaths, pathsFromSource, graceCutoffMs, coldMissing, err := e.resolveScanSources(ctx, q)
 	if err != nil {
 		return 0, err
 	}
@@ -128,7 +128,7 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 	}
 
 	// Build and execute the query
-	sqlStr, args, translateMs, err := e.buildDuckDBQueryWithPlan(ctx, tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, planCtx)
+	sqlStr, args, translateMs, err := e.buildDuckDBQueryWithPlan(ctx, tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, coldMissing, planCtx)
 	if err != nil {
 		return 0, fmt.Errorf("build duckdb federated query: %w", err)
 	}
@@ -146,10 +146,20 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 	}, rowHandler, planCtx)
 }
 
+// schemaCacheByID is the nil-safe metadata-cache accessor shared by the
+// pre-flight (#255 cold-missing computation) and the SQL build.
+func (e *DBFederatedQueryEngine) schemaCacheByID(schemaID int16) (forma.SchemaAttributeCache, bool) {
+	if e == nil || e.metadataCache == nil {
+		return nil, false
+	}
+	return e.metadataCache.GetSchemaCacheByID(schemaID)
+}
+
 // resolveScanSources is the storage-facing pre-flight of a DuckDB federated
 // query: it stamps the #252 flush-grace cutoff, resolves the parquet path
-// set, and validates the parquet system-column invariant.
-func (e *DBFederatedQueryEngine) resolveScanSources(ctx context.Context, q *model.FederatedAttributeQuery) (paths []string, fromSource bool, graceCutoffMs int64, err error) {
+// set, validates the parquet system-column invariant, and computes the #255
+// cold-missing column set from the footer union the validation produced.
+func (e *DBFederatedQueryEngine) resolveScanSources(ctx context.Context, q *model.FederatedAttributeQuery) (paths []string, fromSource bool, graceCutoffMs int64, missing []sqlgen.NullScanColumn, err error) {
 	// The flush-grace cutoff is stamped BEFORE resolution (#252): any row
 	// marked flushed at or after this instant may belong to a delta this
 	// path set does not list yet, so the dirty barrier keeps it hot-readable
@@ -161,7 +171,7 @@ func (e *DBFederatedQueryEngine) resolveScanSources(ctx context.Context, q *mode
 	// gates the read-error classification.
 	paths, fromSource, err = e.resolveParquetPaths(ctx, q)
 	if err != nil {
-		return nil, false, 0, fmt.Errorf("resolve parquet paths: %w", err)
+		return nil, false, 0, nil, fmt.Errorf("resolve parquet paths: %w", err)
 	}
 
 	// An empty path set cannot answer this query (#299). Only warm/cold-wanting
@@ -172,7 +182,7 @@ func (e *DBFederatedQueryEngine) resolveScanSources(ctx context.Context, q *mode
 	// It must precede the validator: that walks the path set and so reports
 	// nothing at all on an empty one.
 	if len(paths) == 0 {
-		return nil, false, 0, &NoParquetPathsError{
+		return nil, false, 0, nil, &NoParquetPathsError{
 			SchemaID:         q.SchemaID,
 			SourceConfigured: e.parquetSource != nil,
 		}
@@ -191,11 +201,31 @@ func (e *DBFederatedQueryEngine) resolveScanSources(ctx context.Context, q *mode
 	// parquetcheck invariant codifies the PRODUCTION exporters, which never
 	// write those IDs (ValidateFixtureSchemaID reserves the range).
 	if !isBenchmarkSchemaID(q.SchemaID) {
-		if _, _, err := e.schemaValidator.Validate(ctx, e.duck, paths); err != nil {
-			return nil, false, 0, fmt.Errorf("pre-read parquet schema validation: %w", err)
+		unionCols, complete, err := e.schemaValidator.Validate(ctx, e.duck, paths)
+		if err != nil {
+			return nil, false, 0, nil, fmt.Errorf("pre-read parquet schema validation: %w", err)
+		}
+		// Never-flushed column augmentation (#255): only a COMPLETE footer
+		// union may drive it — augmenting a column that exists in an
+		// unprobed file would collide with the real column. Incomplete
+		// unions fall back to the unaugmented scan, whose binder failure
+		// stays loud, classified, and degradable (today's contract).
+		//
+		// Accepted listing skew (adjudicated): for a GLOB path set the
+		// validator expands the glob itself while read_parquet re-lists at
+		// execution, so a flush landing between the two puts an unprobed
+		// file in the scan while complete=true. The augmented NULL alias
+		// then collides with that file's real column — a one-time loud,
+		// classified binder failure that self-heals on the next query,
+		// because the missing set is recomputed per query. This is
+		// accepted; do not widen the gate to avoid it.
+		if complete {
+			if cache, ok := e.schemaCacheByID(q.SchemaID); ok {
+				missing = coldMissingColumns(cache, unionCols)
+			}
 		}
 	}
-	return paths, fromSource, graceCutoffMs, nil
+	return paths, fromSource, graceCutoffMs, missing, nil
 }
 
 // fetchAndRecordDirtyIDs fetches dirty row IDs from Postgres and records in execution plan.

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -191,7 +191,7 @@ func (e *DBFederatedQueryEngine) resolveScanSources(ctx context.Context, q *mode
 	// parquetcheck invariant codifies the PRODUCTION exporters, which never
 	// write those IDs (ValidateFixtureSchemaID reserves the range).
 	if !isBenchmarkSchemaID(q.SchemaID) {
-		if err := e.schemaValidator.Validate(ctx, e.duck, paths); err != nil {
+		if _, _, err := e.schemaValidator.Validate(ctx, e.duck, paths); err != nil {
 			return nil, false, 0, fmt.Errorf("pre-read parquet schema validation: %w", err)
 		}
 	}

--- a/internal/federated/duckdb_query_build.go
+++ b/internal/federated/duckdb_query_build.go
@@ -31,19 +31,15 @@ func (e *DBFederatedQueryEngine) buildDuckDBQueryWithPlan(
 	limit, offset int,
 	parquetPaths []string,
 	graceCutoffMs int64,
+	coldMissing []sqlgen.NullScanColumn,
 	planCtx *duckDBExecutionPlanContext,
 ) (string, []any, int64, error) {
-	sqlParams := e.buildDuckDBTemplateBaseParams(tables, q, attributeOrders, limit, offset, parquetPaths, graceCutoffMs)
+	sqlParams := e.buildDuckDBTemplateBaseParams(tables, q, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, coldMissing)
 
 	startTranslate := time.Now()
 
 	// Build dual clauses (PG pushdown + DuckDB logical) if metadata cache available
-	var cache forma.SchemaAttributeCache
-	if e.metadataCache != nil {
-		if c, ok := e.metadataCache.GetSchemaCacheByID(q.SchemaID); ok {
-			cache = c
-		}
-	}
+	cache, _ := e.schemaCacheByID(q.SchemaID)
 	paramIndex := 0
 	dc, err := sqlgen.ToDualClauses(q.Condition, sqlutil.SanitizeIdentifier(tables.EAVData), q.SchemaID, cache, &paramIndex)
 	if err != nil {
@@ -91,7 +87,7 @@ func (e *DBFederatedQueryEngine) buildDuckDBQueryWithPlan(
 	// Compiled-plan cache (#142): skeleton + template args are reused per
 	// (fingerprint, shape, scope); condition/keyset/dirty operands bind per
 	// request. Test hooks and non-advanced templates bypass the cache.
-	if sqlStr, args, ok := e.serveFromPlanCache(tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, sqlParams, &dc, cache, planCtx); ok {
+	if sqlStr, args, ok := e.serveFromPlanCache(tables, q, dirtyIDs, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, coldMissing, sqlParams, &dc, cache, planCtx); ok {
 		translateMs := time.Since(startTranslate).Milliseconds()
 		telemetry.EmitLatency(ctx, "translation", translateMs)
 		return sqlStr, args, translateMs, nil
@@ -117,6 +113,7 @@ func (e *DBFederatedQueryEngine) buildDuckDBTemplateBaseParams(
 	limit, offset int,
 	parquetPaths []string,
 	graceCutoffMs int64,
+	missing []sqlgen.NullScanColumn,
 ) map[string]any {
 	changeLogSchema, changeLogScanTable := duckDBPostgresScanLocation(tables.ChangeLog)
 	mainSchema, mainScanTable := duckDBPostgresScanLocation(tables.EntityMain)
@@ -149,12 +146,55 @@ func (e *DBFederatedQueryEngine) buildDuckDBTemplateBaseParams(
 	if len(parquetPaths) > 0 {
 		sqlParams["DuckDBS3Paths"] = parquetPaths
 	}
+	if len(missing) > 0 {
+		// Cold-absent columns for the #255 scan-source augmentation; the
+		// renderer folds them into S3_SCAN_SOURCE.
+		sqlParams["ColdMissingColumns"] = missing
+	}
 	// Per-request dirty-barrier cutoff (#252), anchored at the query's
 	// path-resolution instant. The direct builder renders it as a literal;
 	// the compiled path overwrites it with the splice sentinel so the cached
 	// skeleton stays cutoff-independent.
 	sqlParams["FlushGraceCutoffMs"] = graceCutoffMs
 	return sqlParams
+}
+
+// duckPlanScopeParts assembles the plan-cache scope components: everything
+// outside the shape hash that renders into the skeleton. The cold-missing
+// set participates (#255): the rendered scan source depends on it, and a
+// glob-hint path string does not change when the first flush lands a
+// column — without this component a skeleton compiled cold-absent would
+// keep projecting NULL and make the newly flushed data invisible until
+// cache invalidation (the issue's poisoning hazard).
+func duckPlanScopeParts(
+	tables model.StorageTables,
+	pgConn string,
+	limit, offset int,
+	hasDirty bool,
+	parquetPaths []string,
+	attributeOrders []model.AttributeOrder,
+	missing []sqlgen.NullScanColumn,
+) []string {
+	parts := []string{
+		"scope-v2",
+		tables.EAVData, tables.EntityMain, tables.ChangeLog,
+		pgConn,
+		strconv.Itoa(limit), strconv.Itoa(offset),
+		strconv.FormatBool(hasDirty),
+	}
+	// The resolved path set (hint or manifest) renders into the skeleton as a
+	// SQL literal, so it must scope the cache key: a changed file set (new
+	// delta flushed, base replaced) recompiles instead of reusing stale paths.
+	parts = append(parts, parquetPaths...)
+	for _, o := range attributeOrders {
+		parts = append(parts, strconv.Itoa(int(o.AttrID)), o.AttrName, o.ColumnName,
+			string(o.StorageLocation), string(o.SortOrder))
+	}
+	parts = append(parts, "cold-missing")
+	for _, mc := range missing {
+		parts = append(parts, mc.Name, mc.DuckDBType)
+	}
+	return parts
 }
 
 // duckCompiledEntry is the artifact stored in the shared plan cache: the
@@ -177,6 +217,7 @@ func (e *DBFederatedQueryEngine) serveFromPlanCache(
 	limit, offset int,
 	parquetPaths []string,
 	graceCutoffMs int64,
+	missing []sqlgen.NullScanColumn,
 	sqlParams map[string]any,
 	dc *sqlgen.DualClauses,
 	cache forma.SchemaAttributeCache,
@@ -196,21 +237,7 @@ func (e *DBFederatedQueryEngine) serveFromPlanCache(
 			fingerprint = fp
 		}
 	}
-	scopeParts := []string{
-		"scope-v1",
-		tables.EAVData, tables.EntityMain, tables.ChangeLog,
-		e.pgConnString,
-		strconv.Itoa(limit), strconv.Itoa(offset),
-		strconv.FormatBool(len(dirtyIDs) > 0),
-	}
-	// The resolved path set (hint or manifest) renders into the skeleton as a
-	// SQL literal, so it must scope the cache key: a changed file set (new
-	// delta flushed, base replaced) recompiles instead of reusing stale paths.
-	scopeParts = append(scopeParts, parquetPaths...)
-	for _, o := range attributeOrders {
-		scopeParts = append(scopeParts, strconv.Itoa(int(o.AttrID)), o.AttrName, o.ColumnName,
-			string(o.StorageLocation), string(o.SortOrder))
-	}
+	scopeParts := duckPlanScopeParts(tables, e.pgConnString, limit, offset, len(dirtyIDs) > 0, parquetPaths, attributeOrders, missing)
 	key := queryplan.Key{
 		Kind:          "duckdb_federated",
 		SchemaVersion: fingerprint,

--- a/internal/federated/engine_fakes_test.go
+++ b/internal/federated/engine_fakes_test.go
@@ -56,6 +56,15 @@ type fakeDuckDBExecutor struct {
 	lastArgs      []any
 	err           error
 	rows          duckDBRowsIterator
+
+	// globFiles, when non-nil, is the expansion every glob probe returns
+	// instead of the default "listing not faked" error. describeCols, when
+	// non-nil, answers DESCRIBE probes per path: the first map key that is a
+	// substring of the probe SQL wins (like scriptedDescribeExecutor).
+	// Both nil — the default — keeps the behavior every other engine-seam
+	// test relies on: fixed system columns, unlistable globs.
+	globFiles    []string
+	describeCols map[string][][2]string
 }
 
 func (f *fakeDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
@@ -66,6 +75,14 @@ func (f *fakeDuckDBExecutor) Query(ctx context.Context, sql string, args ...any)
 		// without the probe consuming the canned rows or lastSQL. Probes are
 		// counted separately so breaker tests can assert none reach storage.
 		f.describeCalls++
+		if f.describeCols != nil {
+			for path, cols := range f.describeCols {
+				if strings.Contains(sql, path) {
+					return &fakeDescribeRows{cols: cols}, nil
+				}
+			}
+			return nil, fmt.Errorf("unexpected describe probe: %s", sql)
+		}
 		return &fakeDescribeRows{cols: [][2]string{
 			{"row_id", "UUID"}, {"changed_at", "BIGINT"}, {"deleted_at", "BIGINT"},
 		}}, nil
@@ -75,6 +92,9 @@ func (f *fakeDuckDBExecutor) Query(ctx context.Context, sql string, args ...any)
 		// mirroring an unreachable store; the validator defers to the main
 		// read.
 		f.describeCalls++
+		if f.globFiles != nil {
+			return &fakeStringRows{vals: f.globFiles}, nil
+		}
 		return nil, fmt.Errorf("glob listing not faked")
 	}
 	f.calls++

--- a/internal/federated/engine_test.go
+++ b/internal/federated/engine_test.go
@@ -56,7 +56,8 @@ const testParquetPath = "s3://b/7/a.parquet"
 func withTestParquetPath() EngineOption {
 	return func(e *DBFederatedQueryEngine) {
 		WithParquetSource(&fakeParquetSource{paths: []string{testParquetPath}})(e)
-		e.schemaValidator.markValidated(testParquetPath)
+		e.schemaValidator.markValidated(testParquetPath,
+			map[string]string{"row_id": "UUID", "changed_at": "BIGINT", "deleted_at": "BIGINT"})
 	}
 }
 

--- a/internal/federated/parquet_schema_validation.go
+++ b/internal/federated/parquet_schema_validation.go
@@ -24,13 +24,16 @@ import (
 // changes and steady-state cost is one footer probe per new object. Glob
 // paths are expanded per query (the match set changes as objects land) and
 // their concrete matches hit the same cache.
+//
+// The cache stores each validated path's footer columns so a repeat query can
+// contribute them to the column union (#255) without a second probe.
 type parquetSchemaValidator struct {
 	mu    sync.Mutex
-	valid map[string]struct{}
+	valid map[string]map[string]string
 }
 
 func newParquetSchemaValidator() *parquetSchemaValidator {
-	return &parquetSchemaValidator{valid: map[string]struct{}{}}
+	return &parquetSchemaValidator{valid: map[string]map[string]string{}}
 }
 
 // Validate probes each scanned path's parquet schema and fails on a system
@@ -41,63 +44,102 @@ func newParquetSchemaValidator() *parquetSchemaValidator {
 // footers and failed glob listings are inconclusive — byte corruption or
 // storage failure, not schema drift — so the main read keeps producing
 // today's classified execution failure (#187 CorruptBytes/Truncated).
-func (v *parquetSchemaValidator) Validate(ctx context.Context, duck DuckDBQueryExecutor, paths []string) error {
+//
+// It also returns the union of the probed footers' columns (name → DuckDB
+// type) and whether that union is complete. The union feeds #255 NULL
+// augmentation for columns that no scanned parquet generation carries yet;
+// complete is true only when every path in the set contributed its footer, so
+// an incomplete union must not drive augmentation — augmenting a column that
+// an unprobed file actually carries would collide with the real column.
+func (v *parquetSchemaValidator) Validate(
+	ctx context.Context, duck DuckDBQueryExecutor, paths []string,
+) (map[string]string, bool, error) {
 	if v == nil || duck == nil {
-		return nil
+		return nil, false, nil
 	}
+	union, complete := map[string]string{}, true
 	for _, path := range paths {
 		if strings.ContainsAny(path, `'";`) {
 			// Cannot embed in a DuckDB literal; the main read fails on it
 			// with its own classification either way.
+			complete = false
 			continue
 		}
 		if strings.ContainsAny(path, "*?[") {
 			expanded, err := globParquetPaths(ctx, duck, path)
 			if err != nil {
-				continue // inconclusive: defer to the execution-path classifier
+				complete = false // inconclusive: defer to the execution-path classifier
+				continue
 			}
-			if err := v.validateConcrete(ctx, duck, expanded); err != nil {
-				return err
+			ok, err := v.validateConcrete(ctx, duck, expanded, union)
+			if err != nil {
+				return nil, false, err
 			}
+			complete = complete && ok
 			continue
 		}
-		if err := v.validateConcrete(ctx, duck, []string{path}); err != nil {
-			return err
+		ok, err := v.validateConcrete(ctx, duck, []string{path}, union)
+		if err != nil {
+			return nil, false, err
 		}
+		complete = complete && ok
 	}
-	return nil
+	return union, complete, nil
 }
 
 // validateConcrete checks concrete (non-glob) paths against the invariant,
-// consulting and feeding the write-once cache.
-func (v *parquetSchemaValidator) validateConcrete(ctx context.Context, duck DuckDBQueryExecutor, paths []string) error {
+// consulting and feeding the write-once cache. It merges every contributing
+// footer into union and reports whether all of the given paths contributed.
+func (v *parquetSchemaValidator) validateConcrete(
+	ctx context.Context, duck DuckDBQueryExecutor, paths []string, union map[string]string,
+) (bool, error) {
+	complete := true
 	for _, path := range paths {
-		if strings.ContainsAny(path, `'";`) || v.isValidated(path) {
+		if strings.ContainsAny(path, `'";`) {
+			complete = false
+			continue
+		}
+		if cols, ok := v.validatedCols(path); ok {
+			mergeColumnUnion(union, cols)
 			continue
 		}
 		cols, err := describeParquetColumns(ctx, duck, path)
 		if err != nil {
-			continue // inconclusive: defer to the execution-path classifier
+			complete = false // inconclusive: defer to the execution-path classifier
+			continue
 		}
 		if err := parquetcheck.Check(path, cols); err != nil {
-			return fmt.Errorf("%w: %w", ErrFederatedReadFailed, err)
+			return false, fmt.Errorf("%w: %w", ErrFederatedReadFailed, err)
 		}
-		v.markValidated(path)
+		v.markValidated(path, cols)
+		mergeColumnUnion(union, cols)
 	}
-	return nil
+	return complete, nil
 }
 
-func (v *parquetSchemaValidator) isValidated(path string) bool {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	_, ok := v.valid[path]
-	return ok
+// mergeColumnUnion folds one footer's columns into the running union.
+// First-seen type wins on a cross-generation type conflict: #255 consumes
+// only the names (a column present anywhere is never augmented), and the
+// scan's union_by_name owns type widening (#189).
+func mergeColumnUnion(union, cols map[string]string) {
+	for name, typ := range cols {
+		if _, ok := union[name]; !ok {
+			union[name] = typ
+		}
+	}
 }
 
-func (v *parquetSchemaValidator) markValidated(path string) {
+func (v *parquetSchemaValidator) validatedCols(path string) (map[string]string, bool) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	v.valid[path] = struct{}{}
+	cols, ok := v.valid[path]
+	return cols, ok
+}
+
+func (v *parquetSchemaValidator) markValidated(path string, cols map[string]string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.valid[path] = cols
 }
 
 // globParquetPaths expands one glob pattern to its concrete matches via

--- a/internal/federated/parquet_schema_validation_test.go
+++ b/internal/federated/parquet_schema_validation_test.go
@@ -195,9 +195,13 @@ func TestParquetSchemaValidator_UnlistableGlobIsInconclusive(t *testing.T) {
 	duck := &scriptedDescribeExecutor{failPaths: map[string]bool{"1/*.parquet": true}}
 	v := newParquetSchemaValidator()
 
-	_, _, err := v.Validate(context.Background(), duck, []string{"s3://b/1/*.parquet"})
+	union, complete, err := v.Validate(context.Background(), duck, []string{"s3://b/1/*.parquet"})
 	require.NoError(t, err)
 	require.Len(t, duck.probes, 1, "the glob listing attempt is the only probe")
+	require.False(t, complete,
+		"a failed listing leaves the footer union unknown: it must not be reported complete, "+
+			"or #255 would augment columns the unlisted files may actually carry")
+	require.Empty(t, union, "nothing was probed, so nothing contributes to the union")
 }
 
 func TestParquetSchemaValidator_NilCollaboratorsAreNoops(t *testing.T) {

--- a/internal/federated/parquet_schema_validation_test.go
+++ b/internal/federated/parquet_schema_validation_test.go
@@ -116,11 +116,13 @@ func TestParquetSchemaValidator_ValidPathsPassAndCache(t *testing.T) {
 	v := newParquetSchemaValidator()
 	paths := []string{"s3://b/1/a.parquet", "s3://b/1/b.parquet"}
 
-	require.NoError(t, v.Validate(context.Background(), duck, paths))
+	_, _, err := v.Validate(context.Background(), duck, paths)
+	require.NoError(t, err)
 	require.Len(t, duck.probes, 2)
 
 	// Parquet objects are write-once: validated paths are never re-probed.
-	require.NoError(t, v.Validate(context.Background(), duck, paths))
+	_, _, err = v.Validate(context.Background(), duck, paths)
+	require.NoError(t, err)
 	require.Len(t, duck.probes, 2)
 }
 
@@ -130,7 +132,7 @@ func TestParquetSchemaValidator_MissingSystemColumnFailsClassified(t *testing.T)
 	}}
 	v := newParquetSchemaValidator()
 
-	err := v.Validate(context.Background(), duck, []string{"s3://b/1/wrong.parquet"})
+	_, _, err := v.Validate(context.Background(), duck, []string{"s3://b/1/wrong.parquet"})
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFederatedReadFailed)
 	require.NotErrorIs(t, err, ErrParquetSetInconsistent)
@@ -144,7 +146,7 @@ func TestParquetSchemaValidator_WrongSystemColumnTypeFailsClassified(t *testing.
 	}}
 	v := newParquetSchemaValidator()
 
-	err := v.Validate(context.Background(), duck, []string{"s3://b/1/poisoned.parquet"})
+	_, _, err := v.Validate(context.Background(), duck, []string{"s3://b/1/poisoned.parquet"})
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFederatedReadFailed)
 	require.Contains(t, err.Error(), `"row_id"`)
@@ -159,11 +161,13 @@ func TestParquetSchemaValidator_UnreadableFooterIsInconclusive(t *testing.T) {
 	duck := &scriptedDescribeExecutor{failPaths: map[string]bool{"corrupt.parquet": true}}
 	v := newParquetSchemaValidator()
 
-	require.NoError(t, v.Validate(context.Background(), duck, []string{"s3://b/1/corrupt.parquet"}))
+	_, _, err := v.Validate(context.Background(), duck, []string{"s3://b/1/corrupt.parquet"})
+	require.NoError(t, err)
 	require.Len(t, duck.probes, 1)
 
 	// Inconclusive results are not cached: the next query re-probes.
-	require.NoError(t, v.Validate(context.Background(), duck, []string{"s3://b/1/corrupt.parquet"}))
+	_, _, err = v.Validate(context.Background(), duck, []string{"s3://b/1/corrupt.parquet"})
+	require.NoError(t, err)
 	require.Len(t, duck.probes, 2)
 }
 
@@ -181,7 +185,7 @@ func TestParquetSchemaValidator_GlobExpandsAndValidatesMatches(t *testing.T) {
 	}
 	v := newParquetSchemaValidator()
 
-	err := v.Validate(context.Background(), duck, []string{"s3://b/1/*.parquet"})
+	_, _, err := v.Validate(context.Background(), duck, []string{"s3://b/1/*.parquet"})
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFederatedReadFailed)
 	require.Contains(t, err.Error(), "wrong.parquet")
@@ -191,15 +195,18 @@ func TestParquetSchemaValidator_UnlistableGlobIsInconclusive(t *testing.T) {
 	duck := &scriptedDescribeExecutor{failPaths: map[string]bool{"1/*.parquet": true}}
 	v := newParquetSchemaValidator()
 
-	require.NoError(t, v.Validate(context.Background(), duck, []string{"s3://b/1/*.parquet"}))
+	_, _, err := v.Validate(context.Background(), duck, []string{"s3://b/1/*.parquet"})
+	require.NoError(t, err)
 	require.Len(t, duck.probes, 1, "the glob listing attempt is the only probe")
 }
 
 func TestParquetSchemaValidator_NilCollaboratorsAreNoops(t *testing.T) {
 	duck := &scriptedDescribeExecutor{}
 	var nilValidator *parquetSchemaValidator
-	require.NoError(t, nilValidator.Validate(context.Background(), duck, []string{"s3://b/1/a.parquet"}))
-	require.NoError(t, newParquetSchemaValidator().Validate(context.Background(), nil, []string{"s3://b/1/a.parquet"}))
+	_, _, err := nilValidator.Validate(context.Background(), duck, []string{"s3://b/1/a.parquet"})
+	require.NoError(t, err)
+	_, _, err = newParquetSchemaValidator().Validate(context.Background(), nil, []string{"s3://b/1/a.parquet"})
+	require.NoError(t, err)
 	require.Empty(t, duck.probes)
 }
 
@@ -275,6 +282,55 @@ func TestBreakerOpenRejectsBeforeSchemaProbes(t *testing.T) {
 	require.Equal(t, 0, duck.describeCalls, "open breaker must reject before schema probes reach storage")
 	require.Equal(t, 0, duck.calls, "open breaker must reject before the main scan")
 	require.Equal(t, 0, src.pathsCalls, "open breaker must reject before path resolution")
+}
+
+// #255: Validate reports the union of footer columns and whether it is
+// complete. The union drives NULL augmentation for never-flushed columns,
+// so an incomplete union must be reported as such — augmenting a column
+// that exists in an unprobed file would collide with the real column.
+func TestValidateReturnsCompleteColumnUnion(t *testing.T) {
+	exec := &scriptedDescribeExecutor{cols: map[string][][2]string{
+		"base.parquet":  append(buildValidSystemCols(), [2]string{"name", "VARCHAR"}),
+		"delta.parquet": append(buildValidSystemCols(), [2]string{"name", "VARCHAR"}, [2]string{"score", "INTEGER"}),
+	}}
+	v := newParquetSchemaValidator()
+	union, complete, err := v.Validate(context.Background(), exec,
+		[]string{"s3://b/base.parquet", "s3://b/delta.parquet"})
+	require.NoError(t, err)
+	require.True(t, complete)
+	require.Contains(t, union, "name")
+	require.Contains(t, union, "score")
+	require.Contains(t, union, "row_id")
+}
+
+func TestValidateUnionIncompleteOnProbeFailure(t *testing.T) {
+	exec := &scriptedDescribeExecutor{
+		cols:      map[string][][2]string{"good.parquet": buildValidSystemCols()},
+		failPaths: map[string]bool{"bad.parquet": true},
+	}
+	v := newParquetSchemaValidator()
+	union, complete, err := v.Validate(context.Background(), exec,
+		[]string{"s3://b/good.parquet", "s3://b/bad.parquet"})
+	require.NoError(t, err, "unreadable footer stays inconclusive, not an error")
+	require.False(t, complete)
+	require.Contains(t, union, "row_id", "probed files still contribute")
+}
+
+// A cache hit must contribute its stored columns without a second probe.
+func TestValidateCachedPathContributesColumnsWithoutReprobe(t *testing.T) {
+	exec := &scriptedDescribeExecutor{cols: map[string][][2]string{
+		"a.parquet": append(buildValidSystemCols(), [2]string{"score", "INTEGER"}),
+	}}
+	v := newParquetSchemaValidator()
+	_, _, err := v.Validate(context.Background(), exec, []string{"s3://b/a.parquet"})
+	require.NoError(t, err)
+	probesAfterFirst := len(exec.probes)
+
+	union, complete, err := v.Validate(context.Background(), exec, []string{"s3://b/a.parquet"})
+	require.NoError(t, err)
+	require.True(t, complete)
+	require.Contains(t, union, "score")
+	require.Len(t, exec.probes, probesAfterFirst, "cached path must not re-probe")
 }
 
 // describeOverridingExecutor overrides the DESCRIBE answer while delegating

--- a/internal/sqlgen/advanced_query_template_duckdb.go
+++ b/internal/sqlgen/advanced_query_template_duckdb.go
@@ -54,7 +54,9 @@ s3_source AS (
   -- (which silently corrupted values on integer→double evolution). The
   -- corruption loudness this relaxes is restored by the pre-read
   -- system-column invariant validator (parquet_schema_validation.go).
-  FROM read_parquet({{.S3_PATHS}}, union_by_name=true)
+  -- A column absent from EVERY file is projected as a typed NULL by the
+  -- scan source instead (#255, never-flushed attributes).
+  FROM {{.S3_SCAN_SOURCE}}
   WHERE
     CAST(row_id AS UUID) NOT IN (SELECT row_id FROM dirty_ids)
     -- Predicate pushdown as a row_id semijoin: a row qualifies when ANY of
@@ -64,7 +66,7 @@ s3_source AS (
     -- versions pre-dedup and resurrected stale base rows whose old values
     -- still matched (#173).
     AND row_id IN (
-      SELECT row_id FROM read_parquet({{.S3_PATHS}}, union_by_name=true)
+      SELECT row_id FROM {{.S3_SCAN_SOURCE}}
       WHERE ({{.LOGICAL_WHERE_CLAUSE}})
     )
 ),

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -163,8 +163,10 @@ func resolveMainTableColumn(attr string, meta forma.AttributeMetadata) string {
 //
 // Dotted attribute names fold through ParquetAttrColumn (#260): the CTEs
 // project every attribute under its parquet column alias, because the same
-// clause also runs against raw read_parquet output where only the physical
-// (folded) column exists.
+// clause also runs against the parquet scan source, which exposes the physical
+// (folded) columns. Since #255 that scan source may additionally project typed
+// NULLs (BuildParquetScanSource) for attributes absent from EVERY file in the
+// set — those aliases are folded names too, so the clause binds either way.
 func resolveDuckDBColumn(attr string) string {
 	return ParquetAttrColumn(attr)
 }

--- a/internal/sqlgen/duckdb_cold_scan.go
+++ b/internal/sqlgen/duckdb_cold_scan.go
@@ -1,0 +1,72 @@
+package sqlgen
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lychee-technology/forma"
+)
+
+// NullScanColumn names one current-schema attribute column that is
+// physically absent from EVERY parquet file in a query's resolved scan set
+// (#255): an attribute added to the schema before its first flush. The scan
+// source projects it as a typed NULL so both the explicit projection
+// (S3SourceSelect) and the semijoin's logical clause bind, with exact SQL
+// NULL semantics for filters, sorts, and keysets.
+type NullScanColumn struct {
+	// Name is the folded parquet column name (ParquetAttrColumn output).
+	Name string
+	// DuckDBType renders as NULL::<type>. It must type-unify with the
+	// pg_source leg of the UNION ALL, so it mirrors the hot-tier EAV pivot
+	// (buildEAVPivotExpr) and the CDC export (cdc.castEAVValue) — the #205
+	// no-widening parity.
+	DuckDBType string
+}
+
+// BuildParquetScanSource renders the parquet scan for the advanced
+// template's two scan sites. With no missing columns the output is
+// byte-identical to the pre-#255 template text — the idle-state invariant
+// every rendered-SQL contract (including the #214 design-doc guard) relies
+// on. With missing columns it wraps the scan so each cold-absent column
+// exists as a typed NULL.
+func BuildParquetScanSource(pathsSQL string, missing []NullScanColumn) string {
+	base := fmt.Sprintf("read_parquet(%s, union_by_name=true)", pathsSQL)
+	if len(missing) == 0 {
+		return base
+	}
+	parts := make([]string, 0, len(missing)+1)
+	parts = append(parts, "*")
+	for _, mc := range missing {
+		parts = append(parts, fmt.Sprintf("NULL::%s AS %s", mc.DuckDBType, mc.Name))
+	}
+	return fmt.Sprintf("(SELECT %s FROM %s) AS cold_scan", strings.Join(parts, ", "), base)
+}
+
+// DuckDBNullScanType maps an attribute's value type to the DuckDB type its
+// parquet column would carry, for NULL::<type> augmentation. Kept in
+// lockstep with buildEAVPivotExpr / eavElementCastExpr (hot leg) and
+// cdc.castEAVValue (export leg): a mismatch would widen the UNION ALL and
+// re-open #205.
+func DuckDBNullScanType(vt forma.ValueType, itemsType forma.ValueType) string {
+	if vt == forma.ValueTypeList {
+		return duckDBNullScalarType(itemsType) + "[]"
+	}
+	return duckDBNullScalarType(vt)
+}
+
+func duckDBNullScalarType(vt forma.ValueType) string {
+	switch vt {
+	case forma.ValueTypeBool:
+		return "BOOLEAN"
+	case forma.ValueTypeBigInt, forma.ValueTypeDate, forma.ValueTypeDateTime:
+		return "BIGINT"
+	case forma.ValueTypeInteger:
+		return "INTEGER"
+	case forma.ValueTypeSmallInt:
+		return "SMALLINT"
+	case forma.ValueTypeNumeric:
+		return "DOUBLE"
+	default: // text / uuid — VARCHAR on every tier
+		return "VARCHAR"
+	}
+}

--- a/internal/sqlgen/duckdb_cold_scan_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_test.go
@@ -1,8 +1,11 @@
 package sqlgen
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
 
 	"github.com/lychee-technology/forma"
 	"github.com/stretchr/testify/require"
@@ -26,6 +29,11 @@ func TestBuildParquetScanSourceWrapsMissingColumnsAsTypedNulls(t *testing.T) {
 		got)
 }
 
+// TestDuckDBNullScanTypeMirrorsTierTypes documents the intended map as a
+// literal table. It cannot detect divergence from the other tiers on its own
+// (it validates the table against itself) — the cross-leg proof is
+// TestDuckDBNullScanTypeMatchesHotLegTypeof below (hot pivot) and
+// cdc.TestCastEAVValueMatchesNullScanTypeof (export leg).
 func TestDuckDBNullScanTypeMirrorsTierTypes(t *testing.T) {
 	cases := []struct {
 		vt, items forma.ValueType
@@ -101,4 +109,61 @@ func TestAdvancedTemplateRendersScanSourceAtBothSites(t *testing.T) {
 	require.NoError(t, AdvancedQueryTemplateDuckDB.Execute(&b, minimalAdvancedParams(t, []NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}})))
 	require.Equal(t, 2, strings.Count(b.String(), "NULL::INTEGER AS score"))
 	require.Equal(t, 2, strings.Count(b.String(), "read_parquet("))
+}
+
+// eavFixtureSubquery mimics the eav_data columns the hot-leg pivot reads, at
+// the types they actually carry in the pivot: value_numeric is DOUBLE (the
+// numeric-family column every scalar cast starts from) and value_text is
+// VARCHAR.
+const eavFixtureSubquery = "(SELECT CAST(1 AS DOUBLE) AS value_numeric, CAST('x' AS VARCHAR) AS value_text)"
+
+// TestDuckDBNullScanTypeMatchesHotLegTypeof is the #255 type-lockstep proof
+// against a real DuckDB engine: for every value type, the type DuckDB gives
+// the hot-leg EAV cast (eavElementCastExpr) must equal the type DuckDB gives
+// NULL::DuckDBNullScanType(...). Divergence widens the UNION ALL between the
+// pg_source leg and the NULL-augmented parquet leg and re-opens #205.
+//
+// The comparison is on typeof() rather than on the rendered SQL text: bool
+// renders as `(value_numeric <> 0)` and text as a bare `value_text`, so
+// neither carries a type literal to extract — only the engine knows.
+func TestDuckDBNullScanTypeMatchesHotLegTypeof(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	typeOf := func(t *testing.T, expr string) string {
+		t.Helper()
+		var typ string
+		require.NoError(t, db.QueryRow("SELECT typeof("+expr+")").Scan(&typ), "expr %q must evaluate", expr)
+		return typ
+	}
+
+	scalars := []forma.ValueType{
+		forma.ValueTypeBool, forma.ValueTypeBigInt, forma.ValueTypeDate,
+		forma.ValueTypeDateTime, forma.ValueTypeInteger, forma.ValueTypeSmallInt,
+		forma.ValueTypeNumeric, forma.ValueTypeText, forma.ValueTypeUUID,
+	}
+	for _, vt := range scalars {
+		t.Run(string(vt), func(t *testing.T) {
+			var hot string
+			hotExpr := "typeof((" + eavElementCastExpr(vt) + ")) FROM " + eavFixtureSubquery
+			require.NoError(t, db.QueryRow("SELECT "+hotExpr).Scan(&hot),
+				"hot-leg cast %q must evaluate", eavElementCastExpr(vt))
+
+			cold := typeOf(t, "NULL::"+DuckDBNullScanType(vt, ""))
+			require.Equal(t, hot, cold,
+				"cold NULL scan type must equal the hot-leg EAV cast type for %s (#205 no-widening)", vt)
+		})
+	}
+
+	// LIST: the elem+"[]" construction has to name the same type DuckDB gives
+	// an aggregated list of the element cast.
+	t.Run("list_bigint", func(t *testing.T) {
+		var hot string
+		require.NoError(t, db.QueryRow(
+			"SELECT typeof(list(x)) FROM (SELECT "+eavElementCastExpr(forma.ValueTypeBigInt)+
+				" AS x FROM "+eavFixtureSubquery+")").Scan(&hot))
+		cold := typeOf(t, "NULL::"+DuckDBNullScanType(forma.ValueTypeList, forma.ValueTypeBigInt))
+		require.Equal(t, hot, cold, "LIST element type must round-trip through the []-suffix construction")
+	})
 }

--- a/internal/sqlgen/duckdb_cold_scan_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_test.go
@@ -157,13 +157,75 @@ func TestDuckDBNullScanTypeMatchesHotLegTypeof(t *testing.T) {
 	}
 
 	// LIST: the elem+"[]" construction has to name the same type DuckDB gives
-	// an aggregated list of the element cast.
-	t.Run("list_bigint", func(t *testing.T) {
-		var hot string
+	// an aggregated list of the element cast — for every items type, since each
+	// takes a different eavElementCastExpr arm.
+	for _, items := range scalars {
+		t.Run("list_"+string(items), func(t *testing.T) {
+			var hot string
+			require.NoError(t, db.QueryRow(
+				"SELECT typeof(list(x)) FROM (SELECT "+eavElementCastExpr(items)+
+					" AS x FROM "+eavFixtureSubquery+")").Scan(&hot))
+			cold := typeOf(t, "NULL::"+DuckDBNullScanType(forma.ValueTypeList, items))
+			require.Equal(t, hot, cold, "LIST element type must round-trip through the []-suffix construction for items=%s", items)
+		})
+	}
+}
+
+// eavPivotFixtureSubquery extends eavFixtureSubquery with the columns the full
+// pivot expression additionally reads: attr_id (matching the probe's attribute
+// ID 9) and array_indices (a non-empty element index, so the list branch's
+// FILTER keeps the row).
+const eavPivotFixtureSubquery = "(SELECT 9 AS attr_id, CAST(1 AS DOUBLE) AS value_numeric, " +
+	"CAST('x' AS VARCHAR) AS value_text, CAST('0' AS VARCHAR) AS array_indices)"
+
+// TestDuckDBNullScanTypeMatchesPivotLegTypeof asserts the SAME lockstep against
+// the full hot-leg pivot expression (buildEAVPivotExpr) rather than only the
+// element cast. The two are type-identical today because every pivot arm wraps
+// the element cast's type unchanged (MAX/list preserve it, the bool arm renders
+// BOOLEAN either way) — but nothing else enforces that, and it is the pivot,
+// not the bare element cast, that pg_source actually projects into the UNION
+// ALL. If a future pivot arm diverges from eavElementCastExpr for some scalar,
+// this test fails where the sibling above cannot (round-2 review observation).
+func TestDuckDBNullScanTypeMatchesPivotLegTypeof(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	pivotTypeof := func(t *testing.T, meta forma.AttributeMetadata) string {
+		t.Helper()
+		expr := buildEAVPivotExpr(attrProjectionInfo{attrID: 9, meta: meta})
+		var typ string
 		require.NoError(t, db.QueryRow(
-			"SELECT typeof(list(x)) FROM (SELECT "+eavElementCastExpr(forma.ValueTypeBigInt)+
-				" AS x FROM "+eavFixtureSubquery+")").Scan(&hot))
-		cold := typeOf(t, "NULL::"+DuckDBNullScanType(forma.ValueTypeList, forma.ValueTypeBigInt))
-		require.Equal(t, hot, cold, "LIST element type must round-trip through the []-suffix construction")
-	})
+			"SELECT typeof(("+expr+")) FROM "+eavPivotFixtureSubquery).Scan(&typ),
+			"pivot expr %q must evaluate", expr)
+		return typ
+	}
+	nullTypeof := func(t *testing.T, rendered string) string {
+		t.Helper()
+		var typ string
+		require.NoError(t, db.QueryRow("SELECT typeof(NULL::"+rendered+")").Scan(&typ))
+		return typ
+	}
+
+	scalars := []forma.ValueType{
+		forma.ValueTypeBool, forma.ValueTypeBigInt, forma.ValueTypeDate,
+		forma.ValueTypeDateTime, forma.ValueTypeInteger, forma.ValueTypeSmallInt,
+		forma.ValueTypeNumeric, forma.ValueTypeText, forma.ValueTypeUUID,
+	}
+	for _, vt := range scalars {
+		t.Run(string(vt), func(t *testing.T) {
+			hot := pivotTypeof(t, forma.AttributeMetadata{ValueType: vt})
+			cold := nullTypeof(t, DuckDBNullScanType(vt, ""))
+			require.Equal(t, hot, cold,
+				"cold NULL scan type must equal the hot-leg PIVOT type for %s (#205 no-widening)", vt)
+		})
+	}
+	for _, items := range scalars {
+		t.Run("list_"+string(items), func(t *testing.T) {
+			hot := pivotTypeof(t, forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: items})
+			cold := nullTypeof(t, DuckDBNullScanType(forma.ValueTypeList, items))
+			require.Equal(t, hot, cold,
+				"cold NULL scan type must equal the hot-leg LIST pivot type for items=%s", items)
+		})
+	}
 }

--- a/internal/sqlgen/duckdb_cold_scan_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_test.go
@@ -1,0 +1,104 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// Idle-state invariant (#255): no missing columns renders the exact
+// pre-#255 scan text, keeping every rendered-SQL contract byte-identical.
+func TestBuildParquetScanSourceEmptyIsBareReadParquet(t *testing.T) {
+	got := BuildParquetScanSource("'s3://b/base/a.parquet'", nil)
+	require.Equal(t, "read_parquet('s3://b/base/a.parquet', union_by_name=true)", got)
+}
+
+func TestBuildParquetScanSourceWrapsMissingColumnsAsTypedNulls(t *testing.T) {
+	got := BuildParquetScanSource("['s3://b/a.parquet', 's3://b/b.parquet']", []NullScanColumn{
+		{Name: "score", DuckDBType: "INTEGER"},
+		{Name: "tags", DuckDBType: "BIGINT[]"},
+	})
+	require.Equal(t,
+		"(SELECT *, NULL::INTEGER AS score, NULL::BIGINT[] AS tags "+
+			"FROM read_parquet(['s3://b/a.parquet', 's3://b/b.parquet'], union_by_name=true)) AS cold_scan",
+		got)
+}
+
+func TestDuckDBNullScanTypeMirrorsTierTypes(t *testing.T) {
+	cases := []struct {
+		vt, items forma.ValueType
+		want      string
+	}{
+		{forma.ValueTypeBool, "", "BOOLEAN"},
+		{forma.ValueTypeBigInt, "", "BIGINT"},
+		{forma.ValueTypeDate, "", "BIGINT"},
+		{forma.ValueTypeDateTime, "", "BIGINT"},
+		{forma.ValueTypeInteger, "", "INTEGER"},
+		{forma.ValueTypeSmallInt, "", "SMALLINT"},
+		{forma.ValueTypeNumeric, "", "DOUBLE"},
+		{forma.ValueTypeText, "", "VARCHAR"},
+		{forma.ValueTypeUUID, "", "VARCHAR"},
+		{forma.ValueTypeList, forma.ValueTypeBigInt, "BIGINT[]"},
+		{forma.ValueTypeList, forma.ValueTypeText, "VARCHAR[]"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, DuckDBNullScanType(c.vt, c.items), "vt=%s items=%s", c.vt, c.items)
+	}
+}
+
+// minimalAdvancedParams builds a fully renderable advanced-template param map
+// whose parquet scan source carries the given cold-missing columns. It mirrors
+// the production param set (buildDuckDBQueryWithPlan) closely enough to render
+// the template directly, without going through BuildDuckDBQuery — so the two
+// scan sites can be counted in isolation.
+func minimalAdvancedParams(t *testing.T, missing []NullScanColumn) map[string]any {
+	t.Helper()
+	return injectTestRenderParams(t, map[string]any{
+		"PG_CONN":              "dbname=forma host=localhost",
+		"ChangeLogSchema":      "public",
+		"ChangeLogScanTable":   "change_log",
+		"MainSchema":           "public",
+		"MainScanTable":        "entity_main_dev",
+		"EAVSchema":            "public",
+		"EAVScanTable":         "eav_data_dev",
+		"SCHEMA_ID":            int16(1),
+		"HasHot":               true,
+		"HasDirtyIDs":          false,
+		"DirtyIDsCSV":          "",
+		"FlushGraceCutoffMs":   FlushGraceCutoffDisabled,
+		"LOGICAL_WHERE_CLAUSE": "1=1",
+		"PG_WHERE_CLAUSE":      "1=1",
+		"HAS_KEYSET":           false,
+		"PAGE_SIZE":            10,
+		"OFFSET":               0,
+		"NON_KEYSET_ORDER_BY":  "created_at DESC, row_id ASC",
+		"S3_SCAN_SOURCE":       BuildParquetScanSource("'s3://b/a.parquet'", missing),
+	}, 1)
+}
+
+// The advanced template must consume the scan source at BOTH sites:
+// s3_source's FROM and the pushdown semijoin's inner FROM.
+func TestAdvancedTemplateRendersScanSourceAtBothSites(t *testing.T) {
+	params := map[string]any{"S3_PATHS": "'s3://b/base/a.parquet'"}
+	injectDuckDBTemplateParams(params, nil, nil)
+	// nil query keeps this a pure param-derivation probe.
+	src, _ := params["S3_SCAN_SOURCE"].(string)
+	require.Equal(t, "read_parquet('s3://b/base/a.parquet', union_by_name=true)", src)
+
+	params = map[string]any{
+		"S3_PATHS":           "'s3://b/base/a.parquet'",
+		"ColdMissingColumns": []NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}},
+	}
+	injectDuckDBTemplateParams(params, nil, nil)
+	src, _ = params["S3_SCAN_SOURCE"].(string)
+	require.Contains(t, src, "NULL::INTEGER AS score")
+
+	// End-to-end render: exactly the template's two scan sites carry the
+	// wrapped source (rendered via the real advanced template).
+	var b strings.Builder
+	require.NoError(t, AdvancedQueryTemplateDuckDB.Execute(&b, minimalAdvancedParams(t, []NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}})))
+	require.Equal(t, 2, strings.Count(b.String(), "NULL::INTEGER AS score"))
+	require.Equal(t, 2, strings.Count(b.String(), "read_parquet("))
+}

--- a/internal/sqlgen/duckdb_compiled_query_test.go
+++ b/internal/sqlgen/duckdb_compiled_query_test.go
@@ -106,6 +106,20 @@ func TestCompiledQueryParity(t *testing.T) {
 			dirty,
 			[]NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}, {Name: "tags", DuckDBType: "BIGINT[]"}},
 		},
+		// The augmentation must survive the two shapes that rewrite the
+		// surrounding SQL: the keyset predicate (appended after the logical
+		// clause, so placeholder order is at stake) and the hot-excluded tier
+		// form (which drops the pg_source CTE and its PgMainArgs occurrence).
+		"keyset and cold missing": {
+			keysetQ,
+			dirty,
+			[]NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}},
+		},
+		"cold only and cold missing": {
+			coldOnlyQ,
+			dirty,
+			[]NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}, {Name: "tags", DuckDBType: "BIGINT[]"}},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/sqlgen/duckdb_compiled_query_test.go
+++ b/internal/sqlgen/duckdb_compiled_query_test.go
@@ -1,6 +1,7 @@
 package sqlgen
 
 import (
+	"fmt"
 	"testing"
 	"text/template"
 
@@ -24,22 +25,40 @@ func compiledParityParams(t *testing.T) map[string]any {
 	}, 7)
 }
 
+// coldParityParams is compiledParityParams carrying a #255 cold-missing set,
+// so the scan-source augmentation participates in the parity contract.
+func coldParityParams(t *testing.T, missing []NullScanColumn) map[string]any {
+	t.Helper()
+	params := compiledParityParams(t)
+	if len(missing) > 0 {
+		params["ColdMissingColumns"] = missing
+	}
+	return params
+}
+
 // requireCompiledParity is the #142 phase-5 contract: Compile+Bind must
 // reproduce BuildDuckDBQuery byte-for-byte (SQL) and deep-equal (args) for
-// the production advanced+dual path.
-func requireCompiledParity(t *testing.T, q *model.FederatedAttributeQuery, dual DualClauses, dirtyIDs []uuid.UUID) {
+// the production advanced+dual path. missing carries the #255 cold-missing
+// set (nil for the unaugmented shapes).
+func requireCompiledParity(t *testing.T, q *model.FederatedAttributeQuery, dual DualClauses, dirtyIDs []uuid.UUID, missing []NullScanColumn) {
 	t.Helper()
 
-	wantSQL, wantArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), q, dirtyIDs, &dual)
+	wantSQL, wantArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, coldParityParams(t, missing), q, dirtyIDs, &dual)
 	require.NoError(t, err)
 
-	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), q, &dual, len(dirtyIDs) > 0)
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, coldParityParams(t, missing), q, &dual, len(dirtyIDs) > 0)
 	require.NoError(t, err)
 	require.NotNil(t, compiled)
 
 	gotSQL, gotArgs := compiled.Bind(q, dual, dirtyIDs, FlushGraceCutoffDisabled)
 	require.Equal(t, wantSQL, gotSQL)
 	require.Equal(t, wantArgs, gotArgs)
+
+	// Non-vacuity: a cold-missing case must actually render the augmentation,
+	// otherwise the parity assertion above would hold trivially.
+	for _, mc := range missing {
+		require.Contains(t, gotSQL, fmt.Sprintf("NULL::%s AS %s", mc.DuckDBType, mc.Name))
+	}
 }
 
 func parityDual(t *testing.T, cond forma.Condition, cache forma.SchemaAttributeCache) DualClauses {
@@ -70,18 +89,27 @@ func TestCompiledQueryParity(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		q     *model.FederatedAttributeQuery
-		dirty []uuid.UUID
+		q       *model.FederatedAttributeQuery
+		dirty   []uuid.UUID
+		missing []NullScanColumn
 	}{
-		"plain":            {&model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7, Condition: mixed}}, nil},
-		"with dirty ids":   {&model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7, Condition: mixed}}, dirty},
-		"with keyset":      {keysetQ, nil},
-		"keyset and dirty": {keysetQ, dirty},
-		"cold only":        {coldOnlyQ, dirty},
+		"plain":            {&model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7, Condition: mixed}}, nil, nil},
+		"with dirty ids":   {&model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7, Condition: mixed}}, dirty, nil},
+		"with keyset":      {keysetQ, nil, nil},
+		"keyset and dirty": {keysetQ, dirty, nil},
+		"cold only":        {coldOnlyQ, dirty, nil},
+		// #255: the augmented scan source must render identically on the
+		// compiled skeleton and the direct build, or a cache-served request
+		// would scan a different shape than the one it compiled.
+		"cold missing columns": {
+			&model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7, Condition: mixed}},
+			dirty,
+			[]NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}, {Name: "tags", DuckDBType: "BIGINT[]"}},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			requireCompiledParity(t, tc.q, parityDual(t, tc.q.Condition, cache), tc.dirty)
+			requireCompiledParity(t, tc.q, parityDual(t, tc.q.Condition, cache), tc.dirty, tc.missing)
 		})
 	}
 }

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -181,21 +181,26 @@ func requireProjectionParams(params map[string]any) error {
 	return fmt.Errorf("advanced DuckDB template render is missing schema projection params [%s]; derive them via BuildSchemaProjection or BuildBenchmarkProjections — the toy-schema defaults were retired (#222)", strings.Join(missing, ", "))
 }
 
-// requireS3Paths fails an advanced-template render whose S3_PATHS is unbound.
-// The template renders read_parquet({{.S3_PATHS}}, union_by_name=true) with no
-// guard of its own, so an absent binding used to reach DuckDB as the literal
+// requireS3Paths fails an advanced-template render whose parquet scan source
+// is unbound. The template renders FROM {{.S3_SCAN_SOURCE}} with no guard of
+// its own, so an absent binding used to reach DuckDB as the literal
 // "<no value>" — a parser error that classified as a degradable read failure,
 // indistinguishable from a transient S3 outage (#299). The engine now rejects
 // an empty resolved path set before it gets here (ErrNoParquetPaths); this
 // keeps the bad render unreachable from every other caller too, the same way
 // requireProjectionParams closed the retired toy-projection hole (#222).
+// It checks S3_SCAN_SOURCE rather than S3_PATHS because that is what the
+// template actually consumes since #255 — the scan source is derived from the
+// path set in injectDuckDBTemplateParams, so an unresolved path set still
+// fails here, and a scan source injected directly is equally covered.
 func requireS3Paths(params map[string]any) error {
-	if paths, ok := params["S3_PATHS"].(string); ok && paths != "" {
+	if src, ok := params["S3_SCAN_SOURCE"].(string); ok && src != "" {
 		return nil
 	}
-	return fmt.Errorf("advanced DuckDB template render is missing S3_PATHS; " +
-		"resolve a non-empty parquet path set first (render hint or manifest source) — " +
-		"an unbound value renders read_parquet(<no value>) (#299)")
+	return fmt.Errorf("advanced DuckDB template render is missing S3_SCAN_SOURCE " +
+		"(derived from S3_PATHS); resolve a non-empty parquet path set first " +
+		"(render hint or manifest source) — an unbound value renders a " +
+		"FROM <no value> parser error (#299, #255)")
 }
 
 func defaultIfEmpty(s, fallback string) string {
@@ -233,6 +238,27 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	if _, ok := params["FlushGraceCutoffMs"]; !ok {
 		params["FlushGraceCutoffMs"] = FlushGraceCutoffDisabled
 	}
+
+	// The parquet path set and the scan source derived from it are set before
+	// the nil-q return too: the advanced template consumes S3_SCAN_SOURCE
+	// unconditionally, so every render path (dual, legacy, nil query) must be
+	// able to bind it.
+	if _, ok := params["S3_PATHS"]; !ok {
+		if paths, ok := params["DuckDBS3Paths"].([]string); ok && len(paths) > 0 {
+			params["S3_PATHS"] = formatDuckDBPathList(paths)
+		}
+	}
+	// The scan source folds the resolved path list with the cold-missing
+	// column set (#255). Derived here — the single point both the direct
+	// builder and CompileDuckDBQuery flow through — so the compiled skeleton
+	// and the direct render can never disagree.
+	if _, ok := params["S3_SCAN_SOURCE"]; !ok {
+		if pathsSQL, ok := params["S3_PATHS"].(string); ok && pathsSQL != "" {
+			missing, _ := params["ColdMissingColumns"].([]NullScanColumn)
+			params["S3_SCAN_SOURCE"] = BuildParquetScanSource(pathsSQL, missing)
+		}
+	}
+
 	if q == nil {
 		return
 	}
@@ -274,12 +300,6 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	if _, ok := params["PG_CONN"]; !ok {
 		if raw, ok := params["DuckDBPGConnString"].(string); ok && raw != "" {
 			params["PG_CONN"] = sqlutil.EscapeLiteral(raw)
-		}
-	}
-
-	if _, ok := params["S3_PATHS"]; !ok {
-		if paths, ok := params["DuckDBS3Paths"].([]string); ok && len(paths) > 0 {
-			params["S3_PATHS"] = formatDuckDBPathList(paths)
 		}
 	}
 


### PR DESCRIPTION
Closes #255. Follow-up filed: #345.

## What this delivers

A federated query that projects, filters, sorts, or keysets on a schema attribute added **before its first flush** (physically absent from every parquet file in the resolved scan set) now succeeds with exact SQL NULL semantics, instead of dying as a classified DuckDB binder error. Red-first e2e `TestSchemaEvolutionNeverFlushedColumn` pins the contract: full-scan 8 rows, filter/sort on the never-flushed attribute, cold-only reads, and a pre/post-first-flush transition probe.

## Design — wrapped scan source, not projection mutation

The issue sketched feeding the cold union into `BuildSchemaProjection` (`NULL::<type> AS attr` in the projection). We landed a different shape: both template scan sites — the `s3_source` scan **and** its pushdown semijoin — consume one `{{.S3_SCAN_SOURCE}}` param that renders either the exact pre-#255 `read_parquet(..., union_by_name=true)` text (empty missing set → **byte-identical SQL**, keeping the #214 executable-doc guard and every rendered-SQL contract green untouched) or `(SELECT *, NULL::<type> AS <col> ... FROM read_parquet(...)) AS cold_scan`. Why:

- **One mechanism covers both halves of the issue.** The explicit projection binds, and the semijoin's `LOGICAL_WHERE_CLAUSE` evaluates against a real NULL column — exact SQL NULL semantics for every operator, no predicate pruning/rewriting.
- **`SchemaProjection` stays schema-pure**, so the per-schema `ProjectionCache` (#142) is untouched.
- Derivation lives only in `injectDuckDBTemplateParams`, the single funnel both `CompileDuckDBQuery` and the direct builder pass through — skeleton and direct render structurally cannot disagree (pinned by `TestCompiledQueryParity`, now including keyset/hot-excluded rows with non-empty missing sets and a non-vacuity guard).

**Cold union source:** the #189 pre-read validator already DESCRIBEs every new footer (write-once cache) and expands globs per query; it now caches each path's column map and returns `(union, complete)`. **Only a complete union may augment** — augmenting a column that exists in an unprobed file would collide with the real column — so inconclusive cases keep today's loud, classified, degradable failure. `DuckDBNullScanType` mirrors the hot-leg EAV pivot types case-for-case so the UNION ALL cannot widen (#205 stays closed). Benchmark schemas (100–102) are exempt end-to-end.

## Plan-cache poisoning (the issue's mandatory hazard)

The rendered SQL now depends on the missing set, so the missing set joins the compiled-plan **scope hash** (`scope-v2`, `"cold-missing"` marker, name-sorted). Manifest-authored path sets already re-key on flush (paths are in the scope), but **glob-hint path strings do not change when the first flush lands the column** — the per-query recomputation of the missing set is then the only re-keying signal. Proven at the integration seam by `TestEngineColdMissingSetRekeysPlanCache` (real `WithPlanCache` engine, constant path set, miss→hit→miss with only the footer union changing; mutation-verified: removing the cold-missing scope component makes the stale NULL-projecting skeleton serve — the exact poisoning) plus `TestDuckPlanScopePartsIncludeColdMissingSet` at the unit seam.

## Adjudications (user-ruled during review)

- **Glob listing skew — accepted and documented** (code comment at the augmentation site + design.md): the validator's glob expansion and the scan's `read_parquet` are separate S3 LISTs, so a flush landing between them can collide the NULL alias with the newly-landed real column — a one-time loud classified failure that self-heals on the next query. Strictly better than the status quo, where every such query fails.
- Final review found the e2e's plan-cache probe was structurally vacuous (the production harness engine wires no plan cache — factory does; suite-wide gap now filed as #345); the genuine re-key proof moved to the engine-level unit test above and the e2e comments state exactly what the probe does prove.

## Verification

- Red-first: e2e committed failing with `Binder Error: Referenced column "score" not found` at the full-scan probe; green after wiring.
- `go test -tags=e2e ./internal/e2e_harness/production/ -run 'TestSchemaEvolution|TestParquetCorruption|TestManifestConsistency'` — 15/15 (six evolution scenarios, six corruption incl. `_WrongSchemaFile`/`_WrongTypeFile`, two manifest, the new #255 test).
- `make test` — all packages green (`-count=1` forced on sqlgen/federated/queryplan).
- `make lint` — clean (pinned v1.64.8).
- Design-doc guard `TestDesignDoc*` — green with the §5 fence untouched; new §5-adjacent note documents the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)