### PR TITLE
review: #373 deterministic missing-attribute error + nil-safety comment

### DIFF
--- a/internal/entity_manager.go
+++ b/internal/entity_manager.go
@@ -113,6 +113,8 @@ func NewEntityManager(
 	// EAV required-policy check enforces policies on relation-root children,
 	// which #314 ruled must never gate a write (#315).
 	if aware, ok := transformer.(transform.RelationRootsAware); ok {
+		// Safe when relationIdx is nil: RelationRoots is nil-receiver-safe
+		// (relation_index.go) and installs an empty lookup.
 		aware.SetRelationRoots(relationIdx.RelationRoots)
 	} else if relationIdx != nil {
 		// Loud, not silent: a transformer decorator that does not forward the

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -253,25 +253,32 @@ func (c *AttributeConverter) checkRequiredAttributes(
 	}
 
 	zap.S().Infow("missing EAV records for attrIDs.", "idToName", missingRequired)
-	for missingAttrID, missingAttrName := range missingRequired {
-		// Plain error, deliberately. FromEAVRecords is not write-only: the read
-		// path rebuilds already-stored records through it
-		// (persistent_record.go's FromPersistentRecord), so a persisted row
-		// missing a required EAV row reaches here too. Wrapping
-		// forma.ErrInvalidInput here — as an earlier #301 sweep did — made the
-		// HTTP boundary answer that persisted-drift case with a verbatim 400,
-		// inverting the split AGENTS.md and this repo's error-handling doc
-		// draw: write validation carries the sentinel, read-path consistency
-		// failures stay plain and operator-visible.
-		//
-		// The write path's 400 does not depend on this wrap. It has its own
-		// write-only validator, validateRequiredAttributesFromInput
-		// (transformer.go), which ToAttributes runs against the caller's input
-		// before flattening and which does carry the sentinel.
-		return fmt.Errorf("missing required attribute '%s' (attrID=%d) in EAV records",
-			missingAttrName, missingAttrID)
+	names := make([]string, 0, len(missingRequired))
+	idsByName := make(map[string]int16, len(missingRequired))
+	for id, name := range missingRequired {
+		names = append(names, name)
+		idsByName[name] = id
 	}
-	return nil
+	// Name the alphabetically first missing attribute, not whichever the map
+	// yields first, so the same drift produces the same error on every run.
+	missingAttrName := slices.Min(names)
+
+	// Plain error, deliberately. FromEAVRecords is not write-only: the read
+	// path rebuilds already-stored records through it
+	// (persistent_record.go's FromPersistentRecord), so a persisted row
+	// missing a required EAV row reaches here too. Wrapping
+	// forma.ErrInvalidInput here — as an earlier #301 sweep did — made the
+	// HTTP boundary answer that persisted-drift case with a verbatim 400,
+	// inverting the split AGENTS.md and this repo's error-handling doc
+	// draw: write validation carries the sentinel, read-path consistency
+	// failures stay plain and operator-visible.
+	//
+	// The write path's 400 does not depend on this wrap. It has its own
+	// write-only validator, validateRequiredAttributesFromInput
+	// (transformer.go), which ToAttributes runs against the caller's input
+	// before flattening and which does carry the sentinel.
+	return fmt.Errorf("missing required attribute '%s' (attrID=%d) in EAV records",
+		missingAttrName, idsByName[missingAttrName])
 }
 
 // Helper functions for conversion

--- a/internal/transform/attribute_converter_test.go
+++ b/internal/transform/attribute_converter_test.go
@@ -277,8 +277,47 @@ func TestAttributeConverterFromEAVRecords_NestedArrayRequiredUsesFullIndexPath(t
 	if !strings.Contains(err.Error(), "missing required attribute '") {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "orders.items.price") && !strings.Contains(err.Error(), "contact.phones.kind") {
-		t.Fatalf("expected nested required attribute error, got %v", err)
+	// Both contact.phones.kind and orders.items.price are missing; the error
+	// deterministically names the alphabetically first.
+	if !strings.Contains(err.Error(), "missing required attribute 'contact.phones.kind' (attrID=6)") {
+		t.Fatalf("expected the alphabetically first missing attribute, got %v", err)
+	}
+}
+
+// TestAttributeConverterFromEAVRecords_MissingRequiredErrorIsDeterministic pins
+// the selection rule when several required attributes are missing at once: the
+// alphabetically first is named, on every run, instead of whichever the
+// missingRequired map happens to yield first (PR #373 review, F5). The repeat
+// loop is the red anchor — under map-order selection with four candidates it
+// fails with high probability.
+func TestAttributeConverterFromEAVRecords_MissingRequiredErrorIsDeterministic(t *testing.T) {
+	registry := &stubSchemaRegistry{
+		schemaID:   405,
+		schemaName: "multi_missing_schema",
+		cache: forma.SchemaAttributeCache{
+			"id":     {AttributeID: 1, ValueType: forma.ValueTypeText, Required: true},
+			"delta":  {AttributeID: 2, ValueType: forma.ValueTypeText, Required: true},
+			"bravo":  {AttributeID: 3, ValueType: forma.ValueTypeText, Required: true},
+			"echo":   {AttributeID: 4, ValueType: forma.ValueTypeText, Required: true},
+			"alpha":  {AttributeID: 5, ValueType: forma.ValueTypeText, Required: true},
+			"filled": {AttributeID: 6, ValueType: forma.ValueTypeText},
+		},
+	}
+
+	converter := NewAttributeConverter(registry)
+	rowID := uuid.Must(uuid.NewV7())
+	idValue := "row-1"
+
+	for run := 0; run < 25; run++ {
+		_, err := converter.FromEAVRecords([]model.EAVRecord{
+			{SchemaID: 405, RowID: rowID, AttrID: 1, ValueText: &idValue},
+		})
+		if err == nil {
+			t.Fatal("expected missing required attribute error")
+		}
+		if !strings.Contains(err.Error(), "missing required attribute 'alpha' (attrID=5)") {
+			t.Fatalf("run %d: expected deterministic 'alpha', got %v", run, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up resolving the code-level items from PR #373's post-merge review (https://github.com/Lychee-Technology/forma/pull/373#issuecomment-5212927307).

## F5 — nondeterministic missing-attribute error (resolved)
`checkRequiredAttributes` returned whichever missing attribute Go's map iteration yielded first. It now names the **alphabetically first** via `slices.Min` — same message format, deterministic selection.

- Pinned by `TestAttributeConverterFromEAVRecords_MissingRequiredErrorIsDeterministic` (4 missing candidates, 25 repeat runs — mutation-verified: reinstating map-order selection fails run 0 with `got 'delta'`).
- The pre-existing either/or assertion in `TestAttributeConverterFromEAVRecords_NestedArrayRequiredUsesFullIndexPath` — itself evidence of the nondeterminism — is tightened to the deterministic value.

## Observation 3 — implicit nil-receiver safety (resolved)
`NewEntityManager`'s `aware.SetRelationRoots(relationIdx.RelationRoots)` now carries a two-line comment noting the call is safe when `relationIdx` is nil (nil-receiver-safe method, installs an empty lookup).

## Not changed (responses on PR #373)
Bare `return nil, err` at the `checkRequiredAttributes` call site and the `RelationRootsAware` naming — reasoning posted on the review thread.

Note: `attribute_converter.go` is now 491/500 lines — the next change there must extract (already flagged in the #373 review).

Gates: `make lint` clean, `make test` all packages ok, gofmt clean.

Refs #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)