### PR TITLE
Provenance-bound publication resolution + review fixes from PR #362 (#313)

### DIFF
--- a/client_error.go
+++ b/client_error.go
@@ -27,6 +27,69 @@ type PublicError interface {
 	PublicMessage() string
 }
 
+// ResolvePublicMessage returns the message err deliberately published, if
+// any. It is the canonical resolution used by the HTTP boundary, by
+// WrapPublicf/WithOperatorDetail to qualify their input, and by the
+// decorators' own PublicMessage delegation — one traversal, so the
+// publication a decorator carries is exactly the one the boundary would emit.
+//
+// The walk is preorder, left-first (errors.As order, so wrap prefixes
+// accumulate outermost-wins), and each node is matched the way errors.As
+// matches: direct implementation or the node's As(any) bool protocol
+// (#363 review, P2). A node qualifies only when a client sentinel is
+// reachable from that node's OWN subtree (#362/#363 reviews, P1): two gates
+// searching the whole tree independently let a mixed tree borrow — sentinel
+// evidence from one branch, PublicMessage() from a foreign sibling — and
+// decorating such a tree must not manufacture the same borrow one level up.
+// Non-qualifying nodes are stepped over, not terminal, so a real carrier
+// behind a foreign publisher still resolves. An empty publication is treated
+// as no publication and the walk continues past it.
+func ResolvePublicMessage(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	if pub, ok := publicErrorAt(err); ok && carriesClientSentinel(err) {
+		if msg := pub.PublicMessage(); msg != "" {
+			return msg, true
+		}
+	}
+	switch u := err.(type) {
+	case interface{ Unwrap() error }:
+		return ResolvePublicMessage(u.Unwrap())
+	case interface{ Unwrap() []error }:
+		for _, cause := range u.Unwrap() {
+			if msg, ok := ResolvePublicMessage(cause); ok {
+				return msg, true
+			}
+		}
+	}
+	return "", false
+}
+
+// publicErrorAt matches a single node the way errors.As matches nodes,
+// without descending: direct interface satisfaction first, then the node's
+// own As(any) bool protocol.
+func publicErrorAt(err error) (PublicError, bool) {
+	if pub, ok := err.(PublicError); ok {
+		return pub, true
+	}
+	if as, ok := err.(interface{ As(any) bool }); ok {
+		var pub PublicError
+		if as.As(&pub) && pub != nil {
+			return pub, true
+		}
+	}
+	return nil, false
+}
+
+// carriesClientSentinel reports whether err's subtree proves caller fault —
+// the same three sentinels internal/httpapi classifies status on.
+func carriesClientSentinel(err error) bool {
+	return errors.Is(err, ErrInvalidInput) ||
+		errors.Is(err, ErrNotFound) ||
+		errors.Is(err, ErrConflict)
+}
+
 // InvalidInputf builds a client error classified by ErrInvalidInput whose
 // formatted message is published verbatim. Error() renders
 // "<message>: invalid input".
@@ -60,8 +123,12 @@ func WrapPublicf(err error, format string, args ...any) error {
 		return nil
 	}
 	prefix := fmt.Sprintf(format, args...)
-	var pub PublicError
-	if !errors.As(err, &pub) {
+	// Qualification is the canonical resolution, not a bare errors.As: an
+	// input whose publication ResolvePublicMessage would reject — a foreign
+	// PublicError in a sibling branch of a bare sentinel — must degrade to
+	// the plain wrap, or the decorator would manufacture the very borrow the
+	// resolver exists to prevent (#363 review, P1).
+	if _, ok := ResolvePublicMessage(err); !ok {
 		return fmt.Errorf("%s: %w", prefix, err)
 	}
 	return &publicWrap{prefix: prefix, err: err}
@@ -76,8 +143,11 @@ func WithOperatorDetail(err error, detail error) error {
 	if err == nil {
 		return nil
 	}
-	var pub PublicError
-	if detail == nil || !errors.As(err, &pub) {
+	if detail == nil {
+		return err
+	}
+	// Same qualification rule as WrapPublicf (#363 review, P1).
+	if _, ok := ResolvePublicMessage(err); !ok {
 		return err
 	}
 	return &operatorDetail{err: err, detail: detail}
@@ -106,10 +176,14 @@ func (e *clientError) Error() string         { return e.public + ": " + e.sentin
 func (e *clientError) PublicMessage() string { return e.public }
 func (e *clientError) Unwrap() error         { return e.sentinel }
 
-// publicWrap prefixes both messages of an error already carrying a
-// PublicError; WrapPublicf guarantees the inner resolution succeeds. Being
-// outermost, it is the node errors.As finds first, so prefixes accumulate
-// outside-in exactly as they do in Error().
+// publicWrap prefixes both messages of an error whose publication
+// ResolvePublicMessage accepted; WrapPublicf guarantees that at construction.
+// Being outermost, it is the node the resolver finds first, so prefixes
+// accumulate outside-in exactly as they do in Error(). Delegation re-runs the
+// canonical resolution — never a whole-tree errors.As, which would adopt a
+// foreign sibling's text (#363 review, P1). The structure is immutable, so
+// the empty-string fallback is unreachable; if it were reached, the boundary
+// treats an empty publication as none and denies.
 type publicWrap struct {
 	prefix string
 	err    error
@@ -119,9 +193,11 @@ func (e *publicWrap) Error() string { return e.prefix + ": " + e.err.Error() }
 func (e *publicWrap) Unwrap() error { return e.err }
 
 func (e *publicWrap) PublicMessage() string {
-	var pub PublicError
-	errors.As(e.err, &pub)
-	return e.prefix + ": " + pub.PublicMessage()
+	msg, ok := ResolvePublicMessage(e.err)
+	if !ok {
+		return ""
+	}
+	return e.prefix + ": " + msg
 }
 
 // operatorDetail joins operator-only detail to a publishing error. The detail
@@ -137,7 +213,6 @@ func (e *operatorDetail) Error() string   { return e.err.Error() + ": " + e.deta
 func (e *operatorDetail) Unwrap() []error { return []error{e.err, e.detail} }
 
 func (e *operatorDetail) PublicMessage() string {
-	var pub PublicError
-	errors.As(e.err, &pub)
-	return pub.PublicMessage()
+	msg, _ := ResolvePublicMessage(e.err)
+	return msg
 }

--- a/client_error_test.go
+++ b/client_error_test.go
@@ -6,15 +6,13 @@ import (
 	"testing"
 )
 
-// resolvePublic mirrors the boundary's resolution: the outermost PublicError in
-// preorder left-first DFS wins.
+// resolvePublic is the boundary's resolution: the canonical
+// branch-provenance-bound walk, not a raw errors.As — the raw form finds a
+// PublicError anywhere in the tree, which is exactly the borrow the resolver
+// exists to reject (#362/#363 reviews).
 func resolvePublic(t *testing.T, err error) (string, bool) {
 	t.Helper()
-	var pub PublicError
-	if !errors.As(err, &pub) {
-		return "", false
-	}
-	return pub.PublicMessage(), true
+	return ResolvePublicMessage(err)
 }
 
 func mustPublish(t *testing.T, err error, want string) {
@@ -187,4 +185,77 @@ func TestResolutionOrderOnMultiCauseChains(t *testing.T) {
 		err := WrapPublicf(InvalidInputf("leaf"), "outer")
 		mustPublish(t, err, "outer: leaf")
 	})
+}
+
+// foreignPublication stands in for a type outside this module that satisfies
+// PublicError without being built by the constructors — no guarantee its text
+// was authored for a caller.
+type foreignPublication struct{ msg string }
+
+func (f *foreignPublication) Error() string         { return f.msg }
+func (f *foreignPublication) PublicMessage() string { return f.msg }
+
+// The decorators must not adopt a publication the branch-provenance rule
+// would reject (#363 review, P1): wrapping a mixed tree whose sentinel branch
+// is bare and whose publication branch is foreign must degrade exactly as the
+// unwrapped tree would — no publication.
+func TestDecoratorsDoNotAdoptForeignPublications(t *testing.T) {
+	mixed := errors.Join(
+		fmt.Errorf("bad input: %w", ErrInvalidInput),
+		&foreignPublication{msg: "manifests/lead/22.json"})
+
+	t.Run("WrapPublicf degrades to a plain wrap", func(t *testing.T) {
+		err := WrapPublicf(mixed, "operation[%d]", 0)
+		if _, ok := resolvePublic(t, err); ok {
+			t.Fatalf("a wrap over a foreign publication still published: %v", err)
+		}
+		want := fmt.Errorf("operation[0]: %w", mixed)
+		if err.Error() != want.Error() {
+			t.Fatalf("Error() = %q, want plain-wrap %q", err.Error(), want.Error())
+		}
+	})
+
+	t.Run("WithOperatorDetail passes through unchanged", func(t *testing.T) {
+		if got := WithOperatorDetail(mixed, errors.New("detail")); got != mixed {
+			t.Fatalf("an error without a qualifying publication must pass through, got %v", got)
+		}
+	})
+
+	t.Run("a real carrier in the mixed tree still qualifies", func(t *testing.T) {
+		legit := errors.Join(&foreignPublication{msg: "manifests/lead/22.json"},
+			InvalidInputf("bad filter"))
+		err := WrapPublicf(legit, "operation[%d]", 0)
+		mustPublish(t, err, "operation[0]: bad filter")
+	})
+}
+
+// asProvidedCarrier exposes a PublicError through the As(any) bool protocol
+// rather than by direct implementation — the other half of errors.As node
+// matching, which the resolver must honour (#363 review, P2).
+type asProvidedCarrier struct{ inner error }
+
+func (a *asProvidedCarrier) Error() string { return "as-provided: " + a.inner.Error() }
+func (a *asProvidedCarrier) Unwrap() error { return a.inner }
+
+func (a *asProvidedCarrier) As(target any) bool {
+	if p, ok := target.(*PublicError); ok {
+		*p = &foreignPublication{msg: "published via As"}
+		return true
+	}
+	return false
+}
+
+func TestAsProvidedPublicationResolves(t *testing.T) {
+	// The node's own subtree carries the sentinel, so it qualifies under the
+	// branch-provenance rule even though the PublicError arrives via As.
+	err := fmt.Errorf("ctx: %w", &asProvidedCarrier{inner: InvalidInputf("leaf")})
+	if msg, ok := ResolvePublicMessage(err); !ok || msg != "published via As" {
+		t.Fatalf("As-provided publication not resolved: msg=%q ok=%v", msg, ok)
+	}
+
+	// Without a sentinel in its subtree the same node must not publish.
+	bare := fmt.Errorf("ctx: %w", &asProvidedCarrier{inner: errors.New("operator")})
+	if msg, ok := ResolvePublicMessage(bare); ok {
+		t.Fatalf("sentinel-less As-provided node published %q", msg)
+	}
 }

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -724,6 +724,17 @@ joined anywhere in a mixed chain publishes only its own message
 denied whatever its shape (`TestUnconvertedSentinelIsRedacted4xx`,
 `TestMixedChainIsRedacted`, `TestMultiVerbWrapChainIsRedacted`).
 
+**Resolution is provenance-bound (#362 review, P1).** A `PublicError` node
+qualifies only when a client sentinel is reachable from that node's *own*
+subtree — the forma constructors guarantee this by construction. Two gates
+searching the whole tree independently would let a mixed chain borrow:
+`errors.Join(bareSentinelWrap, foreignPublicError)` has sentinel evidence in
+one branch and a `PublicMessage()` in the other, and the foreign text would
+cross on the 400. Non-qualifying nodes are stepped over rather than terminal,
+so a legitimate carrier behind a foreign publisher still resolves. Pinned by
+`TestForeignPublicationCannotBorrowSentinelBranch` and
+`TestForeignNodeDoesNotBlockCarrierResolution`.
+
 Note the deliberate semantic shift from #307: `errors.Join(operatorErr,
 carrier)` now *publishes* the carrier's message at a 4xx, where the shape rule
 would have redacted it. That is the intended reading of deny-by-default on the

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -830,7 +830,7 @@ The clearest case is an unknown schema. `POST /api/v1/nosuchschema` returns
 ```json
 {
   "success": false,
-  "error": "batch create failed: operation[0]: failed to get schema: schema not found: nosuchschema"
+  "error": "batch create failed: operation[0]: schema not found: nosuchschema"
 }
 ```
 
@@ -840,7 +840,9 @@ name-keyed `forma.NotFoundf` leaf publishes the schema name the caller sent,
 index, so `classifyManagerError` returns `404` on sentinel evidence and the
 boundary emits the accumulated publication — logged at `Debugw`, with no
 `error_class`, no `error_id` and no `schema_id`. (Before #313 the body ended in
-`: not found`; the sentinel suffix no longer crosses.) Pinned by
+`: not found`; the sentinel suffix no longer crosses. The `failed to get
+schema` phase context is a plain wrap per the authorship rule — #362 review,
+P2 — so it stays in `Error()` and the log, not the body.) Pinned by
 `TestCreateUnknownSchemaIs404AndVerbatim`.
 
 Clients keying on `500` to detect create failures must key on `success: false`

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -724,16 +724,28 @@ joined anywhere in a mixed chain publishes only its own message
 denied whatever its shape (`TestUnconvertedSentinelIsRedacted4xx`,
 `TestMixedChainIsRedacted`, `TestMultiVerbWrapChainIsRedacted`).
 
-**Resolution is provenance-bound (#362 review, P1).** A `PublicError` node
+**Resolution is provenance-bound and canonical (#362/#363 reviews, P1).**
+`forma.ResolvePublicMessage` is the one traversal: the HTTP boundary calls it,
+`WrapPublicf`/`WithOperatorDetail` qualify their input with it, and the
+decorators' own `PublicMessage()` delegates through it. A `PublicError` node
 qualifies only when a client sentinel is reachable from that node's *own*
 subtree — the forma constructors guarantee this by construction. Two gates
 searching the whole tree independently would let a mixed chain borrow:
 `errors.Join(bareSentinelWrap, foreignPublicError)` has sentinel evidence in
 one branch and a `PublicMessage()` in the other, and the foreign text would
-cross on the 400. Non-qualifying nodes are stepped over rather than terminal,
-so a legitimate carrier behind a foreign publisher still resolves. Pinned by
-`TestForeignPublicationCannotBorrowSentinelBranch` and
-`TestForeignNodeDoesNotBlockCarrierResolution`.
+cross on the 400. Confining the rule to the boundary was not enough — the
+first fix left the decorators qualifying and delegating via whole-tree
+`errors.As`, so `forma.WrapPublicf(thatSameJoin, "operation[0]")`
+reconstructed the borrow one level up; sharing the traversal closes the class,
+not the instance. Node matching follows `errors.As` semantics (direct
+implementation or the node's `As(any) bool` protocol), and non-qualifying
+nodes are stepped over rather than terminal, so a legitimate carrier behind a
+foreign publisher still resolves. Pinned by
+`TestForeignPublicationCannotBorrowSentinelBranch`,
+`TestForeignNodeDoesNotBlockCarrierResolution`,
+`TestDecoratedForeignPublicationIsRedacted`,
+`TestDecoratorsDoNotAdoptForeignPublications`, and
+`TestAsProvidedPublicationResolves`.
 
 Note the deliberate semantic shift from #307: `errors.Join(operatorErr,
 carrier)` now *publishes* the carrier's message at a 4xx, where the shape rule

--- a/internal/entity_batch_service.go
+++ b/internal/entity_batch_service.go
@@ -207,7 +207,7 @@ func (s *entityBatchService) batchCreateAtomic(ctx context.Context, req *forma.B
 
 		schemaID, schemaCache, err := s.registry.GetSchemaAttributeCacheByName(op.SchemaName)
 		if err != nil {
-			return nil, forma.WrapPublicf(err, "operation[%d]: failed to get schema", i)
+			return nil, forma.WrapPublicf(fmt.Errorf("failed to get schema: %w", err), "operation[%d]", i)
 		}
 
 		rowID := uuid.Must(uuid.NewV7())
@@ -233,11 +233,11 @@ func (s *entityBatchService) batchCreateAtomic(ctx context.Context, req *forma.B
 
 		record, err := s.transformer.ToPersistentRecord(ctx, schemaID, rowID, inputData)
 		if err != nil {
-			return nil, forma.WrapPublicf(err, "operation[%d]: failed to transform data to persistent record", i)
+			return nil, forma.WrapPublicf(fmt.Errorf("failed to transform data to persistent record: %w", err), "operation[%d]", i)
 		}
 		attributes, err := s.transformer.FromPersistentRecord(ctx, record)
 		if err != nil {
-			return nil, forma.WrapPublicf(err, "operation[%d]: failed to transform persistent record to json", i)
+			return nil, forma.WrapPublicf(fmt.Errorf("failed to transform persistent record to json: %w", err), "operation[%d]", i)
 		}
 
 		persistentRecords[i] = record
@@ -285,12 +285,12 @@ func (s *entityBatchService) batchUpdateAtomic(ctx context.Context, req *forma.B
 
 		schemaID, schemaCache, err := s.registry.GetSchemaAttributeCacheByName(op.SchemaName)
 		if err != nil {
-			return nil, forma.WrapPublicf(err, "operation[%d]: failed to get schema", i)
+			return nil, forma.WrapPublicf(fmt.Errorf("failed to get schema: %w", err), "operation[%d]", i)
 		}
 
 		existingRecord, err := s.repository.GetPersistentRecord(ctx, tables, schemaID, op.RowID)
 		if err != nil {
-			return nil, forma.WrapPublicf(err, "operation[%d]: failed to load existing record", i)
+			return nil, forma.WrapPublicf(fmt.Errorf("failed to load existing record: %w", err), "operation[%d]", i)
 		}
 		if existingRecord == nil {
 			return nil, forma.NotFoundf("operation[%d]: entity not found: %s/%s", i, op.SchemaName, op.RowID)
@@ -298,7 +298,7 @@ func (s *entityBatchService) batchUpdateAtomic(ctx context.Context, req *forma.B
 
 		existingData, err := s.transformer.FromPersistentRecord(ctx, existingRecord)
 		if err != nil {
-			return nil, forma.WrapPublicf(err, "operation[%d]: failed to transform existing record", i)
+			return nil, forma.WrapPublicf(fmt.Errorf("failed to transform existing record: %w", err), "operation[%d]", i)
 		}
 
 		mergedData := mergeMaps(existingData, op.Updates)
@@ -323,7 +323,7 @@ func (s *entityBatchService) batchUpdateAtomic(ctx context.Context, req *forma.B
 
 		updatedRecord, err := s.transformer.ToPersistentRecord(ctx, schemaID, op.RowID, mergedData)
 		if err != nil {
-			return nil, forma.WrapPublicf(err, "operation[%d]: failed to transform merged data", i)
+			return nil, forma.WrapPublicf(fmt.Errorf("failed to transform merged data: %w", err), "operation[%d]", i)
 		}
 		updatedRecord.CreatedAt = existingRecord.CreatedAt
 		updatedRecord.DeletedAt = existingRecord.DeletedAt
@@ -370,7 +370,7 @@ func (s *entityBatchService) batchDeleteAtomic(ctx context.Context, req *forma.B
 
 		schemaID, _, err := s.registry.GetSchemaAttributeCacheByName(op.SchemaName)
 		if err != nil {
-			return nil, forma.WrapPublicf(err, "operation[%d]: failed to get schema", i)
+			return nil, forma.WrapPublicf(fmt.Errorf("failed to get schema: %w", err), "operation[%d]", i)
 		}
 
 		keys[i] = model.PersistentRecordKey{SchemaID: schemaID, RowID: op.RowID}

--- a/internal/entity_service_publication_test.go
+++ b/internal/entity_service_publication_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/lychee-technology/forma"
@@ -107,5 +108,43 @@ func TestQueryServiceWiringGuardsAreNotClientErrors(t *testing.T) {
 		t.Fatalf("expected the cross-schema config guard to fail")
 	} else if errors.Is(alsoErr, forma.ErrInvalidInput) {
 		t.Fatalf("internal wiring guard still classified as caller fault: %v", alsoErr)
+	}
+}
+
+// Phase context stays operator-only (#362 review, P2): a batch failure whose
+// leaf publishes must reach the caller as index + leaf, without the service's
+// internal phase names ("failed to get schema", "failed to transform …").
+func TestBatchCreateAtomicPublishesWithoutPhaseNames(t *testing.T) {
+	ctx := context.Background()
+	registry, err := newFileSchemaRegistryFromDir("../cmd/server/schemas")
+	if err != nil {
+		t.Fatalf("failed to create schema registry: %v", err)
+	}
+	em := NewEntityManager(transform.NewPersistentRecordTransformer(registry),
+		newMockPersistentRecordRepository(), nil, registry, createTestConfig(), nil)
+
+	req := &forma.BatchOperation{
+		Atomic: true,
+		Operations: []forma.EntityOperation{
+			{
+				EntityIdentifier: forma.EntityIdentifier{SchemaName: "nosuchschema"},
+				Type:             forma.OperationCreate,
+				Data:             map[string]any{"name": "x"},
+			},
+		},
+	}
+
+	_, err = em.BatchCreate(ctx, req)
+	if err == nil {
+		t.Fatalf("expected the unknown schema to fail the atomic batch")
+	}
+	if !errors.Is(err, forma.ErrNotFound) {
+		t.Fatalf("registry miss lost its sentinel: %v", err)
+	}
+	if got, want := publicMessageOf(t, err), "operation[0]: schema not found: nosuchschema"; got != want {
+		t.Fatalf("published message = %q, want %q", got, want)
+	}
+	if !strings.Contains(err.Error(), "failed to get schema") {
+		t.Fatalf("the operator copy lost the phase context: %v", err)
 	}
 }

--- a/internal/federated/parquet_source_publication_test.go
+++ b/internal/federated/parquet_source_publication_test.go
@@ -1,0 +1,44 @@
+package federated
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// The broken-hint 400 must publish the caller's own template and the reason,
+// while text/template's parse prose stays operator-only (#313). This is the
+// issue's motivating case: before typed publications this mixed chain
+// collapsed to an opaque redacted body.
+func TestParquetSource_InvalidHintPublishesTemplateWithoutRenderInternals(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	src := &fakeParquetSource{paths: []string{"s3://b/1/from-manifest.parquet"}}
+	duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: uuid.New()}}
+	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 1}}
+	engine := NewDBFederatedQueryEngine(pg, &fakeDirtyIDFetcher{}, duck, nil,
+		hybridDuckConfig(), testMetadataCacheSchema7(t), "host=x", WithParquetSource(src))
+
+	q := coldTierQuery()
+	q.DuckDBHints = &model.DuckDBRenderHints{S3ParquetPathTemplate: "s3://b/{{.Broken"}
+	_, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		q, &model.FederatedQueryOptions{AllowPartialDegradedMode: true})
+	require.Error(t, err)
+
+	var pub forma.PublicError
+	require.True(t, errors.As(err, &pub), "broken hint publishes no client message: %v", err)
+	require.Contains(t, pub.PublicMessage(), `"s3://b/{{.Broken"`)
+	require.Contains(t, pub.PublicMessage(), "not renderable")
+	require.NotContains(t, pub.PublicMessage(), "unclosed action",
+		"text/template internals must stay operator-only")
+	require.Contains(t, err.Error(), "unclosed action",
+		"the operator copy must keep the render error")
+	require.True(t, forma.HasOperatorDetail(err))
+}

--- a/internal/federated/parquet_source_test.go
+++ b/internal/federated/parquet_source_test.go
@@ -484,35 +484,3 @@ func TestRecordCorruptExclusionEmptyIsNoop(t *testing.T) {
 
 	require.Len(t, opts.ExecutionPlan.Notes, before)
 }
-
-// The broken-hint 400 must publish the caller's own template and the reason,
-// while text/template's parse prose stays operator-only (#313). This is the
-// issue's motivating case: before typed publications this mixed chain
-// collapsed to an opaque redacted body.
-func TestParquetSource_InvalidHintPublishesTemplateWithoutRenderInternals(t *testing.T) {
-	restore := initTestDescriptors()
-	defer restore()
-
-	src := &fakeParquetSource{paths: []string{"s3://b/1/from-manifest.parquet"}}
-	duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: uuid.New()}}
-	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 1}}
-	engine := NewDBFederatedQueryEngine(pg, &fakeDirtyIDFetcher{}, duck, nil,
-		hybridDuckConfig(), testMetadataCacheSchema7(t), "host=x", WithParquetSource(src))
-
-	q := coldTierQuery()
-	q.DuckDBHints = &model.DuckDBRenderHints{S3ParquetPathTemplate: "s3://b/{{.Broken"}
-	_, err := engine.Query(context.Background(),
-		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
-		q, &model.FederatedQueryOptions{AllowPartialDegradedMode: true})
-	require.Error(t, err)
-
-	var pub forma.PublicError
-	require.True(t, errors.As(err, &pub), "broken hint publishes no client message: %v", err)
-	require.Contains(t, pub.PublicMessage(), `"s3://b/{{.Broken"`)
-	require.Contains(t, pub.PublicMessage(), "not renderable")
-	require.NotContains(t, pub.PublicMessage(), "unclosed action",
-		"text/template internals must stay operator-only")
-	require.Contains(t, err.Error(), "unclosed action",
-		"the operator copy must keep the render error")
-	require.True(t, forma.HasOperatorDetail(err))
-}

--- a/internal/httpapi/error_leak_test.go
+++ b/internal/httpapi/error_leak_test.go
@@ -171,10 +171,12 @@ func TestCreateValidationErrorIsClientError(t *testing.T) {
 // POST to an unknown schema returns 404 instead of 500.
 //
 // It also pins that this 404 publishes. The chain is the shape the batch
-// service now builds — the registry's name-keyed forma.NotFoundf leaf under
-// the batch loop's forma.WrapPublicf — so the body names the schema the
-// caller sent while staying free of error_class/error_id, which is what
-// distinguishes it from an error carrying no publication at all
+// service now builds — the registry's name-keyed forma.NotFoundf leaf under a
+// plain phase wrap under the batch loop's forma.WrapPublicf — so the body
+// names the schema the caller sent plus the batch index, while the phase
+// context ("failed to get schema") stays operator-only (#362 review, P2) and
+// the body stays free of error_class/error_id, which is what distinguishes it
+// from an error carrying no publication at all
 // (TestUnconvertedSentinelIsRedacted4xx).
 func TestCreateUnknownSchemaIs404AndVerbatim(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
@@ -182,8 +184,9 @@ func TestCreateUnknownSchemaIs404AndVerbatim(t *testing.T) {
 
 	manager := &mockEntityManager{
 		batchCreateErr: forma.WrapPublicf(
-			forma.NotFoundf("schema not found: %s", "nosuchschema"),
-			"operation[0]: failed to get schema"),
+			fmt.Errorf("failed to get schema: %w",
+				forma.NotFoundf("schema not found: %s", "nosuchschema")),
+			"operation[0]"),
 	}
 	srv := NewServer(manager, Options{})
 
@@ -199,8 +202,11 @@ func TestCreateUnknownSchemaIs404AndVerbatim(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("body is not valid JSON: %v", err)
 	}
-	if !strings.Contains(resp.Error, "nosuchschema") {
-		t.Fatalf("expected the verbatim message naming the schema, got %q", resp.Error)
+	if !strings.Contains(resp.Error, "operation[0]: schema not found: nosuchschema") {
+		t.Fatalf("expected the published message naming the index and schema, got %q", resp.Error)
+	}
+	if strings.Contains(resp.Error, "failed to get schema") {
+		t.Fatalf("an internal phase name reached the 404 body: %q", resp.Error)
 	}
 	if resp.ErrorClass != "" || resp.ErrorID != "" {
 		t.Fatalf("a sentinel-carrying error took the redacted branch: error_class=%q error_id=%q",

--- a/internal/httpapi/error_response.go
+++ b/internal/httpapi/error_response.go
@@ -234,11 +234,10 @@ func respondError(w http.ResponseWriter, op string, err error, logFields ...any)
 // disclosed branch.
 //
 // It is necessary but not sufficient: disclosure additionally requires a
-// deliberately published message (resolvePublicMessage). Keeping the sentinel
-// conjunct means a foreign type that happens to implement PublicMessage()
-// cannot publish itself through this boundary without also carrying a client
-// sentinel — the same "necessary, never sufficient" relationship the status
-// conjunct has.
+// deliberately published message resolved from the same branch
+// (resolvePublicMessage). The whole-tree form here still gates the disclosed
+// branch as a cheap precondition, but the load-bearing provenance check is
+// per-node inside the resolver.
 func isClientError(err error) bool {
 	return errors.Is(err, forma.ErrInvalidInput) ||
 		errors.Is(err, forma.ErrNotFound) ||
@@ -253,22 +252,43 @@ func isClientError(err error) bool {
 // text, and the one live mixed chain (an unrenderable caller-supplied path
 // template, internal/federated/duckdb_query_build.go) collapsed to an opaque
 // body precisely when the caller needed guidance. Publication is decided where
-// the error is authored: errors.As resolves the outermost forma.PublicError
-// (preorder, left-first), so wrap prefixes accumulate and a carrier joined
-// anywhere in a multi-cause chain still publishes only its own text.
+// the error is authored.
 //
-// An empty publication is treated as no publication: nothing about an empty
-// string proves a wrap site authored it deliberately.
+// The walk is preorder, left-first — errors.As order, so wrap prefixes
+// accumulate outermost-wins — but a node qualifies only when the client
+// sentinel is reachable from that node's OWN subtree (#362 review, P1). The
+// two gates searching the whole tree independently let a mixed chain borrow:
+// errors.Join(bareSentinelWrap, foreignPublicError) had sentinel evidence in
+// one branch and a PublicMessage() in the other, and the foreign text — never
+// authored for a caller — crossed on the 400. The forma constructors bind
+// message and sentinel into the same branch, so every real carrier qualifies;
+// a foreign PublicError qualifies only by doing the same, which is the
+// contract, not a loophole. Non-qualifying nodes are stepped over, not
+// terminal: a carrier behind a foreign publisher still resolves.
+//
+// An empty publication is treated as no publication — nothing about an empty
+// string proves a wrap site authored it deliberately — and the walk continues
+// past it.
 func resolvePublicMessage(err error) (string, bool) {
-	var pub forma.PublicError
-	if !errors.As(err, &pub) {
+	if err == nil {
 		return "", false
 	}
-	msg := pub.PublicMessage()
-	if msg == "" {
-		return "", false
+	if pub, ok := err.(forma.PublicError); ok && isClientError(err) {
+		if msg := pub.PublicMessage(); msg != "" {
+			return msg, true
+		}
 	}
-	return msg, true
+	switch u := err.(type) {
+	case interface{ Unwrap() error }:
+		return resolvePublicMessage(u.Unwrap())
+	case interface{ Unwrap() []error }:
+		for _, cause := range u.Unwrap() {
+			if msg, ok := resolvePublicMessage(cause); ok {
+				return msg, true
+			}
+		}
+	}
+	return "", false
 }
 
 // respondErrorWithStatus is respondError for callers that have already

--- a/internal/httpapi/error_response.go
+++ b/internal/httpapi/error_response.go
@@ -254,41 +254,17 @@ func isClientError(err error) bool {
 // body precisely when the caller needed guidance. Publication is decided where
 // the error is authored.
 //
-// The walk is preorder, left-first — errors.As order, so wrap prefixes
-// accumulate outermost-wins — but a node qualifies only when the client
-// sentinel is reachable from that node's OWN subtree (#362 review, P1). The
-// two gates searching the whole tree independently let a mixed chain borrow:
-// errors.Join(bareSentinelWrap, foreignPublicError) had sentinel evidence in
-// one branch and a PublicMessage() in the other, and the foreign text — never
-// authored for a caller — crossed on the 400. The forma constructors bind
-// message and sentinel into the same branch, so every real carrier qualifies;
-// a foreign PublicError qualifies only by doing the same, which is the
-// contract, not a loophole. Non-qualifying nodes are stepped over, not
-// terminal: a carrier behind a foreign publisher still resolves.
-//
-// An empty publication is treated as no publication — nothing about an empty
-// string proves a wrap site authored it deliberately — and the walk continues
-// past it.
+// The resolution itself is forma.ResolvePublicMessage — branch-provenance
+// bound (a node publishes only if a client sentinel is reachable from its own
+// subtree) and node-matched the way errors.As matches (#362/#363 reviews).
+// It lives in the forma package because the decorators' own PublicMessage
+// delegation must apply the identical rule: after the #362 fix confined the
+// rule to this boundary, wrapping a mixed tree in forma.WrapPublicf
+// reconstructed the borrow one level up (#363 review, P1). One shared
+// traversal means what a decorator carries is exactly what this boundary
+// emits.
 func resolvePublicMessage(err error) (string, bool) {
-	if err == nil {
-		return "", false
-	}
-	if pub, ok := err.(forma.PublicError); ok && isClientError(err) {
-		if msg := pub.PublicMessage(); msg != "" {
-			return msg, true
-		}
-	}
-	switch u := err.(type) {
-	case interface{ Unwrap() error }:
-		return resolvePublicMessage(u.Unwrap())
-	case interface{ Unwrap() []error }:
-		for _, cause := range u.Unwrap() {
-			if msg, ok := resolvePublicMessage(cause); ok {
-				return msg, true
-			}
-		}
-	}
-	return "", false
+	return forma.ResolvePublicMessage(err)
 }
 
 // respondErrorWithStatus is respondError for callers that have already

--- a/internal/httpapi/multi_cause_chain_test.go
+++ b/internal/httpapi/multi_cause_chain_test.go
@@ -262,3 +262,76 @@ func TestPublishedMessageIsCredentialScrubbed(t *testing.T) {
 		t.Fatalf("expected the credential replaced in place, got %s", rec.Body.String())
 	}
 }
+
+// foreignPublicError stands in for any type outside this module that happens
+// to satisfy forma.PublicError without being built by the forma constructors —
+// and therefore without any guarantee that its text was authored for a caller.
+type foreignPublicError struct{ msg string }
+
+func (f *foreignPublicError) Error() string         { return f.msg }
+func (f *foreignPublicError) PublicMessage() string { return f.msg }
+
+// TestForeignPublicationCannotBorrowSentinelBranch pins the provenance
+// binding (#362 review, P1). Before it, isClientError and
+// resolvePublicMessage searched the whole tree independently, so a join of a
+// bare-sentinel branch and an unrelated PublicError branch passed both gates
+// and the foreign text — here an operator's manifest path — crossed on a 400.
+// The publication must come from the branch that carries the client sentinel;
+// this chain has no such branch, so it takes the deny shape.
+func TestForeignPublicationCannotBorrowSentinelBranch(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	err := errors.Join(
+		fmt.Errorf("bad input: %w", forma.ErrInvalidInput),
+		&foreignPublicError{msg: "manifests/lead/22.json"})
+
+	rec := httptest.NewRecorder()
+	respondError(rec, "query failed", err, "schema", "orders")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 from the sentinel branch, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "manifests/") {
+		t.Fatalf("a foreign publication borrowed the sentinel branch: %s", rec.Body.String())
+	}
+
+	var resp APIResponse
+	if uerr := json.Unmarshal(rec.Body.Bytes(), &resp); uerr != nil {
+		t.Fatalf("body is not valid JSON: %v", uerr)
+	}
+	if resp.ErrorClass == "" || resp.ErrorID == "" {
+		t.Fatalf("expected the deny shape, got class=%q id=%q", resp.ErrorClass, resp.ErrorID)
+	}
+}
+
+// TestForeignNodeDoesNotBlockCarrierResolution pins the other half of the
+// branch-aware walk: a non-qualifying PublicError encountered first must be
+// stepped over, not treated as the final answer — otherwise joining any
+// foreign publisher in front of a legitimate carrier would silently degrade
+// the caller's 400 to the deny shape.
+func TestForeignNodeDoesNotBlockCarrierResolution(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	err := errors.Join(
+		&foreignPublicError{msg: "manifests/lead/22.json"},
+		forma.InvalidInputf("bad filter"))
+
+	rec := httptest.NewRecorder()
+	respondError(rec, "query failed", err, "schema", "orders")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var resp APIResponse
+	if uerr := json.Unmarshal(rec.Body.Bytes(), &resp); uerr != nil {
+		t.Fatalf("body is not valid JSON: %v", uerr)
+	}
+	if !strings.Contains(resp.Error, "bad filter") {
+		t.Fatalf("the carrier's publication was lost behind a foreign node: %q", resp.Error)
+	}
+	if strings.Contains(rec.Body.String(), "manifests/") {
+		t.Fatalf("the foreign text crossed: %s", rec.Body.String())
+	}
+}

--- a/internal/httpapi/multi_cause_chain_test.go
+++ b/internal/httpapi/multi_cause_chain_test.go
@@ -338,3 +338,45 @@ func TestForeignNodeDoesNotBlockCarrierResolution(t *testing.T) {
 		t.Fatalf("the foreign text crossed: %s", rec.Body.String())
 	}
 }
+
+// TestDecoratedForeignPublicationIsRedacted pins the round-2 P1 (#363
+// review): after the #362 fix bound resolution at this boundary, wrapping the
+// same mixed tree in forma.WrapPublicf (or WithOperatorDetail) reconstructed
+// the borrow one level up — the decorator qualified via whole-tree errors.As
+// and its PublicMessage delegated the same way, so the boundary saw a
+// directly-implemented carrier whose subtree held a sentinel, and the foreign
+// sibling's text crossed as "operation[0]: <foreign>". Qualification and
+// delegation now run the same canonical resolution (forma.ResolvePublicMessage),
+// so both decorators degrade and the deny shape answers.
+func TestDecoratedForeignPublicationIsRedacted(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	mixed := errors.Join(
+		fmt.Errorf("bad input: %w", forma.ErrInvalidInput),
+		&foreignPublicError{msg: "manifests/lead/22.json"})
+
+	for name, err := range map[string]error{
+		"WrapPublicf":        forma.WrapPublicf(mixed, "operation[%d]", 0),
+		"WithOperatorDetail": forma.WithOperatorDetail(mixed, errors.New("op detail")),
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			respondError(rec, "query failed", err, "schema", "orders")
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 from the sentinel branch, got %d", rec.Code)
+			}
+			if strings.Contains(rec.Body.String(), "manifests/") {
+				t.Fatalf("a decorated foreign publication crossed: %s", rec.Body.String())
+			}
+			var resp APIResponse
+			if uerr := json.Unmarshal(rec.Body.Bytes(), &resp); uerr != nil {
+				t.Fatalf("body is not valid JSON: %v", uerr)
+			}
+			if resp.ErrorClass == "" || resp.ErrorID == "" {
+				t.Fatalf("expected the deny shape, got class=%q id=%q", resp.ErrorClass, resp.ErrorID)
+			}
+		})
+	}
+}

--- a/internal/httpapi/multi_cause_chain_test.go
+++ b/internal/httpapi/multi_cause_chain_test.go
@@ -193,7 +193,7 @@ func TestCarrierSurvivesReWrapping(t *testing.T) {
 	defer restore()
 
 	leaf := forma.InvalidInputf("invalid value for attribute 'age' (attrID=2): cannot convert string to float64")
-	err := forma.WrapPublicf(leaf, "operation[0]: failed to transform data to persistent record")
+	err := forma.WrapPublicf(fmt.Errorf("failed to transform data to persistent record: %w", leaf), "operation[0]")
 	err = fmt.Errorf("batch create: %w", err)
 	err = fmt.Errorf("manager: %w", err)
 
@@ -208,6 +208,9 @@ func TestCarrierSurvivesReWrapping(t *testing.T) {
 		if !strings.Contains(body, required) {
 			t.Fatalf("published message lost %q; body: %s", required, body)
 		}
+	}
+	if strings.Contains(body, "failed to transform") {
+		t.Fatalf("an internal phase name reached the body (#362 review, P2): %s", body)
 	}
 }
 

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -339,7 +339,11 @@ func (t *transformer) flattenToAttributes(
 		attrName := strings.Join(path, ".")
 		meta, ok := cache[attrName]
 		if !ok {
-			return forma.InvalidInputf("attribute '%s' is not defined for schema %d", attrName, schemaID)
+			// The internal schema id is operator detail: the caller addressed a
+			// schema by name and cannot act on the int16 (#362 review, P2).
+			return forma.WithOperatorDetail(
+				forma.InvalidInputf("attribute '%s' is not defined for this schema", attrName),
+				fmt.Errorf("schema %d", schemaID))
 		}
 
 		attr := model.EAVRecord{


### PR DESCRIPTION
Addresses all four findings from the post-merge review on #362 (issue #313).

## F1 (P1) — publication must come from the sentinel-bearing branch

Confirmed by reproduction before fixing: `errors.Join(fmt.Errorf("bad input: %w", forma.ErrInvalidInput), foreignPublicError{manifestPath})` disclosed the foreign branch's text on a 400 under the merged boundary.

`resolvePublicMessage` is now a preorder left-first walk (errors.As order, so outermost-wins and prefix accumulation are unchanged) in which a `PublicError` node qualifies only when a client sentinel is reachable from **that node's own subtree**. All forma constructors bind message and sentinel into one branch, so every real carrier qualifies unchanged; a foreign implementer qualifies only by doing the same — the contract, not a loophole.

Writing the second regression test surfaced a worse half of the same defect: under the old resolver, `errors.Join(foreignPublicError, forma.InvalidInputf("bad filter"))` published the **foreign** text and lost the legitimate carrier's message (`errors.As` first-hit). Non-qualifying nodes are now stepped over, not terminal. Both tests were red against the merged boundary before the fix.

## F2 (P2) — batch phase context out of publications

The eight phase-text sites become `WrapPublicf(fmt.Errorf("<phase>: %w", err), "operation[%d]", i)`: `Error()` byte-identical, publication = index + leaf. Docs worked example updated (`operation[0]: schema not found: nosuchschema`); the unknown-schema and re-wrap tests assert the phase name absent from the body, and a new production-path test pins it through the real registry + batch service.

## F3 (P2) — internal schema id withheld at `transformer.go`

`attribute '%s' is not defined for this schema` published; `schema %d` moves to `WithOperatorDetail` so `Error()`/logs keep it. No test asserted the old text. Scope note: the `attrID=%d` occurrences elsewhere in transform are deliberately unchanged — docs' message-style section prescribes naming the attrID; happy to sweep those too if you want the internal-id rule applied uniformly.

## F4 (P3) — `parquet_source_test.go` back under 500

Mechanical move of the added test to `parquet_source_publication_test.go` (486 + 44 lines).

## Verification

`make lint` + `make test` green at every commit; F1 red-first with both regression tests failing against the merged boundary; e2e infra smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)