### PR TITLE
fix(httpapi): finish UseNumber adoption — exact validation instances, pointer-shape sidecar, HTTP round-trip probe (#282)

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -418,7 +418,7 @@ delegates to it, and `executeGet` (`internal/httpapi/server.go:175`) calls
 
 Handlers also call `writeError` directly — 33 sites in `server.go` — and those
 bodies are verbatim without passing the gate. They are safe because every one of
-them reports a request-parsing failure (`parsePath`, `readEntityJSONBody`,
+them reports a request-parsing failure (`parsePath`, `readJSONBody`,
 `parseUUID`, `parseCreateObjects`, `parseSortParams`); none touches the manager,
 the engine, S3, or `PG_CONN`. What holds that line is the source-level guard
 `TestWriteErrorAlwaysCarriesALiteral4xxStatus`

--- a/internal/e2e_harness/production/http_bigint_roundtrip_e2e_test.go
+++ b/internal/e2e_harness/production/http_bigint_roundtrip_e2e_test.go
@@ -1,0 +1,80 @@
+//go:build e2e
+
+package production
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/httpapi"
+)
+
+// TestHTTPBigintRoundTripAbove2p53 is #282's acceptance probe: an integer
+// payload above 2^53 must survive the full HTTP surface — UseNumber decode,
+// JSON-schema validation, the exact-int64 transform sidecar, bound-column
+// storage — and read back over HTTP as the same literal. Pre-#284 the default
+// decoder rounded it at the door regardless of #205's exact write path.
+func TestHTTPBigintRoundTripAbove2p53(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	wide := DefaultSchemaFixtures()[1]
+
+	srv := httptest.NewServer(httpapi.NewServer(env.EntityManager(), httpapi.Options{}).Handler())
+	defer srv.Close()
+
+	literals := []string{
+		"9007199254740993",     // 2^53+1: first integer float64 cannot represent
+		"9223372036854775807",  // MaxInt64
+		"-9223372036854775807", // -MaxInt64 (pre-#205 rounded to MinInt64)
+	}
+	for _, lit := range literals {
+		t.Run(lit, func(t *testing.T) {
+			body := fmt.Sprintf(`{"title":"http-bigint-%s","amount":%s}`, lit, lit)
+			resp, err := http.Post(srv.URL+"/api/v1/"+wide.Name, "application/json", bytes.NewReader([]byte(body)))
+			if err != nil {
+				t.Fatalf("create request: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusCreated {
+				t.Fatalf("create status = %d, want %d", resp.StatusCode, http.StatusCreated)
+			}
+			var created struct {
+				RowID string `json:"row_id"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+				t.Fatalf("decode create response: %v", err)
+			}
+			if created.RowID == "" {
+				t.Fatal("create response carries no row_id")
+			}
+
+			getResp, err := http.Get(srv.URL + "/api/v1/" + wide.Name + "/" + created.RowID)
+			if err != nil {
+				t.Fatalf("get request: %v", err)
+			}
+			defer getResp.Body.Close()
+			if getResp.StatusCode != http.StatusOK {
+				t.Fatalf("get status = %d, want %d", getResp.StatusCode, http.StatusOK)
+			}
+			var record struct {
+				Attributes map[string]any `json:"attributes"`
+			}
+			dec := json.NewDecoder(getResp.Body)
+			dec.UseNumber()
+			if err := dec.Decode(&record); err != nil {
+				t.Fatalf("decode get response: %v", err)
+			}
+			got, ok := record.Attributes["amount"]
+			if !ok {
+				t.Fatalf("get response missing amount attribute: %v", record.Attributes)
+			}
+			if want := json.Number(lit); got != want {
+				t.Fatalf("amount round-tripped as %#v (%T), want %#v", got, got, want)
+			}
+		})
+	}
+}

--- a/internal/httpapi/error_leak_test.go
+++ b/internal/httpapi/error_leak_test.go
@@ -287,7 +287,7 @@ var writeErrorAllowed4xx = map[string]bool{
 // *status* expression; it cannot tell whether the third argument is safe to
 // disclose. That judgement belongs to canDiscloseVerbatim inside
 // respondErrorWithStatus, and the direct call sites stay safe only because their
-// messages come from request parsing (parsePath, readEntityJSONBody, parseUUID,
+// messages come from request parsing (parsePath, readJSONBody, parseUUID,
 // parseCreateObjects, parseSortParams), never from the manager, the engine, S3,
 // or PG_CONN.
 func TestWriteErrorAlwaysCarriesALiteral4xxStatus(t *testing.T) {

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -78,7 +78,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	zap.S().Infow("create request received", "schema", schemaName)
 
 	var rawBody any
-	if err := readEntityJSONBody(r, &rawBody); err != nil {
+	if err := readJSONBody(r, &rawBody); err != nil {
 		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid json body: %v", err))
 		return
 	}
@@ -266,7 +266,7 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body map[string]any
-	if err := readEntityJSONBody(r, &body); err != nil {
+	if err := readJSONBody(r, &body); err != nil {
 		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid json body: %v", err))
 		return
 	}
@@ -619,17 +619,11 @@ func parseUUID(s string) (uuid.UUID, error) {
 	return uuid.Parse(s)
 }
 
-// readJSONBody reads and decodes JSON from request body.
+// readJSONBody reads and decodes JSON from the request body. Numeric literals
+// decode as json.Number so integer attribute values above 2^53 reach any-typed
+// sinks (entity data maps) undamaged (#205, #282); decoding into typed struct
+// fields is unaffected by UseNumber.
 func readJSONBody(r *http.Request, v any) error {
-	defer r.Body.Close()
-	return json.NewDecoder(r.Body).Decode(v)
-}
-
-// readEntityJSONBody decodes an entity data payload with json.Number for
-// numeric literals, so integer attribute values above 2^53 reach the
-// transform chain undamaged (#205). Non-entity payloads (row-id arrays,
-// typed query requests) keep readJSONBody's plain decoding.
-func readEntityJSONBody(r *http.Request, v any) error {
 	defer r.Body.Close()
 	dec := json.NewDecoder(r.Body)
 	dec.UseNumber()

--- a/internal/httpapi/utils_test.go
+++ b/internal/httpapi/utils_test.go
@@ -1,8 +1,12 @@
 package httpapi
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/lychee-technology/forma"
@@ -161,5 +165,22 @@ func TestParseSortParams(t *testing.T) {
 				t.Fatalf("expected order %q, got %q", tt.wantOrder, order)
 			}
 		})
+	}
+}
+
+// TestReadJSONBodyDecodesNumbersExactly guards #282: every HTTP body decode
+// must deliver json.Number for numeric literals landing in any-typed sinks,
+// so no payload rides float64 at the door.
+func TestReadJSONBodyDecodesNumbersExactly(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"n": 9007199254740993}`))
+
+	var decoded map[string]any
+	if err := readJSONBody(req, &decoded); err != nil {
+		t.Fatalf("readJSONBody: %v", err)
+	}
+
+	got := decoded["n"]
+	if want := json.Number("9007199254740993"); got != want {
+		t.Fatalf("decoded[n] = %#v (%T), want %#v", got, got, want)
 	}
 }

--- a/internal/schemavalidate/number_instance.go
+++ b/internal/schemavalidate/number_instance.go
@@ -1,0 +1,53 @@
+package schemavalidate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// exactNumberInstance rewrites every json.Number in a decoded instance tree
+// to int64 (when the literal is integral and in int64 range) or float64
+// (otherwise), recursing through objects and arrays.
+//
+// The rewrite exists because jsonschema-go classifies a raw json.Number as
+// type "string" (jsonType switches on reflect.Kind), while int64 and float64
+// classify as "integer"/"number"; numeric constraint checks (minimum,
+// maximum, multipleOf, enum, const) compare via big.Rat, so an int64 instance
+// keeps full exactness above 2^53 where a float64 instance silently rounded
+// (#282).
+//
+// It mutates the tree in place and must only receive Validate's private
+// round-tripped copy, never the caller's document (#312 relies on the stored
+// doc keeping its original values).
+func exactNumberInstance(v any) (any, error) {
+	switch t := v.(type) {
+	case json.Number:
+		if i, err := t.Int64(); err == nil {
+			return i, nil
+		}
+		if f, err := t.Float64(); err == nil {
+			return f, nil
+		}
+		return nil, fmt.Errorf("numeric literal %q fits neither int64 nor float64", t.String())
+	case map[string]any:
+		for key, item := range t {
+			converted, err := exactNumberInstance(item)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert numeric value at property %q: %w", key, err)
+			}
+			t[key] = converted
+		}
+		return t, nil
+	case []any:
+		for i, item := range t {
+			converted, err := exactNumberInstance(item)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert numeric value at index %d: %w", i, err)
+			}
+			t[i] = converted
+		}
+		return t, nil
+	default:
+		return v, nil
+	}
+}

--- a/internal/schemavalidate/number_instance.go
+++ b/internal/schemavalidate/number_instance.go
@@ -25,10 +25,11 @@ func exactNumberInstance(v any) (any, error) {
 		if i, err := t.Int64(); err == nil {
 			return i, nil
 		}
-		if f, err := t.Float64(); err == nil {
-			return f, nil
+		f, err := t.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("numeric literal %q fits neither int64 nor float64: %w", t.String(), err)
 		}
-		return nil, fmt.Errorf("numeric literal %q fits neither int64 nor float64", t.String())
+		return f, nil
 	case map[string]any:
 		for key, item := range t {
 			converted, err := exactNumberInstance(item)

--- a/internal/schemavalidate/number_instance_test.go
+++ b/internal/schemavalidate/number_instance_test.go
@@ -1,0 +1,74 @@
+package schemavalidate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateChecksBoundsAbove2p53 guards #282: the validation instance must
+// carry integers exactly. Pre-#282 the round-trip decode rode float64, so
+// 2^53+1 rounded to exactly 2^53 and slipped past a maximum of 2^53 even
+// though the stored value (exact via the transform sidecar) violated it.
+func TestValidateChecksBoundsAbove2p53(t *testing.T) {
+	dir := shippedSchemaDir(t)
+	schema := `{"type":"object","properties":{"amount":{"type":"integer","maximum":9007199254740992}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	require.NoError(t, v.Validate(3, map[string]any{"amount": json.Number("9007199254740992")}))
+
+	err = v.Validate(3, map[string]any{"amount": json.Number("9007199254740993")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}
+
+// TestValidateNumberInstanceTypeChecks pins that the exact-number rewrite
+// keeps jsonschema type checking intact: a raw json.Number would classify as
+// "string" if it leaked through (jsonType has no json.Number case), and a
+// fractional literal must satisfy "number" but not "integer".
+func TestValidateNumberInstanceTypeChecks(t *testing.T) {
+	dir := shippedSchemaDir(t)
+	schema := `{"type":"object","properties":{"i":{"type":"integer"},"f":{"type":"number"}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	require.NoError(t, v.Validate(3, map[string]any{"i": json.Number("9223372036854775807")}))
+	require.NoError(t, v.Validate(3, map[string]any{"f": json.Number("1.5")}))
+
+	err = v.Validate(3, map[string]any{"i": json.Number("1.5")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}
+
+// TestValidateNumericEnumEquality pins enum comparison across the int64
+// rewrite: jsonschema-go compares numbers via big.Rat, so an int64 instance
+// must still match a float64-decoded schema enum literal.
+func TestValidateNumericEnumEquality(t *testing.T) {
+	dir := shippedSchemaDir(t)
+	schema := `{"type":"object","properties":{"level":{"enum":[1,2,3]}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	require.NoError(t, v.Validate(3, map[string]any{"level": json.Number("2")}))
+
+	err = v.Validate(3, map[string]any{"level": json.Number("4")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}
+
+// TestValidateNestedNumbersAbove2p53 pins that the rewrite walks nested
+// objects and arrays, not just top-level properties.
+func TestValidateNestedNumbersAbove2p53(t *testing.T) {
+	dir := shippedSchemaDir(t)
+	schema := `{"type":"object","properties":{"o":{"type":"object","properties":{"xs":{"type":"array","items":{"type":"integer","maximum":9007199254740992}}}}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	doc := map[string]any{"o": map[string]any{"xs": []any{json.Number("9007199254740993")}}}
+	err = v.Validate(3, doc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}

--- a/internal/schemavalidate/validator.go
+++ b/internal/schemavalidate/validator.go
@@ -14,6 +14,7 @@
 package schemavalidate
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -249,7 +250,8 @@ func New(registry forma.SchemaRegistry, schemaDir string) (*Validator, error) {
 // doc is marshalled before validating. Native Go values do not carry their JSON
 // types: time.Time presents as an object and fails a "type":"string" property
 // until round-tripped, and two production call sites assign time.Now() to
-// string-typed properties.
+// string-typed properties. The round-trip decodes with UseNumber and rewrites
+// numbers via exactNumberInstance so constraint checks stay exact above 2^53.
 //
 // A nil receiver is treated as "no schema resolved" rather than panicking:
 // callers may hold a *Validator that is nil when validation is unconfigured.
@@ -267,8 +269,14 @@ func (v *Validator) Validate(schemaID int16, doc any) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal payload for schema %d: %w", schemaID, err)
 	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
 	var instance any
-	if err := json.Unmarshal(raw, &instance); err != nil {
+	if err := dec.Decode(&instance); err != nil {
+		return fmt.Errorf("failed to decode payload for schema %d: %w", schemaID, err)
+	}
+	instance, err = exactNumberInstance(instance)
+	if err != nil {
 		return fmt.Errorf("failed to decode payload for schema %d: %w", schemaID, err)
 	}
 

--- a/internal/schemavalidate/validator_test.go
+++ b/internal/schemavalidate/validator_test.go
@@ -1,6 +1,7 @@
 package schemavalidate
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -469,4 +470,69 @@ func writeSchemaFile(t *testing.T, dir, name, body string) {
 	full := filepath.Join(dir, name)
 	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
 	require.NoError(t, os.WriteFile(full, []byte(body), 0o600))
+}
+
+// TestValidateChecksBoundsAbove2p53 guards #282: the validation instance must
+// carry integers exactly. Pre-#282 the round-trip decode rode float64, so
+// 2^53+1 rounded to exactly 2^53 and slipped past a maximum of 2^53 even
+// though the stored value (exact via the transform sidecar) violated it.
+func TestValidateChecksBoundsAbove2p53(t *testing.T) {
+	dir := shippedSchemaDir(t)
+	schema := `{"type":"object","properties":{"amount":{"type":"integer","maximum":9007199254740992}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	require.NoError(t, v.Validate(3, map[string]any{"amount": json.Number("9007199254740992")}))
+
+	err = v.Validate(3, map[string]any{"amount": json.Number("9007199254740993")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}
+
+// TestValidateNumberInstanceTypeChecks pins that the exact-number rewrite
+// keeps jsonschema type checking intact: a raw json.Number would classify as
+// "string" if it leaked through (jsonType has no json.Number case), and a
+// fractional literal must satisfy "number" but not "integer".
+func TestValidateNumberInstanceTypeChecks(t *testing.T) {
+	dir := shippedSchemaDir(t)
+	schema := `{"type":"object","properties":{"i":{"type":"integer"},"f":{"type":"number"}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	require.NoError(t, v.Validate(3, map[string]any{"i": json.Number("9223372036854775807")}))
+	require.NoError(t, v.Validate(3, map[string]any{"f": json.Number("1.5")}))
+
+	err = v.Validate(3, map[string]any{"i": json.Number("1.5")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}
+
+// TestValidateNumericEnumEquality pins enum comparison across the int64
+// rewrite: jsonschema-go compares numbers via big.Rat, so an int64 instance
+// must still match a float64-decoded schema enum literal.
+func TestValidateNumericEnumEquality(t *testing.T) {
+	dir := shippedSchemaDir(t)
+	schema := `{"type":"object","properties":{"level":{"enum":[1,2,3]}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	require.NoError(t, v.Validate(3, map[string]any{"level": json.Number("2")}))
+
+	err = v.Validate(3, map[string]any{"level": json.Number("4")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}
+
+// TestValidateNestedNumbersAbove2p53 pins that the rewrite walks nested
+// objects and arrays, not just top-level properties.
+func TestValidateNestedNumbersAbove2p53(t *testing.T) {
+	dir := shippedSchemaDir(t)
+	schema := `{"type":"object","properties":{"o":{"type":"object","properties":{"xs":{"type":"array","items":{"type":"integer","maximum":9007199254740992}}}}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	doc := map[string]any{"o": map[string]any{"xs": []any{json.Number("9007199254740993")}}}
+	err = v.Validate(3, doc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
 }

--- a/internal/schemavalidate/validator_test.go
+++ b/internal/schemavalidate/validator_test.go
@@ -1,7 +1,6 @@
 package schemavalidate
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -470,69 +469,4 @@ func writeSchemaFile(t *testing.T, dir, name, body string) {
 	full := filepath.Join(dir, name)
 	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
 	require.NoError(t, os.WriteFile(full, []byte(body), 0o600))
-}
-
-// TestValidateChecksBoundsAbove2p53 guards #282: the validation instance must
-// carry integers exactly. Pre-#282 the round-trip decode rode float64, so
-// 2^53+1 rounded to exactly 2^53 and slipped past a maximum of 2^53 even
-// though the stored value (exact via the transform sidecar) violated it.
-func TestValidateChecksBoundsAbove2p53(t *testing.T) {
-	dir := shippedSchemaDir(t)
-	schema := `{"type":"object","properties":{"amount":{"type":"integer","maximum":9007199254740992}}}`
-	v, err := New(registryWith(t, "ev", schema, 3), dir)
-	require.NoError(t, err)
-
-	require.NoError(t, v.Validate(3, map[string]any{"amount": json.Number("9007199254740992")}))
-
-	err = v.Validate(3, map[string]any{"amount": json.Number("9007199254740993")})
-	require.Error(t, err)
-	require.ErrorIs(t, err, forma.ErrInvalidInput)
-}
-
-// TestValidateNumberInstanceTypeChecks pins that the exact-number rewrite
-// keeps jsonschema type checking intact: a raw json.Number would classify as
-// "string" if it leaked through (jsonType has no json.Number case), and a
-// fractional literal must satisfy "number" but not "integer".
-func TestValidateNumberInstanceTypeChecks(t *testing.T) {
-	dir := shippedSchemaDir(t)
-	schema := `{"type":"object","properties":{"i":{"type":"integer"},"f":{"type":"number"}}}`
-	v, err := New(registryWith(t, "ev", schema, 3), dir)
-	require.NoError(t, err)
-
-	require.NoError(t, v.Validate(3, map[string]any{"i": json.Number("9223372036854775807")}))
-	require.NoError(t, v.Validate(3, map[string]any{"f": json.Number("1.5")}))
-
-	err = v.Validate(3, map[string]any{"i": json.Number("1.5")})
-	require.Error(t, err)
-	require.ErrorIs(t, err, forma.ErrInvalidInput)
-}
-
-// TestValidateNumericEnumEquality pins enum comparison across the int64
-// rewrite: jsonschema-go compares numbers via big.Rat, so an int64 instance
-// must still match a float64-decoded schema enum literal.
-func TestValidateNumericEnumEquality(t *testing.T) {
-	dir := shippedSchemaDir(t)
-	schema := `{"type":"object","properties":{"level":{"enum":[1,2,3]}}}`
-	v, err := New(registryWith(t, "ev", schema, 3), dir)
-	require.NoError(t, err)
-
-	require.NoError(t, v.Validate(3, map[string]any{"level": json.Number("2")}))
-
-	err = v.Validate(3, map[string]any{"level": json.Number("4")})
-	require.Error(t, err)
-	require.ErrorIs(t, err, forma.ErrInvalidInput)
-}
-
-// TestValidateNestedNumbersAbove2p53 pins that the rewrite walks nested
-// objects and arrays, not just top-level properties.
-func TestValidateNestedNumbersAbove2p53(t *testing.T) {
-	dir := shippedSchemaDir(t)
-	schema := `{"type":"object","properties":{"o":{"type":"object","properties":{"xs":{"type":"array","items":{"type":"integer","maximum":9007199254740992}}}}}}`
-	v, err := New(registryWith(t, "ev", schema, 3), dir)
-	require.NoError(t, err)
-
-	doc := map[string]any{"o": map[string]any{"xs": []any{json.Number("9007199254740993")}}}
-	err = v.Validate(3, doc)
-	require.Error(t, err)
-	require.ErrorIs(t, err, forma.ErrInvalidInput)
 }

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -335,6 +335,12 @@ func toBoolForEAV(value any) (bool, error) {
 			return false, err
 		}
 		return float64ToBool(num), nil
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return false, fmt.Errorf("cannot convert json.Number %q to bool: %w", v.String(), err)
+		}
+		return f != 0, nil
 	default:
 		return false, fmt.Errorf("cannot convert %T to bool", value)
 	}

--- a/internal/transform/attribute_converter_test.go
+++ b/internal/transform/attribute_converter_test.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -88,6 +89,33 @@ func TestToBoolForEAV(t *testing.T) {
 		{"ptr float64 nil", (*float64)(nil), false, true},
 
 		{"unsupported slice", []int{1, 2}, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toBoolForEAV(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("toBoolForEAV(%#v) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("toBoolForEAV(%#v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToBoolForEAVJSONNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   json.Number
+		want    bool
+		wantErr bool
+	}{
+		{"json.Number 1", json.Number("1"), true, false},
+		{"json.Number 0", json.Number("0"), false, false},
+		{"json.Number 2", json.Number("2"), true, false},
+		{"json.Number -1", json.Number("-1"), true, false},
+		{"json.Number invalid", json.Number("abc"), false, true},
 	}
 
 	for _, tt := range tests {

--- a/internal/transform/bigint_precision_test.go
+++ b/internal/transform/bigint_precision_test.go
@@ -122,3 +122,42 @@ func TestToPersistentRecordClearsSidecarForEAVOnlyBigint(t *testing.T) {
 		"EAV-only bigint must not carry the exact sidecar")
 	require.NotNil(t, rec.OtherAttributes[0].ValueNumeric)
 }
+
+// TestToInt64ExactForEAVPointerShapes guards the #282 fold-in of the #205
+// final-review gap: every integral pointer shape toFloat64ForEAV accepts must
+// also reach the exact-int64 sidecar, or the value silently rides the float64
+// fallback and rounds above 2^53.
+func TestToInt64ExactForEAVPointerShapes(t *testing.T) {
+	i := int(9007199254740993)
+	i16 := int16(32767)
+	i32 := int32(2147483647)
+	i64 := int64(math.MaxInt64)
+	f64 := float64(1 << 50)
+	s := "9007199254740993"
+
+	cases := []struct {
+		name  string
+		value any
+		want  int64
+	}{
+		{"ptr-int", &i, 9007199254740993},
+		{"ptr-int16", &i16, 32767},
+		{"ptr-int32", &i32, 2147483647},
+		{"ptr-int64", &i64, math.MaxInt64},
+		{"ptr-float64-integral", &f64, 1 << 50},
+		{"ptr-string-integer", &s, 9007199254740993},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := toInt64ExactForEAV(tc.value)
+			if !ok || got != tc.want {
+				t.Fatalf("toInt64ExactForEAV(%T) = (%d, %t), want (%d, true)", tc.value, got, ok, tc.want)
+			}
+		})
+	}
+
+	var nilInt *int
+	if _, ok := toInt64ExactForEAV(nilInt); ok {
+		t.Fatal("nil *int must not report exact")
+	}
+}

--- a/internal/transform/typed_value.go
+++ b/internal/transform/typed_value.go
@@ -98,13 +98,36 @@ func toString(value any) (string, error) {
 }
 
 // toInt64ExactForEAV mirrors numutil.Int64Exact but also accepts the pointer
-// shapes ToEAVRecord tolerates for numeric values.
+// shapes ToEAVRecord tolerates for numeric values (#282): every pointer type
+// toFloat64ForEAV dereferences must also reach the exact path, or the value
+// silently rides the float64 fallback and rounds above 2^53. *float32 is
+// deliberately absent: numutil.Int64Exact has no float32 case, and a float32
+// cannot hold an integer wide enough to need the exact sidecar.
 func toInt64ExactForEAV(value any) (int64, bool) {
-	if p, ok := value.(*int64); ok {
-		if p == nil {
-			return 0, false
-		}
-		return *p, true
+	switch p := value.(type) {
+	case *int64:
+		return derefInt64Exact(p)
+	case *int:
+		return derefInt64Exact(p)
+	case *int16:
+		return derefInt64Exact(p)
+	case *int32:
+		return derefInt64Exact(p)
+	case *float64:
+		return derefInt64Exact(p)
+	case *string:
+		return derefInt64Exact(p)
+	default:
+		return numutil.Int64Exact(value)
 	}
-	return numutil.Int64Exact(value)
+}
+
+// derefInt64Exact dereferences a pointer shape and delegates to
+// numutil.Int64Exact; a nil pointer reports not-exact so the caller keeps the
+// existing nil handling of the float64 path.
+func derefInt64Exact[T any](p *T) (int64, bool) {
+	if p == nil {
+		return 0, false
+	}
+	return numutil.Int64Exact(*p)
 }


### PR DESCRIPTION
Closes #282.

Finishes the `dec.UseNumber()` adoption decided on #282 (option 1). PR #284 already covered the entity create/update decode sites; this PR closes the remaining surface:

- **`internal/httpapi`** — `readJSONBody` and `readEntityJSONBody` are merged into a single `readJSONBody` that always decodes with `UseNumber`. For the two remaining plain callers this is provably a no-op (`handleDelete` decodes `[]string`; `handleAdvancedQuery` decodes the fully-typed `forma.QueryRequest`, whose custom `UnmarshalJSON` receives raw bytes and whose condition values are the `"op:value"` string DSL) — but it removes the float64-at-the-door trap for any future `any`-typed payload. Pinned by `TestReadJSONBodyDecodesNumbersExactly`.
- **`internal/schemavalidate`** — the real finding of the consumer audit: `Validate`'s marshal→unmarshal round-trip re-decoded with a plain decoder, so the *validation instance* rode float64 and numeric bounds silently rounded above 2^53 (a `maximum: 2^53` failed to catch `2^53+1` while storage kept the exact value). The round-trip now decodes with `UseNumber` and rewrites every `json.Number` to `int64`/`float64` via `exactNumberInstance` before validating. The rewrite is mandatory: jsonschema-go v0.4.2's `jsonType` classifies a raw `json.Number` as `"string"` (it switches on `reflect.Kind`), which would fail every `"type": "integer"` property, while `int64` classifies as `"integer"` and all numeric constraint checks (`minimum`/`maximum`/`multipleOf`, `enum`, `const`) compare via `big.Rat` — exact. The rewrite mutates only `Validate`'s private round-tripped copy; the caller's document is untouched (#312/#314 constraint).
- **`internal/transform`** — the #205-final-review fold-in: `toInt64ExactForEAV` now dereferences `*int`/`*int16`/`*int32`/`*float64`/`*string` (previously only `*int64`), so those pointer shapes reach the exact-int64 sidecar instead of riding the float64 fallback. `*float32` is deliberately absent (every float32-representable integer is losslessly representable in float64). Plus `toBoolForEAV` gains the `json.Number` case mirroring `toBool` (see audit table).
- **Acceptance (e2e)** — `TestHTTPBigintRoundTripAbove2p53`: the production harness's real `EntityManager` (validator wired) behind the real `httpapi` server via `httptest`; POST `9007199254740993` / `±MaxInt64` as raw JSON integer literals, GET back by `row_id`, assert the exact literal in the response. Full `make test-e2e-production` green.

## Consumer audit (mandated by the decision comment)

| Consumer of UseNumber-decoded maps | State |
|---|---|
| Transform chain — numeric (`numutil.Int64Exact`, `numutil.Float64`) and `toBool` | ✅ handled since #205/#284 |
| Transform chain — `toBoolForEAV` | ⚠️ had no `json.Number` case (gap dates to #284). Fixed here mirroring `toBool` (`f != 0`). Note: on the current production chain, bool values are normalized before reaching it (`populateTypedValue` → `FromEAVRecords` hands back Go `bool`), so this is defense-in-depth, not a reproducible failure |
| `schemavalidate.Validator.Validate` | ❌ was rounding the validation instance → **fixed in this PR** |
| Relation handling (`entity_relation_service.go` et al.) | ✅ no numeric type-switches; relation values are UUID strings |
| Query condition parsing | N/A — `KvCondition.Value` is a string DSL parsed by `conditionexpr` + `TryParseNumber` (int64-exact for integral literals); never sees decoder output. Comparison-side exactness is #281 |
| `model.ParseAttributesJSON` (`.(float64)` asserts) | ✅ decodes DB-side JSON_AGG output internally; never sees an HTTP body |
| `model.EntityAttribute.Numeric()/BigInt()` | ✅ no non-test callers |
| `schemameta/schema_parser.go` | ✅ parses schema documents loaded internally, not request payloads |

## Known boundaries (documented, deliberate)

- **Exactness ceiling:** integral literals ≥2^63 still fall back to float64 in the validation instance (and int64 storage cannot hold them anyway) — unchanged semantics.
- **Schema-side bounds round:** jsonschema-go's `Minimum`/`Maximum`/`ExclusiveMin`/`Max`/`MultipleOf` are `*float64`, so a schema-declared bound above 2^53 is itself rounded by the library. This PR makes the *instance* exact, not the *bound*.
- **Pre-existing since #284 (not introduced here):** a literal outside float64 range (e.g. `1e400`) now passes the boundary decode (json.Number is lazy) and fails in `Validate`'s round-trip as a plain error → 500, where pre-#284 the boundary decode 400'd. It is caller input and arguably deserves `forma.ErrInvalidInput` → 4xx; follow-up candidate.
- **e2e anchor note:** the MaxInt64 subtest is not a reliable pre-fix red anchor on arm64 (float→int saturation false-pass, the #174 hazard); the `2^53+1` and `-MaxInt64` subtests carry the platform-independent proof.

## Sequencing

This lands **before** #281 (per the decision comment): the comparison-side audit can now trace a final decoder that delivers `json.Number`, not a state about to change. No comparison/keyset code is touched here.

## Verification

- `make test` green; `make lint` (pinned golangci-lint v1.64.8) clean; `go test -race` on the three touched packages green.
- Targeted e2e 3/3 + full `make test-e2e-production` green (131s).
- Four-task subagent execution with per-task spec+quality reviews, one whole-branch final review (finding fixed in `b3bd76e`), scoped re-reviews after every fix round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
