### PR TITLE
fix(tools): #315 resolve $ref in generate-attributes; guard and repair schema artifact drift

### DIFF
--- a/cmd/server/schemas/lead_attributes.json
+++ b/cmd/server/schemas/lead_attributes.json
@@ -5,7 +5,8 @@
   },
   "communications": {
     "attributeID": 2,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "contact.annualIncome": {
     "attributeID": 3,
@@ -86,7 +87,8 @@
   },
   "contact.phones": {
     "attributeID": 19,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "contact.preferredChannel": {
     "attributeID": 20,
@@ -241,11 +243,13 @@
   },
   "requirement.mustHave": {
     "attributeID": 54,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "requirement.niceToHave": {
     "attributeID": 55,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "requirement.propertyType": {
     "attributeID": 56,
@@ -281,7 +285,8 @@
   },
   "requirement.unwantedConditions": {
     "attributeID": 64,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "score": {
     "attributeID": 65,
@@ -316,7 +321,8 @@
   },
   "tags": {
     "attributeID": 72,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "temperature": {
     "attributeID": 73,
@@ -338,6 +344,7 @@
   },
   "visits": {
     "attributeID": 76,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   }
 }

--- a/cmd/server/schemas/lead_full.json
+++ b/cmd/server/schemas/lead_full.json
@@ -46,6 +46,10 @@
           "description": "Employer or company name",
           "type": "string"
         },
+        "contactCode": {
+          "description": "Code for the contact when it is anonymous",
+          "type": "string"
+        },
         "currentResidence": {
           "description": "Current residential address or area",
           "type": "string"
@@ -65,6 +69,10 @@
           "description": "Number of family members excluding the lead",
           "minimum": 0,
           "type": "integer"
+        },
+        "isAnonymous": {
+          "description": "Whether the contact is anonymous",
+          "type": "boolean"
         },
         "isBlacklisted": {
           "description": "Whether the lead is blacklisted",
@@ -99,6 +107,10 @@
         },
         "nameNative": {
           "description": "Native language name",
+          "type": "string"
+        },
+        "nickname": {
+          "description": "Nickname for the contact. Used when the contact is anonymous.",
           "type": "string"
         },
         "occupation": {
@@ -147,13 +159,17 @@
         }
       },
       "required": [
-        "name"
+        "isAnonymous"
       ],
       "type": "object"
     },
     "createdAt": {
       "description": "Record creation timestamp",
       "format": "date-time",
+      "type": "string"
+    },
+    "createdBy": {
+      "description": "User ID of who created the visit record",
       "type": "string"
     },
     "firstTouchAt": {
@@ -175,6 +191,10 @@
     "nextFollowUpAt": {
       "description": "Scheduled next follow-up time",
       "format": "date-time",
+      "type": "string"
+    },
+    "ownerTeam": {
+      "description": "Team that owns the visit record",
       "type": "string"
     },
     "ownerUserId": {
@@ -493,6 +513,10 @@
     "updatedAt": {
       "description": "Last update timestamp",
       "format": "date-time",
+      "type": "string"
+    },
+    "updatedBy": {
+      "description": "User ID of who last updated the visit record",
       "type": "string"
     },
     "visits": {

--- a/cmd/server/schemas/lead_full_attributes.json
+++ b/cmd/server/schemas/lead_full_attributes.json
@@ -5,7 +5,8 @@
   },
   "communications": {
     "attributeID": 2,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "contact.annualIncome": {
     "attributeID": 3,
@@ -23,6 +24,10 @@
     "attributeID": 6,
     "valueType": "text"
   },
+  "contact.contactCode": {
+    "attributeID": 77,
+    "valueType": "text"
+  },
   "contact.currentResidence": {
     "attributeID": 7,
     "valueType": "text"
@@ -38,6 +43,11 @@
   "contact.familySize": {
     "attributeID": 10,
     "valueType": "numeric"
+  },
+  "contact.isAnonymous": {
+    "attributeID": 78,
+    "valueType": "bool",
+    "required_policy": "required_always"
   },
   "contact.isBlacklisted": {
     "attributeID": 11,
@@ -57,8 +67,7 @@
   },
   "contact.name": {
     "attributeID": 15,
-    "valueType": "text",
-    "required_policy": "required_always"
+    "valueType": "text"
   },
   "contact.nameKana": {
     "attributeID": 16,
@@ -68,13 +77,18 @@
     "attributeID": 17,
     "valueType": "text"
   },
+  "contact.nickname": {
+    "attributeID": 79,
+    "valueType": "text"
+  },
   "contact.occupation": {
     "attributeID": 18,
     "valueType": "text"
   },
   "contact.phones": {
     "attributeID": 19,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "contact.preferredChannel": {
     "attributeID": 20,
@@ -97,6 +111,10 @@
     "valueType": "date",
     "required_policy": "required_always"
   },
+  "createdBy": {
+    "attributeID": 80,
+    "valueType": "text"
+  },
   "firstTouchAt": {
     "attributeID": 25,
     "valueType": "date"
@@ -113,6 +131,10 @@
   "nextFollowUpAt": {
     "attributeID": 28,
     "valueType": "date"
+  },
+  "ownerTeam": {
+    "attributeID": 81,
+    "valueType": "text"
   },
   "ownerUserId": {
     "attributeID": 29,
@@ -221,11 +243,13 @@
   },
   "requirement.mustHave": {
     "attributeID": 54,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "requirement.niceToHave": {
     "attributeID": 55,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "requirement.propertyType": {
     "attributeID": 56,
@@ -261,7 +285,8 @@
   },
   "requirement.unwantedConditions": {
     "attributeID": 64,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "score": {
     "attributeID": 65,
@@ -296,7 +321,8 @@
   },
   "tags": {
     "attributeID": 72,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "temperature": {
     "attributeID": 73,
@@ -312,8 +338,13 @@
     "valueType": "date",
     "required_policy": "required_always"
   },
+  "updatedBy": {
+    "attributeID": 82,
+    "valueType": "text"
+  },
   "visits": {
     "attributeID": 76,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   }
 }

--- a/cmd/server/schemas/log_full.json
+++ b/cmd/server/schemas/log_full.json
@@ -7,8 +7,11 @@
       "format": "date-time",
       "type": "string"
     },
+    "createdBy": {
+      "description": "User ID of who created the visit record",
+      "type": "string"
+    },
     "data": {
-      "description": "Base64 encoded data content (audio, image, or text)",
       "type": "string"
     },
     "id": {
@@ -29,6 +32,10 @@
     },
     "ownerId": {
       "description": "Owner/creator of this log entry",
+      "type": "string"
+    },
+    "ownerTeam": {
+      "description": "Team that owns the visit record",
       "type": "string"
     },
     "summary": {
@@ -53,6 +60,10 @@
       "format": "date-time",
       "type": "string"
     },
+    "updatedBy": {
+      "description": "User ID of who last updated the visit record",
+      "type": "string"
+    },
     "visitId": {
       "description": "Visit identifier",
       "format": "uuid",
@@ -62,7 +73,6 @@
   },
   "required": [
     "id",
-    "leadId",
     "ownerId",
     "type",
     "createdAt"

--- a/cmd/server/schemas/log_full_attributes.json
+++ b/cmd/server/schemas/log_full_attributes.json
@@ -4,6 +4,10 @@
     "valueType": "date",
     "required_policy": "required_always"
   },
+  "createdBy": {
+    "attributeID": 11,
+    "valueType": "text"
+  },
   "data": {
     "attributeID": 2,
     "valueType": "text"
@@ -15,8 +19,7 @@
   },
   "leadId": {
     "attributeID": 4,
-    "valueType": "text",
-    "required_policy": "required_always"
+    "valueType": "text"
   },
   "noteId": {
     "attributeID": 5,
@@ -26,6 +29,10 @@
     "attributeID": 6,
     "valueType": "text",
     "required_policy": "required_always"
+  },
+  "ownerTeam": {
+    "attributeID": 12,
+    "valueType": "text"
   },
   "summary": {
     "attributeID": 7,
@@ -39,6 +46,10 @@
   "updatedAt": {
     "attributeID": 9,
     "valueType": "date"
+  },
+  "updatedBy": {
+    "attributeID": 13,
+    "valueType": "text"
   },
   "visitId": {
     "attributeID": 10,

--- a/cmd/server/schemas/visit_attributes.json
+++ b/cmd/server/schemas/visit_attributes.json
@@ -9,10 +9,68 @@
   },
   "attendees": {
     "attributeID": 3,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "contactSnapshot": {
     "attributeID": 25,
+    "valueType": "text"
+  },
+  "contactSnapshot.annualIncome": {
+    "attributeID": 29,
+    "valueType": "numeric"
+  },
+  "contactSnapshot.annualIncomeCurrency": {
+    "attributeID": 30,
+    "valueType": "text"
+  },
+  "contactSnapshot.birthday": {
+    "attributeID": 31,
+    "valueType": "date"
+  },
+  "contactSnapshot.company": {
+    "attributeID": 32,
+    "valueType": "text"
+  },
+  "contactSnapshot.contactCode": {
+    "attributeID": 33,
+    "valueType": "text"
+  },
+  "contactSnapshot.currentResidence": {
+    "attributeID": 34,
+    "valueType": "text"
+  },
+  "contactSnapshot.email": {
+    "attributeID": 35,
+    "valueType": "text"
+  },
+  "contactSnapshot.employmentYear": {
+    "attributeID": 36,
+    "valueType": "numeric"
+  },
+  "contactSnapshot.familySize": {
+    "attributeID": 37,
+    "valueType": "numeric"
+  },
+  "contactSnapshot.isAnonymous": {
+    "attributeID": 38,
+    "valueType": "bool",
+    "required_policy": "required_if_parent_present"
+  },
+  "contactSnapshot.isBlacklisted": {
+    "attributeID": 39,
+    "valueType": "bool"
+  },
+  "contactSnapshot.lineId": {
+    "attributeID": 40,
+    "valueType": "text"
+  },
+  "contactSnapshot.maritalStatus": {
+    "attributeID": 41,
+    "valueType": "text"
+  },
+  "contactSnapshot.memo": {
+    "attributeID": 42,
     "valueType": "text"
   },
   "contactSnapshot.name": {
@@ -27,8 +85,33 @@
     "attributeID": 23,
     "valueType": "text"
   },
+  "contactSnapshot.nickname": {
+    "attributeID": 43,
+    "valueType": "text"
+  },
+  "contactSnapshot.occupation": {
+    "attributeID": 44,
+    "valueType": "text"
+  },
+  "contactSnapshot.phones": {
+    "attributeID": 45,
+    "valueType": "list",
+    "items_type": "text"
+  },
+  "contactSnapshot.preferredChannel": {
+    "attributeID": 46,
+    "valueType": "text"
+  },
+  "contactSnapshot.preferredLanguage": {
+    "attributeID": 47,
+    "valueType": "text"
+  },
   "contactSnapshot.primaryPhone": {
     "attributeID": 24,
+    "valueType": "text"
+  },
+  "contactSnapshot.wechatId": {
+    "attributeID": 48,
     "valueType": "text"
   },
   "createdAt": {

--- a/cmd/server/schemas/visit_full.json
+++ b/cmd/server/schemas/visit_full.json
@@ -50,6 +50,10 @@
           "description": "Employer or company name",
           "type": "string"
         },
+        "contactCode": {
+          "description": "Code for the contact when it is anonymous",
+          "type": "string"
+        },
         "currentResidence": {
           "description": "Current residential address or area",
           "type": "string"
@@ -69,6 +73,10 @@
           "description": "Number of family members excluding the lead",
           "minimum": 0,
           "type": "integer"
+        },
+        "isAnonymous": {
+          "description": "Whether the contact is anonymous",
+          "type": "boolean"
         },
         "isBlacklisted": {
           "description": "Whether the lead is blacklisted",
@@ -103,6 +111,10 @@
         },
         "nameNative": {
           "description": "Native language name",
+          "type": "string"
+        },
+        "nickname": {
+          "description": "Nickname for the contact. Used when the contact is anonymous.",
           "type": "string"
         },
         "occupation": {
@@ -151,13 +163,17 @@
         }
       },
       "required": [
-        "name"
+        "isAnonymous"
       ],
       "type": "object"
     },
     "createdAt": {
       "description": "Record creation timestamp",
       "format": "date-time",
+      "type": "string"
+    },
+    "createdBy": {
+      "description": "User ID of who created the visit record",
       "type": "string"
     },
     "feedback": {
@@ -176,17 +192,13 @@
       "pattern": "^[a-zA-Z0-9_-]+$",
       "type": "string"
     },
-    "logs": {
-      "description": "Visit log IDs tied to this visit",
-      "items": {
-        "description": "Log ID",
-        "type": "string"
-      },
-      "type": "array"
-    },
     "nextFollowUpAt": {
       "description": "Next follow-up time derived from the visit",
       "format": "date-time",
+      "type": "string"
+    },
+    "ownerTeam": {
+      "description": "Team that owns the visit record",
       "type": "string"
     },
     "propertyId": {
@@ -240,6 +252,10 @@
     "updatedAt": {
       "description": "Last update timestamp",
       "format": "date-time",
+      "type": "string"
+    },
+    "updatedBy": {
+      "description": "User ID of who last updated the visit record",
       "type": "string"
     },
     "userId": {

--- a/cmd/server/schemas/visit_full_attributes.json
+++ b/cmd/server/schemas/visit_full_attributes.json
@@ -9,7 +9,8 @@
   },
   "attendees": {
     "attributeID": 3,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "contactSnapshot.annualIncome": {
     "attributeID": 4,
@@ -27,6 +28,10 @@
     "attributeID": 7,
     "valueType": "text"
   },
+  "contactSnapshot.contactCode": {
+    "attributeID": 42,
+    "valueType": "text"
+  },
   "contactSnapshot.currentResidence": {
     "attributeID": 8,
     "valueType": "text"
@@ -42,6 +47,11 @@
   "contactSnapshot.familySize": {
     "attributeID": 11,
     "valueType": "numeric"
+  },
+  "contactSnapshot.isAnonymous": {
+    "attributeID": 43,
+    "valueType": "bool",
+    "required_policy": "required_if_parent_present"
   },
   "contactSnapshot.isBlacklisted": {
     "attributeID": 12,
@@ -61,8 +71,7 @@
   },
   "contactSnapshot.name": {
     "attributeID": 16,
-    "valueType": "text",
-    "required_policy": "required_if_parent_present"
+    "valueType": "text"
   },
   "contactSnapshot.nameKana": {
     "attributeID": 17,
@@ -72,13 +81,18 @@
     "attributeID": 18,
     "valueType": "text"
   },
+  "contactSnapshot.nickname": {
+    "attributeID": 44,
+    "valueType": "text"
+  },
   "contactSnapshot.occupation": {
     "attributeID": 19,
     "valueType": "text"
   },
   "contactSnapshot.phones": {
     "attributeID": 20,
-    "valueType": "text"
+    "valueType": "list",
+    "items_type": "text"
   },
   "contactSnapshot.preferredChannel": {
     "attributeID": 21,
@@ -99,6 +113,10 @@
   "createdAt": {
     "attributeID": 25,
     "valueType": "date"
+  },
+  "createdBy": {
+    "attributeID": 45,
+    "valueType": "text"
   },
   "feedback": {
     "attributeID": 26,
@@ -121,6 +139,10 @@
   "nextFollowUpAt": {
     "attributeID": 30,
     "valueType": "date"
+  },
+  "ownerTeam": {
+    "attributeID": 46,
+    "valueType": "text"
   },
   "propertyId": {
     "attributeID": 31,
@@ -164,6 +186,10 @@
   "updatedAt": {
     "attributeID": 40,
     "valueType": "date"
+  },
+  "updatedBy": {
+    "attributeID": 47,
+    "valueType": "text"
   },
   "userId": {
     "attributeID": 41,

--- a/cmd/tools/README.md
+++ b/cmd/tools/README.md
@@ -18,10 +18,12 @@ generate-attributes
 - `-schema`：Schema 名（不含 `.json`）；与 `-schema-file` 互斥。
 - `-schema-file`：Schema 文件全路径；优先于 `-schema/-schema-dir`。
 - `-out`：输出文件路径；默认写到 schema 同目录的 `<name>_attributes.json`。
+- `-init`：允许创建全新的 attributes 文件；不指定此标志时，输出文件缺失会导致错误（因为生成会将所有 attributeID 从 1 重新编号）。
 
 示例：
-- `go run ./cmd/tools generate-attributes -schema lead`
-- `go run ./cmd/tools generate-attributes -schema-file /path/to/schema.json -out /tmp/schema_attributes.json`
+- `go run ./cmd/tools generate-attributes -schema lead`（更新既有 attributes 文件）
+- `go run ./cmd/tools generate-attributes -schema-file /path/to/schema.json`（再生成）
+- `go run ./cmd/tools generate-attributes -schema-file /path/to/schema.json -out /tmp/schema_attributes.json -init`（创建新文件）
 
 init-db
 -------

--- a/cmd/tools/generate_attributes.go
+++ b/cmd/tools/generate_attributes.go
@@ -70,14 +70,18 @@ func runGenerateAttributes(_ context.Context, args []string) error {
 }
 
 func generateAttributesJSON(schemaPath, outputPath string) error {
-	data, err := os.ReadFile(schemaPath)
+	inliner := NewSchemaInliner(filepath.Dir(schemaPath))
+	schema, err := inliner.InlineFile(schemaPath)
 	if err != nil {
-		return fmt.Errorf("read schema file: %w", err)
-	}
-
-	var schema map[string]any
-	if err := json.Unmarshal(data, &schema); err != nil {
-		return fmt.Errorf("parse schema JSON: %w", err)
+		// Adapt inliner error messages to match legacy test expectations
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "read file") {
+			return fmt.Errorf("read schema file: %w", err)
+		}
+		if strings.Contains(errMsg, "parse JSON") {
+			return fmt.Errorf("parse schema JSON: %w", err)
+		}
+		return fmt.Errorf("inline schema: %w", err)
 	}
 
 	// Extract attributes from the schema

--- a/cmd/tools/generate_attributes.go
+++ b/cmd/tools/generate_attributes.go
@@ -73,15 +73,7 @@ func generateAttributesJSON(schemaPath, outputPath string) error {
 	inliner := NewSchemaInliner(filepath.Dir(schemaPath))
 	schema, err := inliner.InlineFile(schemaPath)
 	if err != nil {
-		// Adapt inliner error messages to match legacy test expectations
-		errMsg := err.Error()
-		if strings.Contains(errMsg, "read file") {
-			return fmt.Errorf("read schema file: %w", err)
-		}
-		if strings.Contains(errMsg, "parse JSON") {
-			return fmt.Errorf("parse schema JSON: %w", err)
-		}
-		return fmt.Errorf("inline schema: %w", err)
+		return fmt.Errorf("inline schema %s: %w", schemaPath, err)
 	}
 
 	// Extract attributes from the schema

--- a/cmd/tools/generate_attributes.go
+++ b/cmd/tools/generate_attributes.go
@@ -39,6 +39,7 @@ func runGenerateAttributes(_ context.Context, args []string) error {
 	schemaName := flags.String("schema", "", "Schema name without extension (mutually exclusive with -schema-file)")
 	schemaFile := flags.String("schema-file", "", "Path to the JSON schema file (overrides -schema and -schema-dir)")
 	outputFile := flags.String("out", "", "Path to write the generated attributes JSON (defaults next to schema file)")
+	initNew := flags.Bool("init", false, "Allow creating a brand-new attributes file (without it, a missing output file is an error because generation would renumber every attributeID from 1)")
 
 	if err := flags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -61,7 +62,7 @@ func runGenerateAttributes(_ context.Context, args []string) error {
 		resolvedOutputPath = filepath.Join(filepath.Dir(resolvedSchemaPath), base+"_attributes.json")
 	}
 
-	if err := generateAttributesJSON(resolvedSchemaPath, resolvedOutputPath); err != nil {
+	if err := generateAttributesJSON(resolvedSchemaPath, resolvedOutputPath, *initNew); err != nil {
 		return err
 	}
 
@@ -69,7 +70,16 @@ func runGenerateAttributes(_ context.Context, args []string) error {
 	return nil
 }
 
-func generateAttributesJSON(schemaPath, outputPath string) error {
+func generateAttributesJSON(schemaPath, outputPath string, allowNew bool) error {
+	if _, err := os.Stat(outputPath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("stat output file %s: %w", outputPath, err)
+		}
+		if !allowNew {
+			return fmt.Errorf("output file %s does not exist: generating without it would renumber every attributeID from 1 (attributeIDs are physical EAV keys); pass -init only for a genuinely new schema", outputPath)
+		}
+	}
+
 	inliner := NewSchemaInliner(filepath.Dir(schemaPath))
 	schema, err := inliner.InlineFile(schemaPath)
 	if err != nil {

--- a/cmd/tools/generate_attributes_files_test.go
+++ b/cmd/tools/generate_attributes_files_test.go
@@ -192,7 +192,7 @@ func TestGenerateAttributesJSONNewFile(t *testing.T) {
 		t.Fatalf("failed to write schema file: %v", err)
 	}
 
-	err := generateAttributesJSON(schemaPath, outputPath)
+	err := generateAttributesJSON(schemaPath, outputPath, true)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -240,7 +240,7 @@ func TestGenerateAttributesJSONPreserveExistingIDs(t *testing.T) {
 		t.Fatalf("failed to write schema file: %v", err)
 	}
 
-	_ = generateAttributesJSON(schemaPath, outputPath)
+	_ = generateAttributesJSON(schemaPath, outputPath, true)
 
 	// Read first generation result
 	data, _ := os.ReadFile(outputPath)
@@ -266,7 +266,7 @@ func TestGenerateAttributesJSONPreserveExistingIDs(t *testing.T) {
 		t.Fatalf("failed to write schema file: %v", err)
 	}
 
-	_ = generateAttributesJSON(schemaPath, outputPath)
+	_ = generateAttributesJSON(schemaPath, outputPath, true)
 
 	// Read second generation result
 	data, _ = os.ReadFile(outputPath)
@@ -309,7 +309,7 @@ func TestGenerateAttributesJSONRemoveAttributeFromSchema(t *testing.T) {
 	schemaData, _ := json.Marshal(schema1)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	_ = generateAttributesJSON(schemaPath, outputPath)
+	_ = generateAttributesJSON(schemaPath, outputPath, true)
 
 	// Now remove one attribute from schema
 	schema2 := map[string]any{
@@ -322,7 +322,7 @@ func TestGenerateAttributesJSONRemoveAttributeFromSchema(t *testing.T) {
 	schemaData, _ = json.Marshal(schema2)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	_ = generateAttributesJSON(schemaPath, outputPath)
+	_ = generateAttributesJSON(schemaPath, outputPath, true)
 
 	// Verify that email is still in the attributes file
 	data, _ := os.ReadFile(outputPath)
@@ -359,7 +359,7 @@ func TestGenerateAttributesJSONRemovedAttributeClearsRequiredFlag(t *testing.T) 
 	schemaData, _ := json.Marshal(initialSchema)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+	if err := generateAttributesJSON(schemaPath, outputPath, true); err != nil {
 		t.Fatalf("expected no error on initial generation, got %v", err)
 	}
 
@@ -375,7 +375,7 @@ func TestGenerateAttributesJSONRemovedAttributeClearsRequiredFlag(t *testing.T) 
 	schemaData, _ = json.Marshal(updatedSchema)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+	if err := generateAttributesJSON(schemaPath, outputPath, true); err != nil {
 		t.Fatalf("expected no error on regeneration, got %v", err)
 	}
 

--- a/cmd/tools/generate_attributes_merge_test.go
+++ b/cmd/tools/generate_attributes_merge_test.go
@@ -220,7 +220,7 @@ func TestGenerateAttributesJSONInvalidSchemaFile(t *testing.T) {
 	outputPath := filepath.Join(tempDir, "attributes.json")
 
 	err := generateAttributesJSON(schemaPath, outputPath)
-	if err == nil || !strings.Contains(err.Error(), "read schema file") {
+	if err == nil || !strings.Contains(err.Error(), "inline schema") {
 		t.Fatalf("expected read error, got %v", err)
 	}
 }
@@ -234,7 +234,7 @@ func TestGenerateAttributesJSONInvalidJSON(t *testing.T) {
 	_ = os.WriteFile(schemaPath, []byte("{invalid json"), 0o644)
 
 	err := generateAttributesJSON(schemaPath, outputPath)
-	if err == nil || !strings.Contains(err.Error(), "parse schema JSON") {
+	if err == nil || !strings.Contains(err.Error(), "inline schema") {
 		t.Fatalf("expected parse error, got %v", err)
 	}
 }

--- a/cmd/tools/generate_attributes_merge_test.go
+++ b/cmd/tools/generate_attributes_merge_test.go
@@ -25,7 +25,7 @@ func TestGenerateAttributesJSONUpdateValueType(t *testing.T) {
 	schemaData, _ := json.Marshal(schema1)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	_ = generateAttributesJSON(schemaPath, outputPath)
+	_ = generateAttributesJSON(schemaPath, outputPath, true)
 
 	// Update schema to add date format
 	schema2 := map[string]any{
@@ -40,7 +40,7 @@ func TestGenerateAttributesJSONUpdateValueType(t *testing.T) {
 	schemaData, _ = json.Marshal(schema2)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	_ = generateAttributesJSON(schemaPath, outputPath)
+	_ = generateAttributesJSON(schemaPath, outputPath, true)
 
 	// Verify value type was updated
 	data, _ := os.ReadFile(outputPath)
@@ -72,7 +72,7 @@ func TestGenerateAttributesJSONMarksRequiredAttributes(t *testing.T) {
 	schemaData, _ := json.Marshal(schema)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+	if err := generateAttributesJSON(schemaPath, outputPath, true); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -112,7 +112,7 @@ func TestGenerateAttributesJSONUpdatesRequiredFlag(t *testing.T) {
 	schemaData, _ := json.Marshal(initialSchema)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+	if err := generateAttributesJSON(schemaPath, outputPath, true); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -140,7 +140,7 @@ func TestGenerateAttributesJSONUpdatesRequiredFlag(t *testing.T) {
 	schemaData, _ = json.Marshal(updatedSchema)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+	if err := generateAttributesJSON(schemaPath, outputPath, true); err != nil {
 		t.Fatalf("expected no error on regeneration, got %v", err)
 	}
 
@@ -194,7 +194,7 @@ func TestGenerateAttributesJSONMaxIDCalculation(t *testing.T) {
 	schemaData, _ := json.Marshal(schema)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	_ = generateAttributesJSON(schemaPath, outputPath)
+	_ = generateAttributesJSON(schemaPath, outputPath, true)
 
 	// Verify new IDs start after maxID (10)
 	data, _ := os.ReadFile(outputPath)
@@ -219,7 +219,7 @@ func TestGenerateAttributesJSONInvalidSchemaFile(t *testing.T) {
 	schemaPath := filepath.Join(tempDir, "nonexistent.json")
 	outputPath := filepath.Join(tempDir, "attributes.json")
 
-	err := generateAttributesJSON(schemaPath, outputPath)
+	err := generateAttributesJSON(schemaPath, outputPath, true)
 	if err == nil || !strings.Contains(err.Error(), "inline schema") {
 		t.Fatalf("expected read error, got %v", err)
 	}
@@ -233,7 +233,7 @@ func TestGenerateAttributesJSONInvalidJSON(t *testing.T) {
 
 	_ = os.WriteFile(schemaPath, []byte("{invalid json"), 0o644)
 
-	err := generateAttributesJSON(schemaPath, outputPath)
+	err := generateAttributesJSON(schemaPath, outputPath, true)
 	if err == nil || !strings.Contains(err.Error(), "inline schema") {
 		t.Fatalf("expected parse error, got %v", err)
 	}
@@ -305,7 +305,7 @@ func TestIntegrationWorkflow(t *testing.T) {
 	schemaData, _ := json.Marshal(schema1)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	err := generateAttributesJSON(schemaPath, outputPath)
+	err := generateAttributesJSON(schemaPath, outputPath, true)
 	if err != nil {
 		t.Fatalf("first generation failed: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestIntegrationWorkflow(t *testing.T) {
 	schemaData, _ = json.Marshal(schema2)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	err = generateAttributesJSON(schemaPath, outputPath)
+	err = generateAttributesJSON(schemaPath, outputPath, true)
 	if err != nil {
 		t.Fatalf("second generation failed: %v", err)
 	}
@@ -405,7 +405,7 @@ func TestGenerateAttributesJSONNewAttributesAreSorted(t *testing.T) {
 	schemaData, _ := json.Marshal(schema)
 	_ = os.WriteFile(schemaPath, schemaData, 0o644)
 
-	_ = generateAttributesJSON(schemaPath, outputPath)
+	_ = generateAttributesJSON(schemaPath, outputPath, true)
 
 	data, _ := os.ReadFile(outputPath)
 	var result map[string]map[string]any

--- a/cmd/tools/generate_attributes_ref_test.go
+++ b/cmd/tools/generate_attributes_ref_test.go
@@ -66,7 +66,7 @@ func TestGenerateAttributesExpandsObjectRef(t *testing.T) {
 }`)
 	outputPath := filepath.Join(dir, "main_attributes.json")
 
-	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+	if err := generateAttributesJSON(schemaPath, outputPath, true); err != nil {
 		t.Fatalf("generateAttributesJSON: %v", err)
 	}
 	attrs := readGeneratedAttributes(t, outputPath)
@@ -115,7 +115,7 @@ func TestGenerateAttributesScalarRefUsesTargetKeywords(t *testing.T) {
 }`)
 	outputPath := filepath.Join(dir, "main_attributes.json")
 
-	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+	if err := generateAttributesJSON(schemaPath, outputPath, true); err != nil {
 		t.Fatalf("generateAttributesJSON: %v", err)
 	}
 	attrs := readGeneratedAttributes(t, outputPath)

--- a/cmd/tools/generate_attributes_ref_test.go
+++ b/cmd/tools/generate_attributes_ref_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func writeSchemaFixture(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write schema fixture %s: %v", name, err)
+	}
+	return path
+}
+
+func readGeneratedAttributes(t *testing.T, path string) map[string]map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated attributes %s: %v", path, err)
+	}
+	var attrs map[string]map[string]any
+	if err := json.Unmarshal(data, &attrs); err != nil {
+		t.Fatalf("parse generated attributes %s: %v", path, err)
+	}
+	return attrs
+}
+
+func sortedAttrKeys(attrs map[string]map[string]any) []string {
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// #315: an object-valued $ref in properties must expand into dotted
+// attributes exactly as the equivalent inline object would, instead of
+// collapsing to a single scalar and shifting every later attributeID.
+func TestGenerateAttributesExpandsObjectRef(t *testing.T) {
+	dir := t.TempDir()
+	writeSchemaFixture(t, dir, "common.json", `{
+  "$defs": {
+    "address": {
+      "type": "object",
+      "required": ["street"],
+      "properties": {
+        "street": {"type": "string"},
+        "zip": {"type": "integer"}
+      }
+    }
+  }
+}`)
+	schemaPath := writeSchemaFixture(t, dir, "main.json", `{
+  "type": "object",
+  "required": ["address"],
+  "properties": {
+    "address": {"$ref": "common.json#/$defs/address"},
+    "name": {"type": "string"}
+  }
+}`)
+	outputPath := filepath.Join(dir, "main_attributes.json")
+
+	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+		t.Fatalf("generateAttributesJSON: %v", err)
+	}
+	attrs := readGeneratedAttributes(t, outputPath)
+
+	if _, exists := attrs["address"]; exists {
+		t.Errorf("object $ref collapsed to scalar attribute \"address\"; keys: %v", sortedAttrKeys(attrs))
+	}
+	street, ok := attrs["address.street"]
+	if !ok {
+		t.Fatalf("expected expanded attribute \"address.street\"; keys: %v", sortedAttrKeys(attrs))
+	}
+	if got := street["valueType"]; got != "text" {
+		t.Errorf("address.street valueType = %v, want text", got)
+	}
+	if got := street["required_policy"]; got != "required_always" {
+		t.Errorf("address.street required_policy = %v, want required_always", got)
+	}
+	zip, ok := attrs["address.zip"]
+	if !ok {
+		t.Fatalf("expected expanded attribute \"address.zip\"; keys: %v", sortedAttrKeys(attrs))
+	}
+	if got := zip["valueType"]; got != "numeric" {
+		t.Errorf("address.zip valueType = %v, want numeric", got)
+	}
+	if _, hasPolicy := zip["required_policy"]; hasPolicy {
+		t.Errorf("address.zip should be optional (no required_policy), got %v", zip["required_policy"])
+	}
+	if name, ok := attrs["name"]; !ok || name["valueType"] != "text" {
+		t.Errorf("inline scalar \"name\" should survive unchanged as text, got %v", name)
+	}
+}
+
+// Spec §"Generator fix": scalar $ref nodes now see the target's real
+// keywords. A $ref to a date-time string must emit valueType "date"
+// (previously the accidental fallthrough emitted "text").
+func TestGenerateAttributesScalarRefUsesTargetKeywords(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := writeSchemaFixture(t, dir, "main.json", `{
+  "type": "object",
+  "$defs": {
+    "ts": {"type": "string", "format": "date-time"}
+  },
+  "properties": {
+    "when": {"$ref": "#/$defs/ts"}
+  }
+}`)
+	outputPath := filepath.Join(dir, "main_attributes.json")
+
+	if err := generateAttributesJSON(schemaPath, outputPath); err != nil {
+		t.Fatalf("generateAttributesJSON: %v", err)
+	}
+	attrs := readGeneratedAttributes(t, outputPath)
+	when, ok := attrs["when"]
+	if !ok {
+		t.Fatalf("expected attribute \"when\"; keys: %v", sortedAttrKeys(attrs))
+	}
+	if got := when["valueType"]; got != "date" {
+		t.Errorf("when valueType = %v, want date (inlined format date-time)", got)
+	}
+}

--- a/cmd/tools/generate_attributes_regen_guard_test.go
+++ b/cmd/tools/generate_attributes_regen_guard_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// shippedSchemasDir points at the schema artifacts this repo ships. Both
+// guards below fail loudly if discovery finds nothing, so a moved directory
+// cannot silently disable them.
+const shippedSchemasDir = "../server/schemas"
+
+// firstDivergence returns a printable window around the first byte where a
+// and b differ, so a guard failure names the drift instead of just "bytes
+// differ".
+func firstDivergence(a, b []byte) string {
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
+	}
+	i := 0
+	for i < limit && a[i] == b[i] {
+		i++
+	}
+	start := i - 80
+	if start < 0 {
+		start = 0
+	}
+	end := i + 80
+	clamp := func(s []byte) string {
+		e := end
+		if e > len(s) {
+			e = len(s)
+		}
+		if start >= len(s) {
+			return ""
+		}
+		return string(s[start:e])
+	}
+	return "committed: ..." + clamp(a) + "...\nregenerated: ..." + clamp(b) + "..."
+}
+
+// TestShippedAttributesRegenerateByteIdentical seeds each committed
+// *_attributes.json onto a scratch path (the generator preserves
+// attributeIDs only when the output file already exists — #315), regenerates
+// it from its schema, and requires byte identity. A failure means an edit to
+// a shipped schema (or to the generator) would retype or shift physical EAV
+// attributeIDs; regenerate deliberately and review the diff instead of
+// weakening this test.
+func TestShippedAttributesRegenerateByteIdentical(t *testing.T) {
+	matches, err := filepath.Glob(filepath.Join(shippedSchemasDir, "*_attributes.json"))
+	if err != nil {
+		t.Fatalf("glob shipped attributes files: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no *_attributes.json found under %s — guard is scanning the wrong directory", shippedSchemasDir)
+	}
+	for _, committedPath := range matches {
+		name := strings.TrimSuffix(filepath.Base(committedPath), "_attributes.json")
+		t.Run(name, func(t *testing.T) {
+			schemaPath := filepath.Join(shippedSchemasDir, name+".json")
+			committed, err := os.ReadFile(committedPath)
+			if err != nil {
+				t.Fatalf("read committed attributes: %v", err)
+			}
+			scratch := filepath.Join(t.TempDir(), name+"_attributes.json")
+			if err := os.WriteFile(scratch, committed, 0o644); err != nil {
+				t.Fatalf("seed scratch attributes: %v", err)
+			}
+			if err := generateAttributesJSON(schemaPath, scratch, false); err != nil {
+				t.Fatalf("regenerate attributes for %s: %v", name, err)
+			}
+			regenerated, err := os.ReadFile(scratch)
+			if err != nil {
+				t.Fatalf("read regenerated attributes: %v", err)
+			}
+			if !bytes.Equal(committed, regenerated) {
+				t.Errorf("%s_attributes.json does not regenerate byte-identically (committed %d bytes, regenerated %d bytes)\n%s",
+					name, len(committed), len(regenerated), firstDivergence(committed, regenerated))
+			}
+		})
+	}
+}
+
+// TestShippedFullSchemasMatchInlineOutput pins every committed *_full.json
+// to the inline-schema tool's output for its base schema, closing the drift
+// channel where schema edits land without re-inlining (#315 findings §3).
+func TestShippedFullSchemasMatchInlineOutput(t *testing.T) {
+	matches, err := filepath.Glob(filepath.Join(shippedSchemasDir, "*_full.json"))
+	if err != nil {
+		t.Fatalf("glob shipped full schemas: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no *_full.json found under %s — guard is scanning the wrong directory", shippedSchemasDir)
+	}
+	for _, fullPath := range matches {
+		name := strings.TrimSuffix(filepath.Base(fullPath), "_full.json")
+		t.Run(name, func(t *testing.T) {
+			basePath := filepath.Join(shippedSchemasDir, name+".json")
+			inliner := NewSchemaInliner(shippedSchemasDir)
+			result, err := inliner.InlineFile(basePath)
+			if err != nil {
+				t.Fatalf("inline %s: %v", basePath, err)
+			}
+			// Same encoding as runInlineSchema writes.
+			encoded, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal inlined schema: %v", err)
+			}
+			committed, err := os.ReadFile(fullPath)
+			if err != nil {
+				t.Fatalf("read committed full schema: %v", err)
+			}
+			if !bytes.Equal(committed, encoded) {
+				t.Errorf("%s_full.json does not match inline-schema output (committed %d bytes, inlined %d bytes)\n%s",
+					name, len(committed), len(encoded), firstDivergence(committed, encoded))
+			}
+		})
+	}
+}

--- a/cmd/tools/generate_attributes_test.go
+++ b/cmd/tools/generate_attributes_test.go
@@ -55,6 +55,7 @@ func TestRunGenerateAttributesWithSchemaName(t *testing.T) {
 		"-schema-dir", tempDir,
 		"-schema", "test",
 		"-out", outputPath,
+		"-init",
 	}
 	err := runGenerateAttributes(context.Background(), args)
 	if err != nil {
@@ -90,6 +91,7 @@ func TestRunGenerateAttributesWithSchemaFile(t *testing.T) {
 	args := []string{
 		"-schema-file", schemaPath,
 		"-out", outputPath,
+		"-init",
 	}
 	err := runGenerateAttributes(context.Background(), args)
 	if err != nil {
@@ -123,6 +125,7 @@ func TestRunGenerateAttributesDefaultOutputPath(t *testing.T) {
 
 	args := []string{
 		"-schema-file", schemaPath,
+		"-init",
 	}
 	err := runGenerateAttributes(context.Background(), args)
 	if err != nil {
@@ -236,5 +239,42 @@ func TestGetValueType(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, result)
 			}
 		})
+	}
+}
+
+// #315: a missing output file makes the generator renumber every
+// attributeID from 1 (loadExistingAttributes returns an empty map on
+// ENOENT). That must be an explicit opt-in, never an accident.
+func TestRunGenerateAttributesRefusesMissingOutputWithoutInit(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "thing.json")
+	if err := os.WriteFile(schemaPath, []byte(`{"type":"object","properties":{"a":{"type":"string"}}}`), 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+
+	err := runGenerateAttributes(context.Background(), []string{"-schema-file", schemaPath})
+	if err == nil {
+		t.Fatal("expected error for missing output file without -init, got nil")
+	}
+	if !strings.Contains(err.Error(), "-init") || !strings.Contains(err.Error(), "renumber") {
+		t.Fatalf("error should explain the renumbering trap and name -init, got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "thing_attributes.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("refusal must not create the output file, stat err: %v", statErr)
+	}
+}
+
+func TestRunGenerateAttributesInitCreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "thing.json")
+	if err := os.WriteFile(schemaPath, []byte(`{"type":"object","properties":{"a":{"type":"string"}}}`), 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+
+	if err := runGenerateAttributes(context.Background(), []string{"-schema-file", schemaPath, "-init"}); err != nil {
+		t.Fatalf("expected success with -init, got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "thing_attributes.json")); statErr != nil {
+		t.Fatalf("output file should exist after -init run: %v", statErr)
 	}
 }

--- a/cmd/tools/main_test.go
+++ b/cmd/tools/main_test.go
@@ -50,6 +50,7 @@ func TestRunToolMain_Success(t *testing.T) {
 		"generate-attributes",
 		"-schema-file", schemaPath,
 		"-out", outputPath,
+		"-init",
 	}, &out)
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d output=%q", exitCode, out.String())

--- a/internal/entity_manager.go
+++ b/internal/entity_manager.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemavalidate"
+	"github.com/lychee-technology/forma/internal/transform"
 
 	"github.com/lychee-technology/forma"
 	"go.uber.org/zap"
@@ -107,6 +108,19 @@ func NewEntityManager(
 			relationIdx = idx
 		}
 	}
+	// The relation index is loaded here, from config, so the transformer this
+	// manager was handed predates it. Install the roots now: without them the
+	// EAV required-policy check enforces policies on relation-root children,
+	// which #314 ruled must never gate a write (#315).
+	if aware, ok := transformer.(transform.RelationRootsAware); ok {
+		aware.SetRelationRoots(relationIdx.RelationRoots)
+	} else if relationIdx != nil {
+		// Loud, not silent: a transformer decorator that does not forward the
+		// install leaves relation-root children under required-policy
+		// enforcement, which rejects writes #314 ruled acceptable.
+		zap.S().Warn("transformer does not accept relation roots; required-policy enforcement will not honour the #314 relation-root carve-out")
+	}
+
 	em := &entityManager{
 		transformer:          transformer,
 		repository:           repository,

--- a/internal/entity_write_validation_test.go
+++ b/internal/entity_write_validation_test.go
@@ -111,6 +111,15 @@ func (w *writeSpy) FromPersistentRecord(ctx context.Context, record *model.Persi
 	return w.inner.FromPersistentRecord(ctx, record)
 }
 
+// SetRelationRoots forwards the install to the wrapped transformer. A decorator
+// that swallows this optional interface silently disables the #314/#315
+// relation-root carve-out, so the spy has to stay transparent to it.
+func (w *writeSpy) SetRelationRoots(lookup transform.RelationRootsLookup) {
+	if aware, ok := w.inner.(transform.RelationRootsAware); ok {
+		aware.SetRelationRoots(lookup)
+	}
+}
+
 // newValidationHarness builds a validating manager over validationRegistry.
 func newValidationHarness(
 	t *testing.T, strict bool,

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -19,7 +19,8 @@ import (
 
 // AttributeConverter provides conversion between model.EntityAttribute and model.EAVRecord
 type AttributeConverter struct {
-	registry forma.SchemaRegistry
+	registry      forma.SchemaRegistry
+	relationRoots RelationRootsLookup
 }
 
 // NewAttributeConverter creates a new AttributeConverter instance
@@ -27,6 +28,26 @@ func NewAttributeConverter(registry forma.SchemaRegistry) *AttributeConverter {
 	return &AttributeConverter{
 		registry: registry,
 	}
+}
+
+// SetRelationRoots installs the relation-root lookup consulted by the
+// required-policy check in FromEAVRecords. A nil lookup, or one that answers an
+// empty set, leaves enforcement exactly as it was.
+func (c *AttributeConverter) SetRelationRoots(lookup RelationRootsLookup) {
+	c.relationRoots = lookup
+}
+
+// relationRootsFor resolves the relation roots of schemaID, translating the ID
+// to the schema name the lookup is keyed by.
+func (c *AttributeConverter) relationRootsFor(schemaID int16) (RelationRoots, error) {
+	if c.relationRoots == nil {
+		return nil, nil
+	}
+	schemaName, _, err := c.registry.GetSchemaByID(schemaID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema name for id %d: %w", schemaID, err)
+	}
+	return c.relationRoots(schemaName), nil
 }
 
 // ToEAVRecord converts an model.EntityAttribute to an model.EAVRecord
@@ -187,8 +208,35 @@ func (c *AttributeConverter) FromEAVRecords(records []model.EAVRecord) ([]model.
 			"schemaID", schemaID, "rowID", records[0].RowID, "attrIDs", ids)
 	}
 
+	if err := c.checkRequiredAttributes(schemaID, cache, presentAttrIndices); err != nil {
+		return nil, err
+	}
+
+	return attributes, nil
+}
+
+// checkRequiredAttributes enforces each attribute's required policy against the
+// attribute names the records actually carried, per array-index context.
+func (c *AttributeConverter) checkRequiredAttributes(
+	schemaID int16,
+	cache forma.SchemaAttributeCache,
+	presentAttrIndices map[string]map[string]struct{},
+) error {
+	relationRoots, err := c.relationRootsFor(schemaID)
+	if err != nil {
+		return fmt.Errorf("resolve relation roots for required-policy check: %w", err)
+	}
+
 	missingRequired := make(map[int16]string)
 	for attrName, metadata := range cache {
+		// #314/#315: relation-root data is derived on read and never
+		// schema-validated on write (the documented #314 gap), so required
+		// policies beneath a root must follow the same rule — otherwise
+		// expanding a root's attributes (#315 resolved contactSnapshot's $ref)
+		// turns payloads #314 ruled acceptable into 400s.
+		if relationRoots.Covers(attrName) {
+			continue
+		}
 		switch metadata.EffectiveRequiredPolicy() {
 		case forma.RequiredPolicyAlways:
 			if isRequiredAttributeMissing(attrName, presentAttrIndices, true) {
@@ -200,29 +248,30 @@ func (c *AttributeConverter) FromEAVRecords(records []model.EAVRecord) ([]model.
 			}
 		}
 	}
-	if len(missingRequired) > 0 {
-		zap.S().Infow("missing EAV records for attrIDs.", "idToName", missingRequired)
-		for missingAttrID, missingAttrName := range missingRequired {
-			// Plain error, deliberately. FromEAVRecords is not write-only: the read
-			// path rebuilds already-stored records through it
-			// (persistent_record.go's FromPersistentRecord), so a persisted row
-			// missing a required EAV row reaches here too. Wrapping
-			// forma.ErrInvalidInput here — as an earlier #301 sweep did — made the
-			// HTTP boundary answer that persisted-drift case with a verbatim 400,
-			// inverting the split AGENTS.md and this repo's error-handling doc
-			// draw: write validation carries the sentinel, read-path consistency
-			// failures stay plain and operator-visible.
-			//
-			// The write path's 400 does not depend on this wrap. It has its own
-			// write-only validator, validateRequiredAttributesFromInput
-			// (transformer.go), which ToAttributes runs against the caller's input
-			// before flattening and which does carry the sentinel.
-			return nil, fmt.Errorf("missing required attribute '%s' (attrID=%d) in EAV records",
-				missingAttrName, missingAttrID)
-		}
+	if len(missingRequired) == 0 {
+		return nil
 	}
 
-	return attributes, nil
+	zap.S().Infow("missing EAV records for attrIDs.", "idToName", missingRequired)
+	for missingAttrID, missingAttrName := range missingRequired {
+		// Plain error, deliberately. FromEAVRecords is not write-only: the read
+		// path rebuilds already-stored records through it
+		// (persistent_record.go's FromPersistentRecord), so a persisted row
+		// missing a required EAV row reaches here too. Wrapping
+		// forma.ErrInvalidInput here — as an earlier #301 sweep did — made the
+		// HTTP boundary answer that persisted-drift case with a verbatim 400,
+		// inverting the split AGENTS.md and this repo's error-handling doc
+		// draw: write validation carries the sentinel, read-path consistency
+		// failures stay plain and operator-visible.
+		//
+		// The write path's 400 does not depend on this wrap. It has its own
+		// write-only validator, validateRequiredAttributesFromInput
+		// (transformer.go), which ToAttributes runs against the caller's input
+		// before flattening and which does carry the sentinel.
+		return fmt.Errorf("missing required attribute '%s' (attrID=%d) in EAV records",
+			missingAttrName, missingAttrID)
+	}
+	return nil
 }
 
 // Helper functions for conversion

--- a/internal/transform/normalize_keys_arrays_test.go
+++ b/internal/transform/normalize_keys_arrays_test.go
@@ -69,9 +69,12 @@ func leadFullPayload(requirement map[string]any, extra map[string]any) map[strin
 		"pipeline":    "buy",
 		"stage":       "new",
 		"status":      "open",
-		"contact":     map[string]any{"name": "Ada"},
-		"createdAt":   "2026-07-25T00:00:00Z",
-		"updatedAt":   "2026-07-25T00:00:00Z",
+		// contact.isAnonymous is lead.json's only required contact property
+		// (#315: the shipped lead_full.json used to say "name" because it had
+		// drifted from its source schema).
+		"contact":   map[string]any{"name": "Ada", "isAnonymous": false},
+		"createdAt": "2026-07-25T00:00:00Z",
+		"updatedAt": "2026-07-25T00:00:00Z",
 	}
 	if requirement != nil {
 		doc["requirement"] = requirement
@@ -141,7 +144,7 @@ func TestNormalizeExpandsWhenOnlyTheFinalSegmentIsAnArray(t *testing.T) {
 	require.Contains(t, arrays, "contact.phones", "the fixture must exercise a real array path")
 
 	out := NormalizeDottedKeys(leadFullPayload(nil, map[string]any{
-		"contact":        map[string]any{"name": "Ada", "phones": []any{"080-0000-0000"}},
+		"contact":        map[string]any{"name": "Ada", "isAnonymous": false, "phones": []any{"080-0000-0000"}},
 		"contact.phones": []any{"090-1111-2222"},
 	}), cache, arrays, nil)
 
@@ -151,7 +154,7 @@ func TestNormalizeExpandsWhenOnlyTheFinalSegmentIsAnArray(t *testing.T) {
 
 	// The point of expanding: the value is now inside the schema's reach.
 	bad := NormalizeDottedKeys(leadFullPayload(nil, map[string]any{
-		"contact":        map[string]any{"name": "Ada", "phones": []any{"080-0000-0000"}},
+		"contact":        map[string]any{"name": "Ada", "isAnonymous": false, "phones": []any{"080-0000-0000"}},
 		"contact.phones": []any{12345},
 	}), cache, arrays, nil)
 	require.ErrorIs(t, validator.Validate(schemaID, bad), forma.ErrInvalidInput,
@@ -195,7 +198,7 @@ func TestNormalizeStillExpandsAttributeNotUnderArray(t *testing.T) {
 	}
 
 	out := NormalizeDottedKeys(leadFullPayload(nil, map[string]any{
-		"contact":       map[string]any{"name": "Ada"},
+		"contact":       map[string]any{"name": "Ada", "isAnonymous": false},
 		"contact.email": "ada@example.com",
 	}), cache, arrays, nil)
 
@@ -204,7 +207,7 @@ func TestNormalizeStillExpandsAttributeNotUnderArray(t *testing.T) {
 	require.NoError(t, validator.Validate(schemaID, out))
 
 	bad := NormalizeDottedKeys(leadFullPayload(nil, map[string]any{
-		"contact":       map[string]any{"name": "Ada"},
+		"contact":       map[string]any{"name": "Ada", "isAnonymous": false},
 		"contact.email": 12345,
 	}), cache, arrays, nil)
 	require.ErrorIs(t, validator.Validate(schemaID, bad), forma.ErrInvalidInput,

--- a/internal/transform/persistent_record.go
+++ b/internal/transform/persistent_record.go
@@ -14,6 +14,23 @@ import (
 type persistentRecordTransformer struct {
 	registry        forma.SchemaRegistry
 	jsonTransformer *transformer
+	relationRoots   RelationRootsLookup
+}
+
+// SetRelationRoots installs the relation-root lookup on this transformer and on
+// every converter it builds, so the required-policy carve-out (#314/#315)
+// applies on both the write and read halves of this type.
+func (t *persistentRecordTransformer) SetRelationRoots(lookup RelationRootsLookup) {
+	t.relationRoots = lookup
+	t.jsonTransformer.SetRelationRoots(lookup)
+}
+
+// newConverter builds a converter carrying whatever relation-root lookup has
+// been installed.
+func (t *persistentRecordTransformer) newConverter() *AttributeConverter {
+	converter := NewAttributeConverter(t.registry)
+	converter.SetRelationRoots(t.relationRoots)
+	return converter
 }
 
 // NewPersistentRecordTransformer creates a new PersistentRecordTransformer instance
@@ -36,7 +53,7 @@ func (t *persistentRecordTransformer) ToPersistentRecord(ctx context.Context, sc
 	}
 
 	// Convert EntityAttributes to EAVRecords for database layer
-	converter := NewAttributeConverter(t.registry)
+	converter := t.newConverter()
 	eavRecords, err := converter.ToEAVRecords(entityAttributes, rowID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert to EAVRecords: %w", err)
@@ -132,7 +149,7 @@ func (t *persistentRecordTransformer) FromPersistentRecord(ctx context.Context, 
 	attributes = append(attributes, record.OtherAttributes...)
 
 	// Convert EAVRecords to EntityAttributes
-	converter := NewAttributeConverter(t.registry)
+	converter := t.newConverter()
 	entityAttributes, err := converter.FromEAVRecords(attributes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert EAVRecords to EntityAttributes: %w", err)

--- a/internal/transform/relation_root_required_policy_test.go
+++ b/internal/transform/relation_root_required_policy_test.go
@@ -125,6 +125,68 @@ func TestFromEAVRecordsEnforcesRequiredPolicyOnRelationRootItself(t *testing.T) 
 	}
 }
 
+// TestFromEAVRecordsEnforcesRequiredPolicyOnFullVariant is the positive control
+// for the carve-out's blast radius: it must not reach the _full variants.
+//
+// visit_full.json is the inlined artifact, and inlining resolves $ref and drops
+// x-* — so it declares no x-relation and RelationIndex finds no relation roots
+// for it. contactSnapshot is therefore an ordinary nested object there, and its
+// children stay under required-policy enforcement even though the identical
+// names are exempt on visit.
+//
+// The metadata below mirrors visit_full_attributes.json after the #315 repair
+// (synthetic, to match this file's other fixtures): contactSnapshot.name (16)
+// lost required_if_parent_present, contactSnapshot.nameKana (17) never had one,
+// and contactSnapshot.isAnonymous (43) is new and carries it. That combination
+// is a write-contract change on visit_full, and is pinned here deliberately.
+func TestFromEAVRecordsEnforcesRequiredPolicyOnFullVariant(t *testing.T) {
+	registry := &stubSchemaRegistry{
+		schemaID:   501,
+		schemaName: "visit_full_like",
+		cache: forma.SchemaAttributeCache{
+			"id":                          {AttributeID: 1, ValueType: forma.ValueTypeText, RequiredPolicy: forma.RequiredPolicyAlways},
+			"contactSnapshot.name":        {AttributeID: 16, ValueType: forma.ValueTypeText},
+			"contactSnapshot.nameKana":    {AttributeID: 17, ValueType: forma.ValueTypeText},
+			"contactSnapshot.isAnonymous": {AttributeID: 43, ValueType: forma.ValueTypeBool, RequiredPolicy: forma.RequiredPolicyIfParentPresent},
+		},
+	}
+
+	// The lookup is installed and answers "no roots" for this schema, exactly
+	// as RelationIndex does for an inlined _full schema. The carve-out is wired
+	// but must not fire.
+	converter := NewAttributeConverter(registry)
+	converter.SetRelationRoots(func(schemaName string) RelationRoots {
+		if schemaName == "visit_like" {
+			return RelationRoots{"contactSnapshot": struct{}{}}
+		}
+		return nil
+	})
+
+	rowID := uuid.Must(uuid.NewV7())
+	id := "visit-1"
+	nameKana := "Ada"
+	withoutIsAnonymous := []model.EAVRecord{
+		{SchemaID: 501, RowID: rowID, AttrID: 1, ValueText: &id},
+		{SchemaID: 501, RowID: rowID, AttrID: 17, ValueText: &nameKana},
+	}
+
+	_, err := converter.FromEAVRecords(withoutIsAnonymous)
+	if err == nil {
+		t.Fatal("visit_full has no relation roots, so contactSnapshot children stay enforced")
+	}
+	if !strings.Contains(err.Error(), "missing required attribute 'contactSnapshot.isAnonymous'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	isAnonymous := 0.0
+	withIsAnonymous := append(withoutIsAnonymous,
+		model.EAVRecord{SchemaID: 501, RowID: rowID, AttrID: 43, ValueNumeric: &isAnonymous},
+	)
+	if _, err := converter.FromEAVRecords(withIsAnonymous); err != nil {
+		t.Fatalf("supplying contactSnapshot.isAnonymous must satisfy the policy: %v", err)
+	}
+}
+
 // TestFromEAVRecordsWithoutRelationRootsKeepsEnforcement pins that an
 // uninstalled lookup changes nothing — the carve-out is opt-in per wiring.
 func TestFromEAVRecordsWithoutRelationRootsKeepsEnforcement(t *testing.T) {

--- a/internal/transform/relation_root_required_policy_test.go
+++ b/internal/transform/relation_root_required_policy_test.go
@@ -1,0 +1,146 @@
+package transform
+
+// Relation-root carve-out for required-policy enforcement (#314/#315).
+//
+// These tests drive AttributeConverter.FromEAVRecords directly, which is the
+// seam where required policies are enforced against attribute metadata. The
+// integration halves live in package internal
+// (TestCreateAcceptsDottedKeyUnderRelationRoot and its "outside" twin).
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// relationRootPolicyRegistry mirrors the shape #315 created on visit.json:
+// contactSnapshot is a relation root whose expanded children carry required
+// policies, while propertySnapshot is an ordinary nested object whose children
+// carry the same policies and must keep being enforced.
+func relationRootPolicyRegistry() *stubSchemaRegistry {
+	return &stubSchemaRegistry{
+		schemaID:   500,
+		schemaName: "visit_like",
+		cache: forma.SchemaAttributeCache{
+			"id": {AttributeID: 1, ValueType: forma.ValueTypeText, RequiredPolicy: forma.RequiredPolicyAlways},
+
+			// Beneath a relation root: never enforced.
+			"contactSnapshot.name":        {AttributeID: 2, ValueType: forma.ValueTypeText},
+			"contactSnapshot.isAnonymous": {AttributeID: 3, ValueType: forma.ValueTypeBool, RequiredPolicy: forma.RequiredPolicyIfParentPresent},
+			"contactSnapshot.tenantId":    {AttributeID: 4, ValueType: forma.ValueTypeText, RequiredPolicy: forma.RequiredPolicyAlways},
+
+			// Outside every relation root: still enforced.
+			"propertySnapshot.price":  {AttributeID: 5, ValueType: forma.ValueTypeNumeric},
+			"propertySnapshot.status": {AttributeID: 6, ValueType: forma.ValueTypeText, RequiredPolicy: forma.RequiredPolicyIfParentPresent},
+		},
+	}
+}
+
+func relationRootPolicyConverter(t *testing.T) (*AttributeConverter, uuid.UUID) {
+	t.Helper()
+	converter := NewAttributeConverter(relationRootPolicyRegistry())
+	converter.SetRelationRoots(func(schemaName string) RelationRoots {
+		if schemaName != "visit_like" {
+			return nil
+		}
+		return RelationRoots{"contactSnapshot": struct{}{}}
+	})
+	return converter, uuid.Must(uuid.NewV7())
+}
+
+// TestFromEAVRecordsSkipsRequiredPolicyBeneathRelationRoot is the #315 red.
+//
+// A sibling under the relation root is present, which is exactly what makes the
+// parent "present" for required_if_parent_present — and required_always would
+// fire regardless. Neither may be enforced beneath a relation root.
+func TestFromEAVRecordsSkipsRequiredPolicyBeneathRelationRoot(t *testing.T) {
+	converter, rowID := relationRootPolicyConverter(t)
+
+	id := "visit-1"
+	name := "Ada"
+	records := []model.EAVRecord{
+		{SchemaID: 500, RowID: rowID, AttrID: 1, ValueText: &id},
+		{SchemaID: 500, RowID: rowID, AttrID: 2, ValueText: &name},
+	}
+
+	attrs, err := converter.FromEAVRecords(records)
+	if err != nil {
+		t.Fatalf("a required policy beneath a relation root must not be enforced (#314/#315): %v", err)
+	}
+	if len(attrs) != 2 {
+		t.Fatalf("got %d attributes, want 2: %+v", len(attrs), attrs)
+	}
+}
+
+// TestFromEAVRecordsStillEnforcesRequiredPolicyOutsideRelationRoot is the
+// inverse pin: the carve-out must not widen into "nested required policies are
+// not enforced". propertySnapshot is an ordinary object, not a relation root.
+func TestFromEAVRecordsStillEnforcesRequiredPolicyOutsideRelationRoot(t *testing.T) {
+	converter, rowID := relationRootPolicyConverter(t)
+
+	id := "visit-1"
+	price := 100.0
+	records := []model.EAVRecord{
+		{SchemaID: 500, RowID: rowID, AttrID: 1, ValueText: &id},
+		{SchemaID: 500, RowID: rowID, AttrID: 5, ValueNumeric: &price},
+	}
+
+	_, err := converter.FromEAVRecords(records)
+	if err == nil {
+		t.Fatal("a required policy outside every relation root must still be enforced")
+	}
+	if !strings.Contains(err.Error(), "missing required attribute 'propertySnapshot.status'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestFromEAVRecordsEnforcesRequiredPolicyOnRelationRootItself pins Covers'
+// documented boundary: a name that *is* a relation root is not "beneath" one,
+// so the carve-out does not reach it.
+func TestFromEAVRecordsEnforcesRequiredPolicyOnRelationRootItself(t *testing.T) {
+	registry := relationRootPolicyRegistry()
+	registry.cache["contactSnapshot"] = forma.AttributeMetadata{
+		AttributeID:    7,
+		ValueType:      forma.ValueTypeText,
+		RequiredPolicy: forma.RequiredPolicyAlways,
+	}
+	converter := NewAttributeConverter(registry)
+	converter.SetRelationRoots(func(string) RelationRoots {
+		return RelationRoots{"contactSnapshot": struct{}{}}
+	})
+
+	rowID := uuid.Must(uuid.NewV7())
+	id := "visit-1"
+	_, err := converter.FromEAVRecords([]model.EAVRecord{
+		{SchemaID: 500, RowID: rowID, AttrID: 1, ValueText: &id},
+	})
+	if err == nil {
+		t.Fatal("a required policy on the relation root name itself is not covered by the carve-out")
+	}
+	if !strings.Contains(err.Error(), "missing required attribute 'contactSnapshot'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestFromEAVRecordsWithoutRelationRootsKeepsEnforcement pins that an
+// uninstalled lookup changes nothing — the carve-out is opt-in per wiring.
+func TestFromEAVRecordsWithoutRelationRootsKeepsEnforcement(t *testing.T) {
+	converter := NewAttributeConverter(relationRootPolicyRegistry())
+	rowID := uuid.Must(uuid.NewV7())
+
+	id := "visit-1"
+	name := "Ada"
+	_, err := converter.FromEAVRecords([]model.EAVRecord{
+		{SchemaID: 500, RowID: rowID, AttrID: 1, ValueText: &id},
+		{SchemaID: 500, RowID: rowID, AttrID: 2, ValueText: &name},
+	})
+	if err == nil {
+		t.Fatal("without a relation-roots lookup, enforcement must be unchanged")
+	}
+	if !strings.Contains(err.Error(), "missing required attribute 'contactSnapshot.") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/transform/relation_roots.go
+++ b/internal/transform/relation_roots.go
@@ -24,6 +24,21 @@ type RelationRoots map[string]struct{}
 // A name that *is* a relation root is not covered. It never reaches this check
 // in production (the strip deleted it) and it is not dotted, so expansion does
 // not apply to it either way.
+func (r RelationRoots) Covers(name string) bool {
+	if len(r) == 0 {
+		return false
+	}
+	for i, char := range name {
+		if char != '.' {
+			continue
+		}
+		if _, ok := r[name[:i]]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // RelationRootsLookup answers a schema's relation roots by schema name.
 //
 // It exists so package internal — which owns RelationIndex and is the only
@@ -40,19 +55,4 @@ type RelationRootsLookup func(schemaName string) RelationRoots
 // transformer is used concurrently; nothing reads the field until then.
 type RelationRootsAware interface {
 	SetRelationRoots(lookup RelationRootsLookup)
-}
-
-func (r RelationRoots) Covers(name string) bool {
-	if len(r) == 0 {
-		return false
-	}
-	for i, char := range name {
-		if char != '.' {
-			continue
-		}
-		if _, ok := r[name[:i]]; ok {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/transform/relation_roots.go
+++ b/internal/transform/relation_roots.go
@@ -24,6 +24,24 @@ type RelationRoots map[string]struct{}
 // A name that *is* a relation root is not covered. It never reaches this check
 // in production (the strip deleted it) and it is not dotted, so expansion does
 // not apply to it either way.
+// RelationRootsLookup answers a schema's relation roots by schema name.
+//
+// It exists so package internal — which owns RelationIndex and is the only
+// place that can build a RelationRoots set — can hand the set to this package
+// without an import cycle, at the seams that only know a schema ID.
+type RelationRootsLookup func(schemaName string) RelationRoots
+
+// RelationRootsAware is implemented by the transformers in this package so the
+// relation roots can be installed after construction.
+//
+// NewEntityManager loads the relation index itself, from config, and by then
+// the transformer it was handed already exists — so the lookup is installed
+// once at wiring time rather than injected at construction. Install before the
+// transformer is used concurrently; nothing reads the field until then.
+type RelationRootsAware interface {
+	SetRelationRoots(lookup RelationRootsLookup)
+}
+
 func (r RelationRoots) Covers(name string) bool {
 	if len(r) == 0 {
 		return false

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -37,6 +37,12 @@ func NewTransformer(registry forma.SchemaRegistry) *transformer {
 	}
 }
 
+// SetRelationRoots forwards the relation-root lookup to the converter that
+// performs the required-policy check (#314/#315).
+func (t *transformer) SetRelationRoots(lookup RelationRootsLookup) {
+	t.converter.SetRelationRoots(lookup)
+}
+
 func (t *transformer) ToAttributes(ctx context.Context, schemaID int16, rowID uuid.UUID, jsonData any) ([]model.EntityAttribute, error) {
 	if jsonData == nil {
 		return []model.EntityAttribute{}, nil


### PR DESCRIPTION
Closes #315

**Spec:** issue #315 comment [issuecomment-5207776413](https://github.com/Lychee-Technology/forma/issues/315#issuecomment-5207776413) (approved design).
**Implementation plan:** [issuecomment-5207828511](https://github.com/Lychee-Technology/forma/issues/315#issuecomment-5207828511).

---

## What this fixes

`cmd/tools/generate_attributes.go` never resolved `$ref`. `traverseSchemaWithRequiredState` checks `schema["properties"]`; a `$ref`-only node has none, so it fell through to `getSchemaType` and was emitted as a **single scalar attribute**. A `$ref` to a scalar was accidentally correct; a `$ref` to an object silently collapsed the entire subtree — and because `attributeID` is assigned **positionally** over the surviving key set, and `attributeID` *is* the physical `attr_id` column of the EAV table, every subsequent attribute of every stored row was silently remapped.

The exposure is live, not theoretical: `visit.json`'s `contactSnapshot` is `{"$ref": "lead.json#/properties/contact", "x-relation": {...}}` — a 24-property object — as of #314's repointing. The committed `visit_attributes.json` was a hybrid: the collapsed scalar `contactSnapshot` (ID 25) plus 4 stale `contactSnapshot.*` keys (IDs 21–24) from an earlier inline era.

Fix: `generateAttributesJSON` loads the schema through `NewSchemaInliner(...).InlineFile(...)` before traversal, reusing the existing cross-file resolution, JSON-pointer handling, cycle detection and `$ref`-sibling merge instead of adding a second resolver.

---

## User rulings implemented (from the approved spec — do not re-litigate)

1. **list drift: repair by regeneration in this PR.** All `text` → `list`+`items_type` corrections are committed, attributeIDs unchanged. Implementation had to verify stored-row compatibility first — see the compatibility evidence below.
2. **`contactSnapshot` expansion: accepted.** Regenerating the visit family expands `contactSnapshot` into ~20 new `contactSnapshot.*` attributes with freshly appended IDs; the collapsed scalar (ID 25) and the 4 stale keys are preserved and demoted to optional (existing preserve semantics, consistent with #294 tolerate-and-preserve). `x-relation` is a read-time enrichment annotation; attributes are still generated from the schema shape.
3. **`*_full.json` drift: repair in this PR, plus a second guard** pinning every committed `*_full.json` to `inline-schema` output. Taken on `visit_full`; the same-day measurement found `lead_full` and `log_full` drifted the same way, so all three are repaired and the guard covers all six.
4. **ENOENT protection: explicit flag.** `loadExistingAttributes` returns an empty map when the output file does not exist, which renumbers every attribute from 1 in sorted-key order. The generator now refuses to run in that case unless `-init` is passed. `generateAttributesJSON` gained an `allowNew bool` parameter — fail-closed default, so a call site that goes to the zero value gets the *strict* behavior (no #314-style default-value blindness).

---

## Commits

| Hash | Subject |
|---|---|
| `b34285e` | `fix(tools): #315 resolve $ref via SchemaInliner before attribute traversal` |
| `5cb725b` | `fix(tools): #315 unify inline-schema error wrapping per review` |
| `d1a2149` | `feat(tools): #315 require -init to create a new attributes file` |
| `249c1bc` | `docs(tools): #315 document -init flag in cmd/tools README` |
| `835483c` | `fix(schemas): #315 repair drifted artifacts; guard byte-identical regeneration` |
| `d801e03` | `test(transform): #315 update lead_full fixtures for repaired contact required set` |
| `ff905dc` | `fix(transform): #315 exempt relation-root children from required-policy enforcement` |
| `e1cc862` | `review: #315 reattach Covers doc; pin _full-variant required enforcement` |

---

## ⚠️ Migration runbook (required before deploy)

**Plan-owner ruling:** the `text` → `list` flip ships despite the Parquet-tier conflict, because old tier data for these columns is **already silently wrong** — the pre-change `MAX(CASE …)` export collapsed `["alpha","beta"]` to the single string `'beta'`. The flip does not make existing parquet more wrong; it makes it unreadable, loudly.

Before deploying this change to any environment with existing tier data (**devo**):

1. **Stop CDC flush and compaction** for schemas `lead`, `lead_full`, `visit`, `visit_full`.
2. **Purge BOTH** `s3://<prefix>/<schema>/delta/` **and** `s3://<prefix>/<schema>/base/` for those schemas. Note: `cdc-init` replaces the **base** tier only — the delta purge is manual (`internal/cdc/init.go:421`; see follow-up issue #371).
3. **Run `cdc-init`** to rebuild base from Postgres. Hot data is unaffected and remains the source of truth — the EAV rows are physically identical before and after this change (proved below), so nothing is lost.
4. **Verify legacy `_full` rows against the new required policies** (final-review finding — the "hot data unaffected" statement above covers the list flips, not this): `lead_full`'s `contact.isAnonymous` is now `required_always`, so any pre-existing `lead_full` row **without** that EAV attribute fails on read (`FromEAVRecords` required check — plain operator error, incl. Get-before-Update); likewise `visit_full` rows carrying any `contactSnapshot.*` child but no `isAnonymous` (`required_if_parent_present`). Check devo for such rows and backfill `isAnonymous` before deploy, or accept loud read failures until backfilled. This failure class already existed for plain `lead` (which has carried `contact.isAnonymous: required_always` since before this branch); `_full` variants are catching up.
5. **Resume** flush and compaction.

If step 2 is skipped, the first federated query after the metadata flip fails with a DuckDB `Conversion Error`. **That is the designed failure mode, not data loss** — a classified read failure, not corrupted results. Postgres still holds every value.

---

## text→list compatibility evidence

The following is Task 3's evidence report, verbatim.

<details>
<summary>Task 3 — text→list stored-artifact compatibility evidence (click to expand)</summary>

**VERDICT: `INCOMPATIBLE`** — for any deployment whose S3 tier already holds parquet
objects carrying a non-NULL value in one of the 18 affected columns. The Postgres/EAV
side is provably compatible (physically identical rows); the **parquet tier is not**, and
the failure is a hard query error on every federated read, not a degradation.

Environment: worktree `/Users/ruoshi/code/Lychee/LTBase/forma-315`, branch
`fix/315-generate-attributes-ref`. All test output below is real output from throwaway
tests run against the repo's pinned DuckDB (`github.com/duckdb/duckdb-go/v2 v2.5.6`,
`go.mod:15`) with `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false`. The throwaway tests
were deleted after the run; nothing is committed by this task.

---

### 0. Scope: which attributes, which storage

The 18 entries Task 4 would flip are all **EAV-only** (no `columnBinding` in the shipped
`*_attributes.json`), so no `entity_main` hot column is involved. Their folded parquet
column names (`sqlgen.ParquetAttrColumn`, `internal/sqlgen/parquet_attr_column.go:27` —
dots fold to underscores) are:

| schema | attribute | attrID | parquet column |
|---|---|---|---|
| `lead` / `lead_full` | `tags` | 72 | `tags` |
| `lead` / `lead_full` | `communications` | 2 | `communications` |
| `lead` / `lead_full` | `visits` | 76 | `visits` |
| `lead` / `lead_full` | `contact.phones` | 19 | `contact_phones` |
| `lead` / `lead_full` | `requirement.mustHave` | 54 | `requirement_mustHave` |
| `lead` / `lead_full` | `requirement.niceToHave` | 55 | `requirement_niceToHave` |
| `lead` / `lead_full` | `requirement.unwantedConditions` | 64 | `requirement_unwantedConditions` |
| `visit` / `visit_full` | `attendees` | 3 | `attendees` |
| `visit_full` | `contactSnapshot.phones` | 20 | `contactSnapshot_phones` |
| `visit_full` | `logs` | 29 | `logs` |

(7 + 7 + 1 + 3 = 18, matching the plan.)

---

### Step 1 — Pre-change write shape for arrays under `text` metadata

#### Static evidence

`flattenToAttributes`'s `[]any` branch (`internal/transform/transformer.go:305-337`) is
**metadata-independent for non-empty arrays**: it iterates elements and recurses with
`newIndices = append(indices, i)` (`:333-334`). It never consults `cache[attrName].ValueType`
on that path. The recursion bottoms out in the `default:` branch (`:338-364`), which sets
`ArrayIndices: joinIndices(indices)` (`:353`) and calls `populateTypedValue`.

`populateTypedValue` (`internal/transform/typed_value.go:12`) under `ValueTypeText`
(`:29-34`) writes `attr.ValueText`. Under `ValueTypeList` (`:62-78`) it asserts the row
already has indices (`:67`) and then **re-enters itself with `elemMeta.ValueType =
meta.EffectiveItemsType()`** (`:73-78`) — i.e. for `items_type: text` it takes the exact
same `ValueTypeText` branch and writes the exact same `ValueText`.

⇒ For a JSON array of strings the physical EAV rows are byte-identical under `text` and
under `list`+`items_type: text`.

The only metadata-sensitive spot in the `[]any` branch is the **empty** array
(`transformer.go:305-324`): `len(v) == 0` writes the `#204` empty-list marker row *only if*
`meta.ValueType == forma.ValueTypeList` (`:312`). Under `text` metadata it writes nothing.

#### Test evidence (`internal/transform`, throwaway)

```
=== RUN   TestTW315_WriteShapeArrayUnderTextVsList          # body: {"tags": ["alpha","beta"]}
    W1 text metadata (pre-change): attrID=18 indices="0" valueType=text value="alpha"
    W1 text metadata (pre-change): attrID=18 indices="1" valueType=text value="beta"
    W1 list metadata (post-change): attrID=18 indices="0" valueType=text value="alpha"
    W1 list metadata (post-change): attrID=18 indices="1" valueType=text value="beta"
--- PASS
=== RUN   TestTW315_WriteShapeEmptyArray                    # body: {"tags": []}
    W2 text metadata (pre-change): (no attributes)
    W2 list metadata (post-change): attrID=18 indices="" valueType=text value=<nil>
--- PASS
=== RUN   TestTW315_WriteShapeScalarValue                   # body: {"tags": "alpha"}
    W3 text metadata (pre-change): attrID=18 indices="" valueType=text value="alpha"
    W3 list metadata (post-change): ERROR convert value for attribute 'tags':
        invalid value for attribute 'tags' (attrID=18): list attribute requires an
        array value, got scalar alpha: invalid input
--- PASS
```

**Answer to the brief's Step-1 question: per-element rows with `array_indices`, not a
serialized scalar.** Three pre-change stored shapes are therefore possible:

- **(a)** per-element rows, `array_indices` = `"0"`, `"1"`, … — the normal case, identical
  to the post-change shape.
- **(b)** a scalar row with `array_indices = ""` — only if a client sent a bare string
  where the JSON Schema declares an array. Since #314 the write path validates the body
  against the registered JSON Schema (`internal/schemavalidate/`, wired at
  `internal/entity_crud_service.go:27`, `internal/entity_batch_service.go:29`), so such a
  body is rejected today; rows of shape (b) can only predate that guard.
- **(c)** no row at all for an explicit `[]` — pre-change, `{"tags": []}` persisted nothing.

#### #204 history check

`git log --all --oneline --grep='#204'` → `579e78a` is the only implementation commit. Its
diff on `internal/transform/transformer.go` touches only two places: the `FromAttributes`
empty-marker branch and the `len(v) == 0` empty-array branch. **The per-element decomposition
loop is untouched by #204** — it predates the list feature entirely.

The same commit message carries an explicit prior decision that is exactly this task's
question:

> *"Shipped `cmd/server/schemas/*_attributes.json` are intentionally NOT regenerated in this
> change: flipping existing scalar array columns to LIST would conflict with already-exported
> parquet under union_by_name. Existing deployments must re-export (or switch S3 prefix)
> before regenerating."*

The rest of this report verifies that claim empirically rather than inheriting it.

---

### Step 2 — Read behaviour of old-shape artifacts under `list` metadata

#### 2a. OLTP read / assembly — **COMPATIBLE**

`FromEAVRecords` (`internal/transform/attribute_converter.go:131`) substitutes the element
type for the container (`:168-173`), so a list attribute's rows are converted with
`ValueTypeText` — the same conversion the rows were written under.

`FromAttributes` (`internal/transform/transformer.go:99`) is metadata-sensitive in exactly
one place: the `attr.Value == nil` empty-marker branch (`:117-131`). Every other row goes
through `parseIndices(attr.ArrayIndices)` (`:134`, `internal/transform/array_paths.go:22`)
and `setValueAtPath` (`:140`), neither of which reads metadata.

Old rows of shape (a) reconstruct identically. Old rows of shape (b) (`array_indices=""`,
non-NULL value) never hit the marker branch (the branch requires `attr.Value == nil`), so
they take `parseIndices("") → nil` and reconstruct as a scalar — same as before the change,
no error. Shape (c) stays absent.

```
=== RUN   TestTW315_ReadOldPerElementRowsUnderListMetadata
    R1 text metadata (pre-change):  {"tags":["alpha","beta"]}
    R1 list metadata (post-change): {"tags":["alpha","beta"]}     # identical
--- PASS
=== RUN   TestTW315_ReadOldScalarRowUnderListMetadata
    R2 text metadata (pre-change):  {"tags":"alpha"}
    R2 list metadata (post-change): {"tags":"alpha"}              # identical, no error
--- PASS
```

#### 2b. CDC export — tolerates old rows, but **changes the parquet column type**

`buildSchemaDrivenProjection` (`internal/cdc/export_sql_builder.go:99`) branches on
`meta.ValueType == forma.ValueTypeList` at `:143`. Pre-change (`text`) it emits the scalar
collapse at `:158`:

```sql
MAX(CASE WHEN attr_id = 72 THEN value_text END) AS tags        -- → parquet VARCHAR
```

Post-change (`list`) it emits `:153-155`:

```sql
CASE WHEN count(*) FILTER (WHERE attr_id = 72) > 0
     THEN coalesce(list(value_text ORDER BY TRY_CAST(array_indices AS BIGINT))
                   FILTER (WHERE attr_id = 72 AND array_indices <> ''), [])
END AS tags                                                     -- → parquet VARCHAR[]
```

Two consequences:

1. **The parquet column type changes scalar `VARCHAR` → `VARCHAR[]`.** This is the whole
   problem; see 2c.
2. **Old rows are tolerated but shape (b) silently degrades to `[]`.** The `array_indices
   <> ''` filter excludes a legacy scalar row from the element aggregate while `count(*)`
   still sees it, so `coalesce(..., [])` fires. Verified:

```
=== RUN   TestTW315_ListAggregateOverLegacyScalarRow
    legacy scalar row (array_indices='') through the list aggregate -> []interface {}{}
    legacy per-element rows through the list aggregate -> []interface {}{"alpha","beta"}
--- PASS
```

The identical expression is the hot-tier pivot (`internal/sqlgen/duckdb_schema_projection.go:246-248`),
so a shape-(b) row also serves as `[]` from the hot tier. No error, but the value is lost —
worth noting even though it is not the gating failure.

Also worth recording as an improvement, not a regression: pre-change, the `MAX(CASE …)`
collapse already **destroyed** these arrays in parquet — a `["alpha","beta"]` row exported
as the single string `'beta'`. Every warm/cold read of these 18 attributes has been wrong
since the tiers were first populated. The flip fixes that going forward; it does not make
existing parquet more wrong, it makes it unreadable.

#### 2c. Federated / DuckDB read — **INCOMPATIBLE (hard error)**

Two independent binding sites force the old `VARCHAR` column and the new `VARCHAR[]` type
together:

- **Across parquet generations.** `s3_source` reads
  `{{.S3_SCAN_SOURCE}}` = `read_parquet(<paths>, union_by_name=true)`
  (`internal/sqlgen/duckdb_cold_scan.go:110`,
  `internal/sqlgen/advanced_query_template_duckdb.go` `s3_source` CTE). Its projection
  `buildS3Projection` (`internal/sqlgen/duckdb_schema_projection.go:138-151`) emits every
  attribute's folded column unconditionally (`:147-149`) — projection pushdown cannot spare it.
- **Across tiers.** `unified AS (SELECT * FROM s3_source UNION ALL SELECT * FROM pg_source)`
  (`advanced_query_template_duckdb.go:101-105`). `pg_source` carries the hot LIST pivot
  (`duckdb_schema_projection.go:203`, `:246-248`), i.e. `VARCHAR[]`.

Neither site has any tolerance for the type change. Note also that the `#255` cold-union
machinery does **not** help: `coldMissingColumns` (`internal/federated/cold_columns.go:22-39`)
only augments columns absent from *every* file, and `mergeColumnUnion`
(`internal/federated/parquet_schema_validation.go:366-372`) deliberately keeps only names,
first-seen type wins, delegating widening to `union_by_name` (`:365`). The pre-read validator
(`parquet_schema_validation.go:129`) inspects only the *system* columns, so it neither
rejects nor repairs an attribute-column type conflict.

**Real-DuckDB results (throwaway tests, `internal/sqlgen`):**

Case A — mixed parquet generations, old file `attr_tags` VARCHAR `'alpha'`, new file `VARCHAR[]`:

```
CASE A read_parquet(mixed VARCHAR/VARCHAR[]) ERROR:
  Conversion Error: Error while reading file ".../old.parquet":
  failed to cast column "attr_tags" from type VARCHAR to VARCHAR[]:
  Type VARCHAR with value 'alpha' can't be cast to the destination type VARCHAR[]
```

Case A' — `DESCRIBE` over that same mixed set resolves the union to `attr_tags -> VARCHAR[]`.
So the *binding* succeeds and only the *scan* fails: no pre-flight probe in the codebase can
see this coming, and the failure surfaces at query execution time.

Case E — through the production scan source, `sqlgen.BuildParquetScanSource(...)` (system-column
guard + `union_by_name`): **same Conversion Error**. The guard shape changes nothing.

Case B — the tier `UNION ALL` alone, no parquet involved:

```
SELECT 'alpha' AS attr_tags UNION ALL SELECT ['alpha','beta'] AS attr_tags
  → Conversion Error: Type VARCHAR with value 'alpha' can't be cast to the
    destination type VARCHAR[] when casting from source column attr_tags
```

Case G — **the worst case, and the one that decides the verdict**: a cold set containing
*only* pre-change parquet (no new-generation file anywhere) unioned with the post-change hot
leg — i.e. the very first federated query after the metadata flip, before any new export
exists:

```
CASE G ERROR: Conversion Error: Type VARCHAR with value 'alpha' can't be cast
              to the destination type VARCHAR[] when casting from source column attr_tags
```

So the breakage does **not** require a mixed corpus. It requires only (i) the metadata flip
and (ii) one pre-change parquet object with a non-NULL value in one of these columns.

Case D — compaction (`internal/compaction/merge.go:62-85`, `MergeToTmp` → `buildMergeSQL`
over `read_parquet(..., union_by_name=true)`) hits the identical error, so **compaction
cannot heal the corpus**; it fails on it too.

**Blast-radius bound (the one piece of good news).** The cast is per *value*, not per
*schema*, so an old column that is entirely NULL survives:

```
CASE F  old file attr_tags = CAST(NULL AS VARCHAR), new file VARCHAR[]
        → row a tags=<nil>;  row b tags=["alpha","beta"];  rows.Err=<nil>       OK
CASE G' old-only cold (all NULL) UNION ALL new hot LIST
        → row a tags=<nil>;  row b tags=["x","y"];         rows.Err=<nil>       OK
CASE H  CAST(NULL AS VARCHAR) AS VARCHAR[]  → NULL, no error
        CAST('' AS VARCHAR[])               → Conversion Error (empty string DOES fail)
        CAST('[a, b]' AS VARCHAR[])         → ['a','b']  (only bracket-literal text casts)
CASE I  count(*) not projecting the column  → 2, no error
        (irrelevant in production: buildS3Projection always projects it)
```

⇒ **The precise precondition for breakage:** at least one base/delta parquet object under the
deployment's S3 prefix carries a non-NULL, non-`[...]`-shaped string in one of the 10 distinct
folded column names above, for schema `lead`, `lead_full`, `visit`, or `visit_full`. If devo
has ever flushed a lead with `tags`, a contact with `phones`, or a visit with `attendees`, that
precondition is met.

---

### Step 3 — Verdict

**`INCOMPATIBLE`. STOP the plan; do not commit the regenerated `*_attributes.json` without a
paired storage remediation.**

Reasoning:

1. **Postgres/EAV is fine.** The flattener always decomposed JSON arrays into per-element
   rows regardless of declared `valueType` (`transformer.go:305-337`, unchanged by #204), and
   `populateTypedValue`'s list branch delegates to the items type
   (`typed_value.go:62-78`), so the stored rows are byte-identical before and after. OLTP
   reads are byte-identical too (test R1). If parquet were not in play, this would be a
   pure metadata relabel.
2. **Parquet is not fine.** The CDC export changes the physical column type from `VARCHAR`
   to `VARCHAR[]` (`export_sql_builder.go:143-159`), and every DuckDB read path that must
   reconcile the two — `read_parquet(union_by_name=true)`, the `s3_source`/`pg_source`
   `UNION ALL`, and the compaction merge — raises a hard `Conversion Error` on the first
   non-NULL legacy value (Cases A, B, D, E, G above).
3. **The failure fires immediately, not on the next flush.** Case G proves the hot tier's
   post-flip LIST pivot alone is enough to poison a union against a pre-flip cold set. There
   is no window in which the deployment is "flipped but not yet broken".
4. **It is loud, not silent** — a classified read failure, not corrupted results — which is
   the one mitigating fact, and it matches the failure mode #204's author predicted verbatim
   when he deliberately declined to regenerate these same files.
5. **Compaction cannot repair it**, so there is no self-healing path.

#### Affected surface

Schemas `lead`, `lead_full`, `visit`, `visit_full`; the 18 attribute entries / 10 distinct
folded parquet columns listed in §0. Every federated (warm/cold) query against those four
schemas fails outright once the metadata flips — including queries that never mention the
list attribute, because `buildS3Projection` projects all attribute columns.

#### Remediation options (for the user's decision)

- **A — New S3 prefix.** Flip the metadata and point the deployment at a fresh
  `S3Prefix`, then run `cmd/tools init-db` / `cdc-init` to build a base tier from Postgres
  under the new prefix. Postgres is the source of truth and its EAV rows are already
  correct, so no data is lost. Cleanest; the old prefix can be deleted after verification.
- **B — Full re-export in place.** Purge *both* the `/base/` and `/delta/` object sets and
  their manifests, then re-init. Note `cdc-init` calls
  `manifest.ReplaceTierFiles(..., "base", ...)` (`internal/cdc/init.go:421`) — it replaces
  the **base** tier only, so leftover pre-flip delta objects would still poison the scan.
  Delta must be cleared explicitly.
- **C — Ship the flip only to deployments with an empty/never-flushed S3 tier**, and gate
  devo behind A or B.
- **D — Split the change**: land the `generate_attributes` `$ref` fix (the actual #315
  defect) without regenerating the four affected `*_attributes.json` files, exactly as #204
  did, and track the regeneration + re-export as a separate operational issue.

Whichever is chosen, the metadata flip and the storage remediation must be **atomic from the
reader's point of view** — a server running new metadata against an old prefix is broken for
the duration.

---

#### Appendix — how the evidence was produced

Two throwaway test files (`internal/sqlgen/zz_throwaway_315_{compat,null,agg}_test.go`,
`internal/transform/zz_throwaway_315_test.go`) were written, run with
`GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/sqlgen ./internal/transform -run TestTW315 -v`,
and deleted. Parquet fixtures were produced in-process with
`COPY (SELECT … ) TO '<tmp>.parquet' (FORMAT PARQUET)` against the same DuckDB build the
product links, so the Conversion Errors quoted above are the engine's own text on the pinned
version — not inference from the SQL. `git status` is clean; this task commits nothing.

</details>

**Resolution:** the plan owner chose **B (full re-export in place)**, scoped to devo, executed via the migration runbook above. The `$ref` fix and the regeneration ship together in this PR.

---

## Per-file delta

`git diff --stat cmd/server/schemas/`:

```
 cmd/server/schemas/lead_attributes.json       | 21 ++++---
 cmd/server/schemas/lead_full.json             | 26 +++++++-
 cmd/server/schemas/lead_full_attributes.json  | 49 ++++++++++++---
 cmd/server/schemas/log_full.json              | 14 ++++-
 cmd/server/schemas/log_full_attributes.json   | 15 ++++-
 cmd/server/schemas/visit_attributes.json      | 85 ++++++++++++++++++++++++++-
 cmd/server/schemas/visit_full.json            | 34 ++++++++---
 cmd/server/schemas/visit_full_attributes.json | 34 +++++++++--
 8 files changed, 243 insertions(+), 35 deletions(-)
```

The other 16 shipped schema files are byte-identical, as required.

### Attributes files

| File | text→list flips | new attrs (ID range) | required_policy changes |
|---|---|---|---|
| `activity_attributes.json` | — | — | — (no change) |
| `activity_full_attributes.json` | — | — | — (no change) |
| `communication_attributes.json` | — | — | — (no change) |
| `communication_full_attributes.json` | — | — | — (no change) |
| `contact_attributes.json` | — | — | — (no change) |
| `contact_full_attributes.json` | — | — | — (no change) |
| `lead_attributes.json` | **7** | — | — |
| `lead_full_attributes.json` | **7** | **6** (77..82) | 1 |
| `log_attributes.json` | — | — | — (no change) |
| `log_full_attributes.json` | — | **3** (11..13) | 1 |
| `visit_attributes.json` | **1** | **20** (29..48) | — |
| `visit_full_attributes.json` | **2** | **6** (42..47) | 1 |
| **total** | **17** | **35** | **3** |

**Precise counts.** **17 pre-existing `text` → `list` flips + 1 new-born list attribute (`contactSnapshot.phones`, ID 45 in `visit_attributes.json`) + 35 new attributes total.** Commit `835483c`'s message says "18 text->list corrections" (the spec's wording, used verbatim per instruction); the count above is the precise record — 18 is the number of attributes that end up typed `list`, of which 17 are corrections and 1 is brand new.

Detail:

- `lead_attributes.json` / `lead_full_attributes.json` — same 7 flips each, all `text -> list` with `items_type: text`: `communications`, `contact.phones`, `requirement.mustHave`, `requirement.niceToHave`, `requirement.unwantedConditions`, `tags`, `visits`.
- `lead_full_attributes.json` new (max old ID 76): `contact.contactCode` 77 (text), `contact.isAnonymous` 78 (bool), `contact.nickname` 79 (text), `createdBy` 80 (text), `ownerTeam` 81 (text), `updatedBy` 82 (text). Policy: `contact.name` `required_always -> optional`; the new `contact.isAnonymous` is `required_always`.
- `log_full_attributes.json` new (max old ID 10): `createdBy` 11, `ownerTeam` 12, `updatedBy` 13 (all text). Policy: `leadId` `required_always -> optional`.
- `visit_attributes.json` — 1 flip (`attendees`) + 20 new `contactSnapshot.*` at IDs 29..48: `annualIncome`(29,numeric), `annualIncomeCurrency`(30), `birthday`(31,date), `company`(32), `contactCode`(33), `currentResidence`(34), `email`(35), `employmentYear`(36,numeric), `familySize`(37,numeric), `isAnonymous`(38,bool), `isBlacklisted`(39,bool), `lineId`(40), `maritalStatus`(41), `memo`(42), `nickname`(43), `occupation`(44), `phones`(45,**list**), `preferredChannel`(46), `preferredLanguage`(47), `wechatId`(48).
- `visit_full_attributes.json` — 2 flips (`attendees`, `contactSnapshot.phones`) + 6 new at 42..47 (`contactSnapshot.contactCode` 42, `contactSnapshot.isAnonymous` 43, `contactSnapshot.nickname` 44, `createdBy` 45, `ownerTeam` 46, `updatedBy` 47). Policy: `contactSnapshot.name` `required_if_parent_present -> optional`.

### `_full.json` bodies

- `lead_full.json`: adds `contact.contactCode`, `contact.isAnonymous`, `contact.nickname`, and root `createdBy` / `ownerTeam` / `updatedBy`; `contact.required` changes `["name"] -> ["isAnonymous"]`.
- `visit_full.json`: same three contact-object additions and same three root audit fields; same `contact.required` flip; **removes `logs`** (an array of Log IDs) — `visit.json` no longer declares it.
- `log_full.json`: adds root `createdBy` / `ownerTeam` / `updatedBy`; **removes the description** on `data` (`log.json` has none); drops `leadId` from root `required`.

### Note on `visit_full_attributes.json` having 2 flips, not 3

The missing third is `logs`. The stale `visit_full.json` still carried `logs` as `array of string`, so a prediction made against the stale artifact expects it to flip to `list`. Because the repair regenerates `_full` bodies **first**, `logs` is gone from `visit_full.json` by the time attributes are generated, and the generator preserves it as an orphaned attribute `{"attributeID": 29, "valueType": "text"}`, unchanged. Correct under this ordering, not a defect.

---

## ⚠️ `_full` write-contract changes (client-visible)

Both are intended schema-truth alignment, not regressions, but both change accepted payloads.

**`visit_full`.** The relation-root carve-out (#314/#315) does **not** reach `_full` variants: inlining resolves `$ref` and strips `x-*`, so `visit_full.json` declares no `x-relation` and `RelationIndex` finds no relation roots for it (`grep -c 'x-relation' visit.json` → 1; `visit_full.json` → 0). `contactSnapshot` is therefore an ordinary nested object there. Combined with the #315 repair, `visit_full`'s write contract changes: `contactSnapshot.name` (ID 16) drops `required_if_parent_present` → optional, and the new `contactSnapshot.isAnonymous` (ID 43) carries `required_if_parent_present`. **A `visit_full` write carrying any `contactSnapshot` child but no `isAnonymous` now returns 400 where it previously passed.** Pinned by `TestFromEAVRecordsEnforcesRequiredPolicyOnFullVariant`. Plain `visit` is unaffected — the carve-out exempts it.

**`lead_full`.** `contact.isAnonymous` (ID 78) is now `required_always`, and `contact.name` drops to optional. This is `lead_full` **catching up to `lead`**, not a new demand: `lead_attributes.json` already carried `contact.isAnonymous: {attributeID: 78, required_always}` on `main@d941899`, before this branch. The two layers are now consistent, on the same attribute ID, matching `lead.json`'s own `contact.required: ["isAnonymous"]`.

---

## The relation-root carve-out (`ff905dc`, `e1cc862`)

The `contactSnapshot` expansion (ruling 2) made `contactSnapshot.*` attributes **exist** for `visit` for the first time. Their `required_policy` markers immediately collided with #314's relation-root write semantics: `TestCreateAcceptsDottedKeyUnderRelationRoot` went red —

```
failed to transform data to persistent record: failed to convert to attributes:
  convert to model.EntityAttribute: missing required attribute
  'contactSnapshot.isAnonymous' (attrID=38) in EAV records
```

A caller sending `contactSnapshot.name` alone now makes the parent "present", so the write path demanded `contactSnapshot.isAnonymous`. That is exactly the payload #314 decided must stay accepted; #314 carved out relation roots on the **validator** side, but the EAV `required_policy` side was never carved out because until this repair the attribute did not exist. The repair made a latent hole load-bearing.

**Plan-owner ruling: mirror the carve-out on the EAV side.** Implemented in `AttributeConverter.checkRequiredAttributes` (`internal/transform/attribute_converter.go`) — one `RelationRoots.Covers` guard at the top of the per-attribute loop. `RelationIndex` stays the single source of truth for what a relation root is; the set travels into `transform` via a new `RelationRootsLookup` func type and an optional `RelationRootsAware` interface, installed by `NewEntityManager` right after it loads the relation index.

Rejected alternatives: guarding `validateRequiredAttributesFromInput` (dead code for this case — after `StripComputedFields` the relation root is gone from the input map, so `required_if_parent_present` short-circuits); suppressing `required_policy` in the generator (no relation index there, and it would change bytes the new guards pin); re-deriving relation roots inside `transform` (two detectors that can disagree = silent write-acceptance bug).

**One real finding while wiring this:** the install initially had no effect in the integration harness — `writeSpy` wraps the transformer and did not implement the optional interface, so the lookup was dropped on the floor. The #313 decorator lesson again. `writeSpy` now forwards `SetRelationRoots`, and `NewEntityManager` logs a warning when the transformer is not `RelationRootsAware` while a relation index exists, so the next lossy decorator is visible instead of silent.

**Pinned in both directions** (`internal/transform/relation_root_required_policy_test.go`):

| Test | Pins |
|---|---|
| `TestFromEAVRecordsSkipsRequiredPolicyBeneathRelationRoot` | the carve-out itself |
| `TestFromEAVRecordsStillEnforcesRequiredPolicyOutsideRelationRoot` | the inverse — ordinary nested objects stay enforced; the carve-out must not widen to "nested policies are not enforced" |
| `TestFromEAVRecordsEnforcesRequiredPolicyOnRelationRootItself` | `Covers`' documented boundary — a name that *is* a root is not *beneath* one |
| `TestFromEAVRecordsWithoutRelationRootsKeepsEnforcement` | control: with no lookup installed, byte-for-byte the old behaviour |
| `TestFromEAVRecordsEnforcesRequiredPolicyOnFullVariant` | the `_full` write-contract change disclosed above, both directions |

`FromEAVRecords` was over the 100-line rule after the guard, so the required-policy block moved into `checkRequiredAttributes` (65 / 56 lines; `attribute_converter.go` 484 lines).

---

## attributeID invariant

The load-bearing safety property: **no stored row is remapped.** Checker compares every `*_attributes.json` on `main@d941899` against this branch:

```
$ python3 idcheck.py
checked 12 files
OK: all existing attributeIDs preserved across 12 files
```

Zero attributes disappeared; zero attributeIDs changed value. All new attributes take IDs strictly above each file's previous max (`visit_attributes.json`: max old ID 28, min new ID 29). The five pre-existing `contactSnapshot` entries (IDs 25, 21–24) keep both their IDs and their `text` type.

---

## Guards added

**`TestShippedAttributesRegenerateByteIdentical`** — every committed `*_attributes.json` must regenerate byte-identically (seed-first: copy the committed file onto the output path, regenerate in place, compare bytes).

**`TestShippedFullSchemasMatchInlineOutput`** — every committed `*_full.json` must match `inline-schema` output.

RED before the repair (exact match to the predicted drift set):

```
--- FAIL: TestShippedAttributesRegenerateByteIdentical
    --- PASS: activity  activity_full  communication  communication_full  contact  contact_full  log  log_full
    --- FAIL: lead  lead_full  visit  visit_full
--- FAIL: TestShippedFullSchemasMatchInlineOutput
    --- PASS: activity  communication  contact
    --- FAIL: lead  log  visit
```

with divergence windows like:

```
lead_attributes.json does not regenerate byte-identically (committed 7049 bytes, regenerated 7231 bytes)
  committed:   "communications": { "attributeID": 2, "valueType": "text" }
  regenerated: "communications": { "attributeID": 2, "valueType": "list", "items_type": "text" }
```

GREEN after:

```
--- PASS: TestShippedAttributesRegenerateByteIdentical (0.01s)   [12/12 subtests]
--- PASS: TestShippedFullSchemasMatchInlineOutput (0.00s)        [6/6 subtests]
```

---

## Mutation verification

**Mutant 1 — revert the `$ref` fix.** Task 1's `InlineFile` wiring in `generate_attributes.go` reverted to the old raw `os.ReadFile` + `json.Unmarshal`:

```
$ go test ./cmd/tools -run TestShippedAttributesRegenerateByteIdentical -v -count=1
    generate_attributes_regen_guard_test.go:82: visit_attributes.json does not regenerate
      byte-identically (committed 4104 bytes, regenerated 4051 bytes)
--- FAIL: TestShippedAttributesRegenerateByteIdentical/visit
    --- PASS: (all 11 others, incl. visit_full)
FAIL	github.com/lychee-technology/forma/cmd/tools	0.597s
```

The guard catches the exact #315 failure mode. `visit_full` correctly stays green — `visit_full.json` is the already-inlined artifact and contains zero `$ref` (`grep -c '$ref'` → 0, vs 3 in `visit.json`), so removing the inliner is a no-op for it. Note the mutant is caught by a **53-byte** difference, not by attributes vanishing: without inlining, the generator emits no `contactSnapshot.*` specs but *preserves* the orphaned existing ones, so all 47 survive and only their `required_policy` markers drop. Byte-exactness is what makes the guard sensitive enough to see it. Restored, re-run green.

**Mutant 2 — widen the carve-out** to `relationRoots.Covers(attrName) || strings.Contains(attrName, ".")`:

```
MUTATION: carve-out widened to every nested attribute
--- FAIL: TestAttributeConverterFromEAVRecords_NestedRequiredDependsOnParentPresence
--- FAIL: TestAttributeConverterFromEAVRecords_RequiredChildUsesArrayIndexContext
--- FAIL: TestAttributeConverterFromEAVRecords_NestedArrayRequiredUsesFullIndexPath
--- FAIL: TestAttributeConverterFromEAVRecords_RequiredAlwaysIgnoresParentPresence
--- FAIL: TestFromEAVRecordsStillEnforcesRequiredPolicyOutsideRelationRoot
--- FAIL: TestFromEAVRecordsEnforcesRequiredPolicyOnFullVariant
--- FAIL: TestFromEAVRecordsWithoutRelationRootsKeepsEnforcement
FAIL	github.com/lychee-technology/forma/internal/transform	0.194s
--- restoring ---
ok  	github.com/lychee-technology/forma/internal/transform	0.187s
```

The new `_full` pin is a real pin, not a tautology.

---

## Gates

All run on the branch head, working tree clean.

**`make lint`** — clean, exit 0. golangci-lint `v1.64.8` (the Makefile's pin), installed by the target itself:

```
$ make lint; echo "EXIT=$?"
Installing golangci-lint...
Running golangci-lint...
EXIT=0
$ golangci-lint --version
golangci-lint has version v1.64.8 built with go1.26.5 ...
```

**`make test`** — every package `ok`, zero failures:

```
Running unit tests...
ok  	github.com/lychee-technology/forma	0.315s
ok  	github.com/lychee-technology/forma/cdc	(cached)
ok  	github.com/lychee-technology/forma/cmd/benchmark	1.953s
ok  	github.com/lychee-technology/forma/cmd/lambda	0.595s
ok  	github.com/lychee-technology/forma/cmd/server	2.488s
ok  	github.com/lychee-technology/forma/cmd/tools	3.735s
ok  	github.com/lychee-technology/forma/factory	1.379s
ok  	github.com/lychee-technology/forma/internal	1.595s
ok  	github.com/lychee-technology/forma/internal/bootstrap	(cached)
ok  	github.com/lychee-technology/forma/internal/cdc	(cached)
ok  	github.com/lychee-technology/forma/internal/compaction	(cached)
ok  	github.com/lychee-technology/forma/internal/conditionexpr	(cached)
ok  	github.com/lychee-technology/forma/internal/duckdbinit	(cached)
ok  	github.com/lychee-technology/forma/internal/e2e_harness	(cached)
ok  	github.com/lychee-technology/forma/internal/e2e_harness/federated	(cached)
ok  	github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark	(cached)
ok  	github.com/lychee-technology/forma/internal/e2e_harness/production	(cached)
ok  	github.com/lychee-technology/forma/internal/federated	(cached)
ok  	github.com/lychee-technology/forma/internal/httpapi	2.597s
ok  	github.com/lychee-technology/forma/internal/manifest	(cached)
ok  	github.com/lychee-technology/forma/internal/model	(cached)
ok  	github.com/lychee-technology/forma/internal/numutil	(cached)
ok  	github.com/lychee-technology/forma/internal/parquetcheck	(cached)
ok  	github.com/lychee-technology/forma/internal/pgdsn	(cached)
ok  	github.com/lychee-technology/forma/internal/queryplan	(cached)
ok  	github.com/lychee-technology/forma/internal/reconcile	(cached)
ok  	github.com/lychee-technology/forma/internal/redact	(cached)
ok  	github.com/lychee-technology/forma/internal/schemameta	2.744s
ok  	github.com/lychee-technology/forma/internal/schemavalidate	2.960s
ok  	github.com/lychee-technology/forma/internal/sqlgen	(cached)
ok  	github.com/lychee-technology/forma/internal/sqlutil	(cached)
ok  	github.com/lychee-technology/forma/internal/transform	3.069s
```

**`make test-e2e-production`** — run because `ff905dc` changes runtime write-path behaviour and the production harness exercises the shipped schemas. **123 tests, 0 failures**:

```
--- PASS: TestProductionSmoke (1.65s)
... (123 --- PASS lines, 0 FAIL)
--- PASS: TestInitSchemaScopedIsolation (2.79s)
--- PASS: TestUpdateAfterAttributeRemoval (0.12s)
--- PASS: TestRecreateBetweenExportAndMark (3.75s)
PASS
ok  	github.com/lychee-technology/forma/internal/e2e_harness/production	132.678s
```

**`gofmt -l`** over the file list derived from git (`git diff --name-only d941899..HEAD -- '*.go'` plus `git ls-files --others --exclude-standard -- '*.go'`, #301 lesson — derived, not remembered) — **empty**. 15 changed `.go` files, 0 untracked `.go` files.

**`go vet ./...`** — clean, exit 0.

**Line limits** — every changed `.go` file is inside the 500-line rule; the largest is `internal/transform/transformer.go` at 485.

```
 58 internal/transform/relation_roots.go
 84 cmd/tools/main_test.go
124 cmd/tools/generate_attributes_regen_guard_test.go
129 cmd/tools/generate_attributes_ref_test.go
208 internal/transform/relation_root_required_policy_test.go
238 internal/entity_manager.go
280 cmd/tools/generate_attributes_test.go
335 internal/entity_write_validation_test.go
400 cmd/tools/generate_attributes_files_test.go
403 internal/transform/normalize_keys_arrays_test.go
407 cmd/tools/generate_attributes.go
423 cmd/tools/generate_attributes_merge_test.go
447 internal/transform/persistent_record.go
484 internal/transform/attribute_converter.go
485 internal/transform/transformer.go
```

**Not run:** the federated e2e suite (`-tags=e2e`, ~30m) — CI covers it, and this change's runtime surface is the write path, which the production harness exercises.

---

## Follow-up issues

- **#370** — `Discuss: stable-by-name attributeID assignment for generate-attributes`. Positional assignment is what turns any schema shape change into a physical EAV remap; this PR contains the hazard but does not remove it.
- **#371** — `cdc-init only replaces the base tier; delta files survive re-init` (`internal/cdc/init.go:421`). Directly load-bearing for the migration runbook above.
- **#372** — `Legacy scalar EAV rows under list metadata export/pivot as empty list`. Silent value loss for pre-#314 rows with `array_indices = ''`.
- **Cosmetic, no issue filed:** `log.json`'s audit-field descriptions say "visit record" (`"User ID of who created the visit record"`, etc. — `log.json:69,73,77`), a copy-paste from `visit.json`. It propagates into `log_full.json` through inlining. Fix in the source schema someday; it changes no behaviour.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

