### PR TITLE
fix(query): normalize and reject legacy sort_order values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,10 @@ Two distinct error classes (`docs/error-handling.md`):
 
 Error messages must name the logical value type, the offending column/attribute, and the expected state. Detail an operator needs but a caller cannot act on goes behind `forma.WithOperatorDetail` — it stays in `Error()` and the log, never in the published message.
 
+## Specs and Design Docs
+
+Planning artifacts — specs, design docs, implementation plans — are not committed to the repo (`docs/superpowers/` is gitignored). Post them to the GitHub issue they serve instead: once a spec or design is approved, add its full content as a comment on the relevant issue so the issue carries the complete decision record.
+
 ## Pull Request Rules
 
 * 请不要自动合并PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Error messages must name the logical value type, the offending column/attribute,
 
 ## Specs and Design Docs
 
-Planning artifacts — specs, design docs, implementation plans — are not committed to the repo (`docs/superpowers/` is gitignored). Post them to the GitHub issue they serve instead: once a spec or design is approved, add its full content as a comment on the relevant issue so the issue carries the complete decision record.
+Planning artifacts — specs, design docs, implementation plans — are not committed to the repo (`docs/superpowers/` is gitignored). Post them to the GitHub issue they serve instead: once a spec or design is approved, add its full content as a comment on the relevant issue so the issue carries the complete decision record. This covers per-issue planning artifacts only; reference designs that document the system itself (e.g. `docs/federated-query/design.md`) live in `docs/` as before.
 
 ## Pull Request Rules
 

--- a/docs/cn/api.md
+++ b/docs/cn/api.md
@@ -37,7 +37,7 @@ Reference: [Advanced Query documentation](./advanced_query.md)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `sort_by` + `sort_order` | `string[]` + `string` | Legacy: every key shares the one direction (`asc` default), case-insensitive; other values → 400 (#296). |
+| `sort_by` + `sort_order` | `string[]` + `string` | Legacy: every key shares the one direction (`asc` default), case-insensitive; other values → 400, even when `sort_by` is empty (#296). |
 | `sort` | `{attribute, sort_order}[]` | Per-key directions (#240). `sort_order` per entry: `asc` (default when omitted) or `desc`, case-insensitive. |
 
 Mixed-direction example — `status ASC, created_at DESC`:

--- a/docs/cn/api.md
+++ b/docs/cn/api.md
@@ -37,7 +37,7 @@ Reference: [Advanced Query documentation](./advanced_query.md)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `sort_by` + `sort_order` | `string[]` + `string` | Legacy: every key shares the one direction (`asc` default). |
+| `sort_by` + `sort_order` | `string[]` + `string` | Legacy: every key shares the one direction (`asc` default), case-insensitive; other values → 400 (#296). |
 | `sort` | `{attribute, sort_order}[]` | Per-key directions (#240). `sort_order` per entry: `asc` (default when omitted) or `desc`, case-insensitive. |
 
 Mixed-direction example — `status ASC, created_at DESC`:

--- a/internal/entity_query_sort.go
+++ b/internal/entity_query_sort.go
@@ -29,6 +29,9 @@ func resolveSortKeys(req *forma.QueryRequest) ([]sortKey, error) {
 		// direction that cannot apply to anything is still a caller bug.
 		sortOrder, err := normalizeSortOrder(req.SortOrder)
 		if err != nil {
+			// Returned bare on purpose: a WrapPublicf prefix would leak into the
+			// published body (there is no per-entry attribute to name here), and
+			// buildAttributeOrders adds the operator schema context one level up.
 			return nil, err
 		}
 		keys := make([]sortKey, 0, len(req.SortBy))

--- a/internal/entity_query_sort.go
+++ b/internal/entity_query_sort.go
@@ -29,10 +29,10 @@ func resolveSortKeys(req *forma.QueryRequest) ([]sortKey, error) {
 		// direction that cannot apply to anything is still a caller bug.
 		sortOrder, err := normalizeSortOrder(req.SortOrder)
 		if err != nil {
-			// Returned bare on purpose: a WrapPublicf prefix would leak into the
-			// published body (there is no per-entry attribute to name here), and
-			// buildAttributeOrders adds the operator schema context one level up.
-			return nil, err
+			// A plain wrap on purpose, not WrapPublicf: this prefix is operator
+			// context (there is no per-entry attribute to name), and the published
+			// body must stay exactly the normalizeSortOrder message.
+			return nil, fmt.Errorf("failed to normalize legacy sort_order: %w", err)
 		}
 		keys := make([]sortKey, 0, len(req.SortBy))
 		for _, attr := range req.SortBy {

--- a/internal/entity_query_sort.go
+++ b/internal/entity_query_sort.go
@@ -18,13 +18,18 @@ type sortKey struct {
 
 // resolveSortKeys normalizes the request's two sort surfaces into ordered
 // sortKey pairs. The structured Sort field carries per-key directions (#240);
-// the legacy SortBy list shares the single SortOrder. The two surfaces are
-// mutually exclusive so a caller bug cannot be silently half-applied.
+// the legacy SortBy list shares the single SortOrder, normalized by the same
+// rules as a Sort entry's direction (#296). The two surfaces are mutually
+// exclusive so a caller bug cannot be silently half-applied.
 func resolveSortKeys(req *forma.QueryRequest) ([]sortKey, error) {
 	if len(req.Sort) == 0 {
-		sortOrder := req.SortOrder
-		if sortOrder == "" {
-			sortOrder = forma.SortOrderAsc
+		// The legacy surface shares one direction across all SortBy keys. It goes
+		// through the same normalizeSortOrder as structured Sort entries (#296):
+		// non-empty garbage is invalid input even when SortBy is empty, because a
+		// direction that cannot apply to anything is still a caller bug.
+		sortOrder, err := normalizeSortOrder(req.SortOrder)
+		if err != nil {
+			return nil, err
 		}
 		keys := make([]sortKey, 0, len(req.SortBy))
 		for _, attr := range req.SortBy {

--- a/internal/entity_query_sort_test.go
+++ b/internal/entity_query_sort_test.go
@@ -82,6 +82,43 @@ func TestBuildAttributeOrdersLegacyDefaultAsc(t *testing.T) {
 	}
 }
 
+func TestBuildAttributeOrdersLegacyCaseInsensitiveDesc(t *testing.T) {
+	req := &forma.QueryRequest{
+		SchemaName: "e2e_wide",
+		SortBy:     []string{"rank"},
+		SortOrder:  forma.SortOrder("DESC"),
+	}
+	orders, err := buildAttributeOrders(req, buildSortTestCache())
+	if err != nil {
+		t.Fatalf("buildAttributeOrders legacy DESC: %v", err)
+	}
+	if orders[0].SortOrder != forma.SortOrderDesc {
+		t.Fatalf("legacy orders[0].SortOrder = %s, want folded desc", orders[0].SortOrder)
+	}
+}
+
+func TestBuildAttributeOrdersLegacyInvalidDirectionMessage(t *testing.T) {
+	// Pins the legacy surface to the same carrier and prose as the structured
+	// Sort path (#296): the message is produced by the shared normalizeSortOrder,
+	// so the two surfaces cannot drift.
+	req := &forma.QueryRequest{
+		SchemaName: "e2e_wide",
+		SortBy:     []string{"rank"},
+		SortOrder:  forma.SortOrder("descending"),
+	}
+	_, err := buildAttributeOrders(req, buildSortTestCache())
+	if err == nil {
+		t.Fatalf("expected invalid sort_order error, got nil")
+	}
+	want := "invalid sort_order 'descending': expected 'asc' or 'desc'"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want it to contain %q", err.Error(), want)
+	}
+	if !errors.Is(err, forma.ErrInvalidInput) {
+		t.Fatalf("error %v does not wrap forma.ErrInvalidInput", err)
+	}
+}
+
 func TestBuildAttributeOrdersValidation(t *testing.T) {
 	cases := []struct {
 		name string
@@ -104,6 +141,17 @@ func TestBuildAttributeOrdersValidation(t *testing.T) {
 		{"invalid_direction", &forma.QueryRequest{
 			SchemaName: "e2e_wide",
 			Sort:       []forma.OrderBy{{Attribute: "rank", SortOrder: forma.SortOrder("descending")}},
+		}},
+		{"legacy_invalid_direction", &forma.QueryRequest{
+			SchemaName: "e2e_wide",
+			SortBy:     []string{"rank"},
+			SortOrder:  forma.SortOrder("descending"),
+		}},
+		{"legacy_direction_without_sortby", &forma.QueryRequest{
+			// A garbage direction is caller fault even with no sort_by to apply it
+			// to (#296 boundary contract): non-empty SortOrder is always validated.
+			SchemaName: "e2e_wide",
+			SortOrder:  forma.SortOrder("descending"),
 		}},
 	}
 	for _, tc := range cases {

--- a/internal/entity_service_publication_test.go
+++ b/internal/entity_service_publication_test.go
@@ -90,6 +90,25 @@ func TestSortErrorsPublishTheirMessages(t *testing.T) {
 			t.Fatalf("published message = %q, want %q", got, want)
 		}
 	})
+
+	t.Run("legacy shared direction publishes verbatim", func(t *testing.T) {
+		// The legacy surface (#296) publishes the leaf message with no entry
+		// prefix — there is no per-entry attribute to name — and the operator
+		// wrap buildAttributeOrders adds must stay out of the body.
+		req := &forma.QueryRequest{
+			SchemaName: "e2e_wide",
+			SortBy:     []string{"rank"},
+			SortOrder:  forma.SortOrder("descending"),
+		}
+		_, err := buildAttributeOrders(req, buildSortTestCache())
+		if err == nil {
+			t.Fatalf("expected invalid sort_order error, got nil")
+		}
+		want := "invalid sort_order 'descending': expected 'asc' or 'desc'"
+		if got := publicMessageOf(t, err); got != want {
+			t.Fatalf("published message = %q, want %q", got, want)
+		}
+	})
 }
 
 // The service-wiring guards are operator faults, not caller faults: they no


### PR DESCRIPTION
Closes #296 (remaining scope; the unknown-attribute classification half was completed in #307).

## What

The legacy JSON-body `sort_order` field now goes through the same `normalizeSortOrder` as structured `sort[].sort_order` entries: case-insensitive fold to asc/desc, anything else rejected with a 400 `forma.ErrInvalidInput` carrier. Previously it was passed through verbatim and everything that was not exactly lowercase `"desc"` silently sorted ascending (`AttributeOrder.IsDescending()` compares `== "desc"`).

## Behavior changes (legacy JSON-body surface only)

- `"DESC"` / `"Desc"`: previously silently ascending → now descending (the direction the caller asked for).
- `"descending"` and other garbage: previously silently ascending → now HTTP 400, body `invalid sort_order '<value>': expected 'asc' or 'desc'`.
- Garbage `sort_order` with empty `sort_by`: previously silently ignored → now 400 (non-empty `SortOrder` is always validated; matches the HTTP query-param layer's existing "sort_order requires sort_by" stance).
- `""` and lowercase `"asc"`/`"desc"`: unchanged.

The query-param surface (`parseSortParams`) and structured `Sort` surface already behaved this way; this unifies the third surface on the same contract. Design discussion and approved spec: see #296 comments.

Also carries the AGENTS.md "Specs and Design Docs" convention (planning artifacts are posted to their GitHub issue, not committed — `docs/superpowers/` is gitignored) as a separate docs commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)