### PR TITLE
fix(sqlgen): exact bigint comparison binds above 2^53 — predicates both dialects, keyset contract pinned (#281)

### DIFF
--- a/docs/federated-query/requirements.md
+++ b/docs/federated-query/requirements.md
@@ -736,6 +736,15 @@ def decode_cursor(encoded: str) -> Cursor:
     )
 ```
 
+**Decoder numeric exactness (#281):** the decoder MUST NOT route numeric cursor
+fields through a default JSON number path — Go's `encoding/json` decodes into
+`float64`, which silently rounds integers above 2^53 and makes the resulting
+`BIGINT col > DOUBLE param` boundary skip or duplicate one row of the next page.
+Integer sort keys must either stay strings (as the pseudocode's `sk` already
+models) or decode via `json.Number` to an exact `int64` (`numutil.Int64Exact`)
+before reaching `model.KeysetCursor.Values`, which the SQL generator binds
+verbatim without coercion (pinned by `TestKeysetArgsPreserveInt64Above2p53`).
+
 ### 6.4 Backward Pagination SQL
 
 ```sql

--- a/internal/e2e_harness/production/bigint_filter_boundary_e2e_test.go
+++ b/internal/e2e_harness/production/bigint_filter_boundary_e2e_test.go
@@ -1,0 +1,114 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// boundaryProbe is one filter probe plus the exact set of seeded rows it must
+// return. The expectation is a row-identity set, never an oracle comparison:
+// the oracle normalizes numerics to float64 (oracle.go) and is structurally
+// blind to a 2^53 miss.
+type boundaryProbe struct {
+	name   string
+	filter Filter
+	want   []*Event
+}
+
+// TestBigintFilterBoundaryBothDialects (#281) probes comparison-side exactness
+// for a bound bigint above 2^53 on both binder paths: PreferHot (Postgres,
+// ConvertPgMainValue int64) and federated (DuckDB, parseDuckDBRawParam → exact
+// decimal string). Pre-#281 the DuckDB binder rode float64 + %.15g, so
+// equals:9007199254740993 bound 9007199254740992 and matched the WRONG row —
+// hot and cold tiers disagreed on the same filter. #205 made those values legal
+// column state, so the filter has to be able to address them.
+func TestBigintFilterBoundaryBothDialects(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	atPow53 := CreateEvent(wide, map[string]any{"title": "b-2p53", "amount": int64(1) << 53})        // 9007199254740992
+	abovePow53 := CreateEvent(wide, map[string]any{"title": "b-2p53p1", "amount": int64(1)<<53 + 1}) // 9007199254740993
+	nearMax := CreateEvent(wide, map[string]any{"title": "b-maxm1", "amount": int64(math.MaxInt64) - 1})
+	atMax := CreateEvent(wide, map[string]any{"title": "b-max", "amount": int64(math.MaxInt64)})
+	seeded := []*Event{atPow53, abovePow53, nearMax, atMax}
+	if err := env.ApplyEvents(ctx, seeded...); err != nil {
+		t.Fatalf("apply boundary rows: %v", err)
+	}
+
+	probes := []boundaryProbe{
+		{"equals_2p53_plus_1", Filter{Attr: "amount", Op: "equals", Value: "9007199254740993"}, []*Event{abovePow53}},
+		{"equals_2p53_excludes_neighbor", Filter{Attr: "amount", Op: "equals", Value: "9007199254740992"}, []*Event{atPow53}},
+		{"gt_2p53_boundary", Filter{Attr: "amount", Op: "gt", Value: "9007199254740992"}, []*Event{abovePow53, nearMax, atMax}},
+		{"equals_maxint64_minus_1", Filter{Attr: "amount", Op: "equals", Value: "9223372036854775806"}, []*Event{nearMax}},
+		{"lte_maxint64_minus_1_excludes_max", Filter{Attr: "amount", Op: "lte", Value: "9223372036854775806"}, []*Event{atPow53, abovePow53, nearMax}},
+	}
+
+	// PG dialect: rows are unflushed, PreferHot short-circuits to postgres-only.
+	runBoundaryProbes(ctx, t, env, "hot-pg", Query{Schema: wide, PreferHot: true, Limit: 100}, false, probes)
+
+	// DuckDB dialect: export every row to base, then drop the change_log
+	// entries so the rows leave the dirty set and are served from cold parquet
+	// (the RunInit-plus-DELETE idiom of TestNullAndBoundaryRoundTripAcrossTiers;
+	// RunInit alone leaves the rows unflushed, i.e. still hot).
+	if _, err := env.RunInit(ctx, wide); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	env.ExecSQL(ctx,
+		"DELETE FROM change_log WHERE schema_id = $1 AND row_id = ANY($2)",
+		wide.ID, rowIDs(seeded))
+	runBoundaryProbes(ctx, t, env, "cold-duck", Query{Schema: wide, Limit: 100}, true, probes)
+}
+
+// runBoundaryProbes executes every probe against base and asserts the routing
+// dialect plus the exact row set. wantDuck pins which binder actually ran:
+// without it a mis-routed leg would silently retest the other dialect.
+func runBoundaryProbes(ctx context.Context, t *testing.T, env *Env, label string,
+	base Query, wantDuck bool, probes []boundaryProbe) {
+	t.Helper()
+	for _, p := range probes {
+		q := base
+		q.Filters = []Filter{p.filter}
+		res := mustQuery(ctx, t, env, q)
+		if got := res.Plan.Routing.UseDuckDB; got != wantDuck {
+			t.Errorf("%s/%s: UseDuckDB = %t, want %t (routing %+v)",
+				label, p.name, got, wantDuck, res.Plan.Routing)
+		}
+		assertExactBigintRowSet(t, label+"/"+p.name, res, p.want)
+	}
+}
+
+// assertExactBigintRowSet fails unless res.Records is exactly the given events
+// (as an unordered set) and each carries the exact seeded amount. Both halves
+// matter: a float64 bind can drop a row that should match AND admit its
+// neighbour, and only an exact-set assertion sees both.
+func assertExactBigintRowSet(t *testing.T, label string, res *QueryResult, want []*Event) {
+	t.Helper()
+	got := map[uuid.UUID]int64{}
+	for _, r := range res.Records {
+		got[r.RowID] = r.Int64Items["bigint_01"]
+	}
+	if len(got) != len(want) {
+		t.Errorf("%s: %d rows, want %d (got %v)", label, len(got), len(want), got)
+	}
+	for _, ev := range want {
+		amt, ok := got[ev.RowID]
+		if !ok {
+			t.Errorf("%s: missing row %s (%v)", label, ev.RowID, ev.Attrs["title"])
+			continue
+		}
+		wantAmt, isInt := ev.Attrs["amount"].(int64)
+		if !isInt {
+			t.Fatalf("%s: seeded amount for %v is %T, want int64", label, ev.Attrs["title"], ev.Attrs["amount"])
+		}
+		if amt != wantAmt {
+			t.Errorf("%s: row %s amount = %d, want %d", label, ev.RowID, amt, wantAmt)
+		}
+	}
+}

--- a/internal/e2e_harness/production/bigint_filter_boundary_e2e_test.go
+++ b/internal/e2e_harness/production/bigint_filter_boundary_e2e_test.go
@@ -23,10 +23,13 @@ type boundaryProbe struct {
 // TestBigintFilterBoundaryBothDialects (#281) probes comparison-side exactness
 // for a bound bigint above 2^53 on both binder paths: PreferHot (Postgres,
 // ConvertPgMainValue int64) and federated (DuckDB, parseDuckDBRawParam → exact
-// decimal string). Pre-#281 the DuckDB binder rode float64 + %.15g, so
-// equals:9007199254740993 bound 9007199254740992 and matched the WRONG row —
-// hot and cold tiers disagreed on the same filter. #205 made those values legal
-// column state, so the filter has to be able to address them.
+// decimal string). Pre-#281 the bind rendered via %.15g of the float64
+// ("9.00719925474099e+15" / "9.22337203685478e+18"), so the predicate could not
+// address these values at all — equality probes returned nothing (the rendered
+// literal is a value no row holds, and the MaxInt64-side literal overflows
+// CAST(? AS BIGINT) outright) and hot/cold tiers disagreed on the same filter.
+// #205 made those values legal column state, so the filter has to be able to
+// address them.
 func TestBigintFilterBoundaryBothDialects(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
@@ -86,8 +89,8 @@ func runBoundaryProbes(ctx context.Context, t *testing.T, env *Env, label string
 
 // assertExactBigintRowSet fails unless res.Records is exactly the given events
 // (as an unordered set) and each carries the exact seeded amount. Both halves
-// matter: a float64 bind can drop a row that should match AND admit its
-// neighbour, and only an exact-set assertion sees both.
+// matter: an inexact bind can drop a row that should match and/or admit one
+// that should not, and only an exact-set assertion sees both directions.
 func assertExactBigintRowSet(t *testing.T, label string, res *QueryResult, want []*Event) {
 	t.Helper()
 	got := map[uuid.UUID]int64{}

--- a/internal/e2e_harness/production/bigint_keyset_boundary_e2e_test.go
+++ b/internal/e2e_harness/production/bigint_keyset_boundary_e2e_test.go
@@ -1,0 +1,176 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	forma "github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// keysetBoundaryAmounts are the seeded `amount` (bigint_01) values in ascending
+// order. They straddle 2^53 and the int64 ceiling: 2^53+1 and MaxInt64-1 are the
+// two values a float64 cannot carry (they round to 2^53 and 2^63), so a
+// continuation cursor pinned to either one is exactly where a float64-bound
+// keyset predicate skips or duplicates a row. #205 made these legal column
+// state, so the cursor has to be able to address them.
+var keysetBoundaryAmounts = []int64{
+	1<<53 - 1,         // 9007199254740991 — last float64-exact integer
+	1 << 53,           // 9007199254740992
+	1<<53 + 1,         // 9007199254740993 — NOT float64-representable
+	1<<53 + 2,         // 9007199254740994
+	math.MaxInt64 - 1, // 9223372036854775806 — NOT float64-representable
+	math.MaxInt64,     // 9223372036854775807 — NOT float64-representable
+}
+
+// keysetWalkCase is one full continuation walk: a direction and a page size,
+// plus the exact ascending/descending sequence the walk must observe and the
+// exact `amount` values the continuation cursors must be pinned to. Pinning the
+// cursor values (not just the visited sequence) is what makes the probe
+// meaningful: the page arithmetic is chosen so that every walk positions at
+// least one cursor on a value float64 cannot represent, and a change that
+// silently re-pages away from those boundaries fails here instead of quietly
+// degrading into a float-exact walk.
+type keysetWalkCase struct {
+	name        string
+	desc        bool
+	pageSize    int
+	wantSeen    []int64
+	wantCursors []int64
+}
+
+// TestBigintKeysetBoundaryNoDupNoSkip (#281, #205 M-2) walks keyset cursors over
+// a bound bigint whose values straddle 2^53, building every continuation cursor
+// from the previous page's last record as exact int64 — the raw-bind contract
+// pinned by TestKeysetArgsPreserveInt64Above2p53 (cursor Values bind verbatim;
+// BIGINT columns require int64). Each walk must see every row exactly once, in
+// key order: with an inexact cursor value the `BIGINT col > DOUBLE param`
+// comparison rounds the bound and either re-serves the boundary row (dup) or
+// steps past its neighbour (skip).
+//
+// Keyset is a DuckDB-only feature (no Postgres keyset path exists), so every
+// page asserts Plan.Routing.UseDuckDB. The oracle is deliberately not used: it
+// normalizes numerics to float64 (oracle.go) and is structurally blind to a
+// 2^53 miss — assertions here are exact int64 sequences.
+//
+// A float64-cursor variant is deliberately not asserted: model.KeysetCursor is
+// in-process only (Query.Keyset's JSON tag is encode-only, no decode path
+// exists), so the binder contract makes the caller responsible for the types.
+func TestBigintKeysetBoundaryNoDupNoSkip(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	seeded := make([]*Event, 0, len(keysetBoundaryAmounts))
+	for _, amount := range keysetBoundaryAmounts {
+		seeded = append(seeded, CreateEvent(wide, map[string]any{"title": "ks-bigint", "amount": amount}))
+	}
+	mustApplyEvents(ctx, t, env, "keyset boundary creates", seeded...)
+
+	// Export every row to base, then drop its change_log entry so the rows leave
+	// the dirty set and are genuinely served from cold parquet (the RunInit-plus
+	// DELETE idiom of TestNullAndBoundaryRoundTripAcrossTiers / #281 Task 3;
+	// RunInit alone leaves the rows unflushed, i.e. still hot-served).
+	if _, err := env.RunInit(ctx, wide); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	env.ExecSQL(ctx,
+		"DELETE FROM change_log WHERE schema_id = $1 AND row_id = ANY($2)",
+		wide.ID, rowIDs(seeded))
+
+	// Positive control: the full set is readable before any cursor is involved.
+	assertRowCount(ctx, t, env, "keyset boundary control",
+		Query{Schema: wide, Limit: 100}, len(keysetBoundaryAmounts))
+
+	asc := keysetBoundaryAmounts
+	desc := reversedInt64s(asc)
+	for _, tc := range []keysetWalkCase{
+		// pages [0..2] [3..5] ⇒ the page-1 cursor sits on 2^53+1.
+		{"asc_page3", false, 3, asc, []int64{asc[2], asc[5]}},
+		// pages [0..4] [5] ⇒ the page-1 cursor sits on MaxInt64-1.
+		{"asc_page5", false, 5, asc, []int64{asc[4], asc[5]}},
+		// pages [0,1] [2,3] [4,5] ⇒ cursors on MaxInt64-1 and 2^53+1.
+		{"desc_page2", true, 2, desc, []int64{desc[1], desc[3], desc[5]}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runKeysetBoundaryWalk(ctx, t, env, wide, tc)
+		})
+	}
+}
+
+// runKeysetBoundaryWalk drives one walk to exhaustion and checks the visited
+// sequence and the continuation-cursor positions against the case.
+func runKeysetBoundaryWalk(ctx context.Context, t *testing.T, env *Env, wide SchemaRef, tc keysetWalkCase) {
+	t.Helper()
+
+	dir := forma.SortOrderAsc
+	if tc.desc {
+		dir = forma.SortOrderDesc
+	}
+	cols := []model.KeysetColumn{
+		{Attribute: "amount", Direction: dir},
+		// Required trailing tiebreak (#183). ASC on both directions matches the
+		// non-keyset ORDER BY that serves page 1 (buildNonKeysetOrderBy appends
+		// row_id ASC); amounts here are unique, so the arm never fires anyway.
+		{Attribute: "row_id", Direction: forma.SortOrderAsc},
+	}
+	sorts := []Sort{{Attr: "amount", Desc: tc.desc}} // mirror keyset_lww_e2e_test.go
+
+	var seen, cursorAt []int64
+	var cursor *model.KeysetCursor
+	maxPages := len(tc.wantSeen)/tc.pageSize + 3 // stop runaway loops on a dup
+	for page := 0; page < maxPages; page++ {
+		res := mustQuery(ctx, t, env, Query{
+			Schema: wide, Sorts: sorts, Limit: tc.pageSize, Keyset: cursor,
+		})
+		if !res.Plan.Routing.UseDuckDB {
+			t.Fatalf("page %d: keyset walk must route to DuckDB, got %+v", page, res.Plan.Routing)
+		}
+		if len(res.Records) == 0 {
+			break
+		}
+		for _, r := range res.Records {
+			seen = append(seen, r.Int64Items["bigint_01"])
+		}
+		// The continuation bound is the last record's exact int64 amount and its
+		// row_id string — never round-tripped through float64 or JSON.
+		last := res.Records[len(res.Records)-1]
+		bound := last.Int64Items["bigint_01"]
+		cursorAt = append(cursorAt, bound)
+		cursor = &model.KeysetCursor{
+			Columns: cols,
+			Values:  []any{bound, last.RowID.String()},
+			Mode:    model.KeysetCursorModeAfter,
+		}
+	}
+
+	assertInt64Seq(t, "visited sequence (skip or dup at the 2^53 boundary)", seen, tc.wantSeen)
+	assertInt64Seq(t, "continuation cursor positions", cursorAt, tc.wantCursors)
+}
+
+// assertInt64Seq requires two int64 sequences to be equal, reporting the first
+// divergence together with both full sequences.
+func assertInt64Seq(t *testing.T, label string, got, want []int64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %d values %v, want %d %v", label, len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s: [%d] = %d, want %d (got %v, want %v)", label, i, got[i], want[i], got, want)
+		}
+	}
+}
+
+// reversedInt64s returns a reversed copy, leaving the input untouched.
+func reversedInt64s(in []int64) []int64 {
+	out := make([]int64, len(in))
+	for i, v := range in {
+		out[len(in)-1-i] = v
+	}
+	return out
+}

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -119,7 +119,24 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		}
 		return valStr, nil
 
-	case forma.ValueTypeNumeric, forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt:
+	case forma.ValueTypeNumeric, forma.ValueTypeBigInt:
+		// Integral literals bind as exact int64 (#281): ToDuckDBParam renders
+		// int64 via %d, so a bigint predicate above 2^53 — legal column state
+		// since #205 — compares exactly instead of riding float64 + %.15g.
+		// Fractional literals keep float64, the numeric family's storage
+		// contract. EAV-only bigints round at write (2^53 ceiling), so exact
+		// binds above it miss on every tier alike — tier parity preserved.
+		if i, e := strconv.ParseInt(valStr, 10, 64); e == nil {
+			return i, nil
+		}
+		if f, e := strconv.ParseFloat(valStr, 64); e == nil {
+			return f, nil
+		}
+		return nil, fmt.Errorf("invalid numeric literal for %s: %s: %w", attr, valStr, forma.ErrInvalidInput)
+
+	case forma.ValueTypeSmallInt, forma.ValueTypeInteger:
+		// Stays float64: INTEGER/SMALLINT ranges end at 2^31/2^15, float64 is
+		// exact through 2^53, and ToDuckDBParam's integer arm takes float64.
 		if f, e := strconv.ParseFloat(valStr, 64); e == nil {
 			return f, nil
 		}

--- a/internal/sqlgen/duckdb_type_mapper_test.go
+++ b/internal/sqlgen/duckdb_type_mapper_test.go
@@ -1,6 +1,7 @@
 package sqlgen
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -296,6 +297,16 @@ func TestToDuckDBParam_Numeric_FromInt64(t *testing.T) {
 	result, err := ToDuckDBParam(val, forma.ValueTypeBigInt)
 	require.NoError(t, err)
 	require.Equal(t, "42", result)
+}
+
+// TestToDuckDBParam_Numeric_FromInt64MaxValue pins the exactness the #281 binder
+// fix rests on: the bigint/numeric arm renders int64 with %d, so all 19
+// significant digits of MaxInt64 survive. The float64 path (decimalString's
+// %.15g) caps at 15 and would emit "9.22337203685478e+18" instead.
+func TestToDuckDBParam_Numeric_FromInt64MaxValue(t *testing.T) {
+	result, err := ToDuckDBParam(int64(math.MaxInt64), forma.ValueTypeBigInt)
+	require.NoError(t, err)
+	require.Equal(t, "9223372036854775807", result)
 }
 
 func TestToDuckDBParam_Numeric_FromString(t *testing.T) {

--- a/internal/sqlgen/keyset_precision_test.go
+++ b/internal/sqlgen/keyset_precision_test.go
@@ -1,0 +1,83 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKeysetArgsPreserveInt64Above2p53 pins the raw-bind contract (#281,
+// #205 final review M-2): keyset cursor values bind verbatim — an int64 above
+// 2^53 must reach the DuckDB arg list as int64, never float64. DuckDB widens
+// `BIGINT col > DOUBLE param` to DOUBLE, so a float64 cursor value at a >2^53
+// page boundary rounds and can skip or duplicate one row of the next page.
+//
+// There is no continuation-token codec in the repo today: model.KeysetCursor
+// is in-process only (forma.QueryRequest carries no cursor field), so the M-2
+// scenario has zero live instances and this test guards the invariant that
+// nothing else does. Any future cursor decoder must produce int64 for integer
+// cursor values (json.Number / numutil.Int64Exact — never a plain
+// encoding/json float64 path) or this contract breaks silently.
+func TestKeysetArgsPreserveInt64Above2p53(t *testing.T) {
+	// 2^53+1 is the smallest positive integer float64 cannot represent: a
+	// round-trip through float64 lands on 2^53. If this probe value is ever
+	// weakened to a float64-safe number the test stops proving anything.
+	wantAmount := int64(1)<<53 + 1
+	require.NotEqual(t, wantAmount, int64(float64(wantAmount)),
+		"probe value must be inexact in float64, else the test cannot detect coercion")
+
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{
+			{Attribute: "amount", Direction: forma.SortOrderAsc},
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+		},
+		Values: []interface{}{wantAmount, "0f000000-0000-0000-0000-000000000000"},
+		Mode:   model.KeysetCursorModeAfter,
+	}
+	q := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0},
+		KeysetCursor:   cursor,
+	}
+	dual := &DualClauses{
+		DuckClause: "age > ?",
+		DuckArgs:   []any{int64(25)},
+	}
+
+	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, injectTestRenderParams(t, map[string]any{}, 1), q, nil, dual)
+	require.NoError(t, err)
+
+	// [DuckArgs(1), PgMainArgs(0), DuckArgs(1), keyset(3)] — a 2-column cursor
+	// repeats its prefix value once per disjunct, so the keyset tail is
+	// n(n+1)/2 = 3 args: [amount, amount, row_id].
+	require.Len(t, args, 5)
+	keysetArgs := args[len(args)-3:]
+	require.Equal(t, "0f000000-0000-0000-0000-000000000000", keysetArgs[2],
+		"row_id tiebreak binds last")
+
+	// Every occurrence of the amount value — not just the first — must be a
+	// verbatim int64: a coercion that reached only the repeated prefix arg
+	// would still corrupt the page boundary.
+	occurrences := 0
+	for i, arg := range keysetArgs {
+		if f, isFloat := arg.(float64); isFloat {
+			t.Fatalf("keyset arg %d is float64 %v; cursor values must bind verbatim as int64", i, f)
+		}
+		v, isInt := arg.(int64)
+		if !isInt {
+			continue
+		}
+		require.Equal(t, wantAmount, v,
+			"keyset arg %d is int64 %d, want the cursor value %d bound verbatim", i, v, wantAmount)
+		occurrences++
+	}
+	require.Equal(t, 2, occurrences,
+		"amount must appear twice as int64 in %v (once per disjunct)", keysetArgs)
+
+	require.NotContains(t, sql, "$", "keyset queries must not reintroduce $n placeholders")
+	require.Equal(t, len(args), strings.Count(sql, "?"),
+		"placeholder count must equal arg count for positional binding")
+}

--- a/internal/sqlgen/keyset_where.go
+++ b/internal/sqlgen/keyset_where.go
@@ -17,6 +17,13 @@ import (
 // its args are appended last. Prefix columns repeat across disjuncts, so
 // each value is appended once per occurrence: an n-column cursor yields
 // n(n+1)/2 args.
+//
+// Values bind verbatim — no type coercion, no metadata lookup. The caller
+// owns exactness: BIGINT cursor columns require int64 values (a float64
+// above 2^53 makes `BIGINT col > DOUBLE param` skip or duplicate one page
+// row — #281 / #205 M-2). No continuation-token codec exists today; a
+// future decoder must produce int64 for integer values (UseNumber /
+// numutil.Int64Exact), pinned by TestKeysetArgsPreserveInt64Above2p53.
 func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (string, []interface{}) {
 	if cursor == nil || len(cursor.Columns) == 0 {
 		return "1=1", nil

--- a/internal/sqlgen/predicate_characterization_bigint_test.go
+++ b/internal/sqlgen/predicate_characterization_bigint_test.go
@@ -1,0 +1,51 @@
+package sqlgen
+
+import "math"
+
+// buildCharBigIntCases covers the bigint storage class above 2^53, where a
+// float64 bind stops being exact (#281). It lives in its own file so the main
+// characterization matrix stays inside the 500-line source limit; the cases are
+// appended to the same matrix by TestToDualClauses_Characterization.
+func buildCharBigIntCases() []charCase {
+	return []charCase{
+		{
+			// #281: bound bigint above 2^53 — all three emitters bind exactly.
+			// Duck param is the exact decimal string (toDuckDBDecimalParam renders
+			// int64 via %d); pre-#281 it was "9.00719925474099e+15" (%.15g of the
+			// rounded float64) and PgArgs carried float64(9007199254740992).
+			name: "bigint bound above 2^53: main/eav int64, duck exact string",
+			cond: charKv("amount", "equals:9007199254740993"),
+			want: DualClauses{
+				PgMainClause: "m.bigint_02 = ?", PgMainArgs: []any{int64(9007199254740993)},
+				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(12), int64(9007199254740993)},
+				DuckClause: "amount = CAST(? AS BIGINT)", DuckArgs: []any{"9007199254740993"},
+			},
+			span: 3,
+		},
+		{
+			name: "bigint bound MaxInt64: 19 digits survive %d, would die in %.15g",
+			cond: charKv("amount", "gte:9223372036854775807"),
+			want: DualClauses{
+				PgMainClause: "m.bigint_02 >= ?", PgMainArgs: []any{int64(math.MaxInt64)},
+				PgClause: charEavClause("$2", "value_numeric", ">=", "$3"), PgArgs: []any{int16(12), int64(math.MaxInt64)},
+				DuckClause: "amount >= CAST(? AS BIGINT)", DuckArgs: []any{"9223372036854775807"},
+			},
+			span: 3,
+		},
+		{
+			// EAV-only bigint: the bind is exact, but eav_data storage rounds at
+			// write (2^53 ceiling, #205) — so above 2^53 an exact equality bind
+			// misses on every tier alike. That parity is the contract; the
+			// pre-#281 float64 bind "matched" only by colliding with the same
+			// rounding error.
+			name: "bigint EAV-only above 2^53: exact bind, storage-capped semantics",
+			cond: charKv("total", "equals:9007199254740993"),
+			want: DualClauses{
+				PgMainClause: "", PgMainArgs: nil,
+				PgClause: charEavClause("$1", "value_numeric", "=", "$2"), PgArgs: []any{int16(13), int64(9007199254740993)},
+				DuckClause: "total = CAST(? AS BIGINT)", DuckArgs: []any{"9007199254740993"},
+			},
+			span: 2,
+		},
+	}
+}

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -29,6 +29,9 @@ func characterizationCache() forma.SchemaAttributeCache {
 			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_03"), Encoding: forma.MainColumnEncodingISO8601}},
 		"seen": {AttributeID: 10, ValueType: forma.ValueTypeDateTime},
 		"ref":  {AttributeID: 11, ValueType: forma.ValueTypeUUID},
+		"amount": {AttributeID: 12, ValueType: forma.ValueTypeBigInt,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("bigint_02")}},
+		"total": {AttributeID: 13, ValueType: forma.ValueTypeBigInt},
 	}
 }
 
@@ -116,16 +119,17 @@ func buildCharTextCases() []charCase {
 }
 
 // buildCharNumericBoolCases covers the numeric and boolean storage classes, including
-// the >2^53 precision split between main (int64) and eav/duck (float64) and the
-// bool-int / bool-text / unbound-bool encodings.
+// the >2^53 precision split between the exact int64 pg binds and the duck INTEGER
+// arm's deliberate float64 (#281) and the bool-int / bool-text / unbound-bool
+// encodings. The bigint storage class lives in predicate_characterization_bigint_test.go.
 func buildCharNumericBoolCases() []charCase {
 	return []charCase{
 		{
-			name: "integer gt: main int64, eav float64, duck float64",
+			name: "integer gt: main/eav int64, duck float64",
 			cond: charKv("age", "gt:30"),
 			want: DualClauses{
 				PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(30)},
-				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), float64(30)},
+				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), int64(30)},
 				DuckClause: "age > CAST(? AS INTEGER)", DuckArgs: []any{float64(30)},
 			},
 			span: 3,
@@ -141,11 +145,11 @@ func buildCharNumericBoolCases() []charCase {
 			span: 2,
 		},
 		{
-			name: "big integral: main keeps int64 beyond 2^53, eav/duck lose to float64",
+			name: "integer above 2^53: main/eav exact int64, duck float64 by design (INTEGER caps at 2^31)",
 			cond: charKv("age", "equals:9007199254740993"),
 			want: DualClauses{
 				PgMainClause: "m.integer_01 = ?", PgMainArgs: []any{int64(9007199254740993)},
-				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), float64(9007199254740992)},
+				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), int64(9007199254740993)},
 				DuckClause: "age = CAST(? AS INTEGER)", DuckArgs: []any{float64(9007199254740992)},
 			},
 			span: 3,
@@ -244,7 +248,7 @@ func buildCharCompositeCases() []charCase {
 				PgClause: "((" + charEavClause("$2", "value_text", "=", "$3") + ") AND (((" +
 					charEavClause("$4", "value_numeric", ">", "$5") + ") OR (" +
 					charEavClause("$6", "value_text", "=", "$7") + "))))",
-				PgArgs:     []any{int16(1), "Alice", int16(2), float64(18), int16(4), "x"},
+				PgArgs:     []any{int16(1), "Alice", int16(2), int64(18), int16(4), "x"},
 				DuckClause: "(username = ?) AND ((age > CAST(? AS INTEGER)) OR (tag = ?))",
 				DuckArgs:   []any{"Alice", float64(18), "x"},
 			},
@@ -257,7 +261,7 @@ func buildCharCompositeCases() []charCase {
 				PgMainClause: "((m.text_01 = ?) OR (m.integer_01 > ?))", PgMainArgs: []any{"A", int64(5)},
 				PgClause: "((" + charEavClause("$3", "value_text", "=", "$4") + ") OR (" +
 					charEavClause("$5", "value_numeric", ">", "$6") + "))",
-				PgArgs:     []any{int16(1), "A", int16(2), float64(5)},
+				PgArgs:     []any{int16(1), "A", int16(2), int64(5)},
 				DuckClause: "(username = ?) OR (age > CAST(? AS INTEGER))",
 				DuckArgs:   []any{"A", float64(5)},
 			},
@@ -270,7 +274,7 @@ func buildCharCompositeCases() []charCase {
 				PgMainClause: "((m.integer_01 > ?) AND (m.integer_01 < ?))", PgMainArgs: []any{int64(10), int64(90)},
 				PgClause: "((" + charEavClause("$3", "value_numeric", ">", "$4") + ") AND (" +
 					charEavClause("$5", "value_numeric", "<", "$6") + "))",
-				PgArgs:     []any{int16(2), float64(10), int16(2), float64(90)},
+				PgArgs:     []any{int16(2), int64(10), int16(2), int64(90)},
 				DuckClause: "(age > CAST(? AS INTEGER)) AND (age < CAST(? AS INTEGER))",
 				DuckArgs:   []any{float64(10), float64(90)},
 			},
@@ -290,6 +294,7 @@ func TestToDualClauses_Characterization(t *testing.T) {
 	var cases []charCase
 	cases = append(cases, buildCharTextCases()...)
 	cases = append(cases, buildCharNumericBoolCases()...)
+	cases = append(cases, buildCharBigIntCases()...)
 	cases = append(cases, buildCharTemporalUuidCases()...)
 	cases = append(cases, buildCharCompositeCases()...)
 

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -253,7 +253,9 @@ func normalizePgEavPayload(kv *forma.KvCondition, meta forma.AttributeMetadata, 
 		parsed := numutil.TryParseNumber(valStr)
 		switch v := parsed.(type) {
 		case int64:
-			parsedValue = float64(v)
+			// Exact bind (#281): pgx encodes int64 into the NUMERIC comparison
+			// losslessly. Mirrors ConvertPgMainValue on the main-table path.
+			parsedValue = v
 		case float64:
 			parsedValue = v
 		default:

--- a/internal/sqlgen/sql_generator_test.go
+++ b/internal/sqlgen/sql_generator_test.go
@@ -73,8 +73,10 @@ func TestSQLGenerator_ToSQLClauses(t *testing.T) {
 		t.Fatalf("unexpected SQL clause.\nexpected: %s\nactual:   %s", expectedClause, sqlClause)
 	}
 
+	// price is `gt:10` on a numeric attribute: integral literals bind as exact
+	// int64 since #281 (fractional literals still bind float64).
 	expectedArgs := []any{
-		int16(10), float64(10),
+		int16(10), int64(10),
 		int16(11), "active",
 		int16(12), "A%",
 	}


### PR DESCRIPTION
Closes #281. Refs #205, #282.

## What the audit found

The issue asked to *trace* the comparison-value path and fix or document what it revealed. The trace found one live bug, one ceiling worth documenting, and one hypothesised risk that turned out not to be reachable today.

**The path.** Condition values arrive as the `"op:value"` **string** DSL and stay strings end to end. So **#282 / `UseNumber` is a no-op for comparisons** — it fixes the write/validation path, not this one. Every float64 hop that mattered was inside `internal/sqlgen`.

**Fixed — predicates disagreed across tiers (the live bug).** Pre-fix, the DuckDB binder `parseDuckDBRawParam` (`internal/sqlgen/dualpath_sql_helpers.go:122-126`) parsed the literal with `ParseFloat`, and `ToDuckDBParam` rendered float64 with `%.15g` (`internal/sqlgen/duckdb_type_mapper.go:208-210`). So `equals:9007199254740993` bound the string `"9.00719925474099e+15"` (= 9007199254740990) — a value **held by no row**: the predicate could not address these values at all, and equality returned nothing. `%.15g` of MaxInt64-adjacent literals renders `"9.22337203685478e+18"`, outside INT64 range, so `CAST(? AS BIGINT)` throws. Meanwhile the PG main-table path (`ConvertPgMainValue`) already bound exact int64 — so **hot and cold tiers evaluated a different filter for the same query**, reachable from `POST /api/v1/advanced_query`. That tier disagreement is the real defect. Separately, the PG EAV path deliberately downcast int64→float64 (`internal/sqlgen/predicate_normalizer.go:255-257`). Both now bind exact int64.

**Documented — the EAV storage ceiling.** EAV-only bigint attributes round at *write* time (2^53, the #205 scope). With exact binds, values above that ceiling now miss on all tiers alike instead of false-matching a colliding rounded row — parity preserved, semantics honest.

**Keyset (M-2) — hypothetical, now fenced.** No continuation-token codec exists anywhere in the tree; `KeysetCursor` is in-process only and not HTTP-reachable, and `generateKeysetWhereClause` binds cursor values verbatim. No precision is lost today, so no code change — only a pinned contract.

## Changes

5 commits on `issue-281-bigint-comparison-exactness` (base `6a2de1c`):

- **2dc0167** `fix(sqlgen)`: bind integral bigint/numeric predicates as exact int64 on both dialects. `parseDuckDBRawParam` parses int64-first for `Numeric`/`BigInt` so `ToDuckDBParam` renders the exact decimal via `%d`; `normalizePgEavPayload` stops downcasting int64→float64. `ToDuckDBParam`'s float64 arm is untouched — the fix stops *routing* integral literals through it.
- **05c3455** `test(sqlgen)`: pin the keyset raw-bind int64 exactness contract (`TestKeysetArgsPreserveInt64Above2p53`), document the M-2 defense at the binder (`internal/sqlgen/keyset_where.go`) and as a decoder rule in `docs/federated-query/requirements.md` §6.3.
- **acaa056** `test(e2e)`: bigint filter probes above 2^53 on both dialects.
- **3b582ee** `test(e2e)`: correct the pre-#281 mechanism narrative in the filter-probe comments (the earlier "matched the wrong row" story was refuted — the pre-fix binder addressed a value no row held).
- **1ccb09f** `test(e2e)`: keyset continuation walk across the 2^53 boundary (`TestBigintKeysetBoundaryNoDupNoSkip`).

Also: characterization matrix gains a bigint fixture with >2^53 / MaxInt64 rows across all three emitters; integer-family EAV args flip to int64.

## Behavior changes reviewers should weigh

1. **Below 2^53 as well.** PG EAV args for the whole numeric family flip float64→int64 on integral literals — the comparison becomes `numeric = bigint`, which is param-promoting and index-friendly instead of casting the column to `float8`. And DuckDB integral numeric/bigint literals with **≥16 significant digits** now bind exactly; old `%.15g` corrupted those even below 2^53.
2. **User-visible semantics change for EAV-only bigint attrs.** Exact binds above 2^53 now *miss* on all tiers, where pre-fix equality could false-match via colliding rounding. This is intended per the #205 storage ceiling — tier parity is preserved and the miss is the honest answer.
3. **INTEGER/SMALLINT DuckDB binds deliberately stay float64** (column ranges cap at 2^31 / 2^15, far below float64's exact-integer range) — pinned in the characterization matrix. Latent edge noted: an EAV-only *integer-typed* attribute has no physical range cap, so a >2^53 value on such an attribute could still produce PG-vs-DuckDB disagreement. Folded into follow-up #355 rather than widened here.
4. **Keyset: no code change** — contract pin only. No token codec exists (M-2 is hypothetical), now fenced by the unit pin + binder doc comment + `requirements.md` §6.3 decoder rule, so a future decoder cannot silently reintroduce the float64 hop.
5. **Note for reviewers of the e2e tests:** the harness oracle is float64-blind by design, so the new tests use exact-set / exact-sequence assertions rather than oracle comparison. The cold leg uses the `RunInit` + `DELETE change_log` idiom — `RunInit` alone leaves rows dirty and hot-served, which would have made the DuckDB-binder claim vacuous.

## Plan deviations (both strengthened the plan)

- **Task 3:** the plan's cold-leg setup (`RunInit` alone) was insufficient — rows stayed dirty and hot-served. Fixed with the `RunInit` + `DELETE change_log` idiom, so the DuckDB-binder claim is genuine.
- **Task 4:** the plan's page-size-2 walk never landed a cursor on 2^53+1 (cursors fell on 2^53 and 2^53+2). Replaced with table-driven walks (page sizes 3/5/2; asc/asc/desc) so every walk pins a continuation cursor on a float64-unrepresentable value, with cursor positions asserted.

## Follow-ups filed

- #354 — hot-only routing silently drops the keyset cursor (`internal/federated/engine.go:150-153`): `PreferHot` / hot-only tiers short-circuit to `queryPostgresOnlyWithPlan`, which has no keyset support, so a cursor-bearing query returns an unfiltered page instead of paginating or erroring. Engine-correctness bug, independent of precision.
- #355 — `GetPersistentRecordsByAttrValues` binds `[]float64` (`internal/postgres_persistent_repository_by_attr_values.go:87-98`): batch `value_numeric = ANY($n)` builds args via `ParseFloat`. Same int64-first treatment as this PR if that path must be exact for bigint attrs (may be document-only under the #205 ceiling). Also carries the EAV integer-typed-attr edge from item 3 above.

## Verification

- `make lint` (pinned golangci-lint v1.64.8), red-anchor-verified.
- `make test` and the `-race` variant: all green.
- Full production e2e suite: **213/213 in 2m25s**, no flake re-runs needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
