### PR TITLE
Typed public client messages: 4xx bodies carry only deliberately published text (#313)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,10 +74,10 @@ Module: `github.com/lychee-technology/forma`.
 
 Two distinct error classes (`docs/error-handling.md`):
 
-- **Write-path validation** wraps `forma.ErrInvalidInput` → surfaces as user-facing 4xx.
+- **Write-path validation** builds `forma.InvalidInputf` (or `NotFoundf`/`Conflictf`) carriers → surfaces as user-facing 4xx whose body is the carrier's published message (#313). A bare `%w` wrap of a sentinel earns the status but answers a redacted body, and fails the `TestNoBareSentinelWraps` guard.
 - **Read-path consistency** errors (metadata drift, storage column mismatch) are plain errors → operator-visible failures, not 4xx.
 
-Error messages must name the logical value type, the offending column/attribute, and the expected state.
+Error messages must name the logical value type, the offending column/attribute, and the expected state. Detail an operator needs but a caller cannot act on goes behind `forma.WithOperatorDetail` — it stays in `Error()` and the log, never in the published message.
 
 ## Pull Request Rules
 

--- a/client_error.go
+++ b/client_error.go
@@ -1,0 +1,143 @@
+package forma
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Typed public client messages (#313).
+//
+// A client-facing error carries two messages with different audiences. Error()
+// is the operator's copy: the full chain, safe to log, never safe to publish.
+// PublicMessage() is the only text that may cross a public transport, and it
+// exists only because a wrap site deliberately authored it. The HTTP boundary
+// (internal/httpapi) resolves the outermost PublicError in the chain and emits
+// nothing else on 4xx — an error built by wrapping a bare sentinel keeps its
+// status but loses its body. Deny-by-default on the disclosure axis, matching
+// what sentinel classification already does on the status axis (#301).
+//
+// Constructors return error rather than a concrete type so no call site can
+// hold a typed nil or reach past the interface. The carriers stay unexported:
+// the contract is PublicError plus errors.Is on the sentinel, nothing more.
+
+// PublicError is implemented by an error that carries a message deliberately
+// published to API clients.
+type PublicError interface {
+	error
+	PublicMessage() string
+}
+
+// InvalidInputf builds a client error classified by ErrInvalidInput whose
+// formatted message is published verbatim. Error() renders
+// "<message>: invalid input".
+func InvalidInputf(format string, args ...any) error {
+	return &clientError{sentinel: ErrInvalidInput, public: fmt.Sprintf(format, args...)}
+}
+
+// NotFoundf builds a client error classified by ErrNotFound. Error() renders
+// "<message>: not found".
+func NotFoundf(format string, args ...any) error {
+	return &clientError{sentinel: ErrNotFound, public: fmt.Sprintf(format, args...)}
+}
+
+// Conflictf builds a client error classified by ErrConflict. Error() renders
+// "<message>: conflict".
+func Conflictf(format string, args ...any) error {
+	return &clientError{sentinel: ErrConflict, public: fmt.Sprintf(format, args...)}
+}
+
+// WrapPublicf adds caller-actionable context to err, prefixing BOTH its
+// operator message and its published message: Error() is identical to
+// fmt.Errorf("<prefix>: %w", err) either way. When err carries no PublicError
+// the result IS exactly that plain wrap — an operator error can never gain a
+// publication by being wrapped. Returns nil for a nil err.
+//
+// Use it only where the wrap adds identification the caller can act on (a
+// batch index, a caller-supplied name). A layer that adds operator context
+// should stay a plain fmt.Errorf so its prefix stays out of the body.
+func WrapPublicf(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	prefix := fmt.Sprintf(format, args...)
+	var pub PublicError
+	if !errors.As(err, &pub) {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	return &publicWrap{prefix: prefix, err: err}
+}
+
+// WithOperatorDetail attaches operator-only detail to a client error. The
+// detail joins the chain (errors.Is/As still see it) and its text reaches
+// Error(), so logs keep it — but it never reaches PublicMessage(). Returns err
+// unchanged when detail is nil or err carries no PublicError, and nil for a
+// nil err.
+func WithOperatorDetail(err error, detail error) error {
+	if err == nil {
+		return nil
+	}
+	var pub PublicError
+	if detail == nil || !errors.As(err, &pub) {
+		return err
+	}
+	return &operatorDetail{err: err, detail: detail}
+}
+
+// HasOperatorDetail reports whether err withholds detail from its published
+// message. internal/httpapi keys a log level on it: a disclosed 4xx whose
+// chain still holds operator text makes the log line the only copy of that
+// text.
+func HasOperatorDetail(err error) bool {
+	var d *operatorDetail
+	return errors.As(err, &d)
+}
+
+// clientError is the leaf carrier: a sentinel for classification and a
+// deliberately published message. Error() reproduces the pre-#313 wrap shape
+// fmt.Errorf("<message>: %w", sentinel) byte for byte, which is what keeps
+// message-text assertions outside internal/httpapi green across the
+// conversion.
+type clientError struct {
+	sentinel error
+	public   string
+}
+
+func (e *clientError) Error() string         { return e.public + ": " + e.sentinel.Error() }
+func (e *clientError) PublicMessage() string { return e.public }
+func (e *clientError) Unwrap() error         { return e.sentinel }
+
+// publicWrap prefixes both messages of an error already carrying a
+// PublicError; WrapPublicf guarantees the inner resolution succeeds. Being
+// outermost, it is the node errors.As finds first, so prefixes accumulate
+// outside-in exactly as they do in Error().
+type publicWrap struct {
+	prefix string
+	err    error
+}
+
+func (e *publicWrap) Error() string { return e.prefix + ": " + e.err.Error() }
+func (e *publicWrap) Unwrap() error { return e.err }
+
+func (e *publicWrap) PublicMessage() string {
+	var pub PublicError
+	errors.As(e.err, &pub)
+	return e.prefix + ": " + pub.PublicMessage()
+}
+
+// operatorDetail joins operator-only detail to a publishing error. The detail
+// is a real chain member — errors.Is/As descend into it — but PublicMessage()
+// delegates to the publishing side only, so the detail's text stays in
+// Error() and out of every body.
+type operatorDetail struct {
+	err    error
+	detail error
+}
+
+func (e *operatorDetail) Error() string   { return e.err.Error() + ": " + e.detail.Error() }
+func (e *operatorDetail) Unwrap() []error { return []error{e.err, e.detail} }
+
+func (e *operatorDetail) PublicMessage() string {
+	var pub PublicError
+	errors.As(e.err, &pub)
+	return pub.PublicMessage()
+}

--- a/client_error_guard_test.go
+++ b/client_error_guard_test.go
@@ -1,0 +1,120 @@
+package forma
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoBareSentinelWraps is a source-level guard for #313's deny-by-default
+// contract. A client error must be built with InvalidInputf/NotFoundf/
+// Conflictf (or re-wrapped with WrapPublicf) so it carries a published
+// message; a bare fmt.Errorf("…: %w", forma.ErrInvalidInput) or an
+// errors.Join with a sentinel still earns its 4xx status but answers an
+// opaque redacted body. The boundary makes that safe; this guard makes it
+// discoverable — the runtime failure mode is "the caller's 400 became
+// useless", which a feature author without a body assertion never notices.
+//
+// Idiom follows TestWriteErrorAlwaysCarriesALiteral4xxStatus
+// (internal/httpapi/error_leak_test.go): fail loudly on a vacuous pass,
+// report every offender rather than the first, and state the blind spots.
+//
+// Blind spots, deliberately accepted: the guard sees fmt.Errorf and
+// errors.Join argument lists only. A hand-rolled type whose Unwrap returns a
+// sentinel is invisible here — the boundary's deny shape covers it at
+// runtime. Test files are excluded: tests may build bare wraps on purpose to
+// pin the deny shape itself.
+func TestNoBareSentinelWraps(t *testing.T) {
+	sentinels := map[string]bool{
+		"ErrInvalidInput": true,
+		"ErrNotFound":     true,
+		"ErrConflict":     true,
+	}
+	skipDirs := map[string]bool{
+		".git": true, ".gocache": true, "build": true,
+		"node_modules": true, "testdata": true, "vendor": true,
+	}
+
+	referencesSentinel := func(e ast.Expr) bool {
+		switch v := e.(type) {
+		case *ast.SelectorExpr:
+			// forma.ErrInvalidInput from any package (the X identifier is not
+			// checked: an aliased import must not slip through).
+			return sentinels[v.Sel.Name]
+		case *ast.Ident:
+			// Bare ErrInvalidInput inside package forma itself.
+			return sentinels[v.Name]
+		}
+		return false
+	}
+
+	isWrapCall := func(call *ast.CallExpr) bool {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		return (pkg.Name == "fmt" && sel.Sel.Name == "Errorf") ||
+			(pkg.Name == "errors" && sel.Sel.Name == "Join")
+	}
+
+	var offenders []string
+	scanned := 0
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return fmt.Errorf("parse %s: %w", path, perr)
+		}
+		scanned++
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isWrapCall(call) {
+				return true
+			}
+			for _, arg := range call.Args {
+				if referencesSentinel(arg) {
+					offenders = append(offenders, fset.Position(call.Pos()).String())
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the module: %v", err)
+	}
+
+	// A vacuous pass is a broken guard, not a clean sweep: this test runs from
+	// the module root and must see the whole tree.
+	if scanned < 50 {
+		t.Fatalf("guard scanned only %d non-test Go files; the walk is broken", scanned)
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf("found %d bare sentinel wrap(s); build these with forma.InvalidInputf/NotFoundf/Conflictf "+
+			"(or forma.WrapPublicf) so the 4xx body carries a published message (#313):\n%s",
+			len(offenders), strings.Join(offenders, "\n"))
+	}
+}

--- a/client_error_test.go
+++ b/client_error_test.go
@@ -1,0 +1,190 @@
+package forma
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// resolvePublic mirrors the boundary's resolution: the outermost PublicError in
+// preorder left-first DFS wins.
+func resolvePublic(t *testing.T, err error) (string, bool) {
+	t.Helper()
+	var pub PublicError
+	if !errors.As(err, &pub) {
+		return "", false
+	}
+	return pub.PublicMessage(), true
+}
+
+func mustPublish(t *testing.T, err error, want string) {
+	t.Helper()
+	got, ok := resolvePublic(t, err)
+	if !ok {
+		t.Fatalf("expected a PublicError in chain of %v, found none", err)
+	}
+	if got != want {
+		t.Fatalf("PublicMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestConstructorsRenderSentinelSuffixedError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		sentinel error
+		wantErr  string
+		wantPub  string
+	}{
+		{"invalid input", InvalidInputf("schema name is required"), ErrInvalidInput,
+			"schema name is required: invalid input", "schema name is required"},
+		{"not found", NotFoundf("schema not found: %s", "lead"), ErrNotFound,
+			"schema not found: lead: not found", "schema not found: lead"},
+		{"conflict", Conflictf("the write conflicts with a row that already exists"), ErrConflict,
+			"the write conflicts with a row that already exists: conflict",
+			"the write conflicts with a row that already exists"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.wantErr {
+				t.Fatalf("Error() = %q, want %q", got, tc.wantErr)
+			}
+			if !errors.Is(tc.err, tc.sentinel) {
+				t.Fatalf("errors.Is(err, sentinel) = false, want true")
+			}
+			mustPublish(t, tc.err, tc.wantPub)
+		})
+	}
+}
+
+func TestConstructorMatchesOnlyItsOwnSentinel(t *testing.T) {
+	err := InvalidInputf("x")
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrConflict) {
+		t.Fatalf("InvalidInputf matched a foreign sentinel")
+	}
+}
+
+func TestWithOperatorDetailWithholdsDetailFromPublication(t *testing.T) {
+	detail := errors.New(`IO Error: reading base/schema_22/CANARY-KEY.parquet`)
+	err := WithOperatorDetail(NotFoundf("schema not found"), fmt.Errorf("schema id %d", 402))
+
+	if want := "schema not found: not found: schema id 402"; err.Error() != want {
+		t.Fatalf("Error() = %q, want %q", err.Error(), want)
+	}
+	mustPublish(t, err, "schema not found")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("detail attachment broke errors.Is on the sentinel")
+	}
+	if !HasOperatorDetail(err) {
+		t.Fatalf("HasOperatorDetail = false after WithOperatorDetail")
+	}
+
+	err = WithOperatorDetail(InvalidInputf("bad template"), detail)
+	if msg, _ := resolvePublic(t, err); msg != "bad template" {
+		t.Fatalf("operator detail leaked into publication: %q", msg)
+	}
+}
+
+func TestWithOperatorDetailKeepsDetailInChain(t *testing.T) {
+	sentinelDetail := fmt.Errorf("cause: %w", ErrNoParquetPaths)
+	err := WithOperatorDetail(InvalidInputf("bad filter"), sentinelDetail)
+	if !errors.Is(err, ErrNoParquetPaths) {
+		t.Fatalf("detail left the chain: errors.Is cannot see it")
+	}
+}
+
+func TestWithOperatorDetailDegenerateInputs(t *testing.T) {
+	carrier := InvalidInputf("x")
+	if got := WithOperatorDetail(carrier, nil); got != carrier {
+		t.Fatalf("nil detail must return err unchanged")
+	}
+	plain := errors.New("operator error")
+	if got := WithOperatorDetail(plain, errors.New("d")); got != plain {
+		t.Fatalf("an error without a PublicError must pass through unchanged")
+	}
+	if got := WithOperatorDetail(nil, errors.New("d")); got != nil {
+		t.Fatalf("nil err must return nil")
+	}
+	if HasOperatorDetail(carrier) {
+		t.Fatalf("HasOperatorDetail = true for a carrier without detail")
+	}
+	if HasOperatorDetail(nil) {
+		t.Fatalf("HasOperatorDetail = true for nil")
+	}
+}
+
+func TestWrapPublicfPrefixesBothMessages(t *testing.T) {
+	leaf := InvalidInputf("row id is required for update operation")
+	err := WrapPublicf(leaf, "operation[%d]", 3)
+
+	wantErr := "operation[3]: row id is required for update operation: invalid input"
+	if err.Error() != wantErr {
+		t.Fatalf("Error() = %q, want %q", err.Error(), wantErr)
+	}
+	mustPublish(t, err, "operation[3]: row id is required for update operation")
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("wrap broke errors.Is on the sentinel")
+	}
+}
+
+func TestWrapPublicfDegradesToPlainWrapForOperatorErrors(t *testing.T) {
+	opErr := errors.New("load record: connection refused")
+	err := WrapPublicf(opErr, "operation[%d]: failed to load record", 1)
+
+	want := fmt.Errorf("operation[1]: failed to load record: %w", opErr)
+	if err.Error() != want.Error() {
+		t.Fatalf("Error() = %q, want %q", err.Error(), want.Error())
+	}
+	if _, ok := resolvePublic(t, err); ok {
+		t.Fatalf("an operator error gained a publication by being wrapped")
+	}
+	if !errors.Is(err, opErr) {
+		t.Fatalf("degraded wrap must still unwrap to the cause")
+	}
+}
+
+func TestWrapPublicfNilReturnsNil(t *testing.T) {
+	if got := WrapPublicf(nil, "prefix"); got != nil {
+		t.Fatalf("WrapPublicf(nil) = %v, want nil", got)
+	}
+}
+
+func TestPublicationSurvivesReWrapping(t *testing.T) {
+	leaf := InvalidInputf("invalid value for attribute 'age' (attrID=2): cannot convert string to float64")
+	err := WrapPublicf(leaf, "operation[0]: failed to transform data to persistent record")
+	err = fmt.Errorf("batch create: %w", err)
+	err = fmt.Errorf("manager: %w", err)
+
+	mustPublish(t, err,
+		"operation[0]: failed to transform data to persistent record: "+
+			"invalid value for attribute 'age' (attrID=2): cannot convert string to float64")
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("re-wrapping broke errors.Is")
+	}
+}
+
+// The boundary resolves the first PublicError in preorder left-first DFS order.
+// These cases pin the multi-cause semantics the conversion relies on.
+func TestResolutionOrderOnMultiCauseChains(t *testing.T) {
+	opErr := errors.New(`template: s3path:1:2: function "Bad" not defined`)
+
+	t.Run("carrier joined before an operator cause wins", func(t *testing.T) {
+		err := fmt.Errorf("render: %w: %w", InvalidInputf("the template is not renderable"), opErr)
+		mustPublish(t, err, "the template is not renderable")
+	})
+
+	t.Run("carrier behind an operator cause is still found", func(t *testing.T) {
+		err := errors.Join(opErr, InvalidInputf("bad filter"))
+		mustPublish(t, err, "bad filter")
+	})
+
+	t.Run("first of two joined carriers wins", func(t *testing.T) {
+		err := errors.Join(InvalidInputf("first"), InvalidInputf("second"))
+		mustPublish(t, err, "first")
+	})
+
+	t.Run("outermost wrap wins over the leaf", func(t *testing.T) {
+		err := WrapPublicf(InvalidInputf("leaf"), "outer")
+		mustPublish(t, err, "outer: leaf")
+	})
+}

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -6,8 +6,11 @@ Forma uses two error classes in the schema/metadata pipeline.
 
 ## Write-path validation errors
 
-Write operations wrap `forma.ErrInvalidInput` when the caller provides data that
-cannot be accepted.
+Write operations build a `forma.InvalidInputf` carrier when the caller provides
+data that cannot be accepted. The carrier does two things at once: it wraps
+`forma.ErrInvalidInput` (so `errors.Is` classification holds everywhere), and
+it records the message as *deliberately published* (`forma.PublicError`), which
+is what the HTTP boundary emits on the 4xx body (#313).
 
 Examples:
 
@@ -17,7 +20,10 @@ Examples:
 - a payload that violates the entity's JSON Schema (`internal/schemavalidate`) —
   see "JSON Schema enforcement on write" below
 
-These errors are intended to surface as user-facing `4xx` responses.
+These errors are intended to surface as user-facing `4xx` responses. A bare
+`fmt.Errorf("…: %w", forma.ErrInvalidInput)` still earns the 400 status but
+answers a **redacted** body — the deny-by-default shape (#313) — and is
+rejected at build time by `TestNoBareSentinelWraps` (root package).
 
 ## JSON Schema enforcement on write
 
@@ -431,12 +437,14 @@ cannot echo a runtime-classified status without going through `respondError`.
 `forma.ErrConflict` (409), and `forma.ErrInvalidInput` (400); everything else —
 including a `nil` error — is `500`.
 
-**Disclosure needs the same evidence plus an unambiguous chain.**
-`canDiscloseVerbatim` is `isClientError(err) && !hasMultipleCauses(err)`: a body
-is verbatim only when the error *provably* wraps one of those three sentinels
-*and* no node in its chain fans out to more than one cause. Everything else is
-redacted. See "Multi-cause chains are redacted" below for why the second
-conjunct exists.
+**Disclosure needs the same evidence plus a deliberately published message
+(#313).** The gate is `isClientError(err)` plus `resolvePublicMessage(err)`: a
+4xx body carries text only when the error *provably* wraps one of those three
+sentinels *and* the chain holds a `forma.PublicError` — a carrier built by
+`forma.InvalidInputf`/`NotFoundf`/`Conflictf`, optionally prefixed through
+`forma.WrapPublicf`. What crosses is `PublicMessage()`, never `err.Error()`.
+Everything else is redacted. See "Only published text crosses" below for how
+this replaced the earlier chain-shape rule.
 
 There is no substring heuristic. An earlier version classified on message text
 (`not found` → 404, `duplicate` → 409, `invalid`/`required`/`must be` → 400) for
@@ -453,11 +461,11 @@ errors that wrapped no sentinel. It was removed for two reasons:
 - **It was the last site classifying an error by string comparison**, which
   `AGENTS.md` forbids.
 
-The consequence is that a genuine client error earns its 4xx only by wrapping a
-sentinel. Removing the heuristic therefore required a sweep of the sites that had
-been relying on it — every one of them now wraps `forma.ErrInvalidInput`, with
-the human-authored message prefix unchanged (the rendered string gains a
-sentinel suffix — see below):
+The consequence is that a genuine client error earns its 4xx only by carrying a
+sentinel. Removing the heuristic therefore required a sweep of the sites that
+had been relying on it — every one of them now builds a `forma.InvalidInputf`
+carrier, and the message each publishes is the same human-authored text it
+always rendered:
 
 | site | caller mistake |
 | --- | --- |
@@ -472,26 +480,43 @@ attribute would answer `500` with an opaque body instead of naming the attribute
 The `sqlgen`/`conditionexpr` group is reachable through `POST
 /api/v1/advanced_query`, whose `condition` payload is entirely caller-supplied.
 
-**The rendered body is the prefix plus a sentinel suffix, and the suffix is
-deliberate (#309).** Wrapping with `%w` renders the sentinel's own text, so a
-verbatim 4xx body ends in `: invalid input` (likewise `: not found` and
-`: conflict` for the other two sentinels) — e.g.
-`unsupported operator: equals: invalid input`, or the
-`…: schema not found: nosuchschema: not found` body in the worked example under
-"Accepted disclosures inside the allowlist" below. What the sweep preserved is
-the human-authored prefix, not the exact full string. The suffix is kept as part
-of the body contract: clients must not assert on the exact full message — match
-the prefix (this repo's tests use `Contains`) or, better, key on the status
-code. Stripping the suffix would be a message-construction change to every wrap
-site, and #309 decided against it.
+**The sentinel suffix no longer reaches bodies — #309's clause is overturned by
+#313.** `Error()` still renders `<message>: invalid input` (likewise
+`: not found`, `: conflict`), byte-identical to the old `%w` wraps, so logs and
+Go embedders see the same text as before. But the body now carries
+`PublicMessage()`, which is the human-authored message alone — e.g.
+`unsupported operator: equals`, no suffix. #309 declined to strip the suffix
+because doing so meant touching every wrap site; #313 touched every wrap site
+anyway, so the removal came for free. The standing advice is unchanged and now
+enforced by construction: clients must not assert on the exact full message —
+match a substring (this repo's tests use `Contains`) or, better, key on the
+status code.
+
+**Authorship rule for wrap layers.** `forma.WrapPublicf` prefixes both the
+operator message and the published one; use it only where the layer adds
+caller-actionable identification — a batch index (`operation[%d]`), a
+caller-supplied name. A layer that adds operator context (an internal phase
+name like `pg sql generation`, an internal schema id) stays a plain
+`fmt.Errorf`, so its prefix reaches the log and never the body. Operator-only
+facts that belong *on the same error* ride `forma.WithOperatorDetail`: they
+stay in `Error()` and in the chain for `errors.Is`/`As`, and never in
+`PublicMessage()`.
 
 Since #314 there is a **second** write-path validator on the same footing,
-`internal/schemavalidate`'s `Validator.Validate`, which wraps
-`forma.ErrInvalidInput` for a JSON Schema violation — `enum`, `pattern`, `type`,
-`minimum`/`maximum`, and the schema's own `required`. It is independent of the
-`required_policy` row above: the two check different things and both run. Its
-*non*-violation errors deliberately stay plain, so a `500`; see "JSON Schema
-enforcement on write" for the split.
+`internal/schemavalidate`'s `Validator.Validate`, which builds an
+`InvalidInputf` carrier for a JSON Schema violation — `enum`, `pattern`,
+`type`, `minimum`/`maximum`, and the schema's own `required`. It is independent
+of the `required_policy` row above: the two check different things and both
+run. Its *non*-violation errors deliberately stay plain, so a `500`; see "JSON
+Schema enforcement on write" for the split.
+
+Its published message deliberately includes the third-party `jsonschema-go`
+violation prose (decision recorded at the wrap site, `validator.go`): that text
+is `type`/`enum`/`pattern`/`minimum` prose over the caller's own instance and
+the schema's own constraints — no paths, no credentials. Recorded trigger for
+revisiting: the library's `anyOf`/`oneOf` branches render schema objects,
+`$ref` fragments included. No shipped schema uses `anyOf`/`oneOf` today; if one
+ever does, that site switches to `forma.WithOperatorDetail`.
 
 **The sweep also underreached once.** It missed
 `normalizePgEavPayload`'s operator whitelist — the two rejections that pair an
@@ -533,18 +558,17 @@ startup validation) or internal invariants — `schema id must be positive`,
 `500` is the more truthful answer than the misleading 4xx they used to return.
 
 The full disclosure condition is `status < http.StatusInternalServerError &&
-canDiscloseVerbatim(err)`. The status conjunct can only hold disclosure back,
-never grant it: a caller that passes an explicit 5xx to `respondErrorWithStatus`
-gets a redacted body even if the error wraps a sentinel.
+isClientError(err)` plus a resolved publication (`resolvePublicMessage`). The
+status conjunct can only hold disclosure back, never grant it: a caller that
+passes an explicit 5xx to `respondErrorWithStatus` gets a redacted body even if
+the error wraps a publishing carrier. Pinned by `TestCarrierAtA5xxIsRedacted`.
 
-On every live path today **a redacted body is a `500`** — no error in this repo
-joins a client sentinel to an operator cause, so an error without a sentinel
-classifies 500 and redacts, and one with a sentinel classifies 4xx and discloses.
-But status and disclosure are now separately decided in a way that a client must
-not read as coupled: a multi-cause chain carrying a client sentinel classifies
-`4xx` on that sentinel and **still redacts**, producing a `400` body with
-`error_class` and `error_id`. Clients must key on `error_class`/`error_id` being
-present, never on the status, to know whether a body is redacted.
+Status and disclosure are separately decided in a way that a client must not
+read as coupled: an error that carries a client sentinel but publishes nothing
+— a bare sentinel wrap, or a carrier-less mixed chain — classifies `4xx` on
+that sentinel and **still redacts**, producing a `400` body with `error_class`
+and `error_id`. Clients must key on `error_class`/`error_id` being present,
+never on the status, to know whether a body is redacted.
 
 **Redacted bodies (#301)** carry a fixed message, a stable `error_class` token,
 an `error_id`, and — when the chain holds a typed read-path carrier — a
@@ -555,9 +579,9 @@ common case in production** — it absorbs `ErrFederatedReadFailed`,
 `ErrPostgresReadFailed`, metadata drift, and transform failures — so a client
 asserting on the literal `internal read error` would break on the majority of
 redacted responses. Discriminate on `error_class`, never on `error`. The chain
-goes to `zap.S().Errorw`; the verbatim branch logs the same text at `Debugw`,
-where the caller already has it. An operator retrieves the detail from the
-`error_id` the caller quotes.
+goes to `zap.S().Errorw`; the disclosed branch logs the same text at `Debugw` —
+or at `Warnw` when the error withholds operator detail, see "Log levels" below.
+An operator retrieves the detail from the `error_id` the caller quotes.
 
 #### `schema_id` on a redacted body — a reversed decision
 
@@ -578,10 +602,11 @@ asked about. Operators still see both ids — the full message is on the log lin
 "error class + schema id"; the design settled on `error_class` + `error_id` and
 this section previously stated "no schema id" as a constraint on redacted bodies;
 the issue owner reinstated the schema id. The reasoning that justified excluding
-it is what now permits it — a schema ID is a low-value opaque integer, and one
-already crosses verbatim on the ID-keyed 404s recorded under the "Accepted
-disclosures inside the allowlist" section below. What it buys is a redacted body
-a client can correlate without an operator round-trip.
+it is what now permits it — a schema ID is a low-value opaque integer. (When
+this was decided one also crossed inside ID-keyed 404 prose; #313 has since
+closed that, see "Formerly accepted disclosures" below, but the structured
+field here stands on the same low-value reasoning.) What it buys is a redacted
+body a client can correlate without an operator round-trip.
 
 `schema_id` is `omitempty` on `APIResponse`, and that encoding is lossless rather
 than lossy only because **schema IDs are always positive** — the same invariant
@@ -595,9 +620,10 @@ message, so operator log queries filter on `schema_id` instead of parsing prose.
 It is omitted from the log line too when zero, so a log entry never asserts a
 schema the error did not name.
 
-Verbatim 4xx bodies are unaffected: population happens on the redacted branch
-only, so their serialization is byte-identical to pre-#301. Pinned by
-`TestVerbatim4xxBodyCarriesNoSchemaID`.
+Published 4xx bodies are unaffected: population happens on the redacted branch
+only, so a disclosed body carries message text and nothing else — even when the
+chain holds a resolvable carrier as operator detail. Pinned by
+`TestPublished4xxBodyCarriesNoSchemaID`.
 
 ### Credentials are scrubbed before anything is written
 
@@ -666,39 +692,44 @@ Of that list only the schema id also crosses to the client, as its own
 `schema_id` field (see above). Object keys, endpoint URLs and driver prose are
 log-only.
 
-### Multi-cause chains are redacted
+### Only published text crosses
 
 `isClientError` uses `errors.Is`, which matches any leaf. A multi-cause chain —
 `errors.Join(forma.ErrInvalidInput, driverErr)`, or the `fmt.Errorf("%w: %w", …)`
-shape used throughout `internal/federated` — used to take the **verbatim** branch
-on that leaf alone and echo the driver cause alongside the client one.
+shape used throughout `internal/federated` — used to take the **verbatim**
+branch on that leaf alone and echo the driver cause alongside the client one.
 `redactCredentials` covered the credential half, but a non-credential operator
 detail (an S3 object key) reached a public `400`.
 
-`hasMultipleCauses` closes it. Both `errors.Join` and multi-`%w` produce a node
-implementing `Unwrap() []error`; the walk descends the chain and reports any node
-that fans out. A fan-out means the sentinel proves only that *one* branch is
-caller fault, so provenance is ambiguous and the body is redacted regardless of
-sentinel evidence. Note that `errors.Unwrap` alone cannot detect this — it is
-defined for `Unwrap() error` and returns `nil` at a multi-cause node, so a walk
-built on it stops at the fan-out instead of seeing it.
+#307's answer was a chain-*shape* rule, `canDiscloseVerbatim = isClientError &&
+!hasMultipleCauses`, recorded here with the claim **"Blast radius: nil — no
+production error joins a client sentinel to an operator cause."** That claim
+was false when written: `internal/federated/duckdb_query_build.go` joined
+`forma.ErrInvalidInput` to `text/template`'s render error for an unrenderable
+caller-supplied path template, HTTP-reachable through `POST
+/api/v1/advanced_query`. The rule was safe there but harmful: the caller's own
+broken template answered an opaque `"internal error"` 400. Shape was also a
+weak proxy in the other direction — a single-cause wrap can embed driver or
+third-party prose in its own message text and disclosed it verbatim.
 
-**Blast radius: nil.** Every error in this repo that wraps
-`ErrInvalidInput`/`ErrNotFound`/`ErrConflict` is built with a single `%w`, and
-every multi-cause site carries read-path sentinels that already redact —
-`internal/federated`'s `%w: %w` wraps (`ErrFederatedReadFailed`,
-`ErrPostgresReadFailed`), `internal/cdc`'s `ErrSchemaAttrCacheUnavailable` and
-its `errors.Join` of per-schema flush failures, and `internal/compaction`'s
-`ErrConcurrentModification`. None of those is a client sentinel, and the CDC and
-compaction paths do not reach the HTTP boundary at all. So no live response
-changes; what changes is that a future client error built multi-cause loses its
-verbatim body rather than keeps leaking.
+#313 replaces shape with **provenance of the text itself**. A client error is
+built as a `forma.PublicError` carrier (`InvalidInputf`/`NotFoundf`/
+`Conflictf`, prefixed via `WrapPublicf`, operator facts attached via
+`WithOperatorDetail`), and the boundary emits `PublicMessage()` — text some
+wrap site deliberately authored for the caller — or nothing.
+`hasMultipleCauses` and `canDiscloseVerbatim` are **deleted**: chain shape
+stopped carrying information once raw chain text stopped crossing. A carrier
+joined anywhere in a mixed chain publishes only its own message
+(`TestMixedChainPublishesClientTextOnly`); a sentinel without a carrier is
+denied whatever its shape (`TestUnconvertedSentinelIsRedacted4xx`,
+`TestMixedChainIsRedacted`, `TestMultiVerbWrapChainIsRedacted`).
 
-This is the narrower of the two options considered, and the one the issue owner
-endorsed. The alternative — giving client errors typed public messages instead of
-echoing chain text — is a redesign of the 4xx surface and remains a follow-up.
-Pinned by `TestMixedChainIsRedacted`, `TestMultiVerbWrapChainIsRedacted`,
-`TestSingleCauseClientErrorStaysVerbatim`, and `TestHasMultipleCauses`.
+Note the deliberate semantic shift from #307: `errors.Join(operatorErr,
+carrier)` now *publishes* the carrier's message at a 4xx, where the shape rule
+would have redacted it. That is the intended reading of deny-by-default on the
+disclosure axis — the join proves nothing about the carrier's own text, which
+was authored for the caller regardless of what it is joined to. The operator
+branch of the join still never crosses.
 
 ```json
 {
@@ -742,42 +773,38 @@ The success path has the matching rule: `toExecutionPlan`
 the source SQL embeds the `postgres_scan` connection string, and notes can echo
 raw engine errors. Pinned by `TestToExecutionPlan_DoesNotLeakCredentials`.
 
-### Accepted disclosures inside the allowlist
+### Formerly accepted disclosures — both closed by #313
 
-The allowlist is a gate on *provenance*, not on content: an error that wraps a
-client sentinel down a single-cause chain is disclosed verbatim. Two live cases
-put more than the caller's own input into a 4xx body. Both are accepted, not
-bugs — recorded here so the boundary is stated rather than discovered. Both are
-single-cause chains, so `hasMultipleCauses` does not reach them.
+Under the verbatim regime the allowlist was a gate on *provenance*, not on
+content, and two live cases put more than the caller's own input into a 4xx
+body. Both were recorded here as accepted; both are now **closed**, each by the
+remedy this section itself prescribed — summarise at the wrap site, not widen
+the redaction gate.
 
-- **Postgres driver prose on a 409.**
-  `internal/postgres_persistent_repository_main_table.go:25` wraps `pgErr.Detail`
-  with `forma.ErrConflict`, so a unique-violation body carries driver-authored
-  text naming physical columns, e.g.
-  `Key (schema_id, row_id)=(…) already exists.` No credentials or object keys
-  cross, but this is the one remaining case where driver text reaches a public
-  body. If the detail ever needs to stop leaking the physical column layout, the
-  fix is to summarise at the wrap site, not to widen the redaction gate.
-- **Schema identifiers on a 404.** The eleven `forma.ErrNotFound` chains in
-  `internal/schemameta/file_registry.go:199-299` split two ways. Four are
-  name-keyed (`:222`, `:227`, `:276`, `:281`) and echo only the schema name the
-  caller put in the URL — nothing is disclosed that the caller did not supply.
-  The other seven (`:199`, `:204`, `:209`, `:242`, `:247`, `:294`, `:299`) are
-  ID-keyed and render the internal `int16`, e.g. `schema not found for ID: 402`.
-  A caller never supplies that: the URL carries a schema *name* and the system
-  resolves the ID internally, so this genuinely exposes an internal identifier.
-  It is accepted because a schema ID is a low-value opaque integer — not a
-  credential, not a storage path, and not something an attacker can act on
-  without already holding the access the 404 just denied.
+- **Postgres driver prose on a 409 — closed.** `classifyPgError`
+  (`internal/postgres_persistent_repository_main_table.go`) used to wrap
+  `pgErr.Detail`, so a unique-violation body carried driver-authored text
+  naming physical columns (`Key (schema_id, row_id)=(…) already exists.`). It
+  now publishes a curated summary — `the write conflicts with a row that
+  already exists` — and pushes the whole driver error, `Detail` included, into
+  operator detail. Pinned by `TestClassifyPgError`.
+- **Internal schema identifiers on a 404 — closed.** The seven ID-keyed
+  `forma.ErrNotFound` chains in `internal/schemameta/file_registry.go` used to
+  render the internal `int16` (`schema not found for ID: 402`) into the body —
+  an identifier the caller never supplied (the URL carries a schema *name*).
+  They now publish `schema not found` (likewise `schema data not found` /
+  `attribute id index not found`) and carry `schema id N` as operator detail,
+  so the log keeps it. The four name-keyed chains still publish the name — it
+  is the caller's own URL segment. The three repository not-found sites
+  (`postgres_persistent_repository{,_main_table,_batch}.go`) follow the same
+  split: the caller-supplied row id (and batch `key[%d]`) is published, the
+  internal schema id is operator detail. Pinned by
+  `TestRegistryNotFoundPublications`.
 
-  That judgement is no longer confined to the verbatim branch. "No schema id"
-  was originally a stated constraint on *redacted* bodies, and this bullet
-  existed to record where the constraint stopped applying. The constraint has
-  since been **lifted** — the issue owner reinstated the schema id on redacted
-  bodies, on exactly the reasoning above (see the "`schema_id` on a redacted
-  body" subsection above). Both branches now agree that a bare schema ID may
-  cross; the difference is that the redacted branch emits it as a structured
-  `schema_id` field rather than inside prose.
+A bare schema ID may still cross on a **redacted** body as the structured
+`schema_id` field (see "`schema_id` on a redacted body" above) — that decision
+predates #313 and stands; what #313 removed is internal ids riding inside
+published prose.
 
 ### Status change: create errors are now classified
 
@@ -787,21 +814,22 @@ status like every other handler. This is a public contract change, and it is
 independent of redaction.
 
 The clearest case is an unknown schema. `POST /api/v1/nosuchschema` returns
-**`404` instead of `500`**, and its body is **verbatim, not redacted**:
+**`404` instead of `500`**, and its body is **published, not redacted**:
 
 ```json
 {
   "success": false,
-  "error": "batch create failed: operation[0]: failed to get schema: schema not found: nosuchschema: not found"
+  "error": "batch create failed: operation[0]: failed to get schema: schema not found: nosuchschema"
 }
 ```
 
-That follows from the gate rather than contradicting it. The chain built by
-`file_registry.go:222` wraps `forma.ErrNotFound`, and `batchCreateAtomic` wraps
-that in turn, so `classifyManagerError` returns `404` on sentinel evidence and
-`canDiscloseVerbatim` is true — single `%w` at every level, so no fan-out — the
-verbatim branch, logged at `Debugw`, with no
-`error_class`, no `error_id` and no `schema_id`. Pinned by
+That follows from the gate rather than contradicting it. The registry's
+name-keyed `forma.NotFoundf` leaf publishes the schema name the caller sent,
+`batchCreateAtomic` prefixes it through `forma.WrapPublicf` with the batch
+index, so `classifyManagerError` returns `404` on sentinel evidence and the
+boundary emits the accumulated publication — logged at `Debugw`, with no
+`error_class`, no `error_id` and no `schema_id`. (Before #313 the body ended in
+`: not found`; the sentinel suffix no longer crosses.) Pinned by
 `TestCreateUnknownSchemaIs404AndVerbatim`.
 
 Clients keying on `500` to detect create failures must key on `success: false`
@@ -822,23 +850,22 @@ error wraps `forma.ErrInvalidInput` as part of the sweep above.
 | | before (pre-#301) | after |
 | --- | --- | --- |
 | status | `404` | `400` |
-| body | verbatim | verbatim |
+| body | verbatim | disclosed (published since #313) |
 
-**Only the status changed.** The body was verbatim before and is verbatim now —
-this endpoint reached `writeError` directly with the full message, and redaction
-did not exist at all before #301. No `error_class`, `error_id` or `schema_id`
-appeared on this response before, and none appears now: it takes the verbatim
-branch, so its serialization is byte-identical to pre-#301. A client
-keying on `404` to detect a filter typo breaks silently, and that is the whole of
-the migration impact.
+**Only the status changed at #301.** The message a caller reads is the same
+human-authored text throughout; since #313 it arrives as the carrier's
+published message (minus the sentinel suffix) rather than as raw chain text.
+No `error_class`, `error_id` or `schema_id` appeared on this response before,
+and none appears now. A client keying on `404` to detect a filter typo breaks
+silently, and that is the whole of the migration impact.
 
 **Most other condition-DSL errors did not change.** Unparseable filter values,
 unknown operators and malformed `"op:value"` all contain `invalid` or
-`unsupported`, so the heuristic already classified them `400` with a verbatim
-body, and they still answer `400` with a verbatim body. For those, wrapping the
-sentinel *preserved* the existing contract rather than altering it — without it,
-deleting the heuristic would have regressed them to a redacted `500`. That is what
-the sweep was for.
+`unsupported`, so the heuristic already classified them `400` with a usable
+body, and they still answer `400` with the same message published. For those,
+carrying the sentinel *preserved* the existing contract rather than altering
+it — without it, deleting the heuristic would have regressed them to a
+redacted `500`. That is what the sweep was for.
 
 ### Status change: an operator the attribute's type rejects is now 400, not 500
 
@@ -856,7 +883,7 @@ verbatim body; after #301 removed the heuristic it answered `500` with a
 | | before (pre-#301) | after #307, before round 4 | now |
 | --- | --- | --- | --- |
 | status | `500` | `500` | **`400`** |
-| body | verbatim | redacted | verbatim |
+| body | verbatim | redacted | published (#313) |
 
 The sweep simply missed this function; the operator is caller-supplied and the
 message names exactly what to change, so `400` is what the DSL contract always
@@ -935,8 +962,37 @@ of it, including a shortened or emptied list.
 `insertEAVAttributes` additionally routes its `tx.Exec` error through
 `classifyPgError`, matching the two `entity_main` sites. Any residual `23505` the
 dedupe cannot reach — a concurrent writer racing the same row, which could not be
-settled without a live database — therefore answers `409` with a verbatim body
-rather than a redacted `500`.
+settled without a live database — therefore answers `409` with the published
+conflict summary rather than a redacted `500`.
+
+### Status change: service-wiring guards are now 500, not 400 (#313)
+
+Four guards in `internal/entity_query_service.go` — `entity manager config is
+required` and `entity query service is not initialized`, at the head of `Query`
+and `CrossSchemaSearch` — used to wrap `forma.ErrInvalidInput` and answer
+`400`. Nothing about the request is wrong there: they report a mis-wired
+service, which is precisely the operator-fault class. They are plain errors
+now, so they answer a redacted `500`, matching the crud service's existing
+wiring guard. Unreachable through `factory`-wired production servers; visible
+only to embedders that construct the service partially. Pinned by
+`TestQueryServiceWiringGuardsAreNotClientErrors`.
+
+### Log levels are contract
+
+Three levels, decided by what the body withheld (`respondErrorWithStatus`):
+
+| branch | level | why |
+| --- | --- | --- |
+| redacted (any status) | `Errorw` | the body carries no text; the log line is the operator's only copy, and production runs at Info (`cmd/server/main.go`) |
+| disclosed 4xx, no withheld detail | `Debugw` | the caller already has everything; client mistakes must not page anyone |
+| disclosed 4xx with withheld detail (`forma.HasOperatorDetail`) | `Warnw` | the boundary just withheld text whose only remaining copy is this line — it must clear the Info threshold, but `Errorw` would hand callers an alert trigger they can pull at will |
+
+The standing hazard this creates: a disclosed 4xx that withholds detail carries
+**no `error_id`** for the caller to quote back (correlation fields are a
+redacted-branch shape, pinned by six assertions). If withheld-detail 4xxs turn
+out to need operator correlation in practice, adding `error_id` to disclosed
+bodies is a separate contract change — recorded as a follow-up candidate, not
+done here.
 
 ### Known gap
 
@@ -945,6 +1001,10 @@ scrubs them at the HTTP boundary, so nothing served or logged by
 `internal/httpapi` carries one — but a Go embedder using
 `factory.NewEntityManager*` receives the raw `error` and can capture the password
 in its own logs. Scrubbing at the engine's error wraps is tracked by #306.
+
+The same applies to publications: `PublicMessage()` is scrubbed at the HTTP
+boundary as defence in depth, but an embedder reading it directly gets the
+wrap site's text as authored.
 
 ## Message style
 
@@ -958,4 +1018,10 @@ Examples:
 
 - `storage type mismatch for numeric: value_text should not be populated (expected value_numeric)`
 - `missing required attribute 'name' (attrID=1) in EAV records`
-- `attribute 'age' (attrID=2): invalid value: invalid input: cannot convert string to float64`
+- `attribute 'age' (attrID=2): invalid value: cannot convert string to float64`
+
+For client errors, the published message is the whole body the caller sees, so
+the same rules apply to it directly. Anything an operator needs but a caller
+cannot act on — internal ids, driver detail, third-party render prose — goes
+behind `forma.WithOperatorDetail`, which keeps it in `Error()` and the log
+while withholding it from the publication.

--- a/internal/conditionexpr/parser.go
+++ b/internal/conditionexpr/parser.go
@@ -43,7 +43,7 @@ func ParseOperatorValueStrict(raw string) (OperatorValue, error) {
 		opPart := before
 		valPart := after
 		if opPart == "" || valPart == "" {
-			return OperatorValue{}, fmt.Errorf("invalid KvCondition value format: %s: %w", raw, forma.ErrInvalidInput)
+			return OperatorValue{}, forma.InvalidInputf("invalid KvCondition value format: %s", raw)
 		}
 		return OperatorValue{Operator: opPart, Value: valPart}, nil
 	}
@@ -97,7 +97,7 @@ func ToSQLOperator(op, value string) (SQLOperatorResult, error) {
 	case "contains":
 		return SQLOperatorResult{SQLOperator: "LIKE", Value: "%" + value + "%"}, nil
 	default:
-		return SQLOperatorResult{}, fmt.Errorf("unsupported operator: %s: %w", op, forma.ErrInvalidInput)
+		return SQLOperatorResult{}, forma.InvalidInputf("unsupported operator: %s", op)
 	}
 }
 
@@ -119,7 +119,7 @@ func ParseRFC3339OrUnixMs(raw string) (time.Time, error) {
 	}
 	ms, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("invalid date value: expected ISO 8601 format or unix milliseconds, got '%s': %w", raw, forma.ErrInvalidInput)
+		return time.Time{}, forma.InvalidInputf("invalid date value: expected ISO 8601 format or unix milliseconds, got '%s'", raw)
 	}
 	return time.UnixMilli(ms), nil
 }

--- a/internal/entity_batch_service.go
+++ b/internal/entity_batch_service.go
@@ -62,7 +62,7 @@ func newEntityBatchService(em *entityManager, crud *entityCRUDService) *entityBa
 
 func validateBatchOperation(req *forma.BatchOperation) error {
 	if req == nil {
-		return fmt.Errorf("batch operation cannot be nil: %w", forma.ErrInvalidInput)
+		return forma.InvalidInputf("batch operation cannot be nil")
 	}
 	return nil
 }
@@ -199,15 +199,15 @@ func (s *entityBatchService) batchCreateAtomic(ctx context.Context, req *forma.B
 
 	for i, op := range req.Operations {
 		if op.SchemaName == "" {
-			return nil, fmt.Errorf("operation[%d]: schema name is required: %w", i, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("operation[%d]: schema name is required", i)
 		}
 		if op.Data == nil {
-			return nil, fmt.Errorf("operation[%d]: data is required for create operation: %w", i, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("operation[%d]: data is required for create operation", i)
 		}
 
 		schemaID, schemaCache, err := s.registry.GetSchemaAttributeCacheByName(op.SchemaName)
 		if err != nil {
-			return nil, fmt.Errorf("operation[%d]: failed to get schema: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]: failed to get schema", i)
 		}
 
 		rowID := uuid.Must(uuid.NewV7())
@@ -228,16 +228,16 @@ func (s *entityBatchService) batchCreateAtomic(ctx context.Context, req *forma.B
 			data:       inputData,
 			enforce:    true,
 		}); err != nil {
-			return nil, fmt.Errorf("operation[%d]: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]", i)
 		}
 
 		record, err := s.transformer.ToPersistentRecord(ctx, schemaID, rowID, inputData)
 		if err != nil {
-			return nil, fmt.Errorf("operation[%d]: failed to transform data to persistent record: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]: failed to transform data to persistent record", i)
 		}
 		attributes, err := s.transformer.FromPersistentRecord(ctx, record)
 		if err != nil {
-			return nil, fmt.Errorf("operation[%d]: failed to transform persistent record to json: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]: failed to transform persistent record to json", i)
 		}
 
 		persistentRecords[i] = record
@@ -274,31 +274,31 @@ func (s *entityBatchService) batchUpdateAtomic(ctx context.Context, req *forma.B
 
 	for i, op := range req.Operations {
 		if op.SchemaName == "" {
-			return nil, fmt.Errorf("operation[%d]: schema name is required: %w", i, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("operation[%d]: schema name is required", i)
 		}
 		if op.RowID == (uuid.UUID{}) {
-			return nil, fmt.Errorf("operation[%d]: row id is required for update operation: %w", i, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("operation[%d]: row id is required for update operation", i)
 		}
 		if op.Updates == nil {
-			return nil, fmt.Errorf("operation[%d]: updates are required for update operation: %w", i, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("operation[%d]: updates are required for update operation", i)
 		}
 
 		schemaID, schemaCache, err := s.registry.GetSchemaAttributeCacheByName(op.SchemaName)
 		if err != nil {
-			return nil, fmt.Errorf("operation[%d]: failed to get schema: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]: failed to get schema", i)
 		}
 
 		existingRecord, err := s.repository.GetPersistentRecord(ctx, tables, schemaID, op.RowID)
 		if err != nil {
-			return nil, fmt.Errorf("operation[%d]: failed to load existing record: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]: failed to load existing record", i)
 		}
 		if existingRecord == nil {
-			return nil, fmt.Errorf("operation[%d]: entity not found: %s/%s: %w", i, op.SchemaName, op.RowID, forma.ErrNotFound)
+			return nil, forma.NotFoundf("operation[%d]: entity not found: %s/%s", i, op.SchemaName, op.RowID)
 		}
 
 		existingData, err := s.transformer.FromPersistentRecord(ctx, existingRecord)
 		if err != nil {
-			return nil, fmt.Errorf("operation[%d]: failed to transform existing record: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]: failed to transform existing record", i)
 		}
 
 		mergedData := mergeMaps(existingData, op.Updates)
@@ -318,12 +318,12 @@ func (s *entityBatchService) batchUpdateAtomic(ctx context.Context, req *forma.B
 			data:       mergedData,
 			enforce:    s.validateUpdatesStrict,
 		}); err != nil {
-			return nil, fmt.Errorf("operation[%d]: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]", i)
 		}
 
 		updatedRecord, err := s.transformer.ToPersistentRecord(ctx, schemaID, op.RowID, mergedData)
 		if err != nil {
-			return nil, fmt.Errorf("operation[%d]: failed to transform merged data: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]: failed to transform merged data", i)
 		}
 		updatedRecord.CreatedAt = existingRecord.CreatedAt
 		updatedRecord.DeletedAt = existingRecord.DeletedAt
@@ -362,15 +362,15 @@ func (s *entityBatchService) batchDeleteAtomic(ctx context.Context, req *forma.B
 
 	for i, op := range req.Operations {
 		if op.SchemaName == "" {
-			return nil, fmt.Errorf("operation[%d]: schema name is required: %w", i, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("operation[%d]: schema name is required", i)
 		}
 		if op.RowID == (uuid.UUID{}) {
-			return nil, fmt.Errorf("operation[%d]: row id is required for delete operation: %w", i, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("operation[%d]: row id is required for delete operation", i)
 		}
 
 		schemaID, _, err := s.registry.GetSchemaAttributeCacheByName(op.SchemaName)
 		if err != nil {
-			return nil, fmt.Errorf("operation[%d]: failed to get schema: %w", i, err)
+			return nil, forma.WrapPublicf(err, "operation[%d]: failed to get schema", i)
 		}
 
 		keys[i] = model.PersistentRecordKey{SchemaID: schemaID, RowID: op.RowID}

--- a/internal/entity_crud_service.go
+++ b/internal/entity_crud_service.go
@@ -52,15 +52,15 @@ func (s *entityCRUDService) Create(ctx context.Context, req *forma.EntityOperati
 	}
 
 	if req == nil {
-		return nil, fmt.Errorf("entity operation cannot be nil: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("entity operation cannot be nil")
 	}
 
 	if req.SchemaName == "" {
-		return nil, fmt.Errorf("schema name is required: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("schema name is required")
 	}
 
 	if req.Data == nil {
-		return nil, fmt.Errorf("data is required for create operation: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("data is required for create operation")
 	}
 
 	// Get schema by name to obtain schema ID and the attribute cache the
@@ -132,15 +132,15 @@ func (s *entityCRUDService) Get(ctx context.Context, req *forma.QueryRequest) (*
 	}
 
 	if req == nil {
-		return nil, fmt.Errorf("query request cannot be nil: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("query request cannot be nil")
 	}
 
 	if req.SchemaName == "" {
-		return nil, fmt.Errorf("schema name is required: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("schema name is required")
 	}
 
 	if req.RowID == nil {
-		return nil, fmt.Errorf("row ID is required for get operation: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("row ID is required for get operation")
 	}
 
 	// Verify schema exists and fetch schema ID.
@@ -154,7 +154,7 @@ func (s *entityCRUDService) Get(ctx context.Context, req *forma.QueryRequest) (*
 		return nil, fmt.Errorf("failed to load persistent record: %w", err)
 	}
 	if record == nil {
-		return nil, fmt.Errorf("entity not found: %s/%s: %w", req.SchemaName, req.RowID, forma.ErrNotFound)
+		return nil, forma.NotFoundf("entity not found: %s/%s", req.SchemaName, req.RowID)
 	}
 
 	dataRecord, err := s.toDataRecord(ctx, req.SchemaName, record)
@@ -177,19 +177,19 @@ func (s *entityCRUDService) Update(ctx context.Context, req *forma.EntityOperati
 	}
 
 	if req == nil {
-		return nil, fmt.Errorf("entity operation cannot be nil: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("entity operation cannot be nil")
 	}
 
 	if req.SchemaName == "" {
-		return nil, fmt.Errorf("schema name is required: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("schema name is required")
 	}
 
 	if req.RowID == (uuid.UUID{}) {
-		return nil, fmt.Errorf("row ID is required for update operation: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("row ID is required for update operation")
 	}
 
 	if req.Updates == nil {
-		return nil, fmt.Errorf("updates are required for update operation: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("updates are required for update operation")
 	}
 
 	// Get schema by name.
@@ -204,7 +204,7 @@ func (s *entityCRUDService) Update(ctx context.Context, req *forma.EntityOperati
 		return nil, fmt.Errorf("failed to load existing record: %w", err)
 	}
 	if existingRecord == nil {
-		return nil, fmt.Errorf("entity not found: %s/%s: %w", req.SchemaName, req.RowID, forma.ErrNotFound)
+		return nil, forma.NotFoundf("entity not found: %s/%s", req.SchemaName, req.RowID)
 	}
 
 	existingData, err := s.transformer.FromPersistentRecord(ctx, existingRecord)
@@ -258,15 +258,15 @@ func (s *entityCRUDService) Delete(ctx context.Context, req *forma.EntityOperati
 	}
 
 	if req == nil {
-		return fmt.Errorf("entity operation cannot be nil: %w", forma.ErrInvalidInput)
+		return forma.InvalidInputf("entity operation cannot be nil")
 	}
 
 	if req.SchemaName == "" {
-		return fmt.Errorf("schema name is required: %w", forma.ErrInvalidInput)
+		return forma.InvalidInputf("schema name is required")
 	}
 
 	if req.RowID == (uuid.UUID{}) {
-		return fmt.Errorf("row ID is required for delete operation: %w", forma.ErrInvalidInput)
+		return forma.InvalidInputf("row ID is required for delete operation")
 	}
 
 	schemaID, _, err := s.registry.GetSchemaAttributeCacheByName(req.SchemaName)

--- a/internal/entity_query_service.go
+++ b/internal/entity_query_service.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -44,18 +45,18 @@ func newEntityQueryService(em *entityManager) *entityQueryService {
 
 func (s *entityQueryService) Query(ctx context.Context, req *forma.QueryRequest) (*forma.QueryResult, error) {
 	if s.config == nil {
-		return nil, fmt.Errorf("entity manager config is required: %w", forma.ErrInvalidInput)
+		return nil, errors.New("entity manager config is required")
 	}
 	if s.registry == nil || s.repository == nil || s.toDataRecord == nil || s.enrichDataRecords == nil {
-		return nil, fmt.Errorf("entity query service is not initialized: %w", forma.ErrInvalidInput)
+		return nil, errors.New("entity query service is not initialized")
 	}
 
 	if req == nil {
-		return nil, fmt.Errorf("query request cannot be nil: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("query request cannot be nil")
 	}
 
 	if req.SchemaName == "" {
-		return nil, fmt.Errorf("schema name is required: %w", forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("schema name is required")
 	}
 
 	if req.Page < 1 {
@@ -247,10 +248,10 @@ func federatedPreferredTiers(tiers []string) []model.DataTier {
 
 func (s *entityQueryService) CrossSchemaSearch(ctx context.Context, req *forma.CrossSchemaRequest) (*forma.QueryResult, error) {
 	if s.config == nil {
-		return nil, fmt.Errorf("entity manager config is required: %w", forma.ErrInvalidInput)
+		return nil, errors.New("entity manager config is required")
 	}
 	if s.registry == nil || s.repository == nil || s.toDataRecord == nil || s.enrichDataRecords == nil {
-		return nil, fmt.Errorf("entity query service is not initialized: %w", forma.ErrInvalidInput)
+		return nil, errors.New("entity query service is not initialized")
 	}
 
 	if err := s.validateCrossSchemaRequest(req); err != nil {
@@ -305,13 +306,13 @@ func (s *entityQueryService) CrossSchemaSearch(ctx context.Context, req *forma.C
 // validateCrossSchemaRequest validates the cross schema search request parameters.
 func (s *entityQueryService) validateCrossSchemaRequest(req *forma.CrossSchemaRequest) error {
 	if req == nil {
-		return fmt.Errorf("cross schema request cannot be nil: %w", forma.ErrInvalidInput)
+		return forma.InvalidInputf("cross schema request cannot be nil")
 	}
 	if len(req.SchemaNames) == 0 {
-		return fmt.Errorf("schema names are required: %w", forma.ErrInvalidInput)
+		return forma.InvalidInputf("schema names are required")
 	}
 	if req.SearchTerm == "" {
-		return fmt.Errorf("search term is required: %w", forma.ErrInvalidInput)
+		return forma.InvalidInputf("search term is required")
 	}
 	if req.Page < 1 {
 		req.Page = 1

--- a/internal/entity_query_sort.go
+++ b/internal/entity_query_sort.go
@@ -34,20 +34,21 @@ func resolveSortKeys(req *forma.QueryRequest) ([]sortKey, error) {
 	}
 
 	if len(req.SortBy) > 0 || req.SortOrder != "" {
-		return nil, fmt.Errorf(
-			"sort cannot be combined with sort_by/sort_order: use sort alone for per-key directions: %w",
-			forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf(
+			"sort cannot be combined with sort_by/sort_order: use sort alone for per-key directions")
 	}
 
 	keys := make([]sortKey, 0, len(req.Sort))
 	for i, entry := range req.Sort {
 		attr := strings.TrimSpace(entry.Attribute)
 		if attr == "" {
-			return nil, fmt.Errorf("sort entry %d has an empty attribute: %w", i, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("sort entry %d has an empty attribute", i)
 		}
 		order, err := normalizeSortOrder(entry.SortOrder)
 		if err != nil {
-			return nil, fmt.Errorf("sort entry for attribute '%s': %w", attr, err)
+			// The attribute name identifies which entry is wrong — caller-actionable,
+			// so the prefix belongs in the published message too.
+			return nil, forma.WrapPublicf(err, "sort entry for attribute '%s'", attr)
 		}
 		keys = append(keys, sortKey{attr: attr, order: order})
 	}
@@ -63,7 +64,7 @@ func normalizeSortOrder(raw forma.SortOrder) (forma.SortOrder, error) {
 	case forma.SortOrderDesc:
 		return forma.SortOrderDesc, nil
 	default:
-		return "", fmt.Errorf("invalid sort_order '%s': expected 'asc' or 'desc': %w", raw, forma.ErrInvalidInput)
+		return "", forma.InvalidInputf("invalid sort_order '%s': expected 'asc' or 'desc'", raw)
 	}
 }
 
@@ -81,15 +82,12 @@ func buildAttributeOrders(req *forma.QueryRequest, schemaCache forma.SchemaAttri
 	for _, key := range keys {
 		meta, ok := schemaCache[key.attr]
 		if !ok {
-			// Wraps forma.ErrInvalidInput (#296): naming an attribute the schema
-			// does not define is caller fault, and the HTTP boundary now classifies
-			// on sentinel evidence alone (#301). Without the sentinel this would
-			// answer 500 with a redacted body instead of 400 with the guidance the
-			// caller needs. The human-authored prefix is unchanged on purpose — it
-			// is what callers and tests match on — while the %w rendering appends
-			// ": invalid input" to the full string (#309).
-			return nil, fmt.Errorf("cannot sort by unknown attribute '%s' in schema '%s': %w",
-				key.attr, req.SchemaName, forma.ErrInvalidInput)
+			// A client error (#296): naming an attribute the schema does not define
+			// is caller fault, and the HTTP boundary classifies on sentinel evidence
+			// alone (#301). The carrier's published message is the whole body text
+			// the caller sees (#313), so it must name the attribute and the schema.
+			return nil, forma.InvalidInputf("cannot sort by unknown attribute '%s' in schema '%s'",
+				key.attr, req.SchemaName)
 		}
 		order := model.AttributeOrder{
 			AttrID:    meta.AttributeID,

--- a/internal/entity_service_publication_test.go
+++ b/internal/entity_service_publication_test.go
@@ -1,0 +1,111 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/transform"
+)
+
+// publicMessageOf resolves the deliberately published message the HTTP
+// boundary would emit for err (#313), or fails the test if err publishes
+// nothing.
+func publicMessageOf(t *testing.T, err error) string {
+	t.Helper()
+	var pub forma.PublicError
+	if !errors.As(err, &pub) {
+		t.Fatalf("error publishes no client message: %v", err)
+	}
+	return pub.PublicMessage()
+}
+
+// The operation index is the piece of a batch error the caller cannot recover
+// from anywhere else in the response; it must survive into the published
+// message, not just into Error().
+func TestBatchCreateAtomicPublishesOperationIndex(t *testing.T) {
+	ctx := context.Background()
+	registry, err := newFileSchemaRegistryFromDir("../cmd/server/schemas")
+	if err != nil {
+		t.Fatalf("failed to create schema registry: %v", err)
+	}
+	em := NewEntityManager(transform.NewPersistentRecordTransformer(registry),
+		newMockPersistentRecordRepository(), nil, registry, createTestConfig(), nil)
+
+	req := &forma.BatchOperation{
+		Atomic: true,
+		Operations: []forma.EntityOperation{
+			{
+				EntityIdentifier: forma.EntityIdentifier{SchemaName: "visit"},
+				Type:             forma.OperationCreate,
+				Data:             visitPayload("visit-pub-1"),
+			},
+			{
+				EntityIdentifier: forma.EntityIdentifier{SchemaName: "visit"},
+				Type:             forma.OperationCreate,
+			},
+		},
+	}
+
+	_, err = em.BatchCreate(ctx, req)
+	if err == nil {
+		t.Fatalf("expected the nil-data guard to fail the atomic batch")
+	}
+	if !errors.Is(err, forma.ErrInvalidInput) {
+		t.Fatalf("guard error lost its sentinel: %v", err)
+	}
+	if got, want := publicMessageOf(t, err), "operation[1]: data is required for create operation"; got != want {
+		t.Fatalf("published message = %q, want %q", got, want)
+	}
+}
+
+func TestSortErrorsPublishTheirMessages(t *testing.T) {
+	t.Run("leaf names attribute and schema", func(t *testing.T) {
+		req := &forma.QueryRequest{
+			SchemaName: "e2e_wide",
+			Sort:       []forma.OrderBy{{Attribute: "ghost"}},
+		}
+		_, err := buildAttributeOrders(req, buildSortTestCache())
+		if err == nil {
+			t.Fatalf("expected unknown-attribute error, got nil")
+		}
+		want := "cannot sort by unknown attribute 'ghost' in schema 'e2e_wide'"
+		if got := publicMessageOf(t, err); got != want {
+			t.Fatalf("published message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("wrap prefixes the offending entry", func(t *testing.T) {
+		req := &forma.QueryRequest{
+			Sort: []forma.OrderBy{{Attribute: "name", SortOrder: "sideways"}},
+		}
+		_, err := resolveSortKeys(req)
+		if err == nil {
+			t.Fatalf("expected invalid sort_order error, got nil")
+		}
+		want := "sort entry for attribute 'name': invalid sort_order 'sideways': expected 'asc' or 'desc'"
+		if got := publicMessageOf(t, err); got != want {
+			t.Fatalf("published message = %q, want %q", got, want)
+		}
+	})
+}
+
+// The service-wiring guards are operator faults, not caller faults: they no
+// longer carry forma.ErrInvalidInput, so the boundary answers 500 rather than
+// blaming the request (#313).
+func TestQueryServiceWiringGuardsAreNotClientErrors(t *testing.T) {
+	s := &entityQueryService{}
+	_, err := s.Query(context.Background(), nil)
+	if err == nil {
+		t.Fatalf("expected the config guard to fail")
+	}
+	if errors.Is(err, forma.ErrInvalidInput) {
+		t.Fatalf("internal wiring guard still classified as caller fault: %v", err)
+	}
+	if _, alsoErr := s.CrossSchemaSearch(context.Background(), nil); alsoErr == nil {
+		t.Fatalf("expected the cross-schema config guard to fail")
+	} else if errors.Is(alsoErr, forma.ErrInvalidInput) {
+		t.Fatalf("internal wiring guard still classified as caller fault: %v", alsoErr)
+	}
+}

--- a/internal/federated/duckdb_query_build.go
+++ b/internal/federated/duckdb_query_build.go
@@ -284,9 +284,12 @@ func duckDBParquetPathsForQuery(q *model.FederatedAttributeQuery) ([]string, err
 		// A caller-supplied template that cannot render is invalid input, not
 		// an absent hint: swallowing it would silently serve the query from a
 		// different path set (the manifest source, or none) than the caller
-		// explicitly requested (#249 review).
-		return nil, fmt.Errorf("render s3 parquet path template %q: %w: %w",
-			q.DuckDBHints.S3ParquetPathTemplate, forma.ErrInvalidInput, err)
+		// explicitly requested (#249 review). The template is the caller's own
+		// payload field, so the published message may echo it; text/template's
+		// render prose is operator detail and stays log-only (#313).
+		return nil, forma.WithOperatorDetail(
+			forma.InvalidInputf("render s3 parquet path template %q: the template is not renderable",
+				q.DuckDBHints.S3ParquetPathTemplate), err)
 	}
 	parts := strings.Split(rendered, ",")
 	paths := make([]string, 0, len(parts))
@@ -304,8 +307,8 @@ func duckDBParquetPathsForQuery(q *model.FederatedAttributeQuery) ([]string, err
 		// the caller explicitly requested. Same rule as an unrenderable
 		// template: explicit hints always win, including when they fail
 		// (#250 PR review).
-		return nil, fmt.Errorf("s3 parquet path template %q rendered no usable paths: %w",
-			q.DuckDBHints.S3ParquetPathTemplate, forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("s3 parquet path template %q rendered no usable paths",
+			q.DuckDBHints.S3ParquetPathTemplate)
 	}
 	return paths, nil
 }

--- a/internal/federated/parquet_source_test.go
+++ b/internal/federated/parquet_source_test.go
@@ -484,3 +484,35 @@ func TestRecordCorruptExclusionEmptyIsNoop(t *testing.T) {
 
 	require.Len(t, opts.ExecutionPlan.Notes, before)
 }
+
+// The broken-hint 400 must publish the caller's own template and the reason,
+// while text/template's parse prose stays operator-only (#313). This is the
+// issue's motivating case: before typed publications this mixed chain
+// collapsed to an opaque redacted body.
+func TestParquetSource_InvalidHintPublishesTemplateWithoutRenderInternals(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	src := &fakeParquetSource{paths: []string{"s3://b/1/from-manifest.parquet"}}
+	duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: uuid.New()}}
+	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 1}}
+	engine := NewDBFederatedQueryEngine(pg, &fakeDirtyIDFetcher{}, duck, nil,
+		hybridDuckConfig(), testMetadataCacheSchema7(t), "host=x", WithParquetSource(src))
+
+	q := coldTierQuery()
+	q.DuckDBHints = &model.DuckDBRenderHints{S3ParquetPathTemplate: "s3://b/{{.Broken"}
+	_, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		q, &model.FederatedQueryOptions{AllowPartialDegradedMode: true})
+	require.Error(t, err)
+
+	var pub forma.PublicError
+	require.True(t, errors.As(err, &pub), "broken hint publishes no client message: %v", err)
+	require.Contains(t, pub.PublicMessage(), `"s3://b/{{.Broken"`)
+	require.Contains(t, pub.PublicMessage(), "not renderable")
+	require.NotContains(t, pub.PublicMessage(), "unclosed action",
+		"text/template internals must stay operator-only")
+	require.Contains(t, err.Error(), "unclosed action",
+		"the operator copy must keep the render error")
+	require.True(t, forma.HasOperatorDetail(err))
+}

--- a/internal/httpapi/error_leak_test.go
+++ b/internal/httpapi/error_leak_test.go
@@ -150,7 +150,7 @@ func TestCreateValidationErrorIsClientError(t *testing.T) {
 	defer restore()
 
 	manager := &mockEntityManager{
-		batchCreateErr: fmt.Errorf("attribute 'age' (attrID=2): %w: cannot convert string to float64", forma.ErrInvalidInput),
+		batchCreateErr: forma.InvalidInputf("attribute 'age' (attrID=2): cannot convert string to float64"),
 	}
 	srv := NewServer(manager, Options{})
 
@@ -166,24 +166,24 @@ func TestCreateValidationErrorIsClientError(t *testing.T) {
 	}
 }
 
-// TestCreateUnknownSchemaIs404AndVerbatim pins the only externally visible
-// behaviour change in #301: handleCreate stopped hardcoding 500 and now answers
-// its classified status, so POST to an unknown schema returns 404 instead of
-// 500.
+// TestCreateUnknownSchemaIs404AndVerbatim pins the externally visible
+// behaviour change from #301: handleCreate answers its classified status, so
+// POST to an unknown schema returns 404 instead of 500.
 //
-// It also pins that this 404 takes the *verbatim* branch. The chain is the real
-// one — internal/schemameta/file_registry.go:222 wraps forma.ErrNotFound — so
-// classifyManagerError reaches 404 on sentinel evidence and isClientError is
-// true. That combination must leave the body unredacted and free of
-// error_class/error_id, which is what distinguishes it from an error carrying no
-// sentinel at all (TestSentinelLessErrorIsRedacted500).
+// It also pins that this 404 publishes. The chain is the shape the batch
+// service now builds — the registry's name-keyed forma.NotFoundf leaf under
+// the batch loop's forma.WrapPublicf — so the body names the schema the
+// caller sent while staying free of error_class/error_id, which is what
+// distinguishes it from an error carrying no publication at all
+// (TestUnconvertedSentinelIsRedacted4xx).
 func TestCreateUnknownSchemaIs404AndVerbatim(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
 	defer restore()
 
 	manager := &mockEntityManager{
-		batchCreateErr: fmt.Errorf("operation[0]: failed to get schema: %w",
-			fmt.Errorf("schema not found: %s: %w", "nosuchschema", forma.ErrNotFound)),
+		batchCreateErr: forma.WrapPublicf(
+			forma.NotFoundf("schema not found: %s", "nosuchschema"),
+			"operation[0]: failed to get schema"),
 	}
 	srv := NewServer(manager, Options{})
 
@@ -265,9 +265,10 @@ var writeErrorAllowed4xx = map[string]bool{
 // The invariant: every writeError call in a non-test file passes a literal 4xx
 // http.Status* constant from writeErrorAllowed4xx, with exactly one sanctioned
 // exception — respondErrorWithStatus in error_response.go, which passes the
-// variable `status` under a runtime gate (canDiscloseVerbatim) that is what actually
-// constrains it. That exception is exempted by asserting it is unique, so if it
-// moves, multiplies, or reappears in another file the guard fails.
+// variable `status` under a runtime gate (isClientError + resolvePublicMessage,
+// #313) that is what actually constrains it. That exception is exempted by
+// asserting it is unique, so if it moves, multiplies, or reappears in another
+// file the guard fails.
 //
 // It is an allowlist rather than a blocklist of bad statuses because a blocklist
 // can be spelled around, and the most likely regression shape spells around it
@@ -285,7 +286,7 @@ var writeErrorAllowed4xx = map[string]bool{
 //
 // NOTE: the other unchecked axis is the message. This guard reads only the
 // *status* expression; it cannot tell whether the third argument is safe to
-// disclose. That judgement belongs to canDiscloseVerbatim inside
+// disclose. That judgement belongs to resolvePublicMessage inside
 // respondErrorWithStatus, and the direct call sites stay safe only because their
 // messages come from request parsing (parsePath, readJSONBody, parseUUID,
 // parseCreateObjects, parseSortParams), never from the manager, the engine, S3,

--- a/internal/httpapi/error_response.go
+++ b/internal/httpapi/error_response.go
@@ -20,12 +20,11 @@ import (
 // the operator log line.
 //
 // Classification keys off sentinel evidence alone; disclosure needs that *and*
-// an unambiguous chain (canDiscloseVerbatim). So a redacted body is a 500 on
-// every live path today — no production error joins a client sentinel to an
-// operator cause — but the two are separately decided and a redacted 4xx is now
-// reachable by construction: a multi-cause chain carrying a client sentinel
-// classifies 4xx on that sentinel and still redacts. Such a body carries
-// error_class "internal" plus an error_id, like any other redacted response.
+// a deliberately published message (#313, resolvePublicMessage). A client
+// error built without a forma.PublicError carrier keeps its 4xx status but
+// takes the redacted branch — deny-by-default on the disclosure axis. Such a
+// body carries error_class "internal" plus an error_id, like any other
+// redacted response.
 //
 // errorClassInternal deliberately absorbs ErrFederatedReadFailed,
 // ErrPostgresReadFailed, metadata drift, and transform failures. A client-facing
@@ -163,12 +162,10 @@ func writeError(w http.ResponseWriter, statusCode int, message string) error {
 // Deleting the heuristic also removes the last site in the codebase that
 // classified an error by string comparison, which AGENTS.md forbids outright.
 //
-// The cost is that a genuine client error only earns its 4xx by wrapping a
+// The cost is that a genuine client error only earns its 4xx by carrying a
 // sentinel, and removing the heuristic therefore required a sweep. Six sites
-// across four packages had been relying on it and now wrap forma.ErrInvalidInput.
-// The human-authored message prefix is unchanged; the %w rendering appends
-// ": invalid input" to the full string, and that suffix is a kept part of the
-// body contract (#309):
+// across four packages had been relying on it and now carry
+// forma.ErrInvalidInput (since #313 via the forma.InvalidInputf carrier):
 //
 //   - internal/entity_query_sort.go — unknown sort attribute (#296)
 //   - internal/transform/transformer.go — create or update body omitting a
@@ -187,10 +184,12 @@ func writeError(w http.ResponseWriter, statusCode int, message string) error {
 // The table in docs/error-handling.md ("Public HTTP error surface") is the
 // maintained list, with the caller mistake each one represents.
 //
-// IF YOU ADD A VALIDATOR that rejects caller input anywhere behind this boundary,
-// wrap forma.ErrInvalidInput. There is no message-text fallback any more: an
-// unwrapped validation error is a 500 with an opaque body, and the caller is told
-// nothing about what they got wrong.
+// IF YOU ADD A VALIDATOR that rejects caller input anywhere behind this
+// boundary, build the error with forma.InvalidInputf (or NotFoundf/Conflictf)
+// so it carries both the sentinel and a published message. There is no
+// message-text fallback: an error with no sentinel is a 500 with an opaque
+// body, and a bare fmt.Errorf wrap of a sentinel is a 4xx with an opaque body
+// (#313) — either way the caller is told nothing about what they got wrong.
 func classifyManagerError(err error) int {
 	switch {
 	case err == nil:
@@ -209,10 +208,10 @@ func classifyManagerError(err error) int {
 // respondError classifies err, records the chain for operators under
 // redactCredentials, and writes a client-safe body.
 //
-// A 4xx that carries positive sentinel evidence of caller fault down an
-// unambiguous chain (canDiscloseVerbatim) keeps the verbatim message: it
-// describes caller-supplied input, the caller needs to know what to fix, and
-// nothing on the write path touches S3 or the postgres_scan connection string.
+// A 4xx that carries positive sentinel evidence of caller fault AND a
+// deliberately published message (forma.PublicError) emits that message: it
+// was authored at the wrap site for the caller, and nothing else from the
+// chain rides along (#313).
 //
 // Everything else carries no error text at all (#301). Errors reaching this point hold
 // bucket-relative S3 object keys and — when DuckDB fails to attach
@@ -227,96 +226,76 @@ func respondError(w http.ResponseWriter, op string, err error, logFields ...any)
 
 // isClientError reports whether err is provably the caller's fault.
 //
-// Positive sentinel evidence is the only safe gate for disclosure (#301). It is
-// now also what classifyManagerError decides on, so for a respondError caller the
-// two agree by construction. The check stays separate because
-// respondErrorWithStatus also serves callers that pass their own status
-// (executeGet), and a status alone must never be able to open the verbatim branch.
+// Positive sentinel evidence is the first conjunct of the disclosure decision
+// (#301). It is also what classifyManagerError decides on, so for a
+// respondError caller the two agree by construction. The check stays separate
+// because respondErrorWithStatus also serves callers that pass their own
+// status (executeGet), and a status alone must never be able to open the
+// disclosed branch.
 //
-// It is necessary but no longer sufficient for disclosure: errors.Is matches any
-// leaf, so a sentinel found inside a multi-cause chain proves only that *some*
-// branch is caller fault. hasMultipleCauses is the second conjunct — see
-// canDiscloseVerbatim.
+// It is necessary but not sufficient: disclosure additionally requires a
+// deliberately published message (resolvePublicMessage). Keeping the sentinel
+// conjunct means a foreign type that happens to implement PublicMessage()
+// cannot publish itself through this boundary without also carrying a client
+// sentinel — the same "necessary, never sufficient" relationship the status
+// conjunct has.
 func isClientError(err error) bool {
 	return errors.Is(err, forma.ErrInvalidInput) ||
 		errors.Is(err, forma.ErrNotFound) ||
 		errors.Is(err, forma.ErrConflict)
 }
 
-// hasMultipleCauses reports whether any node in err's chain fans out to more
-// than one cause.
+// resolvePublicMessage returns the message err deliberately published, if any.
 //
-// Both errors.Join and a multi-verb fmt.Errorf("%w: %w", …) produce a node
-// implementing `Unwrap() []error`, and that is the shape that makes provenance
-// ambiguous: errors.Is descends into every branch, so a client sentinel in one
-// branch cannot tell you the *other* branch is also the caller's fault.
+// This replaces #307's chain-shape heuristic (canDiscloseVerbatim's
+// "single-cause chains may disclose verbatim"): shape proved a weak proxy for
+// provenance — a single-cause wrap could still embed driver prose in its own
+// text, and the one live mixed chain (an unrenderable caller-supplied path
+// template, internal/federated/duckdb_query_build.go) collapsed to an opaque
+// body precisely when the caller needed guidance. Publication is decided where
+// the error is authored: errors.As resolves the outermost forma.PublicError
+// (preorder, left-first), so wrap prefixes accumulate and a carrier joined
+// anywhere in a multi-cause chain still publishes only its own text.
 //
-// errors.Unwrap alone cannot walk this: it is defined only for `Unwrap() error`
-// and returns nil at a multi-cause node, so a loop built on it would stop at the
-// fan-out instead of detecting it. Single-cause nodes are followed through so a
-// join wrapped in context is still caught.
-func hasMultipleCauses(err error) bool {
-	for err != nil {
-		joined, ok := err.(interface{ Unwrap() []error })
-		if !ok {
-			err = errors.Unwrap(err)
-			continue
-		}
-		causes := joined.Unwrap()
-		if len(causes) > 1 {
-			return true
-		}
-		if len(causes) == 0 {
-			return false
-		}
-		err = causes[0]
+// An empty publication is treated as no publication: nothing about an empty
+// string proves a wrap site authored it deliberately.
+func resolvePublicMessage(err error) (string, bool) {
+	var pub forma.PublicError
+	if !errors.As(err, &pub) {
+		return "", false
 	}
-	return false
-}
-
-// canDiscloseVerbatim reports whether err's message may cross to the client
-// unchanged (#301, Finding 3).
-//
-// Two conjuncts, both required. isClientError is the positive sentinel evidence
-// that the error describes caller-supplied input. hasMultipleCauses is the
-// provenance check: a chain that fans out carries causes the sentinel says
-// nothing about, so it is treated as ambiguous and redacted regardless of the
-// sentinel. Previously any client-sentinel leaf granted disclosure, so
-// errors.Join(clientSentinel, operatorError) published the operator cause —
-// credentials scrubbed, but an S3 object key still reached a 400 body.
-//
-// The blast radius of the second conjunct is nil in this repo: every error that
-// wraps forma.ErrInvalidInput/ErrNotFound/ErrConflict is built with a single
-// `%w`, and every multi-cause site (internal/federated's `%w: %w` wraps,
-// internal/compaction, internal/cdc's errors.Join) carries read-path sentinels
-// that already redact. A future client error built multi-cause would lose its
-// verbatim body rather than gain a wrong status — the conservative direction,
-// and the one the issue owner asked for over the alternative of narrowing
-// errors.Is to the outermost cause.
-func canDiscloseVerbatim(err error) bool {
-	return isClientError(err) && !hasMultipleCauses(err)
+	msg := pub.PublicMessage()
+	if msg == "" {
+		return "", false
+	}
+	return msg, true
 }
 
 // respondErrorWithStatus is respondError for callers that have already
 // classified in order to choose their message (executeGet's 404 wording).
 //
-// The gate on disclosure is canDiscloseVerbatim — positive sentinel evidence
-// down an unambiguous chain — not the status code, so a caller-supplied 4xx
-// cannot promote an operator error to verbatim. The status conjunct only ever
-// holds disclosure back.
+// The gate on disclosure is sentinel evidence plus a published message
+// (isClientError + resolvePublicMessage) — not the status code, so a
+// caller-supplied 4xx cannot promote an operator error to disclosure. The
+// status conjunct only ever holds disclosure back.
 //
-// Every string that leaves this function passes through redactCredentials first,
-// body and log alike. The log needs it because DuckDB puts the postgres_scan
-// connection string, password included, into its own attach-failure prose, and
-// this package's Errorw line is where that would otherwise enter log collection
-// and retention. The body keeps it as defence in depth: the multi-cause chains
-// that could carry driver text now take the redacted branch anyway, so nothing
-// depends on the scrub to keep a password out of a response.
+// Every string that leaves this function passes through redactCredentials
+// first, body and log alike. The log needs it because DuckDB puts the
+// postgres_scan connection string, password included, into its own
+// attach-failure prose, and this package's Errorw line is where that would
+// otherwise enter log collection and retention. The published message is
+// scrubbed too, as defence in depth: it is authored at a wrap site, and a wrap
+// site can interpolate a DSN by accident.
 //
-// Every redacted response logs at Errorw whatever its status, because a redacted
-// body is the operator's only remaining copy of the detail and the production
-// logger runs at Info (cmd/server/main.go). Only the verbatim branch logs at
-// Debugw: there, the caller already has the full message.
+// Log levels are contract. Every redacted response logs at Errorw whatever its
+// status, because a redacted body is the operator's only remaining copy of the
+// detail and the production logger runs at Info (cmd/server/main.go). A
+// disclosed 4xx logs at Debugw when the chain holds nothing beyond its
+// publication — the caller already has everything — but at Warnw when
+// operator detail was withheld (forma.HasOperatorDetail): that line is the
+// only copy of the detail, so it must clear the Info threshold, without
+// inheriting Errorw's alerting weight for something a caller can trigger at
+// will.
 func respondErrorWithStatus(w http.ResponseWriter, status int, op string, err error, logFields ...any) {
 	fields := make([]any, 0, len(logFields)+8)
 	fields = append(fields, logFields...)
@@ -331,10 +310,14 @@ func respondErrorWithStatus(w http.ResponseWriter, status int, op string, err er
 	}
 	safe := redactCredentials(err.Error())
 
-	if status < http.StatusInternalServerError && canDiscloseVerbatim(err) {
+	if msg, ok := resolvePublicMessage(err); ok && status < http.StatusInternalServerError && isClientError(err) {
 		fields = append(fields, "error", safe)
-		zap.S().Debugw(op, fields...)
-		_ = writeError(w, status, fmt.Sprintf("%s: %s", op, safe))
+		if forma.HasOperatorDetail(err) {
+			zap.S().Warnw(op, fields...)
+		} else {
+			zap.S().Debugw(op, fields...)
+		}
+		_ = writeError(w, status, fmt.Sprintf("%s: %s", op, redactCredentials(msg)))
 		return
 	}
 

--- a/internal/httpapi/error_response_test.go
+++ b/internal/httpapi/error_response_test.go
@@ -164,15 +164,19 @@ func TestRespondErrorRedacts5xxAndLogsFullChain(t *testing.T) {
 	}
 }
 
-// TestRespondErrorKeeps4xxMessageVerbatim pins the other half of the contract:
-// a client error describes caller-supplied input, so the caller still gets the
-// full message and no correlation fields are emitted.
-func TestRespondErrorKeeps4xxMessageVerbatim(t *testing.T) {
-	core, logs := observer.New(zap.ErrorLevel)
+// TestRespondError4xxPublishesOnlyTheCarriersMessage pins the other half of
+// the contract (#313): the caller gets the deliberately published message —
+// and only that. Operator detail attached to the same error stays out of the
+// body, and its presence promotes the log line to WARN because the boundary
+// just withheld text whose only remaining copy is that line.
+func TestRespondError4xxPublishesOnlyTheCarriersMessage(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
 	restore := zap.ReplaceGlobals(zap.New(core))
 	defer restore()
 
-	err := fmt.Errorf("attribute 'age' (attrID=2): %w: cannot convert string to float64", forma.ErrInvalidInput)
+	err := forma.WithOperatorDetail(
+		forma.InvalidInputf("attribute 'age' (attrID=2): cannot convert string to float64"),
+		fmt.Errorf("while flushing %s", canaryKey))
 	rec := httptest.NewRecorder()
 	respondError(rec, "create failed", err, "schema", "orders")
 
@@ -185,16 +189,25 @@ func TestRespondErrorKeeps4xxMessageVerbatim(t *testing.T) {
 		t.Fatalf("body is not valid JSON: %v", uerr)
 	}
 	if !strings.Contains(resp.Error, "create failed: attribute 'age' (attrID=2)") {
-		t.Fatalf("4xx message was not preserved verbatim: %q", resp.Error)
+		t.Fatalf("published message was not preserved: %q", resp.Error)
 	}
 	if !strings.Contains(resp.Error, "cannot convert string to float64") {
-		t.Fatalf("4xx message was truncated: %q", resp.Error)
+		t.Fatalf("published message was truncated: %q", resp.Error)
+	}
+	if strings.Contains(rec.Body.String(), canaryKey) {
+		t.Fatalf("operator detail leaked into the 400 body: %s", rec.Body.String())
 	}
 	if resp.ErrorClass != "" || resp.ErrorID != "" {
 		t.Fatalf("4xx must not emit correlation fields, got class=%q id=%q", resp.ErrorClass, resp.ErrorID)
 	}
-	if logs.Len() != 0 {
-		t.Fatalf("a client error must not log at ERROR level, got %d entries", logs.Len())
+
+	entries := logs.All()
+	if len(entries) != 1 || entries[0].Level != zap.WarnLevel {
+		t.Fatalf("withheld operator detail must log at WARN, got %d entries %v", len(entries), entries)
+	}
+	logged, _ := entries[0].ContextMap()["error"].(string)
+	if !strings.Contains(logged, canaryKey) {
+		t.Fatalf("operator log lost the withheld detail; logged: %s", logged)
 	}
 }
 
@@ -206,7 +219,7 @@ func TestRespondErrorWithStatusHonoursCallerStatus(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	respondErrorWithStatus(rec, http.StatusNotFound, "record not found",
-		fmt.Errorf("wrap: %w", forma.ErrNotFound), "schema", "orders")
+		forma.NotFoundf("wrap"), "schema", "orders")
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("expected status 404, got %d", rec.Code)
@@ -282,20 +295,18 @@ func TestReadPathDriverErrorIs500AndRedacted(t *testing.T) {
 	}
 }
 
-// TestUnknownSortAttributeIs400AndVerbatim closes the loop between #301 and #296.
-//
-// Removing the substring heuristic would have regressed the one genuine client
-// error that relied on it — `cannot sort by unknown attribute` — from a 400 with
-// usable guidance to a 500 with an opaque body. internal/entity_query_sort.go now
-// wraps forma.ErrInvalidInput instead, so it reaches 400 through the sentinel
-// branch and keeps its verbatim message. This is the error shape that function
-// actually produces, prose unchanged.
-func TestUnknownSortAttributeIs400AndVerbatim(t *testing.T) {
+// TestUnknownSortAttributeIs400AndPublished closes the loop between #301,
+// #296, and #313: the unknown-sort-attribute error keeps its 400 and its
+// guidance, now as a published carrier message. The sentinel suffix that #309
+// kept as body contract no longer reaches the body at all — only Error()
+// carries it — which the negative assertion pins. This is the error shape
+// internal/entity_query_sort.go actually produces, prose unchanged.
+func TestUnknownSortAttributeIs400AndPublished(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
 	defer restore()
 
-	err := fmt.Errorf("cannot sort by unknown attribute '%s' in schema '%s': %w",
-		"nope", "lead", forma.ErrInvalidInput)
+	err := forma.InvalidInputf("cannot sort by unknown attribute '%s' in schema '%s'",
+		"nope", "lead")
 
 	rec := httptest.NewRecorder()
 	respondError(rec, "query failed", err, "schema", "lead")
@@ -309,10 +320,13 @@ func TestUnknownSortAttributeIs400AndVerbatim(t *testing.T) {
 		t.Fatalf("body is not valid JSON: %v", uerr)
 	}
 	if !strings.Contains(resp.Error, "cannot sort by unknown attribute 'nope' in schema 'lead'") {
-		t.Fatalf("expected the guidance preserved verbatim, got %q", resp.Error)
+		t.Fatalf("expected the guidance preserved, got %q", resp.Error)
+	}
+	if strings.Contains(resp.Error, ": invalid input") {
+		t.Fatalf("the sentinel suffix must stay out of the body (#313), got %q", resp.Error)
 	}
 	if resp.ErrorClass != "" || resp.ErrorID != "" {
-		t.Fatalf("a sentinel-carrying 400 must not emit correlation fields, got class=%q id=%q",
+		t.Fatalf("a published 400 must not emit correlation fields, got class=%q id=%q",
 			resp.ErrorClass, resp.ErrorID)
 	}
 }
@@ -348,28 +362,48 @@ func TestSentinelLessErrorIsRedacted500(t *testing.T) {
 	}
 }
 
-// TestRespondErrorLogLevels pins the log level of each branch. Levels are now
+// TestRespondErrorLogLevels pins the log level of each branch. Levels are
 // contract: the redacted branch must be ERROR so it survives production's Info
-// threshold, and the verbatim branch must stay DEBUG so client mistakes do not
-// page anyone. Asserting Debug positively also closes a hole in
-// TestRespondErrorKeeps4xxMessageVerbatim, whose zero-ERROR-entries check would
-// pass even if nothing were logged at all.
+// threshold; a disclosed 4xx with no withheld detail stays DEBUG so client
+// mistakes do not page anyone; a disclosed 4xx that withholds operator detail
+// logs at WARN — that line is the only remaining copy of the detail, and it
+// must clear the Info threshold without inheriting ERROR's alerting weight
+// (a caller can trigger 4xx at will).
 func TestRespondErrorLogLevels(t *testing.T) {
-	t.Run("verbatim client error logs at debug", func(t *testing.T) {
+	t.Run("published client error logs at debug", func(t *testing.T) {
 		core, logs := observer.New(zap.DebugLevel)
 		restore := zap.ReplaceGlobals(zap.New(core))
 		defer restore()
 
 		rec := httptest.NewRecorder()
 		respondError(rec, "create failed",
-			fmt.Errorf("attribute 'age': %w", forma.ErrInvalidInput), "schema", "orders")
+			forma.InvalidInputf("attribute 'age'"), "schema", "orders")
 
 		entries := logs.All()
 		if len(entries) != 1 {
 			t.Fatalf("expected exactly 1 log entry, got %d", len(entries))
 		}
 		if entries[0].Level != zap.DebugLevel {
-			t.Fatalf("expected the verbatim branch to log at DEBUG, got %s", entries[0].Level)
+			t.Fatalf("expected the published branch to log at DEBUG, got %s", entries[0].Level)
+		}
+	})
+
+	t.Run("published client error with withheld detail logs at warn", func(t *testing.T) {
+		core, logs := observer.New(zap.DebugLevel)
+		restore := zap.ReplaceGlobals(zap.New(core))
+		defer restore()
+
+		rec := httptest.NewRecorder()
+		respondError(rec, "create failed",
+			forma.WithOperatorDetail(forma.InvalidInputf("attribute 'age'"),
+				fmt.Errorf("operator cause")), "schema", "orders")
+
+		entries := logs.All()
+		if len(entries) != 1 {
+			t.Fatalf("expected exactly 1 log entry, got %d", len(entries))
+		}
+		if entries[0].Level != zap.WarnLevel {
+			t.Fatalf("expected the withheld-detail branch to log at WARN, got %s", entries[0].Level)
 		}
 	})
 

--- a/internal/httpapi/error_schema_id_test.go
+++ b/internal/httpapi/error_schema_id_test.go
@@ -2,7 +2,6 @@ package httpapi
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -217,39 +216,20 @@ func TestRedactedBodyOmitsSchemaIDWithoutACarrier(t *testing.T) {
 	}
 }
 
-// clientClassifiedCarrier is a single-cause error that classifies as client
-// fault while still holding a typed read-path carrier underneath, so
-// errorSchemaID resolves a non-zero id on the verbatim branch.
-type clientClassifiedCarrier struct {
-	cause error
-}
-
-func (e *clientClassifiedCarrier) Error() string { return "bad filter: " + e.cause.Error() }
-func (e *clientClassifiedCarrier) Unwrap() error { return e.cause }
-func (e *clientClassifiedCarrier) Is(target error) bool {
-	return errors.Is(target, forma.ErrInvalidInput)
-}
-
-// TestVerbatim4xxBodyCarriesNoSchemaID pins that the reversal is confined to the
-// redacted branch. A provable client error keeps a body byte-identical to
-// pre-#301: message only, no correlation fields, no schema id.
-//
-// The chain deliberately carries a schema id that errorSchemaID *would* resolve —
-// a ParquetSetInconsistentError reachable from a client-classified error — so the
-// test fails if the field is populated before the disclosure gate instead of
-// after it.
-//
-// It has to be a *single-cause* chain, which is why the fixture type below exists
-// rather than `fmt.Errorf("%w: %w", …)`: since Finding 3 a multi-cause chain is
-// redacted regardless of sentinel evidence, so the joined form would no longer
-// reach the verbatim branch this test is about.
-func TestVerbatim4xxBodyCarriesNoSchemaID(t *testing.T) {
+// TestPublished4xxBodyCarriesNoSchemaID pins that the schema-id reversal is
+// confined to the redacted branch. A published client error keeps a body of
+// message only: no correlation fields, no schema id — even when the chain
+// deliberately carries a ParquetSetInconsistentError that errorSchemaID
+// *would* resolve, attached as operator detail. The test fails if the field
+// is populated before the disclosure gate instead of after it, and the
+// object-key assertion makes it strictly stronger than its pre-#313 version:
+// the detail's text must not surface either.
+func TestPublished4xxBodyCarriesNoSchemaID(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
 	defer restore()
 
-	err := &clientClassifiedCarrier{
-		cause: &forma.ParquetSetInconsistentError{SchemaID: 22, MissingKeys: []string{"base/k.parquet"}},
-	}
+	err := forma.WithOperatorDetail(forma.InvalidInputf("bad filter"),
+		&forma.ParquetSetInconsistentError{SchemaID: 22, MissingKeys: []string{canaryKey}})
 
 	rec := httptest.NewRecorder()
 	respondError(rec, "query failed", err)
@@ -259,9 +239,12 @@ func TestVerbatim4xxBodyCarriesNoSchemaID(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	for _, forbidden := range []string{"schema_id", "error_class", "error_id"} {
+	for _, forbidden := range []string{"schema_id", "error_class", "error_id", canaryKey} {
 		if strings.Contains(body, forbidden) {
-			t.Fatalf("verbatim 4xx body carried %q; body: %s", forbidden, body)
+			t.Fatalf("published 4xx body carried %q; body: %s", forbidden, body)
 		}
+	}
+	if !strings.Contains(body, "bad filter") {
+		t.Fatalf("expected the published message, got %s", body)
 	}
 }

--- a/internal/httpapi/multi_cause_chain_test.go
+++ b/internal/httpapi/multi_cause_chain_test.go
@@ -13,24 +13,17 @@ import (
 	"go.uber.org/zap"
 )
 
-// This file gates the second conjunct of the disclosure decision (#301,
-// round-4 Finding 3): a chain whose provenance is ambiguous is redacted even
-// when it carries client-sentinel evidence. Sentinel evidence alone lives in
-// error_response_test.go.
+// This file gates the disclosure decision (#301 Finding 3, redesigned by
+// #313): a 4xx body carries a deliberately published message or no message at
+// all. Chain shape stopped being load-bearing — a bare sentinel wrap is
+// denied whether its chain is single- or multi-cause, and a carrier's
+// publication survives any amount of re-wrapping or joining.
 
-// TestMixedChainIsRedacted is the Finding 3 regression.
-//
-// isClientError uses errors.Is, which matches any leaf, so a joined chain
-// carrying both a client sentinel and a driver cause used to take the *verbatim*
-// branch and disclose the driver text — an S3 object key reaching a public 400.
-// `errors.Join` and the `fmt.Errorf("%w: %w", …)` shape used throughout
-// internal/federated both produce that node, so it is not hypothetical.
-//
-// Disclosure now requires an unambiguous chain as well as sentinel evidence
-// (canDiscloseVerbatim). A fan-out means the sentinel says nothing about the
-// other branch, so the body is redacted. The *status* still follows the sentinel
-// — this is a 400 with a redacted body, the one live shape where the two
-// branches disagree.
+// TestMixedChainIsRedacted is the Finding 3 regression, now serving as the
+// deny-shape pin: a chain that carries client-sentinel evidence but no
+// published message is redacted, so a joined driver cause can never reach a
+// 400 body. The *status* still follows the sentinel — a 400 with a redacted
+// body is the deny shape itself.
 func TestMixedChainIsRedacted(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
 	defer restore()
@@ -67,16 +60,14 @@ func TestMixedChainIsRedacted(t *testing.T) {
 	}
 }
 
-// TestMultiVerbWrapChainIsRedacted covers the other producer of the same node:
-// fmt.Errorf with two %w verbs, which is how internal/federated builds its
-// classified read errors. errors.Unwrap returns nil at such a node, so a walk
-// built on it would miss the fan-out entirely.
+// TestMultiVerbWrapChainIsRedacted covers the other producer of the same
+// carrier-less mixed shape: fmt.Errorf with two %w verbs, wrapped once more so
+// the fan-out is not the outermost node.
 func TestMultiVerbWrapChainIsRedacted(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
 	defer restore()
 
 	driver := fmt.Errorf("HTTP Error: 403 reading %s", canaryKey)
-	// Wrapped once more, so the fan-out is not the outermost node.
 	err := fmt.Errorf("advanced query: %w",
 		fmt.Errorf("filter rejected: %w: %w", forma.ErrInvalidInput, driver))
 
@@ -91,10 +82,12 @@ func TestMultiVerbWrapChainIsRedacted(t *testing.T) {
 	}
 }
 
-// TestSingleCauseClientErrorStaysVerbatim is the other side of the gate: the
-// shape every real client error in this repo has — one %w around one sentinel,
-// wrapped in context — must still reach the caller with its message intact.
-func TestSingleCauseClientErrorStaysVerbatim(t *testing.T) {
+// TestUnconvertedSentinelIsRedacted4xx pins deny-by-default explicitly: a
+// bare fmt.Errorf wrap of a client sentinel — the pre-#313 idiom — earns its
+// status but not a body. This is the enforcement mechanism for future wrap
+// sites: forgetting the carrier degrades the caller's 400 to an opaque one,
+// which the site's own feature test should catch.
+func TestUnconvertedSentinelIsRedacted4xx(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
 	defer restore()
 
@@ -112,40 +105,160 @@ func TestSingleCauseClientErrorStaysVerbatim(t *testing.T) {
 	if uerr := json.Unmarshal(rec.Body.Bytes(), &resp); uerr != nil {
 		t.Fatalf("body is not valid JSON: %v", uerr)
 	}
-	if resp.ErrorClass != "" || resp.ErrorID != "" {
-		t.Fatalf("a single-cause client error took the redacted branch: class=%q id=%q",
+	if resp.ErrorClass == "" || resp.ErrorID == "" {
+		t.Fatalf("a publication-less sentinel wrap must take the redacted branch, got class=%q id=%q",
 			resp.ErrorClass, resp.ErrorID)
 	}
-	if !strings.Contains(resp.Error, "nosuchattr") {
-		t.Fatalf("expected the verbatim message naming the attribute, got %q", resp.Error)
+	if strings.Contains(resp.Error, "nosuchattr") {
+		t.Fatalf("raw chain text reached the 400 body: %q", resp.Error)
 	}
 }
 
-// TestHasMultipleCauses pins the walk itself, including the two shapes a loop
-// built on errors.Unwrap alone would get wrong.
-func TestHasMultipleCauses(t *testing.T) {
-	sentinel := forma.ErrInvalidInput
-	other := errors.New("operator detail")
+// TestClientErrorPublishesItsMessage is the other side of the gate: the shape
+// every converted client error now has — a carrier under plain context wraps —
+// reaches the caller with its published message intact.
+func TestClientErrorPublishesItsMessage(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
 
-	cases := map[string]struct {
-		err  error
-		want bool
-	}{
-		"nil":                     {nil, false},
-		"bare sentinel":           {sentinel, false},
-		"single wrap":             {fmt.Errorf("ctx: %w", sentinel), false},
-		"nested single wraps":     {fmt.Errorf("a: %w", fmt.Errorf("b: %w", sentinel)), false},
-		"join of two":             {errors.Join(sentinel, other), true},
-		"join of one":             {errors.Join(sentinel), false},
-		"multi verb wrap":         {fmt.Errorf("ctx: %w: %w", sentinel, other), true},
-		"join buried under wraps": {fmt.Errorf("a: %w", fmt.Errorf("b: %w", errors.Join(sentinel, other))), true},
+	err := fmt.Errorf("advanced query: %w",
+		forma.InvalidInputf("attribute not found in cache: %s", "nosuchattr"))
+
+	rec := httptest.NewRecorder()
+	respondError(rec, "query failed", err, "schema", "orders")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
 	}
 
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			if got := hasMultipleCauses(tc.err); got != tc.want {
-				t.Fatalf("hasMultipleCauses(%v) = %v, want %v", tc.err, got, tc.want)
-			}
-		})
+	var resp APIResponse
+	if uerr := json.Unmarshal(rec.Body.Bytes(), &resp); uerr != nil {
+		t.Fatalf("body is not valid JSON: %v", uerr)
+	}
+	if resp.ErrorClass != "" || resp.ErrorID != "" {
+		t.Fatalf("a published client error took the redacted branch: class=%q id=%q",
+			resp.ErrorClass, resp.ErrorID)
+	}
+	if !strings.Contains(resp.Error, "nosuchattr") {
+		t.Fatalf("expected the published message naming the attribute, got %q", resp.Error)
+	}
+}
+
+// TestMixedChainPublishesClientTextOnly is the #313 acceptance test, using the
+// shape internal/federated/duckdb_query_build.go actually produces for an
+// unrenderable caller-supplied path template: a carrier with the render error
+// attached as operator detail. Pre-#313 this chain collapsed to an opaque
+// redacted 400; now the caller learns what to fix while the operator cause
+// stays out of the body.
+func TestMixedChainPublishesClientTextOnly(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	renderErr := fmt.Errorf(`template: s3path:1: unclosed action reading %s`, canaryKey)
+	err := fmt.Errorf("render parquet path hint: %w", forma.WithOperatorDetail(
+		forma.InvalidInputf("render s3 parquet path template %q: the template is not renderable",
+			"s3://b/{{.Broken"), renderErr))
+
+	rec := httptest.NewRecorder()
+	respondError(rec, "advanced query failed", err, "schema", "orders")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+
+	var resp APIResponse
+	if uerr := json.Unmarshal(rec.Body.Bytes(), &resp); uerr != nil {
+		t.Fatalf("body is not valid JSON: %v", uerr)
+	}
+	if !strings.Contains(resp.Error, `"s3://b/{{.Broken"`) || !strings.Contains(resp.Error, "not renderable") {
+		t.Fatalf("expected the published template guidance, got %q", resp.Error)
+	}
+	if strings.Contains(rec.Body.String(), canaryKey) {
+		t.Fatalf("operator detail leaked into the 400 body: %s", rec.Body.String())
+	}
+	if strings.Contains(resp.Error, "unclosed action") {
+		t.Fatalf("text/template internals leaked into the 400 body: %q", resp.Error)
+	}
+	if resp.ErrorClass != "" || resp.ErrorID != "" {
+		t.Fatalf("a published 400 must not emit correlation fields, got class=%q id=%q",
+			resp.ErrorClass, resp.ErrorID)
+	}
+}
+
+// TestCarrierSurvivesReWrapping pins the resolution depth: service layers add
+// plain context wraps above WrapPublicf, and the boundary must still find the
+// publication and emit the accumulated prefix + leaf.
+func TestCarrierSurvivesReWrapping(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	leaf := forma.InvalidInputf("invalid value for attribute 'age' (attrID=2): cannot convert string to float64")
+	err := forma.WrapPublicf(leaf, "operation[0]: failed to transform data to persistent record")
+	err = fmt.Errorf("batch create: %w", err)
+	err = fmt.Errorf("manager: %w", err)
+
+	rec := httptest.NewRecorder()
+	respondError(rec, "batch create failed", err)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, required := range []string{"operation[0]", "attribute 'age' (attrID=2)", "cannot convert string to float64"} {
+		if !strings.Contains(body, required) {
+			t.Fatalf("published message lost %q; body: %s", required, body)
+		}
+	}
+}
+
+// TestCarrierAtA5xxIsRedacted pins that a caller-supplied status can only hold
+// disclosure back, never open it: a publishing carrier at a 5xx is redacted
+// like any other operator failure.
+func TestCarrierAtA5xxIsRedacted(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	rec := httptest.NewRecorder()
+	respondErrorWithStatus(rec, http.StatusInternalServerError, "query failed",
+		forma.InvalidInputf("bad filter naming %s", canaryKey))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), canaryKey) {
+		t.Fatalf("a 5xx disclosed a published message: %s", rec.Body.String())
+	}
+
+	var resp APIResponse
+	if uerr := json.Unmarshal(rec.Body.Bytes(), &resp); uerr != nil {
+		t.Fatalf("body is not valid JSON: %v", uerr)
+	}
+	if resp.Error != "internal error" {
+		t.Fatalf("expected the generic message, got %q", resp.Error)
+	}
+}
+
+// TestPublishedMessageIsCredentialScrubbed keeps the boundary's stated
+// invariant — every string leaving it passes redactCredentials — on the new
+// disclosed branch: a wrap site that interpolates a DSN into its published
+// message by accident does not ship the password.
+func TestPublishedMessageIsCredentialScrubbed(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	err := forma.InvalidInputf("cannot use connection string %q",
+		"host=h user=u password="+canarySecret+" dbname=d")
+
+	rec := httptest.NewRecorder()
+	respondError(rec, "create failed", err)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	if leaksCanarySecret(rec.Body.String()) {
+		t.Fatalf("a published message shipped the credential: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "***REDACTED***") {
+		t.Fatalf("expected the credential replaced in place, got %s", rec.Body.String())
 	}
 }

--- a/internal/httpapi/sentinel_status_test.go
+++ b/internal/httpapi/sentinel_status_test.go
@@ -76,7 +76,7 @@ func TestCreateMissingRequiredAttributeIs400AndVerbatim(t *testing.T) {
 	}
 
 	manager := &mockEntityManager{
-		batchCreateErr: fmt.Errorf("operation[0]: %w", writeErr),
+		batchCreateErr: forma.WrapPublicf(writeErr, "operation[0]"),
 	}
 	srv := NewServer(manager, Options{})
 
@@ -93,7 +93,13 @@ func TestCreateMissingRequiredAttributeIs400AndVerbatim(t *testing.T) {
 		t.Fatalf("body is not valid JSON: %v", err)
 	}
 	if !strings.Contains(resp.Error, "missing required attribute 'email'") {
-		t.Fatalf("expected the verbatim message naming the attribute, got %q", resp.Error)
+		t.Fatalf("expected the published message naming the attribute, got %q", resp.Error)
+	}
+	// The batch index is the one piece of the failure the caller cannot recover
+	// from anywhere else in the response; losing it from the published body is
+	// the silent regression this assertion exists to catch (#313).
+	if !strings.Contains(resp.Error, "operation[0]") {
+		t.Fatalf("expected the published message to keep the batch index, got %q", resp.Error)
 	}
 	if resp.ErrorClass != "" || resp.ErrorID != "" {
 		t.Fatalf("a write-validation error took the redacted branch: error_class=%q error_id=%q",
@@ -148,7 +154,13 @@ func TestAdvancedQueryOperatorWhitelistIs400AndVerbatim(t *testing.T) {
 		t.Fatalf("body is not valid JSON: %v", err)
 	}
 	if !strings.Contains(resp.Error, "only supported for text attributes") {
-		t.Fatalf("expected the verbatim message naming the operator constraint, got %q", resp.Error)
+		t.Fatalf("expected the published message naming the operator constraint, got %q", resp.Error)
+	}
+	// The generator's internal phase wraps ("pg main generation",
+	// "pg sql generation") are plain context, not publication — they must stay
+	// out of the body now that only published text crosses (#313).
+	if strings.Contains(resp.Error, "generation") {
+		t.Fatalf("an internal phase name reached the 400 body: %q", resp.Error)
 	}
 	if resp.ErrorClass != "" || resp.ErrorID != "" {
 		t.Fatalf("a condition-DSL error took the redacted branch: error_class=%q error_id=%q",

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -587,11 +587,11 @@ type APIResponse struct {
 	Error   string `json:"error,omitempty"`
 	// ErrorClass and ErrorID are populated on every redacted response (#301):
 	// a stable machine token for client discrimination, and a correlation id
-	// echoed on the operator log line that holds the error chain. Redaction and
-	// classification both key off sentinel evidence, so on every live path this
-	// pair means a 500 — an error with no sentinel classifies 500, and one with
-	// a sentinel takes the verbatim branch. Both are omitempty, so success
-	// bodies and verbatim 4xx bodies are unchanged.
+	// echoed on the operator log line that holds the error chain. Since #313 a
+	// redacted response can be a 4xx as well as a 5xx: an error that carries a
+	// client sentinel but publishes no message (a bare sentinel wrap, or a
+	// carrier-less mixed chain) keeps its status and loses its body. Both are
+	// omitempty, so success bodies and published 4xx bodies are unchanged.
 	ErrorClass string `json:"error_class,omitempty"`
 	ErrorID    string `json:"error_id,omitempty"`
 	// SchemaID names the schema a redacted read failure was addressed to (#301,

--- a/internal/postgres_persistent_repository.go
+++ b/internal/postgres_persistent_repository.go
@@ -199,7 +199,8 @@ func (r *DBPersistentRecordRepository) DeletePersistentRecord(ctx context.Contex
 		return fmt.Errorf("delete entity_main row: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("entity not found (schema=%d row=%s): %w", schemaID, rowID, forma.ErrNotFound)
+		return forma.WithOperatorDetail(forma.NotFoundf("entity not found (row=%s)", rowID),
+			fmt.Errorf("schema=%d", schemaID))
 	}
 
 	deleteEAV := fmt.Sprintf("DELETE FROM %s WHERE schema_id = $1 AND row_id = $2", sanitizeIdentifier(tables.EAVData))

--- a/internal/postgres_persistent_repository_batch.go
+++ b/internal/postgres_persistent_repository_batch.go
@@ -138,7 +138,8 @@ func (r *DBPersistentRecordRepository) BatchDeletePersistentRecords(ctx context.
 			return fmt.Errorf("delete entity_main row for key[%d]: %w", i, err)
 		}
 		if tag.RowsAffected() == 0 {
-			return fmt.Errorf("entity not found for key[%d] (schema=%d row=%s): %w", i, key.SchemaID, key.RowID, forma.ErrNotFound)
+			return forma.WithOperatorDetail(forma.NotFoundf("entity not found for key[%d] (row=%s)", i, key.RowID),
+				fmt.Errorf("schema=%d", key.SchemaID))
 		}
 		if _, err := tx.Exec(ctx, deleteEAV, key.SchemaID, key.RowID); err != nil {
 			return fmt.Errorf("delete eav row for key[%d]: %w", i, err)

--- a/internal/postgres_persistent_repository_main_table.go
+++ b/internal/postgres_persistent_repository_main_table.go
@@ -19,10 +19,20 @@ import (
 // classifyPgError converts well-known PostgreSQL error codes to sentinel errors.
 // Currently handles:
 //   - 23505 unique_violation → forma.ErrConflict
+//
+// The published message is a curated summary: pgErr.Detail names physical
+// columns and constraint layout ("Key (schema_id, row_id)=(…) already
+// exists"), which must not cross a public transport (#313). The whole driver
+// error — Detail included — stays in the chain as operator detail.
 func classifyPgError(err error) error {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-		return fmt.Errorf("%s: %w", pgErr.Detail, forma.ErrConflict)
+		// Detail is prefixed into the operator text explicitly: PgError.Error()
+		// renders severity/message/SQLSTATE only, so without this the offending
+		// key would vanish from the log line too.
+		return forma.WithOperatorDetail(
+			forma.Conflictf("the write conflicts with a row that already exists"),
+			fmt.Errorf("%s: %w", pgErr.Detail, err))
 	}
 	return err
 }
@@ -183,7 +193,8 @@ func (r *DBPersistentRecordRepository) updateMainRow(ctx context.Context, tx pgx
 		return fmt.Errorf("update entity_main: %w", classifyPgError(err))
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("entity not found (schema=%d row=%s): %w", record.SchemaID, record.RowID, forma.ErrNotFound)
+		return forma.WithOperatorDetail(forma.NotFoundf("entity not found (row=%s)", record.RowID),
+			fmt.Errorf("schema=%d", record.SchemaID))
 	}
 	return nil
 }

--- a/internal/postgres_persistent_repository_main_table_test.go
+++ b/internal/postgres_persistent_repository_main_table_test.go
@@ -189,6 +189,19 @@ func TestClassifyPgError(t *testing.T) {
 		assert.ErrorIs(t, err, forma.ErrConflict)
 	})
 
+	t.Run("publishes a summary, not pg detail", func(t *testing.T) {
+		pgDetail := "Key (schema_id, row_id)=(7, abc) already exists."
+		err := classifyPgError(&pgconn.PgError{Code: "23505", Detail: pgDetail})
+		require.Error(t, err)
+
+		var pub forma.PublicError
+		require.True(t, errors.As(err, &pub), "conflict publishes no client message: %v", err)
+		assert.Equal(t, "the write conflicts with a row that already exists", pub.PublicMessage())
+		assert.NotContains(t, pub.PublicMessage(), "Key (")
+		assert.Contains(t, err.Error(), pgDetail, "the operator copy must keep the driver detail")
+		assert.True(t, forma.HasOperatorDetail(err))
+	})
+
 	t.Run("leaves other pg errors unchanged", func(t *testing.T) {
 		original := &pgconn.PgError{Code: "23503", Detail: "violates foreign key constraint"}
 		assert.Same(t, original, classifyPgError(original))

--- a/internal/schemameta/file_registry.go
+++ b/internal/schemameta/file_registry.go
@@ -196,17 +196,17 @@ func (r *fileSchemaRegistry) schemaMetadataForID(id int16) (forma.SchemaAttribut
 	defer r.mu.RUnlock()
 
 	if _, exists := r.idToName[id]; !exists {
-		return nil, nil, fmt.Errorf("schema not found for ID: %d: %w", id, forma.ErrNotFound)
+		return nil, nil, forma.WithOperatorDetail(forma.NotFoundf("schema not found"), fmt.Errorf("schema id %d", id))
 	}
 
 	schema, exists := r.schemaAttributeCaches[id]
 	if !exists {
-		return nil, nil, fmt.Errorf("schema data not found for ID: %d: %w", id, forma.ErrNotFound)
+		return nil, nil, forma.WithOperatorDetail(forma.NotFoundf("schema data not found"), fmt.Errorf("schema id %d", id))
 	}
 
 	idToName, exists := r.attrIDToName[id]
 	if !exists {
-		return nil, nil, fmt.Errorf("attribute id index not found for ID: %d: %w", id, forma.ErrNotFound)
+		return nil, nil, forma.WithOperatorDetail(forma.NotFoundf("attribute id index not found"), fmt.Errorf("schema id %d", id))
 	}
 
 	return schema, idToName, nil
@@ -219,12 +219,12 @@ func (r *fileSchemaRegistry) GetSchemaAttributeCacheByName(name string) (int16, 
 
 	schemaID, exists := r.nameToID[name]
 	if !exists {
-		return 0, nil, fmt.Errorf("schema not found: %s: %w", name, forma.ErrNotFound)
+		return 0, nil, forma.NotFoundf("schema not found: %s", name)
 	}
 
 	schema, exists := r.schemaAttributeCaches[schemaID]
 	if !exists {
-		return 0, nil, fmt.Errorf("schema data not found: %s: %w", name, forma.ErrNotFound)
+		return 0, nil, forma.NotFoundf("schema data not found: %s", name)
 	}
 
 	// Return a copy to prevent external mutations
@@ -239,12 +239,12 @@ func (r *fileSchemaRegistry) GetSchemaAttributeCacheByID(id int16) (string, form
 
 	name, exists := r.idToName[id]
 	if !exists {
-		return "", nil, fmt.Errorf("schema not found for ID: %d: %w", id, forma.ErrNotFound)
+		return "", nil, forma.WithOperatorDetail(forma.NotFoundf("schema not found"), fmt.Errorf("schema id %d", id))
 	}
 
 	schema, exists := r.schemaAttributeCaches[id]
 	if !exists {
-		return "", nil, fmt.Errorf("schema data not found for ID: %d: %w", id, forma.ErrNotFound)
+		return "", nil, forma.WithOperatorDetail(forma.NotFoundf("schema data not found"), fmt.Errorf("schema id %d", id))
 	}
 
 	// Return a copy to prevent external mutations
@@ -273,12 +273,12 @@ func (r *fileSchemaRegistry) GetSchemaByName(name string) (int16, forma.JSONSche
 
 	schemaID, exists := r.nameToID[name]
 	if !exists {
-		return 0, forma.JSONSchema{}, fmt.Errorf("schema not found: %s: %w", name, forma.ErrNotFound)
+		return 0, forma.JSONSchema{}, forma.NotFoundf("schema not found: %s", name)
 	}
 
 	schema, exists := r.schemas[schemaID]
 	if !exists {
-		return 0, forma.JSONSchema{}, fmt.Errorf("schema data not found: %s: %w", name, forma.ErrNotFound)
+		return 0, forma.JSONSchema{}, forma.NotFoundf("schema data not found: %s", name)
 	}
 
 	return schemaID, schema, nil
@@ -291,12 +291,12 @@ func (r *fileSchemaRegistry) GetSchemaByID(id int16) (string, forma.JSONSchema, 
 
 	name, exists := r.idToName[id]
 	if !exists {
-		return "", forma.JSONSchema{}, fmt.Errorf("schema not found for ID: %d: %w", id, forma.ErrNotFound)
+		return "", forma.JSONSchema{}, forma.WithOperatorDetail(forma.NotFoundf("schema not found"), fmt.Errorf("schema id %d", id))
 	}
 
 	schema, exists := r.schemas[id]
 	if !exists {
-		return "", forma.JSONSchema{}, fmt.Errorf("schema data not found for ID: %d: %w", id, forma.ErrNotFound)
+		return "", forma.JSONSchema{}, forma.WithOperatorDetail(forma.NotFoundf("schema data not found"), fmt.Errorf("schema id %d", id))
 	}
 
 	return name, schema, nil

--- a/internal/schemameta/file_registry_publication_test.go
+++ b/internal/schemameta/file_registry_publication_test.go
@@ -1,0 +1,41 @@
+package schemameta
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// ID-keyed lookups withhold the internal int16 from the published message —
+// the caller never supplied it — while Error() keeps it for the operator log
+// (#313). Name-keyed lookups publish the name: it is the caller's own input.
+func TestRegistryNotFoundPublications(t *testing.T) {
+	registry, err := NewFileSchemaRegistryFromDirectory("../../cmd/server/schemas")
+	require.NoError(t, err)
+
+	t.Run("id-keyed withholds the internal id", func(t *testing.T) {
+		_, _, err := registry.GetSchemaAttributeCacheByID(404)
+		require.Error(t, err)
+		require.ErrorIs(t, err, forma.ErrNotFound)
+
+		var pub forma.PublicError
+		require.True(t, errors.As(err, &pub), "registry miss publishes no client message: %v", err)
+		require.Equal(t, "schema not found", pub.PublicMessage())
+		require.True(t, forma.HasOperatorDetail(err))
+		require.Contains(t, err.Error(), "schema id 404", "the operator copy must keep the id")
+	})
+
+	t.Run("name-keyed publishes the caller's name", func(t *testing.T) {
+		_, _, err := registry.GetSchemaAttributeCacheByName("nosuchschema")
+		require.Error(t, err)
+		require.ErrorIs(t, err, forma.ErrNotFound)
+
+		var pub forma.PublicError
+		require.True(t, errors.As(err, &pub))
+		require.Equal(t, "schema not found: nosuchschema", pub.PublicMessage())
+		require.False(t, strings.Contains(pub.PublicMessage(), "schema id"))
+	})
+}

--- a/internal/schemavalidate/validator.go
+++ b/internal/schemavalidate/validator.go
@@ -281,7 +281,12 @@ func (v *Validator) Validate(schemaID int16, doc any) error {
 	}
 
 	if err := resolved.Validate(instance); err != nil {
-		return fmt.Errorf("schema validation failed: %v: %w", err, forma.ErrInvalidInput)
+		// Deliberately publishes the library's violation prose (#313): it is
+		// type/enum/pattern/minimum text over the caller's own instance and the
+		// schema's own constraints — no paths, no credentials. If a shipped schema
+		// ever uses anyOf/oneOf (whose branches render schema objects, $ref
+		// fragments included), switch this site to forma.WithOperatorDetail.
+		return forma.InvalidInputf("schema validation failed: %v", err)
 	}
 	return nil
 }

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -32,7 +32,7 @@ func ConvertPgMainValue(valStr string, attr string, meta forma.AttributeMetadata
 		case float64:
 			return v, nil
 		default:
-			return nil, fmt.Errorf("invalid numeric value for '%s': %s: %w", attr, valStr, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("invalid numeric value for '%s': %s", attr, valStr)
 		}
 
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
@@ -54,7 +54,7 @@ func ConvertPgMainValue(valStr string, attr string, meta forma.AttributeMetadata
 func convertPgBoolValue(valStr string, attr string, meta forma.AttributeMetadata) (any, error) {
 	parsedInt, err := strconv.Atoi(valStr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid boolean value for '%s': %s: %w", attr, valStr, forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("invalid boolean value for '%s': %s", attr, valStr)
 	}
 
 	if meta.ColumnBinding == nil {
@@ -137,7 +137,7 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		case float64:
 			return v, nil
 		default:
-			return nil, fmt.Errorf("invalid numeric literal for %s: %s: %w", attr, valStr, forma.ErrInvalidInput)
+			return nil, forma.InvalidInputf("invalid numeric literal for %s: %s", attr, valStr)
 		}
 
 	case forma.ValueTypeSmallInt, forma.ValueTypeInteger:
@@ -146,7 +146,7 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		if f, e := strconv.ParseFloat(valStr, 64); e == nil {
 			return f, nil
 		}
-		return nil, fmt.Errorf("invalid numeric literal for %s: %s: %w", attr, valStr, forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("invalid numeric literal for %s: %s", attr, valStr)
 
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
 		// Epoch-ms int64: date columns in the federated CTEs are BIGINT (#200).
@@ -155,7 +155,7 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		} else if i, e := strconv.ParseInt(valStr, 10, 64); e == nil {
 			return i, nil
 		}
-		return nil, fmt.Errorf("invalid date literal for %s: %s: %w", attr, valStr, forma.ErrInvalidInput)
+		return nil, forma.InvalidInputf("invalid date literal for %s: %s", attr, valStr)
 
 	default:
 		return valStr, nil

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -231,7 +231,7 @@ func classifyPredicate(kv *forma.KvCondition, meta forma.AttributeMetadata) (boo
 // operator whitelist.
 func normalizePgEavPayload(kv *forma.KvCondition, meta forma.AttributeMetadata, hasMeta bool) PgEavLeafPayload {
 	if !hasMeta {
-		return PgEavLeafPayload{Err: fmt.Errorf("attribute not found in cache: %s: %w", kv.Attr, forma.ErrInvalidInput)}
+		return PgEavLeafPayload{Err: forma.InvalidInputf("attribute not found in cache: %s", kv.Attr)}
 	}
 
 	operator, err := conditionexpr.ParseOperatorValueStrict(kv.Value)
@@ -264,10 +264,10 @@ func normalizePgEavPayload(kv *forma.KvCondition, meta forma.AttributeMetadata, 
 	// The `unsupported value_type` default in parsePgEavValue deliberately stays
 	// plain: that names the schema's declared type, not anything the caller sent.
 	if meta.ValueType != forma.ValueTypeText && sqlOp == "LIKE" {
-		return PgEavLeafPayload{Err: fmt.Errorf("operator '%s' only supported for text attributes, not '%s': %w", opStr, meta.ValueType, forma.ErrInvalidInput)}
+		return PgEavLeafPayload{Err: forma.InvalidInputf("operator '%s' only supported for text attributes, not '%s'", opStr, meta.ValueType)}
 	}
 	if meta.ValueType == forma.ValueTypeBool && sqlOp != "=" && sqlOp != "!=" {
-		return PgEavLeafPayload{Err: fmt.Errorf("operator '%s' not supported for boolean attributes: %w", opStr, forma.ErrInvalidInput)}
+		return PgEavLeafPayload{Err: forma.InvalidInputf("operator '%s' not supported for boolean attributes", opStr)}
 	}
 
 	return PgEavLeafPayload{
@@ -297,7 +297,7 @@ func parsePgEavValue(attr string, meta forma.AttributeMetadata, valStr string) (
 		case float64:
 			return "value_numeric", v, nil
 		default:
-			return "", nil, fmt.Errorf("invalid numeric value for '%s': %s: %w", attr, valStr, forma.ErrInvalidInput)
+			return "", nil, forma.InvalidInputf("invalid numeric value for '%s': %s", attr, valStr)
 		}
 
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
@@ -310,7 +310,7 @@ func parsePgEavValue(attr string, meta forma.AttributeMetadata, valStr string) (
 	case forma.ValueTypeBool:
 		parsedInt, boolErr := strconv.Atoi(valStr)
 		if boolErr != nil {
-			return "", nil, fmt.Errorf("invalid boolean value for '%s': %s: %w", attr, valStr, forma.ErrInvalidInput)
+			return "", nil, forma.InvalidInputf("invalid boolean value for '%s': %s", attr, valStr)
 		}
 		if parsedInt > 0 {
 			return "value_numeric", float64(1), nil
@@ -342,7 +342,7 @@ func normalizePgMainPayload(
 		if meta.ColumnBinding == nil {
 			return PgMainLeafPayload{Skip: true}
 		}
-		return PgMainLeafPayload{Err: fmt.Errorf("unsupported operator: %s: %w", lenient.Operator, forma.ErrInvalidInput)}
+		return PgMainLeafPayload{Err: forma.InvalidInputf("unsupported operator: %s", lenient.Operator)}
 	}
 	if lenientSQLErr != nil {
 		return PgMainLeafPayload{Err: lenientSQLErr}

--- a/internal/sqlgen/predicate_publication_test.go
+++ b/internal/sqlgen/predicate_publication_test.go
@@ -1,0 +1,40 @@
+package sqlgen
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// The predicate leaves publish exactly their own message (#313): the
+// generator's "pg main generation"/"pg sql generation" phase wraps stay plain
+// fmt.Errorf, so the internal phase name never reaches a response body.
+func TestPredicateErrorsPublishLeafMessageOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		cond forma.Condition
+		want string
+	}{
+		{"unsupported operator", charKv("username", "similar_to:alice"),
+			"unsupported operator: similar_to"},
+		{"unknown attribute", charKv("ghost", "equals:1"),
+			"attribute not found in cache: ghost"},
+		{"invalid numeric value", charKv("age", "gt:notanumber"),
+			"invalid numeric value for 'age': notanumber"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			paramIndex := 1
+			_, err := ToDualClauses(tc.cond, "eav_table", 22, characterizationCache(), &paramIndex)
+			require.Error(t, err)
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+
+			var pub forma.PublicError
+			require.True(t, errors.As(err, &pub), "predicate error publishes no client message: %v", err)
+			require.Equal(t, tc.want, pub.PublicMessage())
+			require.NotContains(t, pub.PublicMessage(), "generation")
+		})
+	}
+}

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -293,7 +293,7 @@ func (t *transformer) flattenToAttributes(
 			if value == nil {
 				candidateName := strings.Join(append(path, key), ".")
 				if isKnownAttributeOrParent(candidateName, cache) {
-					return fmt.Errorf("attribute '%s' cannot be set to null; omit the key to preserve its current value: %w", candidateName, forma.ErrInvalidInput)
+					return forma.InvalidInputf("attribute '%s' cannot be set to null; omit the key to preserve its current value", candidateName)
 				}
 				continue
 			}
@@ -326,7 +326,7 @@ func (t *transformer) flattenToAttributes(
 			if item == nil {
 				attrName := strings.Join(path, ".")
 				if isKnownAttributeOrParent(attrName, cache) {
-					return fmt.Errorf("attribute '%s' cannot be set to null (array index %d); omit the element to preserve its current value: %w", attrName, i, forma.ErrInvalidInput)
+					return forma.InvalidInputf("attribute '%s' cannot be set to null (array index %d); omit the element to preserve its current value", attrName, i)
 				}
 				continue
 			}
@@ -339,7 +339,7 @@ func (t *transformer) flattenToAttributes(
 		attrName := strings.Join(path, ".")
 		meta, ok := cache[attrName]
 		if !ok {
-			return fmt.Errorf("attribute '%s' is not defined for schema %d: %w", attrName, schemaID, forma.ErrInvalidInput)
+			return forma.InvalidInputf("attribute '%s' is not defined for schema %d", attrName, schemaID)
 		}
 
 		attr := model.EAVRecord{
@@ -387,13 +387,13 @@ func validateRequiredAttributesFromInput(data map[string]any, cache forma.Schema
 			missing = false
 		}
 		if missing {
-			// Wraps forma.ErrInvalidInput: a create/update body that omits a required
-			// attribute is caller fault, and since #301 the HTTP boundary classifies on
+			// A client error: a create/update body that omits a required attribute
+			// is caller fault, and since #301 the HTTP boundary classifies on
 			// sentinel evidence alone — without this the write path would answer 500
 			// with a redacted body instead of a 400 naming the attribute. The sibling
 			// null-rejection errors in this file already carry the sentinel.
-			return fmt.Errorf("missing required attribute '%s' (attrID=%d) in EAV records: %w",
-				attrName, meta.AttributeID, forma.ErrInvalidInput)
+			return forma.InvalidInputf("missing required attribute '%s' (attrID=%d) in EAV records",
+				attrName, meta.AttributeID)
 		}
 	}
 

--- a/internal/transform/typed_value.go
+++ b/internal/transform/typed_value.go
@@ -10,13 +10,12 @@ import (
 )
 
 func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta forma.AttributeMetadata) (bool, error) {
+	// The converter's own text is published: it describes the caller's value
+	// ("cannot convert string to float64") and is the whole point of the 400.
 	handleConversionError := func(err error) (bool, error) {
-		return false, fmt.Errorf(
-			"invalid value for attribute '%s' (attrID=%d): %w",
-			attrName,
-			meta.AttributeID,
-			fmt.Errorf("%w: %v", forma.ErrInvalidInput, err),
-		)
+		return false, forma.InvalidInputf(
+			"invalid value for attribute '%s' (attrID=%d): %v",
+			attrName, meta.AttributeID, err)
 	}
 
 	switch meta.ValueType {


### PR DESCRIPTION
Closes #313.

## What

Client-facing errors now carry two messages with different audiences: `Error()` stays the operator's full-chain copy; `PublicMessage()` (new `forma.PublicError` carrier interface) is the only text the HTTP boundary emits on a 4xx. An error that wraps a client sentinel without a carrier keeps its status and answers the redacted shape (`error_class`/`error_id`) — deny-by-default on the disclosure axis, matching what #301 did on the status axis.

- **Mechanism** (`client_error.go`): `InvalidInputf`/`NotFoundf`/`Conflictf` reproduce the old `fmt.Errorf("<msg>: %w", sentinel)` text byte-for-byte (which is what spared ~50 non-httpapi message assertions); `WrapPublicf` prefixes both messages and degrades to a plain wrap over operator errors; `WithOperatorDetail` keeps operator facts in `Error()`/the chain and out of the publication.
- **Conversion sweep**: all 74 client-sentinel wrap sites (`ErrInvalidInput` 56, `ErrNotFound` 17, `ErrConflict` 1) across entity services, sqlgen/conditionexpr, transform/schemavalidate, federated, schemameta, and the repositories.
- **Boundary flip** (`internal/httpapi/error_response.go`): disclosure gate becomes `isClientError` + `errors.As`-resolved publication; `hasMultipleCauses`/`canDiscloseVerbatim` deleted; published messages still pass `redactCredentials`; log levels Debug (published) / **Warn** (published with withheld detail — the log is its only copy) / Error (redacted).
- **Guard** (`client_error_guard_test.go`): go/ast test — zero `fmt.Errorf`/`errors.Join` calls referencing a client sentinel, empty allowlist, mutation-verified.
- **Docs**: `docs/error-handling.md` rewritten where overturned, including the false "Blast radius: nil" claim (the `duckdb_query_build.go` mixed chain always existed and is HTTP-reachable) and the #309 sentinel-suffix clause; both "accepted disclosures" recorded as closed. `AGENTS.md` Error Semantics updated.

## Externally visible contract changes

1. 4xx bodies lose the sentinel suffix (`: invalid input` etc.) and any non-published chain text; the caller-actionable message itself is unchanged at every converted site.
2. The issue's motivating case flips usefully: an unrenderable caller-supplied `s3_parquet_path_template` now answers 400 naming the template and reason (was: opaque `internal error` 400); `text/template` internals stay log-only.
3. Unique-violation 409s publish a curated summary instead of `pgErr.Detail`'s physical column prose; ID-keyed registry 404s stop rendering internal `int16` ids (both were documented "accepted disclosures" — now closed; ids/detail remain in the operator log).
4. Four service-wiring guards in `entity_query_service.go` ("config is required" / "not initialized") were misclassified 400 → now plain errors → 500 (user decision; recorded in docs status-change log).
5. jsonschema-go violation prose is **deliberately published** (user decision; rationale + `anyOf`/`oneOf` revisit trigger recorded at the wrap site and in docs).

## Decisions taken with the user (2026-08-04)

- Single PR, full 74-site conversion (no partial-disclosure window)
- Publish third-party jsonschema violation text verbatim
- Side channels deferred: #359 (`OperationError.Error` raw chain in batch success bodies), #360 (17 request-parsing `writeError` interpolation sites); #361 records the no-`error_id`-on-disclosed-4xx candidate
- Wiring guards 400→500 in this PR

## Verification

- `make lint` + `make test` green at **every commit** (commits 2–6 change no existing test — the untouched suite is the no-behaviour-change proof for the conversion sweep; commits 1 and 7 are red-first)
- Mutation checks: injected bare sentinel wrap → AST guard reports exact position; reverting `duckdb_query_build.go` to the pre-#313 mixed chain → both the guard and the federated publication test fail; restore is byte-identical (empty diff)
- e2e: infra smoke green; **production harness suite green** (`make test-e2e-production`, 131s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)