### PR TITLE
fix(schemameta): #342 guard against attributeID reuse after attribute removal

### DIFF
--- a/cmd/server/schemas/visit_attributes.json
+++ b/cmd/server/schemas/visit_attributes.json
@@ -14,7 +14,8 @@
   },
   "contactSnapshot": {
     "attributeID": 25,
-    "valueType": "text"
+    "valueType": "text",
+    "retired": true
   },
   "contactSnapshot.annualIncome": {
     "attributeID": 29,

--- a/cmd/server/schemas/visit_full_attributes.json
+++ b/cmd/server/schemas/visit_full_attributes.json
@@ -134,7 +134,8 @@
   },
   "logs": {
     "attributeID": 29,
-    "valueType": "text"
+    "valueType": "text",
+    "retired": true
   },
   "nextFollowUpAt": {
     "attributeID": 30,

--- a/cmd/tools/generate_attributes.go
+++ b/cmd/tools/generate_attributes.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/lychee-technology/forma"
 )
 
 type attributeSpec struct {
@@ -127,7 +129,7 @@ func generateAttributesJSON(schemaPath, outputPath string, allowNew bool) error 
 	// Build the result. First, preserve ALL existing attributes (even ones the
 	// schema dropped): this file is the attributeID ledger (#342).
 	if err := mergeExistingAttributes(existingAttrs, newAttributes, result); err != nil {
-		return err
+		return fmt.Errorf("merge existing attributes from %s: %w", outputPath, err)
 	}
 
 	// Then, add new attributes from the schema
@@ -175,7 +177,7 @@ func mergeExistingAttributes(
 		}
 
 		if err := clearRetiredOnReAdd(name, existingData, spec); err != nil {
-			return err
+			return fmt.Errorf("re-add retired attribute: %w", err)
 		}
 		existingData["valueType"] = spec.ValueType
 		if spec.ItemsType != "" {
@@ -201,7 +203,7 @@ func clearRetiredOnReAdd(name string, existingData map[string]any, spec attribut
 
 	oldType, _ := existingData["valueType"].(string)
 	oldItems, _ := existingData["items_type"].(string)
-	if oldType != spec.ValueType || oldItems != spec.ItemsType {
+	if oldType != spec.ValueType || effectiveItemsType(oldItems) != effectiveItemsType(spec.ItemsType) {
 		return fmt.Errorf(
 			"attribute %s is retired with valueType %s/items_type %q but re-added as %s/%q: preserved EAV rows store the old type and would become unreadable; restore the original type or use a new attribute name",
 			name, oldType, oldItems, spec.ValueType, spec.ItemsType)
@@ -210,6 +212,18 @@ func clearRetiredOnReAdd(name string, existingData map[string]any, spec attribut
 	// Same name, same type: the re-add restores the preserved values.
 	delete(existingData, "retired")
 	return nil
+}
+
+// effectiveItemsType resolves an omitted items_type the way the runtime does:
+// forma.AttributeMetadata.EffectiveItemsType treats an empty items_type as
+// text. A legacy ledger entry stored as a bare `list` therefore describes the
+// same physical rows as one written `list`/`text`, and re-adding it must not be
+// refused for a difference that does not exist on disk (#342).
+func effectiveItemsType(itemsType string) string {
+	if itemsType == "" {
+		return string(forma.ValueTypeText)
+	}
+	return itemsType
 }
 
 // loadExistingAttributes reads an existing attributes file and returns its contents.

--- a/cmd/tools/generate_attributes.go
+++ b/cmd/tools/generate_attributes.go
@@ -124,24 +124,10 @@ func generateAttributesJSON(schemaPath, outputPath string, allowNew bool) error 
 		newIDMap[name] = maxID + i + 1
 	}
 
-	// Build the result
-	// First, preserve ALL existing attributes (even if they are removed from schema)
-	for name, existingData := range existingAttrs {
-		if spec, exists := newAttributes[name]; exists {
-			// Attribute still exists in schema: update valueType if changed
-			existingData["valueType"] = spec.ValueType
-			if spec.ItemsType != "" {
-				existingData["items_type"] = spec.ItemsType
-			} else {
-				delete(existingData, "items_type")
-			}
-			applyRequiredPolicy(existingData, spec.RequiredPolicy)
-		} else {
-			// Attribute no longer exists in schema path; it must not stay required.
-			applyRequiredPolicy(existingData, requiredPolicyOptional)
-		}
-		// Keep the attribute regardless of whether it exists in the new schema
-		result[name] = existingData
+	// Build the result. First, preserve ALL existing attributes (even ones the
+	// schema dropped): this file is the attributeID ledger (#342).
+	if err := mergeExistingAttributes(existingAttrs, newAttributes, result); err != nil {
+		return err
 	}
 
 	// Then, add new attributes from the schema
@@ -164,6 +150,65 @@ func generateAttributesJSON(schemaPath, outputPath string, allowNew bool) error 
 	}
 
 	fmt.Printf("Generated attributes total: %d, new: %d, maxID: %d\n", len(result), len(newAttrNames), maxID+len(newAttrNames))
+	return nil
+}
+
+// mergeExistingAttributes folds every existing ledger entry into result.
+// Entries still present in the schema get their type and required policy
+// refreshed (and a retired marker cleared when the re-add is type-compatible);
+// entries the schema dropped are branded retired so their attributeID stays
+// bound to the EAV rows it already owns instead of being handed to a later
+// attribute (#342), and forced optional so no reader requires a value that can
+// no longer be written.
+func mergeExistingAttributes(
+	existingAttrs map[string]map[string]any,
+	newAttributes map[string]attributeSpec,
+	result map[string]map[string]any,
+) error {
+	for name, existingData := range existingAttrs {
+		spec, stillInSchema := newAttributes[name]
+		if !stillInSchema {
+			existingData["retired"] = true
+			applyRequiredPolicy(existingData, requiredPolicyOptional)
+			result[name] = existingData
+			continue
+		}
+
+		if err := clearRetiredOnReAdd(name, existingData, spec); err != nil {
+			return err
+		}
+		existingData["valueType"] = spec.ValueType
+		if spec.ItemsType != "" {
+			existingData["items_type"] = spec.ItemsType
+		} else {
+			delete(existingData, "items_type")
+		}
+		applyRequiredPolicy(existingData, spec.RequiredPolicy)
+		result[name] = existingData
+	}
+
+	return nil
+}
+
+// clearRetiredOnReAdd un-retires an attribute the schema has re-added under
+// its original physical type, which restores the preserved EAV rows. A
+// re-add under a different type is refused: the stored rows carry the old
+// type and would become unreadable (#342).
+func clearRetiredOnReAdd(name string, existingData map[string]any, spec attributeSpec) error {
+	if retired, _ := existingData["retired"].(bool); !retired {
+		return nil
+	}
+
+	oldType, _ := existingData["valueType"].(string)
+	oldItems, _ := existingData["items_type"].(string)
+	if oldType != spec.ValueType || oldItems != spec.ItemsType {
+		return fmt.Errorf(
+			"attribute %s is retired with valueType %s/items_type %q but re-added as %s/%q: preserved EAV rows store the old type and would become unreadable; restore the original type or use a new attribute name",
+			name, oldType, oldItems, spec.ValueType, spec.ItemsType)
+	}
+
+	// Same name, same type: the re-add restores the preserved values.
+	delete(existingData, "retired")
 	return nil
 }
 

--- a/cmd/tools/generate_attributes_retired_test.go
+++ b/cmd/tools/generate_attributes_retired_test.go
@@ -83,6 +83,33 @@ func TestGenerateAttributes_ReAddDifferentTypeRejected(t *testing.T) {
 	}
 }
 
+// #342: a list attribute keeps its element type in items_type, so a re-add
+// that preserves valueType "list" but swaps the element type is just as
+// destructive as a scalar type change and must be refused too. This pins the
+// items_type leg of the guard, which the valueType cases cannot reach: both
+// sides here are "list", so only the items_type comparison can fail.
+func TestGenerateAttributes_ReAddDifferentItemsTypeRejected(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeSchemaFixture(t, dir, "user.json",
+		`{"type":"object","properties":{"name":{"type":"string"},"old_list":{"type":"array","items":{"type":"number"}}}}`)
+	out := writeSchemaFixture(t, dir, "user_attributes.json", `{
+	  "name":     { "attributeID": 1, "valueType": "text" },
+	  "old_list": { "attributeID": 3, "valueType": "list", "items_type": "text", "retired": true }
+	}`)
+
+	err := generateAttributesJSON(schema, out, false)
+	if err == nil {
+		t.Fatalf("expected items_type-mismatch error on re-add")
+	}
+	// "text" is the retired element type, "numeric" the one the schema now asks
+	// for; naming both is what tells the operator which rows are at stake.
+	for _, want := range []string{"old_list", "text", "numeric"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
 // #342: a retired entry still occupies its attributeID, so a genuinely new
 // attribute must be numbered above it rather than reusing the freed id.
 func TestGenerateAttributes_NewAttributeDoesNotReuseRetiredID(t *testing.T) {

--- a/cmd/tools/generate_attributes_retired_test.go
+++ b/cmd/tools/generate_attributes_retired_test.go
@@ -110,6 +110,36 @@ func TestGenerateAttributes_ReAddDifferentItemsTypeRejected(t *testing.T) {
 	}
 }
 
+// #342: a legacy ledger entry may record a list without any items_type, which
+// the runtime reads as text (forma.AttributeMetadata.EffectiveItemsType). The
+// re-add guard must compare effective types, not literal strings: refusing this
+// re-add would hand the operator an instruction they cannot satisfy, since the
+// generator never writes items_type "text" back as an empty field.
+func TestGenerateAttributes_ReAddListWithoutItemsTypeClearsRetired(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeSchemaFixture(t, dir, "user.json",
+		`{"type":"object","properties":{"name":{"type":"string"},"old_list":{"type":"array","items":{"type":"string"}}}}`)
+	out := writeSchemaFixture(t, dir, "user_attributes.json", `{
+	  "name":     { "attributeID": 1, "valueType": "text" },
+	  "old_list": { "attributeID": 3, "valueType": "list", "retired": true }
+	}`)
+
+	if err := generateAttributesJSON(schema, out, false); err != nil {
+		t.Fatalf("re-add of a legacy items_type-less list must be accepted: %v", err)
+	}
+	attrs := readGeneratedAttributes(t, out)
+	oldList := attrs["old_list"]
+	if _, exists := oldList["retired"]; exists {
+		t.Fatalf("re-added attribute must lose the retired marker: %v", oldList)
+	}
+	if id, _ := oldList["attributeID"].(float64); id != 3 {
+		t.Fatalf("re-add must keep attributeID 3, got %v", oldList["attributeID"])
+	}
+	if items, _ := oldList["items_type"].(string); items != "text" {
+		t.Fatalf("re-add must record the now-explicit element type text, got %v", oldList["items_type"])
+	}
+}
+
 // #342: a retired entry still occupies its attributeID, so a genuinely new
 // attribute must be numbered above it rather than reusing the freed id.
 func TestGenerateAttributes_NewAttributeDoesNotReuseRetiredID(t *testing.T) {

--- a/cmd/tools/generate_attributes_retired_test.go
+++ b/cmd/tools/generate_attributes_retired_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// #342: an attribute dropped from the schema keeps its ledger entry, but the
+// generator must brand it retired so the freed attributeID stays bound to the
+// EAV rows it already owns instead of being handed to a new attribute.
+func TestGenerateAttributes_RemovalMarksRetired(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeSchemaFixture(t, dir, "user.json",
+		`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	out := writeSchemaFixture(t, dir, "user_attributes.json", `{
+	  "name":    { "attributeID": 1, "valueType": "text" },
+	  "old_col": { "attributeID": 3, "valueType": "text", "required_policy": "required_always" }
+	}`)
+
+	if err := generateAttributesJSON(schema, out, false); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	attrs := readGeneratedAttributes(t, out)
+	oldCol, exists := attrs["old_col"]
+	if !exists {
+		t.Fatalf("removed attribute must stay in the ledger")
+	}
+	if retired, _ := oldCol["retired"].(bool); !retired {
+		t.Fatalf("removed attribute must be marked retired, got %v", oldCol)
+	}
+	if id, _ := oldCol["attributeID"].(float64); id != 3 {
+		t.Fatalf("retired attributeID changed: %v", oldCol["attributeID"])
+	}
+	if _, ok := oldCol["required_policy"]; ok {
+		t.Fatalf("retired attribute must be forced optional, got %v", oldCol["required_policy"])
+	}
+}
+
+// #342: re-adding a retired name with the identical physical type restores the
+// preserved rows, so the retired marker must be cleared and the original
+// attributeID kept.
+func TestGenerateAttributes_ReAddSameTypeClearsRetired(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeSchemaFixture(t, dir, "user.json",
+		`{"type":"object","properties":{"name":{"type":"string"},"old_col":{"type":"string"}}}`)
+	out := writeSchemaFixture(t, dir, "user_attributes.json", `{
+	  "name":    { "attributeID": 1, "valueType": "text" },
+	  "old_col": { "attributeID": 3, "valueType": "text", "retired": true }
+	}`)
+
+	if err := generateAttributesJSON(schema, out, false); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	attrs := readGeneratedAttributes(t, out)
+	oldCol := attrs["old_col"]
+	if _, exists := oldCol["retired"]; exists {
+		t.Fatalf("re-added attribute must lose the retired marker: %v", oldCol)
+	}
+	if id, _ := oldCol["attributeID"].(float64); id != 3 {
+		t.Fatalf("re-add must keep attributeID 3, got %v", oldCol["attributeID"])
+	}
+}
+
+// #342: re-adding a retired name under a different physical type would leave
+// the preserved rows unreadable, so the generator must refuse and say so.
+func TestGenerateAttributes_ReAddDifferentTypeRejected(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeSchemaFixture(t, dir, "user.json",
+		`{"type":"object","properties":{"name":{"type":"string"},"old_col":{"type":"number"}}}`)
+	out := writeSchemaFixture(t, dir, "user_attributes.json", `{
+	  "name":    { "attributeID": 1, "valueType": "text" },
+	  "old_col": { "attributeID": 3, "valueType": "text", "retired": true }
+	}`)
+
+	err := generateAttributesJSON(schema, out, false)
+	if err == nil {
+		t.Fatalf("expected type-mismatch error on re-add")
+	}
+	for _, want := range []string{"old_col", "text", "numeric"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
+// #342: a retired entry still occupies its attributeID, so a genuinely new
+// attribute must be numbered above it rather than reusing the freed id.
+func TestGenerateAttributes_NewAttributeDoesNotReuseRetiredID(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeSchemaFixture(t, dir, "user.json",
+		`{"type":"object","properties":{"name":{"type":"string"},"nickname":{"type":"string"}}}`)
+	out := writeSchemaFixture(t, dir, "user_attributes.json", `{
+	  "name":    { "attributeID": 1, "valueType": "text" },
+	  "old_col": { "attributeID": 3, "valueType": "text", "retired": true }
+	}`)
+
+	if err := generateAttributesJSON(schema, out, false); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	attrs := readGeneratedAttributes(t, out)
+	if id, _ := attrs["nickname"]["attributeID"].(float64); id != 4 {
+		t.Fatalf("new attribute must get maxID+1=4 (retired id 3 reserved), got %v", id)
+	}
+}

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -315,6 +315,24 @@ preserved EAV rows would silently bind to the new attribute's name (same value
 type) or make the row unreadable with a storage type mismatch (different value
 type).
 
+Since #342 that rule is enforced. `generate-attributes` keeps the removed
+attribute's entry in `<schema>_attributes.json` marked `"retired": true` and
+forced optional — the file is the attributeID ledger, not just the active
+attribute list. Every metadata registration path (the file registry, the
+DB-backed loader, and `MetadataCache.RegisterSchema`) validates the **full**
+cache with retired entries included, and fails when an active attribute rebinds
+a retired attributeID, a retired main-column binding, or a retired attribute's
+folded parquet column. Retired entries are stripped only after that check and
+never reach a consumer, so a retired attribute reads, writes, flushes, and
+projects exactly as if its entry were absent — the #294 skip-and-preserve
+behavior above is unchanged. Re-adding the same name with the same `valueType`
+and `items_type` clears the marker and restores the preserved values; re-adding
+under a different type is rejected by the generator, which names the attribute
+and both the old and the new type. The guard has no signal for generations
+whose entries were hand-deleted from the ledger before #342 — for those files
+the rule remains documentation-only. Full removal workflow:
+[`schema-consistency-migration.md`](./schema-consistency-migration.md#removing-an-attribute-342).
+
 ### `ErrParquetSetInconsistent`
 
 `forma.ErrParquetSetInconsistent`, carried by

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -318,9 +318,10 @@ type).
 Since #342 that rule is enforced. `generate-attributes` keeps the removed
 attribute's entry in `<schema>_attributes.json` marked `"retired": true` and
 forced optional — the file is the attributeID ledger, not just the active
-attribute list. The two production registration paths — the file registry and
-the DB-backed loader — validate the **full** cache with retired entries
-included, and fail when an active attribute rebinds
+attribute list. Every production registration path — the DB-backed
+`MetadataLoader` file path, and the file registry in both its registry-table
+and directory modes (`cmd/sample` uses the latter) — validates the **full**
+cache with retired entries included, and fails when an active attribute rebinds
 a retired attributeID, a retired main-column binding, or a retired attribute's
 folded parquet column. `MetadataCache.RegisterSchema` applies the same
 validation but has no production callers; it is defence in depth for

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -318,17 +318,28 @@ type).
 Since #342 that rule is enforced. `generate-attributes` keeps the removed
 attribute's entry in `<schema>_attributes.json` marked `"retired": true` and
 forced optional — the file is the attributeID ledger, not just the active
-attribute list. Every metadata registration path (the file registry, the
-DB-backed loader, and `MetadataCache.RegisterSchema`) validates the **full**
-cache with retired entries included, and fails when an active attribute rebinds
+attribute list. The two production registration paths — the file registry and
+the DB-backed loader — validate the **full** cache with retired entries
+included, and fail when an active attribute rebinds
 a retired attributeID, a retired main-column binding, or a retired attribute's
-folded parquet column. Retired entries are stripped only after that check and
-never reach a consumer, so a retired attribute reads, writes, flushes, and
+folded parquet column. `MetadataCache.RegisterSchema` applies the same
+validation but has no production callers; it is defence in depth for
+programmatic registration. Retired entries are stripped only after that check
+and never reach a consumer, so a retired attribute reads, writes, flushes, and
 projects exactly as if its entry were absent — the #294 skip-and-preserve
 behavior above is unchanged. Re-adding the same name with the same `valueType`
-and `items_type` clears the marker and restores the preserved values; re-adding
-under a different type is rejected by the generator, which names the attribute
-and both the old and the new type. The guard has no signal for generations
+and `items_type` clears the marker and restores the preserved values **for rows
+still in the hot tier only**: CDC derives its EAV `attr_id` filter from the
+active cache, so a retired attribute is never exported to parquet, and rows
+already flushed are served from warm/cold where the column is absent. On
+lakehouse (CDC-enabled) deployments treat retirement as effectively
+irreversible for flushed rows — and note the reverse asymmetry, that a
+preserved Postgres row re-flushes on the next write after an un-retire, so a
+value that read `NULL` can reappear later. This is inherited #294 semantics,
+not new to #342; the operator-facing detail is in
+[`schema-consistency-migration.md`](./schema-consistency-migration.md#removing-an-attribute-342).
+Re-adding under a different type is rejected by the generator, which names the
+attribute and both the old and the new type. The guard has no signal for generations
 whose entries were hand-deleted from the ledger before #342 — for those files
 the rule remains documentation-only. Full removal workflow:
 [`schema-consistency-migration.md`](./schema-consistency-migration.md#removing-an-attribute-342).

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -20,7 +20,12 @@ A later release (`#314`) adds one more startup check and one more request-time c
 - any schema registered in `schema_registry` whose `<schema>.json` cannot be loaded and resolved fails **server startup**
 - create payloads that violate their entity's JSON Schema are rejected with `400`
 
-Both are covered below.
+A later release (`#342`) adds one more startup check:
+
+- any active attribute that rebinds a **retired** attributeID, main-column
+  binding, or folded parquet column fails **server startup**
+
+All three are covered below.
 
 ## Recommended Migration Flow
 
@@ -164,7 +169,63 @@ That means the table contains rows that current metadata cannot decode. There ar
 
 If you cannot establish which case applies, treat the rows as case (ii) and leave them alone; keeping undecodable rows costs storage, deleting recoverable ones costs the data.
 
-Whichever case applies, an `attributeID` freed by removing an attribute must never be reused for a different attribute: the preserved rows would silently bind to the new attribute's name, or make the row unreadable with a storage type mismatch.
+Whichever case applies, an `attributeID` freed by removing an attribute must never be reused for a different attribute: the preserved rows would silently bind to the new attribute's name, or make the row unreadable with a storage type mismatch. Since `#342` that is enforced at startup rather than left to convention — see [Removing an attribute](#removing-an-attribute-342) below.
+
+### Removing an attribute (`#342`)
+
+**The blessed workflow is: delete the property from `<schema>.json`, then run
+`generate-attributes`. Never hand-delete an entry from
+`<schema>_attributes.json`.** The attributes file is the schema's attributeID
+ledger, not just its list of active attributes. The generator keeps the dropped
+attribute's entry, marks it `"retired": true`, and forces its required policy to
+optional — so the `attributeID`, any `column_binding`, and the attribute's
+folded parquet column all stay reserved against the EAV rows `#294` preserved.
+
+Retired entries are ledger-only. Every metadata registration path validates the
+**full** file — retired entries included — and strips them only afterwards, so a
+retired attribute reads, writes, flushes, and projects exactly as if its entry
+were absent.
+
+**Startup guard.** Handing a retired `attributeID` to a different attribute
+aborts startup:
+
+```text
+schema contact reuses attribute id 7: retired attribute phone (valueType text) still owns preserved EAV rows and cannot be rebound to mobile; re-add the original name and valueType to restore it, or assign a new id
+```
+
+The main-column analogue fires when an active attribute claims a retired
+attribute's hot column:
+
+```text
+schema contact reuses main column text_01: retired attribute phone (valueType text) still owns its stored values and cannot share the column with mobile; keep the binding retired or assign a new column
+```
+
+A folded-parquet-column collision with a retired attribute is rejected the same
+way: already-flushed parquet files still carry that column. In every case the
+fix is to give the **new** attribute an unused id/column — never to delete the
+retired entry.
+
+**Re-adding.** Putting the property back into `<schema>.json` under the same
+name, the same `valueType` **and** the same `items_type`, then re-running
+`generate-attributes`, clears the `retired` marker; the preserved EAV rows
+become visible again. Re-adding under a different `valueType` or `items_type` is
+a generator error naming the attribute and both the old and the new
+type/items — the stored rows carry the old physical type and would be
+unreadable. Renaming an attribute is *not* a re-add: it needs a fresh
+`attributeID`, and the old entry stays retired.
+
+**Shipped schemas already carrying the marker.** `visit_attributes.json`
+`contactSnapshot` (`attributeID` 25) and `visit_full_attributes.json` `logs`
+(`attributeID` 29) were absent from their schemas but still active in the ledger
+before `#342`; they are now `retired: true`. Their EAV rows flip from visible to
+skipped-on-read. The rows themselves are preserved (`#294`) and reappear if the
+properties are re-added under the same type.
+
+**Residual gap.** An attribute whose ledger entry was hand-deleted *before*
+`#342` leaves no record at all, so the guard cannot see it and its
+`attributeID` looks free. For those schemas the never-reuse rule is still
+documentation-only: check the schema files' version history before assigning any
+`attributeID` that no current entry claims.
 
 ### Storage-column mismatches
 
@@ -257,6 +318,7 @@ LIMIT 50;
   from genuinely orphaned ones, so confirm the reported `attr_id`s against the
   removed attributes and proceed (follow-up tracked on the PR).
 - every schema name in `schema_registry` has a resolvable `<name>.json` in `SCHEMA_DIR` (`#314` startup check)
+- no active attribute reuses a `retired` attributeID, main-column binding, or folded parquet column (`#342` startup check)
 - hardened release deployed
 - validator re-run after deploy
 - smoke CRUD tests pass against existing schemas
@@ -270,5 +332,13 @@ If deploy fails because of newly enforced checks:
 3. fix the reported metadata or EAV inconsistencies
 4. re-run the validator
 5. retry the upgrade
+
+**Rolling back past `#342`.** Binaries older than `#342` do not know the
+`retired` key: they parse the entry as an ordinary attribute and load it
+**active**. Rolling the server back against retired-marked attributes files
+therefore makes those attributes — and the values `#294` preserved under
+them — visible again, and drops the reuse guard entirely. If you must roll back
+that far, either accept the re-exposure or revert the attributes files to their
+pre-`#342` state alongside the binary.
 
 The validator is safe to run repeatedly and is intended to be part of your pre-upgrade checklist.

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -212,14 +212,33 @@ become visible again. Re-adding under a different `valueType` or `items_type` is
 a generator error naming the attribute and both the old and the new
 type/items — the stored rows carry the old physical type and would be
 unreadable. Renaming an attribute is *not* a re-add: it needs a fresh
-`attributeID`, and the old entry stays retired.
+`attributeID`, and the old entry stays retired. Note the boundary: this type
+check fires **only** on retired entries. Changing the `valueType` of a *live*
+attribute is still written straight through by `generate-attributes`, which
+leaves that attribute's existing EAV rows in the wrong physical column — the
+condition the next section tells you to repair. Treat a live type change as a
+remove-then-add-under-a-new-name, not an edit.
 
-**Shipped schemas already carrying the marker.** `visit_attributes.json`
-`contactSnapshot` (`attributeID` 25) and `visit_full_attributes.json` `logs`
-(`attributeID` 29) were absent from their schemas but still active in the ledger
-before `#342`; they are now `retired: true`. Their EAV rows flip from visible to
-skipped-on-read. The rows themselves are preserved (`#294`) and reappear if the
-properties are re-added under the same type.
+**Shipped schemas already carrying the marker.** Two entries are now
+`retired: true`, for different reasons — in both cases because
+`generate-attributes` no longer *produces* the entry, which is what the marker
+records:
+
+- `visit_full_attributes.json` `logs` (`attributeID` 29) — the `logs` property
+  was removed from `visit_full.json`. This is the ordinary removal case.
+- `visit_attributes.json` `contactSnapshot` (`attributeID` 25) — the
+  `contactSnapshot` property is still declared in `visit.json`, but as a `$ref`
+  to `lead.json#/properties/contact`, which is an **object**. The generator now
+  resolves that `$ref` and traverses into it, emitting one entry per leaf
+  (`contactSnapshot.annualIncome`, `contactSnapshot.birthday`, …) and no bare
+  `contactSnapshot` entry. The `attributeID` 25 entry is a leftover from when
+  `$ref`s were not followed and the node was recorded as a single `text` value.
+
+In both cases the EAV rows under those ids flip from visible to skipped-on-read,
+and the rows themselves are preserved (`#294`). `logs` un-retires if the property
+is re-added to `visit_full.json` as `text`. `contactSnapshot` has no property to
+re-add — it would un-retire only if that node ever resolved to a scalar again,
+which is not an operator action; treat `attributeID` 25 as permanently reserved.
 
 **Residual gap.** An attribute whose ledger entry was hand-deleted *before*
 `#342` leaves no record at all, so the guard cannot see it and its

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -186,6 +186,13 @@ Retired entries are ledger-only. Every metadata registration path validates the
 retired attribute reads, writes, flushes, and projects exactly as if its entry
 were absent.
 
+The `retired` marker is **generator-owned**: it records that
+`generate-attributes` no longer produces the entry. Hand-setting it on an
+attribute the schema still declares is not a supported way to hide a live
+attribute — the next `generate-attributes` run finds the property, sees the
+type is unchanged, and silently clears the marker again. To retire an
+attribute, remove it from `<schema>.json` and regenerate.
+
 **Startup guard.** Handing a retired `attributeID` to a different attribute
 aborts startup:
 
@@ -208,7 +215,26 @@ retired entry.
 **Re-adding.** Putting the property back into `<schema>.json` under the same
 name, the same `valueType` **and** the same `items_type`, then re-running
 `generate-attributes`, clears the `retired` marker; the preserved EAV rows
-become visible again. Re-adding under a different `valueType` or `items_type` is
+become visible again — **but only for rows that have not yet been flushed to
+the lakehouse.** The CDC export builds its `attr_id IN (...)` filter from the
+*active* attribute cache, which no longer contains the retired entry
+(`internal/cdc/export_sql_builder.go`), so a retired attribute's values are
+never written to delta or base parquet. Once a row has flushed
+(`change_log.flushed_at != 0`) it is served from the warm/cold tier, where that
+column simply does not exist, and the preserved Postgres EAV row is unreachable
+by federated reads. **On a CDC-enabled (lakehouse) deployment, treat retirement
+as effectively irreversible for already-flushed rows**; un-retiring restores
+values only for rows still resident in the hot tier.
+
+The asymmetry cuts the other way too. Because the Postgres EAV row survives, an
+unrelated later update makes that row hot again, and the *next* flush exports
+the re-added attribute — resurrecting per row a value that read `NULL` while
+the attribute was retired. Plan a retirement on the assumption that the value
+disappears from reads immediately and may reappear row-by-row on subsequent
+writes. This is inherited `#294` tolerate-and-preserve behavior, not something
+`#342` introduced; `#342` only makes the retirement explicit in the ledger.
+
+Re-adding under a different `valueType` or `items_type` is
 a generator error naming the attribute and both the old and the new
 type/items — the stored rows carry the old physical type and would be
 unreadable. Renaming an attribute is *not* a re-add: it needs a fresh
@@ -225,7 +251,8 @@ remove-then-add-under-a-new-name, not an edit.
 records:
 
 - `visit_full_attributes.json` `logs` (`attributeID` 29) — the `logs` property
-  was removed from `visit_full.json`. This is the ordinary removal case.
+  was removed from `visit_full.json`. This is the ordinary removal case, and it
+  is the **breaking** one of the two.
 - `visit_attributes.json` `contactSnapshot` (`attributeID` 25) — the
   `contactSnapshot` property is still declared in `visit.json`, but as a `$ref`
   to `lead.json#/properties/contact`, which is an **object**. The generator now
@@ -235,10 +262,31 @@ records:
   `$ref`s were not followed and the node was recorded as a single `text` value.
 
 In both cases the EAV rows under those ids flip from visible to skipped-on-read,
-and the rows themselves are preserved (`#294`). `logs` un-retires if the property
-is re-added to `visit_full.json` as `text`. `contactSnapshot` has no property to
-re-add — it would un-retire only if that node ever resolved to a scalar again,
-which is not an operator action; treat `attributeID` 25 as permanently reserved.
+and the rows themselves are preserved (`#294`). **The operational impact of the
+two is not symmetric**, so assess them separately:
+
+- **`logs` (29) is write-breaking, not merely read-affecting.**
+  `visit_full.json` declares no `logs` property *and* sets no
+  `additionalProperties`, so JSON Schema validation lets the extra key through:
+  before this change a client could write `logs`, the attribute cache resolved
+  the name, and `attributeID` 29 was written and read back. After this change
+  the attribute is stripped from the active cache, so a write carrying `logs`
+  is rejected with `400 attribute 'logs' is not defined for this schema`, and
+  any values already stored under id 29 disappear from reads. If any client was
+  writing `logs` to `visit_full`, this is a breaking API change for that client
+  — either re-add the property to `visit_full.json` as `text` (which un-retires
+  it, subject to the flushed-row caveat above) or update the client to stop
+  sending the key.
+- **`contactSnapshot` (25) is practically inert.** Reaching the bare
+  `attributeID` 25 leaf requires the client to send `contactSnapshot` as a
+  *scalar*: an object payload recurses through the map branch of the
+  transformer's flattening and lands on `contactSnapshot.<leaf>` entries, never
+  on the bare name. Since `#314`, JSON Schema validation rejects a scalar there
+  anyway, because the `$ref` resolves to an object. So rows under id 25 can only
+  exist if some client once wrote a scalar, and no supported write path can
+  produce new ones. `contactSnapshot` also has no property to re-add — it would
+  un-retire only if that node ever resolved to a scalar again, which is not an
+  operator action; treat `attributeID` 25 as permanently reserved.
 
 **Residual gap.** An attribute whose ledger entry was hand-deleted *before*
 `#342` leaves no record at all, so the guard cannot see it and its
@@ -331,11 +379,15 @@ LIMIT 50;
 - database backup taken
 - `scripts/validate_schema_consistency.sql` returns no duplicate schema IDs
 - `make validate-schema-consistency` returns success — except that on deployments
-  whose schemas have had attributes removed, unknown-attrID findings for exactly
-  those attributes are **expected** (`#294` tolerate-and-preserve) and are **not**
-  a deployment blocker. The tool does not yet classify preserved rows separately
+  whose schemas have had attributes **retired**, unknown-attrID findings for
+  exactly those attributes are **expected** (`#294` tolerate-and-preserve) and
+  are **not** a deployment blocker. With the shipped ledgers this now includes
+  `attr_id` 25 on the `visit` schema and `attr_id` 29 on `visit_full`, which the
+  validator will flag on **every** deployment that holds rows under those ids.
+  The tool does not yet classify preserved rows separately
   from genuinely orphaned ones, so confirm the reported `attr_id`s against the
-  removed attributes and proceed (follow-up tracked on the PR).
+  retired entries in `<schema>_attributes.json` and proceed (follow-up tracked
+  on the PR).
 - every schema name in `schema_registry` has a resolvable `<name>.json` in `SCHEMA_DIR` (`#314` startup check)
 - no active attribute reuses a `retired` attributeID, main-column binding, or folded parquet column (`#342` startup check)
 - hardened release deployed

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -268,15 +268,37 @@ two is not symmetric**, so assess them separately:
 - **`logs` (29) is write-breaking, not merely read-affecting.**
   `visit_full.json` declares no `logs` property *and* sets no
   `additionalProperties`, so JSON Schema validation lets the extra key through:
-  before this change a client could write `logs`, the attribute cache resolved
-  the name, and `attributeID` 29 was written and read back. After this change
-  the attribute is stripped from the active cache, so a write carrying `logs`
-  is rejected with `400 attribute 'logs' is not defined for this schema`, and
-  any values already stored under id 29 disappear from reads. If any client was
-  writing `logs` to `visit_full`, this is a breaking API change for that client
-  — either re-add the property to `visit_full.json` as `text` (which un-retires
-  it, subject to the flushed-row caveat above) or update the client to stop
-  sending the key.
+  before this change **both** payload shapes reached `attributeID` 29. `logs`
+  was declared an *array of strings* until it was removed, and the transformer
+  recurses into an array under the *bare* attribute name — one EAV row per
+  element, distinguished only by `array_indices` — while a scalar payload lands
+  on the same name with empty `array_indices`. Either shape resolved through the
+  attribute cache, so id 29 was written and read back. After this change the
+  attribute is stripped from the active cache, so a write carrying `logs` in any
+  shape is rejected with `400 attribute 'logs' is not defined for this schema`,
+  and any values already stored under id 29 disappear from reads. If any client
+  was writing `logs` to `visit_full`, this is a breaking API change for that
+  client, and — unlike an ordinary retirement — **`attributeID` 29 cannot be
+  restored under its original shape**:
+  - Re-adding the original array declaration makes `generate-attributes` emit
+    `valueType: list` / `items_type: text` (the shape `attendees` carries in the
+    same ledger). Entry 29 is recorded `valueType: text`, so the retired-re-add
+    type check refuses it and tells the operator to "restore the original type
+    or use a new attribute name" — a demand the original type cannot satisfy.
+  - Re-adding it as a scalar `text` property does pass that check and un-retires
+    29, but it does not repair the break: since `#314`, JSON Schema validation
+    rejects the array payload a legacy client sends, and the preserved rows
+    carry `array_indices`, so reads materialize an array under a property the
+    schema now declares a string.
+
+  So there are two honest paths, and neither restores id 29 to service:
+  - Accept the break: update clients to stop sending `logs`. Values under id 29
+    stay preserved on disk but unreadable.
+  - Declare a **new** property under a different name as an array of strings.
+    `generate-attributes` treats an unseen name as new, assigns it a fresh
+    `attributeID` above the current maximum with `valueType: list` /
+    `items_type: text`, and leaves entry 29 retired with its rows untouched. The
+    old values do not migrate themselves — copy them across if they matter.
 - **`contactSnapshot` (25) is practically inert.** Reaching the bare
   `attributeID` 25 leaf requires the client to send `contactSnapshot` as a
   *scalar*: an object payload recurses through the map branch of the
@@ -386,8 +408,10 @@ LIMIT 50;
   validator will flag on **every** deployment that holds rows under those ids.
   The tool does not yet classify preserved rows separately
   from genuinely orphaned ones, so confirm the reported `attr_id`s against the
-  retired entries in `<schema>_attributes.json` and proceed (follow-up tracked
-  on the PR).
+  retired entries in `<schema>_attributes.json` — and, for ledgers generated
+  before `#342`, against the attributes removed in the schema files' version
+  history, since a hand-deleted entry left no retired marker to cross-check —
+  then proceed (follow-up tracked on the PR).
 - every schema name in `schema_registry` has a resolvable `<name>.json` in `SCHEMA_DIR` (`#314` startup check)
 - no active attribute reuses a `retired` attributeID, main-column binding, or folded parquet column (`#342` startup check)
 - hardened release deployed

--- a/internal/e2e_harness/production/update_after_attr_removal_e2e_test.go
+++ b/internal/e2e_harness/production/update_after_attr_removal_e2e_test.go
@@ -38,6 +38,17 @@ const remV2Attrs = `{
 }
 `
 
+// remV2RetiredAttrs is the #342 blessed form of the same removal: instead of
+// deleting old_col's entry, the generation keeps it as the attributeID ledger
+// and marks it retired. Behavior must be identical to remV2Attrs
+// (hand-deleted): invisible on read, row still updatable, value preserved.
+const remV2RetiredAttrs = `{
+  "name": { "attributeID": 1, "valueType": "text", "column_binding": { "col_name": "text_01" } },
+  "value": { "attributeID": 2, "valueType": "numeric" },
+  "old_col": { "attributeID": 3, "valueType": "text", "retired": true }
+}
+`
+
 // jsonNormalizedAttrs round-trips an attribute map through JSON so
 // assertions compare plain strings/float64s rather than the transformer's
 // internal pointer types.
@@ -145,6 +156,90 @@ func TestUpdateAfterAttributeRemoval(t *testing.T) {
 		"value": float64(3),
 	})); err != nil {
 		t.Fatalf("update after re-add: %v", err)
+	}
+	attrs3 := getNormalizedAttrs(ctx, t, env, schema, create.RowID, "after second update")
+	if attrs3["old_col"] != "keep-me" || attrs3["value"] != float64(3) {
+		t.Fatalf("after second update got old_col=%v value=%v, want keep-me / 3", attrs3["old_col"], attrs3["value"])
+	}
+}
+
+// TestRetiredMarkerRemovalWorkflow pins the #342 blessed removal workflow end
+// to end, step for step against TestUpdateAfterAttributeRemoval above: a
+// generation that RETIRES old_col rather than deleting its entry must behave
+// identically to the hand-deleted generation — the preserved EAV row survives
+// the update's replace cycle, stays invisible while retired, and reappears
+// when the attribute is un-retired (re-added with the same id/name/type).
+//
+// The invisibility assertion is the load-bearing one: retired entries are
+// stripped from the active caches (schemameta.activeAttributeCache), so a
+// regression that let a retired entry reach consumers would surface old_col in
+// the read path and fail here.
+func TestRetiredMarkerRemovalWorkflow(t *testing.T) {
+	ctx := context.Background()
+	cluster := SharedCluster(t)
+	v1 := writeSimpleSchemaDir(t, remV1Props, remV1Attrs)
+	v2Retired := writeSimpleSchemaDir(t, remV2Props, remV2RetiredAttrs)
+	env := NewEnv(t, cluster, WithSchemaDir(v1))
+	schema := DefaultSchemaFixtures()[0]
+
+	create := CreateEvent(schema, map[string]any{
+		"name":    "r1",
+		"value":   float64(1),
+		"old_col": "keep-me",
+	})
+	if err := env.ApplyEvents(ctx, create); err != nil {
+		t.Fatalf("seed v1 row: %v", err)
+	}
+
+	if err := env.EvolveSchema(ctx, v2Retired); err != nil {
+		t.Fatalf("evolve schema to retired-marker v2: %v", err)
+	}
+
+	if err := env.ApplyEvents(ctx, UpdateEvent(schema, create.RowID, map[string]any{
+		"value": float64(2),
+	})); err != nil {
+		t.Fatalf("update row carrying retired-attr EAV data under v2: %v", err)
+	}
+
+	// Preserve, not drop: retiring must leave the EAV row physically present.
+	var preserved string
+	if err := env.Pool.QueryRow(ctx,
+		`SELECT value_text FROM eav_data WHERE schema_id = $1 AND row_id = $2 AND attr_id = 3`,
+		schema.ID, create.RowID).Scan(&preserved); err != nil {
+		t.Fatalf("retired old_col EAV row missing after update (tolerate-and-preserve violated): %v", err)
+	}
+	if preserved != "keep-me" {
+		t.Fatalf("retired old_col EAV value = %q, want %q", preserved, "keep-me")
+	}
+
+	// Under the retired-marker generation the value stays invisible on read.
+	attrs := getNormalizedAttrs(ctx, t, env, schema, create.RowID, "under retired-marker v2")
+	if _, ok := attrs["old_col"]; ok {
+		t.Fatalf("retired old_col visible under retired-marker v2 schema: %v", attrs)
+	}
+	if attrs["value"] != float64(2) {
+		t.Fatalf("value = %v, want 2", attrs["value"])
+	}
+
+	// Un-retire old_col (evolve back to the v1 shape, same attributeID 3,
+	// same name and valueType): the preserved value must reappear.
+	if err := env.EvolveSchema(ctx, v1); err != nil {
+		t.Fatalf("un-retire old_col (evolve back to v1 shape): %v", err)
+	}
+	attrs2 := getNormalizedAttrs(ctx, t, env, schema, create.RowID, "after un-retire")
+	if attrs2["old_col"] != "keep-me" {
+		t.Fatalf("old_col after un-retire = %v, want \"keep-me\" (preserve vs drop discriminator)", attrs2["old_col"])
+	}
+	if attrs2["value"] != float64(2) {
+		t.Fatalf("value after un-retire = %v, want 2", attrs2["value"])
+	}
+
+	// The row stays a normal citizen: another update under the restored
+	// schema round-trips old_col like any live attribute.
+	if err := env.ApplyEvents(ctx, UpdateEvent(schema, create.RowID, map[string]any{
+		"value": float64(3),
+	})); err != nil {
+		t.Fatalf("update after un-retire: %v", err)
 	}
 	attrs3 := getNormalizedAttrs(ctx, t, env, schema, create.RowID, "after second update")
 	if attrs3["old_col"] != "keep-me" || attrs3["value"] != float64(3) {

--- a/internal/postgres_persistent_repository_eav.go
+++ b/internal/postgres_persistent_repository_eav.go
@@ -88,10 +88,12 @@ func (r *DBPersistentRecordRepository) knownAttrIDs(schemaID int16) ([]int16, er
 	for _, meta := range cache {
 		ids = append(ids, meta.AttributeID)
 	}
-	// Map iteration order is random; sort for a deterministic bind value. The
-	// compact then drops duplicate IDs (distinct attribute names may share an
-	// attributeID) — Compact only removes consecutive duplicates, which the
-	// preceding sort guarantees are adjacent.
+	// Map iteration order is random; sort for a deterministic bind value.
+	// Since #342 every registration path (file/DB loaders and
+	// MetadataCache.RegisterSchema alike) rejects duplicate attribute ids, so a
+	// cache holding two names on one id is unconstructible. The compact stays as
+	// cheap belt-and-suspenders — Compact only removes consecutive duplicates,
+	// which the preceding sort guarantees are adjacent.
 	slices.Sort(ids)
 	return slices.Compact(ids), nil
 }

--- a/internal/postgres_persistent_repository_eav_test.go
+++ b/internal/postgres_persistent_repository_eav_test.go
@@ -83,8 +83,14 @@ func TestReplaceEAVAttributes(t *testing.T) {
 // TestReplaceEAVAttributes_DeleteScopedToCurrentSchemaAttrIDs is the #294
 // "preserve" half: attrID 99 was dropped by schema evolution, so it is absent
 // from the delete scope and its EAV rows survive the update untouched. The
-// scope is sorted (map iteration order is random) and deduplicated (two
-// attribute names may share an attributeID).
+// scope is sorted, because map iteration order is random and the bind value
+// must be deterministic — the ids below are declared out of order on purpose.
+//
+// Every attribute carries a distinct id. This test previously registered two
+// names on attributeID 12 to exercise the dedup in knownAttrIDs, but since #342
+// duplicate attribute ids are rejected at every registration path — the file
+// and DB loaders and MetadataCache.RegisterSchema alike — so that state is
+// unconstructible and the slices.Compact there is defence in depth only.
 func TestReplaceEAVAttributes_DeleteScopedToCurrentSchemaAttrIDs(t *testing.T) {
 	ctx := context.Background()
 	mock, err := pgxmock.NewPool()
@@ -95,15 +101,15 @@ func TestReplaceEAVAttributes_DeleteScopedToCurrentSchemaAttrIDs(t *testing.T) {
 
 	mc := schemameta.NewMetadataCache()
 	require.NoError(t, mc.RegisterSchema("evolved_schema", 4, forma.SchemaAttributeCache{
-		"zeta":        {AttributeName: "zeta", AttributeID: 21, ValueType: forma.ValueTypeText},
-		"alpha":       {AttributeName: "alpha", AttributeID: 3, ValueType: forma.ValueTypeNumeric},
-		"mid":         {AttributeName: "mid", AttributeID: 12, ValueType: forma.ValueTypeText},
-		"mid_aliased": {AttributeName: "mid_aliased", AttributeID: 12, ValueType: forma.ValueTypeText},
+		"zeta":  {AttributeName: "zeta", AttributeID: 21, ValueType: forma.ValueTypeText},
+		"alpha": {AttributeName: "alpha", AttributeID: 3, ValueType: forma.ValueTypeNumeric},
+		"mid":   {AttributeName: "mid", AttributeID: 12, ValueType: forma.ValueTypeText},
+		"beta":  {AttributeName: "beta", AttributeID: 7, ValueType: forma.ValueTypeText},
 	}))
 
 	// attrID 99 (dropped attribute) is deliberately NOT in the scope.
 	mock.ExpectExec(`^DELETE FROM "eav_table" WHERE schema_id = \$1 AND row_id = \$2 AND attr_id = ANY\(\$3\)$`).
-		WithArgs(int16(4), rowID, []int16{3, 12, 21}).
+		WithArgs(int16(4), rowID, []int16{3, 7, 12, 21}).
 		WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
 	repo := &DBPersistentRecordRepository{metadataCache: mc}

--- a/internal/schemameta/file_registry.go
+++ b/internal/schemameta/file_registry.go
@@ -175,10 +175,12 @@ func (r *fileSchemaRegistry) loadSchemasFromDB(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		// Validate on the FULL cache, then register only the active subset:
+		// retired entries are an attributeID ledger, not consumer state (#342).
 		if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
 			return err
 		}
-		if err := r.registerSchema(schemaName, schemaID, cache, schema); err != nil {
+		if err := r.registerSchema(schemaName, schemaID, activeAttributeCache(cache), schema); err != nil {
 			return err
 		}
 	}
@@ -371,10 +373,12 @@ func (r *fileSchemaRegistry) loadSchemasFromDirectory() error {
 		if err != nil {
 			return err
 		}
+		// Validate on the FULL cache, then register only the active subset:
+		// retired entries are an attributeID ledger, not consumer state (#342).
 		if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
 			return err
 		}
-		if err := r.registerSchema(schemaName, schemaID, cache, schema); err != nil {
+		if err := r.registerSchema(schemaName, schemaID, activeAttributeCache(cache), schema); err != nil {
 			return err
 		}
 		nextSchemaID++

--- a/internal/schemameta/file_registry.go
+++ b/internal/schemameta/file_registry.go
@@ -98,6 +98,11 @@ func (r *fileSchemaRegistry) loadSchemaArtifacts(schemaName string, schemaID int
 	return cache, &jsonSchema, nil
 }
 
+// registerSchema indexes one schema. Its only error comes from
+// buildAttrIDToName, which names the schema and both colliding attributes but
+// not the schema id — so both load paths wrap it with that id: it is the
+// physical key the attributes are indexed under and, in directory mode, is
+// auto-assigned and otherwise invisible to the operator.
 func (r *fileSchemaRegistry) registerSchema(schemaName string, schemaID int16, cache forma.SchemaAttributeCache, schema *forma.JSONSchema) error {
 	attrIDToName, err := buildAttrIDToName(schemaName, cache)
 	if err != nil {
@@ -173,15 +178,14 @@ func (r *fileSchemaRegistry) loadSchemasFromDB(ctx context.Context) error {
 
 		cache, schema, err := r.loadSchemaArtifacts(schemaName, schemaID)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to load schema %s listed in registry table %s: %w", schemaName, r.schemaTable, err)
 		}
-		// Validate on the FULL cache, then register only the active subset:
-		// retired entries are an attributeID ledger, not consumer state (#342).
+		// Validate the FULL cache before stripping — see activeAttributeCache (#342).
 		if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
-			return err
+			return fmt.Errorf("attribute metadata in %s: %w", r.schemaDir, err)
 		}
 		if err := r.registerSchema(schemaName, schemaID, activeAttributeCache(cache), schema); err != nil {
-			return err
+			return fmt.Errorf("register schema id %d: %w", schemaID, err)
 		}
 	}
 
@@ -371,15 +375,14 @@ func (r *fileSchemaRegistry) loadSchemasFromDirectory() error {
 
 		cache, schema, err := r.loadSchemaArtifacts(schemaName, schemaID)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to load schema %s discovered in schema directory: %w", schemaName, err)
 		}
-		// Validate on the FULL cache, then register only the active subset:
-		// retired entries are an attributeID ledger, not consumer state (#342).
+		// Validate the FULL cache before stripping — see activeAttributeCache (#342).
 		if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
-			return err
+			return fmt.Errorf("attribute metadata in %s: %w", r.schemaDir, err)
 		}
 		if err := r.registerSchema(schemaName, schemaID, activeAttributeCache(cache), schema); err != nil {
-			return err
+			return fmt.Errorf("register schema id %d: %w", schemaID, err)
 		}
 		nextSchemaID++
 	}

--- a/internal/schemameta/file_registry.go
+++ b/internal/schemameta/file_registry.go
@@ -61,8 +61,16 @@ func NewFileSchemaRegistryContext(ctx context.Context, pool *pgxpool.Pool, schem
 	return registry, nil
 }
 
+// attributesFilePath returns the on-disk path of a schema's attribute metadata
+// file. Single source for the path so every error that names it — read, parse,
+// and validation wraps alike — names the same exact file rather than the
+// directory it lives in.
+func (r *fileSchemaRegistry) attributesFilePath(schemaName string) string {
+	return filepath.Join(r.schemaDir, schemaName+"_attributes.json")
+}
+
 func (r *fileSchemaRegistry) loadSchemaArtifacts(schemaName string, schemaID int16) (forma.SchemaAttributeCache, *forma.JSONSchema, error) {
-	attributesFile := filepath.Join(r.schemaDir, schemaName+"_attributes.json")
+	attributesFile := r.attributesFilePath(schemaName)
 	attributeData, err := os.ReadFile(attributesFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read attributes file %s: %w", attributesFile, err)
@@ -182,7 +190,7 @@ func (r *fileSchemaRegistry) loadSchemasFromDB(ctx context.Context) error {
 		}
 		// Validate the FULL cache before stripping — see activeAttributeCache (#342).
 		if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
-			return fmt.Errorf("attribute metadata in %s: %w", r.schemaDir, err)
+			return fmt.Errorf("attributes file %s: %w", r.attributesFilePath(schemaName), err)
 		}
 		if err := r.registerSchema(schemaName, schemaID, activeAttributeCache(cache), schema); err != nil {
 			return fmt.Errorf("register schema id %d: %w", schemaID, err)
@@ -379,7 +387,7 @@ func (r *fileSchemaRegistry) loadSchemasFromDirectory() error {
 		}
 		// Validate the FULL cache before stripping — see activeAttributeCache (#342).
 		if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
-			return fmt.Errorf("attribute metadata in %s: %w", r.schemaDir, err)
+			return fmt.Errorf("attributes file %s: %w", r.attributesFilePath(schemaName), err)
 		}
 		if err := r.registerSchema(schemaName, schemaID, activeAttributeCache(cache), schema); err != nil {
 			return fmt.Errorf("register schema id %d: %w", schemaID, err)

--- a/internal/schemameta/loader.go
+++ b/internal/schemameta/loader.go
@@ -59,11 +59,11 @@ func (mc *MetadataCache) RegisterSchema(schemaName string, schemaID int16, cache
 	if existingID, exists := mc.schemaNameToID[schemaName]; exists && existingID != schemaID {
 		return fmt.Errorf("duplicate schema name %s for ids %d and %d", schemaName, existingID, schemaID)
 	}
-	// Validate the FULL cache before stripping: without this the strip below
-	// would swallow a retired/active attributeID or binding collision, silently
-	// dropping the retired entry and rebinding its id to the active one (#342).
+	// Validate the FULL cache before stripping — see activeAttributeCache (#342).
+	// The wrap adds the numeric schema id the validation error cannot know: it
+	// sees the name only, while the id is the physical EAV/registry key.
 	if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
-		return fmt.Errorf("register schema %s: %w", schemaName, err)
+		return fmt.Errorf("register schema id %d: %w", schemaID, err)
 	}
 	// Store a private copy: the caller keeps ownership of its map, so later
 	// caller-side mutations cannot silently invalidate cached plans (#142).
@@ -315,14 +315,17 @@ func (ml *MetadataLoader) loadAttributeMetadataFromFiles(cache *MetadataCache) e
 			}
 			schemaCache[attrName] = meta
 		}
-		// Validate on the FULL cache (retired entries included) and only then
-		// strip them: the retired ledger guards id/binding reuse (#342).
+		// Validate the FULL cache before stripping — see activeAttributeCache (#342).
 		if err := validateSchemaAttributeCache(schemaName, schemaCache); err != nil {
-			return err
+			return fmt.Errorf("attributes file %s: %w", attributesFile, err)
 		}
 		active := activeAttributeCache(schemaCache)
 
-		cache.attributeMetadata[schemaID] = map[string]forma.AttributeMetadata(active)
+		// The two fields never share one map: each is handed out separately
+		// (attributeMetadata directly, schemaCaches via GetSchemaCache), so a
+		// mutation reaching one map must not be observable through the other.
+		// copySchemaAttributeCache also deep-copies *MainColumnBinding.
+		cache.attributeMetadata[schemaID] = map[string]forma.AttributeMetadata(copySchemaAttributeCache(active))
 		cache.schemaCaches[schemaID] = active
 
 		zap.S().Infow("Loaded attributes for schema", "count", len(active), "schema", schemaName)

--- a/internal/schemameta/loader.go
+++ b/internal/schemameta/loader.go
@@ -61,7 +61,8 @@ func (mc *MetadataCache) RegisterSchema(schemaName string, schemaID int16, cache
 	}
 	// Store a private copy: the caller keeps ownership of its map, so later
 	// caller-side mutations cannot silently invalidate cached plans (#142).
-	snapshot := copySchemaAttributeCache(cache)
+	// Retired entries are a validation-only ledger and never reach consumers (#342).
+	snapshot := activeAttributeCache(copySchemaAttributeCache(cache))
 	mc.schemaNameToID[schemaName] = schemaID
 	mc.schemaIDToName[schemaID] = schemaName
 	mc.schemaCaches[schemaID] = snapshot
@@ -299,7 +300,6 @@ func (ml *MetadataLoader) loadAttributeMetadataFromFiles(cache *MetadataCache) e
 		}
 
 		// Convert to AttributeMeta map
-		attrMap := make(map[string]forma.AttributeMetadata)
 		schemaCache := make(forma.SchemaAttributeCache)
 
 		for attrName, attrData := range rawAttributes {
@@ -307,17 +307,19 @@ func (ml *MetadataLoader) loadAttributeMetadataFromFiles(cache *MetadataCache) e
 			if err != nil {
 				return err
 			}
-			attrMap[attrName] = meta
 			schemaCache[attrName] = meta
 		}
+		// Validate on the FULL cache (retired entries included) and only then
+		// strip them: the retired ledger guards id/binding reuse (#342).
 		if err := validateSchemaAttributeCache(schemaName, schemaCache); err != nil {
 			return err
 		}
+		active := activeAttributeCache(schemaCache)
 
-		cache.attributeMetadata[schemaID] = attrMap
-		cache.schemaCaches[schemaID] = schemaCache
+		cache.attributeMetadata[schemaID] = map[string]forma.AttributeMetadata(active)
+		cache.schemaCaches[schemaID] = active
 
-		zap.S().Infow("Loaded attributes for schema", "count", len(attrMap), "schema", schemaName)
+		zap.S().Infow("Loaded attributes for schema", "count", len(active), "schema", schemaName)
 	}
 
 	// Also check for any schema files without database entries

--- a/internal/schemameta/loader.go
+++ b/internal/schemameta/loader.go
@@ -26,6 +26,15 @@ type MetadataCache struct {
 	schemaNameToID map[string]int16
 	schemaIDToName map[int16]string
 
+	// Field-independence invariant, held by EVERY writer of the two fields
+	// below (RegisterSchema and loadAttributeMetadataFromFiles): for a given
+	// schema id they never share one map. The two are handed to different
+	// consumers — attributeMetadata directly, schemaCaches via GetSchemaCache /
+	// GetSchemaCacheByID — so a mutation reaching one must not be observable
+	// through the other. Note a map[string]forma.AttributeMetadata(...)
+	// conversion of a SchemaAttributeCache is NOT a copy and would alias;
+	// copySchemaAttributeCache is, and it deep-copies *MainColumnBinding too.
+
 	// Attribute mappings: (schema_id, attr_name) -> AttributeMeta
 	attributeMetadata map[int16]map[string]forma.AttributeMetadata
 
@@ -65,14 +74,18 @@ func (mc *MetadataCache) RegisterSchema(schemaName string, schemaID int16, cache
 	if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
 		return fmt.Errorf("register schema id %d: %w", schemaID, err)
 	}
-	// Store a private copy: the caller keeps ownership of its map, so later
+	// First copy — caller ownership: the caller keeps its map, so later
 	// caller-side mutations cannot silently invalidate cached plans (#142).
 	// Retired entries are a validation-only ledger and never reach consumers (#342).
 	snapshot := activeAttributeCache(copySchemaAttributeCache(cache))
 	mc.schemaNameToID[schemaName] = schemaID
 	mc.schemaIDToName[schemaID] = schemaName
 	mc.schemaCaches[schemaID] = snapshot
-	mc.attributeMetadata[schemaID] = map[string]forma.AttributeMetadata(snapshot)
+	// Second copy — field independence, a different guarantee from the first and
+	// not redundant with it: the first severs the caller from what is stored,
+	// this one severs the two stored fields from each other. See the invariant
+	// on MetadataCache's field declarations.
+	mc.attributeMetadata[schemaID] = map[string]forma.AttributeMetadata(copySchemaAttributeCache(snapshot))
 	mc.fingerprints[schemaID] = fingerprintSchema(schemaName, snapshot)
 	return nil
 }
@@ -321,10 +334,8 @@ func (ml *MetadataLoader) loadAttributeMetadataFromFiles(cache *MetadataCache) e
 		}
 		active := activeAttributeCache(schemaCache)
 
-		// The two fields never share one map: each is handed out separately
-		// (attributeMetadata directly, schemaCaches via GetSchemaCache), so a
-		// mutation reaching one map must not be observable through the other.
-		// copySchemaAttributeCache also deep-copies *MainColumnBinding.
+		// Copy so the two fields stay independent — see the invariant on
+		// MetadataCache's field declarations.
 		cache.attributeMetadata[schemaID] = map[string]forma.AttributeMetadata(copySchemaAttributeCache(active))
 		cache.schemaCaches[schemaID] = active
 

--- a/internal/schemameta/loader.go
+++ b/internal/schemameta/loader.go
@@ -59,6 +59,12 @@ func (mc *MetadataCache) RegisterSchema(schemaName string, schemaID int16, cache
 	if existingID, exists := mc.schemaNameToID[schemaName]; exists && existingID != schemaID {
 		return fmt.Errorf("duplicate schema name %s for ids %d and %d", schemaName, existingID, schemaID)
 	}
+	// Validate the FULL cache before stripping: without this the strip below
+	// would swallow a retired/active attributeID or binding collision, silently
+	// dropping the retired entry and rebinding its id to the active one (#342).
+	if err := validateSchemaAttributeCache(schemaName, cache); err != nil {
+		return fmt.Errorf("register schema %s: %w", schemaName, err)
+	}
 	// Store a private copy: the caller keeps ownership of its map, so later
 	// caller-side mutations cannot silently invalidate cached plans (#142).
 	// Retired entries are a validation-only ledger and never reach consumers (#342).

--- a/internal/schemameta/loader_test.go
+++ b/internal/schemameta/loader_test.go
@@ -377,6 +377,40 @@ func TestRegisterSchemaCopiesInput(t *testing.T) {
 	require.Equal(t, forma.MainColumn("text_01"), snap["name"].ColumnBinding.ColumnName)
 }
 
+// TestLoadMetadataCacheFieldsAreIndependent pins that the file path stores
+// attributeMetadata and schemaCaches on two independent maps, deep copy
+// included: the two fields are handed to different consumers, so a mutation
+// reaching one must never be observable through the other.
+func TestLoadMetadataCacheFieldsAreIndependent(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	dir := t.TempDir()
+	rows := pgxmock.NewRows([]string{"schema_name", "schema_id"}).AddRow("user", int16(1))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT schema_name, schema_id FROM ` + sanitizeIdentifier("test_registry"))).WillReturnRows(rows)
+	writeJSONFile(t, filepath.Join(dir, "user_attributes.json"), map[string]any{
+		"name": map[string]any{
+			"attributeID":    float64(1),
+			"valueType":      "text",
+			"column_binding": map[string]any{"col_name": "text_01"},
+		},
+	})
+
+	cache, err := NewMetadataLoader(mock, "test_registry", dir).LoadMetadata(context.Background())
+	require.NoError(t, err)
+
+	cache.attributeMetadata[1]["injected"] = forma.AttributeMetadata{AttributeID: 99}
+	cache.attributeMetadata[1]["name"].ColumnBinding.ColumnName = forma.MainColumn("text_09")
+
+	schemaCache, ok := cache.GetSchemaCacheByID(1)
+	require.True(t, ok)
+	assert.NotContains(t, schemaCache, "injected", "the two fields must not share one map")
+	assert.Equal(t, forma.MainColumn("text_01"), schemaCache["name"].ColumnBinding.ColumnName,
+		"the column binding must be deep-copied, not shared by pointer")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSchemaFingerprintTracksContent(t *testing.T) {
 	mcA := NewMetadataCache()
 	require.NoError(t, mcA.RegisterSchema("s", 1, forma.SchemaAttributeCache{

--- a/internal/schemameta/loader_test.go
+++ b/internal/schemameta/loader_test.go
@@ -411,6 +411,32 @@ func TestLoadMetadataCacheFieldsAreIndependent(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestRegisterSchemaCacheFieldsAreIndependent is the RegisterSchema sibling of
+// TestLoadMetadataCacheFieldsAreIndependent: the field-independence invariant on
+// MetadataCache binds every writer, so the registration path must store
+// attributeMetadata and schemaCaches on two independent maps too — deep copy of
+// *MainColumnBinding included. A bare map[string]forma.AttributeMetadata(...)
+// conversion of the stored snapshot aliases and fails both legs below.
+func TestRegisterSchemaCacheFieldsAreIndependent(t *testing.T) {
+	mc := NewMetadataCache()
+	require.NoError(t, mc.RegisterSchema("user", 1, forma.SchemaAttributeCache{
+		"name": {
+			AttributeID:   1,
+			ValueType:     forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumn("text_01")},
+		},
+	}))
+
+	mc.attributeMetadata[1]["injected"] = forma.AttributeMetadata{AttributeID: 99}
+	mc.attributeMetadata[1]["name"].ColumnBinding.ColumnName = forma.MainColumn("text_09")
+
+	schemaCache, ok := mc.GetSchemaCacheByID(1)
+	require.True(t, ok)
+	assert.NotContains(t, schemaCache, "injected", "the two fields must not share one map")
+	assert.Equal(t, forma.MainColumn("text_01"), schemaCache["name"].ColumnBinding.ColumnName,
+		"the column binding must be deep-copied, not shared by pointer")
+}
+
 func TestSchemaFingerprintTracksContent(t *testing.T) {
 	mcA := NewMetadataCache()
 	require.NoError(t, mcA.RegisterSchema("s", 1, forma.SchemaAttributeCache{

--- a/internal/schemameta/parser.go
+++ b/internal/schemameta/parser.go
@@ -8,7 +8,9 @@ import (
 )
 
 // parseAttributeMetadata converts raw JSON metadata into forma.AttributeMetadata structs reused
-// by loaders, registries, and repositories. The source argument is used for readable errors.
+// by loaders, registries, and repositories. The source argument is used for readable errors:
+// every error ends with "in <source>", so callers return it unwrapped rather than repeating
+// the attribute name or the file it came from.
 func parseAttributeMetadata(attrName string, attrData map[string]any, source string) (forma.AttributeMetadata, error) {
 	meta := forma.AttributeMetadata{AttributeName: attrName}
 

--- a/internal/schemameta/parser.go
+++ b/internal/schemameta/parser.go
@@ -47,6 +47,15 @@ func parseAttributeMetadata(attrName string, attrData map[string]any, source str
 
 	meta.ColumnBinding = binding
 
+	if rawRetired, exists := attrData["retired"]; exists {
+		retired, ok := rawRetired.(bool)
+		if !ok {
+			return forma.AttributeMetadata{}, fmt.Errorf(
+				"invalid retired flag for attribute %s in %s: must be a boolean", attrName, source)
+		}
+		meta.Retired = retired
+	}
+
 	return meta, nil
 }
 

--- a/internal/schemameta/parser_test.go
+++ b/internal/schemameta/parser_test.go
@@ -319,3 +319,41 @@ func TestNormalizeColumnEncoding(t *testing.T) {
 	assert.Equal(t, forma.MainColumnEncodingDefault, normalizeColumnEncoding(""))
 	assert.Equal(t, forma.MainColumnEncodingUnixMs, normalizeColumnEncoding(" unix_ms "))
 }
+
+func TestParseAttributeMetadata_RetiredFlag(t *testing.T) {
+	meta, err := parseAttributeMetadata("old_col", map[string]any{
+		"attributeID": float64(3),
+		"valueType":   "text",
+		"retired":     true,
+	}, "test.json")
+	if err != nil {
+		t.Fatalf("parse retired attribute: %v", err)
+	}
+	if !meta.Retired {
+		t.Fatalf("Retired = false, want true")
+	}
+}
+
+func TestParseAttributeMetadata_RetiredAbsentDefaultsFalse(t *testing.T) {
+	meta, err := parseAttributeMetadata("name", map[string]any{
+		"attributeID": float64(1),
+		"valueType":   "text",
+	}, "test.json")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if meta.Retired {
+		t.Fatalf("Retired = true, want false")
+	}
+}
+
+func TestParseAttributeMetadata_RetiredNonBoolRejected(t *testing.T) {
+	_, err := parseAttributeMetadata("old_col", map[string]any{
+		"attributeID": float64(3),
+		"valueType":   "text",
+		"retired":     "yes",
+	}, "test.json")
+	if err == nil {
+		t.Fatalf("expected error for non-bool retired flag")
+	}
+}

--- a/internal/schemameta/retired_guard_test.go
+++ b/internal/schemameta/retired_guard_test.go
@@ -1,9 +1,13 @@
 package schemameta
 
 import (
+	"context"
+	"path/filepath"
+	"regexp"
 	"testing"
 
 	forma "github.com/lychee-technology/forma"
+	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,4 +49,123 @@ func TestValidateSchemaAttributeCache_DistinctRetiredIDStillValid(t *testing.T) 
 	}
 	err := validateSchemaAttributeCache("user", cache)
 	require.NoError(t, err, "distinct ids must validate")
+}
+
+// ---------------------------------------------------------------------------
+// Active-cache stripping (#342 Task 3): retired entries are a validation-only
+// ledger; no stored or registered cache may expose them.
+// ---------------------------------------------------------------------------
+
+func TestDirectoryRegistry_RetiredExcludedFromActiveCache(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONFile(t, filepath.Join(dir, "user.json"), map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"name": map[string]any{"type": "string"}},
+	})
+	writeJSONFile(t, filepath.Join(dir, "user_attributes.json"), map[string]any{
+		"name":    map[string]any{"attributeID": float64(1), "valueType": "text"},
+		"old_col": map[string]any{"attributeID": float64(3), "valueType": "text", "retired": true},
+	})
+
+	registry, err := NewFileSchemaRegistryFromDirectory(dir)
+	require.NoError(t, err, "load directory registry")
+
+	schemaID, cache, err := registry.GetSchemaAttributeCacheByName("user")
+	require.NoError(t, err, "get cache")
+	assert.NotContains(t, cache, "old_col", "retired attribute old_col must not appear in the active cache")
+	assert.Contains(t, cache, "name", "active attribute name missing")
+
+	// The id index must not resolve the retired id either — this is what
+	// keeps the #294 read path skipping attrID 3.
+	byIDName, byIDCache, err := registry.GetSchemaAttributeCacheByID(schemaID)
+	require.NoError(t, err, "get cache by id")
+	assert.Equal(t, "user", byIDName)
+	assert.NotContains(t, byIDCache, "old_col", "retired attribute must not appear in the by-id cache")
+
+	_, idToName, err := GetSchemaMetadata(registry, schemaID)
+	require.NoError(t, err, "GetSchemaMetadata")
+	assert.NotContains(t, idToName, int16(3), "retired attribute id 3 must not be resolvable")
+	assert.Equal(t, "name", idToName[int16(1)])
+}
+
+func TestDirectoryRegistry_RetiredIDReuseFailsLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONFile(t, filepath.Join(dir, "user.json"), map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"nickname": map[string]any{"type": "string"}},
+	})
+	writeJSONFile(t, filepath.Join(dir, "user_attributes.json"), map[string]any{
+		"nickname": map[string]any{"attributeID": float64(3), "valueType": "text"},
+		"old_col":  map[string]any{"attributeID": float64(3), "valueType": "text", "retired": true},
+	})
+
+	_, err := NewFileSchemaRegistryFromDirectory(dir)
+	require.Error(t, err, "expected load failure for retired id reuse")
+	assert.Contains(t, err.Error(), "retired attribute old_col", "error does not carry the reuse diagnosis")
+}
+
+// TestDirectoryRegistry_RetiredReservedFoldedColumnStillRejected pins the
+// ordering invariant: the strip must run strictly AFTER
+// validateSchemaAttributeCache, so retired entries still reach
+// sqlgen.ValidateParquetAttrColumns. A retired attribute's folded column is
+// still present in already-flushed parquet files (#342, #260).
+func TestDirectoryRegistry_RetiredReservedFoldedColumnStillRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONFile(t, filepath.Join(dir, "rowid.json"), map[string]any{"type": "object"})
+	writeJSONFile(t, filepath.Join(dir, "rowid_attributes.json"), map[string]any{
+		"row.id": map[string]any{"attributeID": float64(1), "valueType": "text", "retired": true},
+	})
+
+	_, err := NewFileSchemaRegistryFromDirectory(dir)
+	require.Error(t, err, "retired attribute folding onto a reserved column must still be rejected")
+	assert.Contains(t, err.Error(), "row.id")
+	assert.Contains(t, err.Error(), "reserved")
+}
+
+func TestMetadataCacheRegisterSchema_StripsRetired(t *testing.T) {
+	mc := NewMetadataCache()
+	err := mc.RegisterSchema("user", 100, forma.SchemaAttributeCache{
+		"name":    {AttributeName: "name", AttributeID: 1, ValueType: forma.ValueTypeText},
+		"old_col": {AttributeName: "old_col", AttributeID: 3, ValueType: forma.ValueTypeText, Retired: true},
+	})
+	require.NoError(t, err, "RegisterSchema")
+
+	cache, ok := mc.GetSchemaCacheByID(100)
+	require.True(t, ok, "GetSchemaCacheByID")
+	assert.NotContains(t, cache, "old_col", "retired attribute must be stripped on RegisterSchema")
+	assert.Contains(t, cache, "name")
+	assert.NotContains(t, mc.attributeMetadata[100], "old_col", "retired attribute must be stripped from attributeMetadata")
+}
+
+// TestLoadMetadata_StripsRetiredFromFileCache covers the loader's file path
+// (loadAttributeMetadataFromFiles), the fourth storage point.
+func TestLoadMetadata_StripsRetiredFromFileCache(t *testing.T) {
+	ctx := context.Background()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	dir := t.TempDir()
+	rows := pgxmock.NewRows([]string{"schema_name", "schema_id"}).AddRow("user", int16(1))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT schema_name, schema_id FROM ` + sanitizeIdentifier("test_registry"))).WillReturnRows(rows)
+
+	writeJSONFile(t, filepath.Join(dir, "user_attributes.json"), map[string]any{
+		"name":    map[string]any{"attributeID": float64(1), "valueType": "text"},
+		"old_col": map[string]any{"attributeID": float64(3), "valueType": "text", "retired": true},
+	})
+
+	loader := NewMetadataLoader(mock, "test_registry", dir)
+	cache, err := loader.LoadMetadata(ctx)
+	require.NoError(t, err)
+
+	assert.NotContains(t, cache.attributeMetadata[int16(1)], "old_col", "retired attribute must not reach attributeMetadata")
+	assert.Contains(t, cache.attributeMetadata[int16(1)], "name")
+
+	schemaCache, ok := cache.GetSchemaCacheByID(1)
+	require.True(t, ok)
+	assert.NotContains(t, schemaCache, "old_col", "retired attribute must not reach schemaCaches")
+	assert.Contains(t, schemaCache, "name")
+
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/schemameta/retired_guard_test.go
+++ b/internal/schemameta/retired_guard_test.go
@@ -1,0 +1,48 @@
+package schemameta
+
+import (
+	"testing"
+
+	forma "github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSchemaAttributeCache_RetiredIDReuseRejected(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"old_col":  {AttributeName: "old_col", AttributeID: 3, ValueType: forma.ValueTypeText, Retired: true},
+		"nickname": {AttributeName: "nickname", AttributeID: 3, ValueType: forma.ValueTypeText},
+	}
+	err := validateSchemaAttributeCache("user", cache)
+	require.NotNil(t, err, "expected reuse error for retired attribute id 3")
+
+	errStr := err.Error()
+	for _, want := range []string{"attribute id 3", "retired", "old_col", "text", "nickname"} {
+		assert.Contains(t, errStr, want, "error does not name %q", want)
+	}
+}
+
+func TestValidateSchemaAttributeCache_RetiredColumnBindingReuseRejected(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"old_col": {AttributeName: "old_col", AttributeID: 3, ValueType: forma.ValueTypeText, Retired: true,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: "text_01"}},
+		"nickname": {AttributeName: "nickname", AttributeID: 4, ValueType: forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: "text_01"}},
+	}
+	err := validateSchemaAttributeCache("user", cache)
+	require.NotNil(t, err, "expected reuse error for retired column binding text_01")
+
+	errStr := err.Error()
+	for _, want := range []string{"text_01", "retired", "old_col", "nickname"} {
+		assert.Contains(t, errStr, want, "error does not name %q", want)
+	}
+}
+
+func TestValidateSchemaAttributeCache_DistinctRetiredIDStillValid(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"old_col":  {AttributeName: "old_col", AttributeID: 3, ValueType: forma.ValueTypeText, Retired: true},
+		"nickname": {AttributeName: "nickname", AttributeID: 4, ValueType: forma.ValueTypeText},
+	}
+	err := validateSchemaAttributeCache("user", cache)
+	require.NoError(t, err, "distinct ids must validate")
+}

--- a/internal/schemameta/retired_guard_test.go
+++ b/internal/schemameta/retired_guard_test.go
@@ -137,6 +137,24 @@ func TestMetadataCacheRegisterSchema_StripsRetired(t *testing.T) {
 	assert.NotContains(t, mc.attributeMetadata[100], "old_col", "retired attribute must be stripped from attributeMetadata")
 }
 
+// TestMetadataCacheRegisterSchema_RejectsRetiredIDReuse pins that the strip
+// never swallows a collision: RegisterSchema validates the FULL cache before
+// stripping, so a retired/active id clash is an error rather than a silent
+// drop that would rebind the retired id to the active attribute (#342).
+func TestMetadataCacheRegisterSchema_RejectsRetiredIDReuse(t *testing.T) {
+	mc := NewMetadataCache()
+	err := mc.RegisterSchema("user", 100, forma.SchemaAttributeCache{
+		"nickname": {AttributeName: "nickname", AttributeID: 3, ValueType: forma.ValueTypeText},
+		"old_col":  {AttributeName: "old_col", AttributeID: 3, ValueType: forma.ValueTypeText, Retired: true},
+	})
+	require.Error(t, err, "retired id reuse must not register silently")
+	assert.Contains(t, err.Error(), "retired attribute old_col", "error does not carry the reuse diagnosis")
+
+	_, ok := mc.GetSchemaCacheByID(100)
+	assert.False(t, ok, "a rejected schema must not be registered")
+	assert.NotContains(t, mc.schemaNameToID, "user", "a rejected schema must not appear in the name index")
+}
+
 // TestLoadMetadata_StripsRetiredFromFileCache covers the loader's file path
 // (loadAttributeMetadataFromFiles), the fourth storage point.
 func TestLoadMetadata_StripsRetiredFromFileCache(t *testing.T) {

--- a/internal/schemameta/validation.go
+++ b/internal/schemameta/validation.go
@@ -27,7 +27,7 @@ func validateSchemaAttributeCache(schemaName string, cache forma.SchemaAttribute
 	seenBindings := make(map[forma.MainColumn]string)
 	for attrName, meta := range cache {
 		if existingAttr, exists := seenAttrIDs[meta.AttributeID]; exists {
-			return fmt.Errorf("schema %s has duplicate attribute id %d for %s and %s", schemaName, meta.AttributeID, existingAttr, attrName)
+			return attrIDCollisionError(schemaName, cache, meta.AttributeID, existingAttr, attrName)
 		}
 		seenAttrIDs[meta.AttributeID] = attrName
 
@@ -35,7 +35,7 @@ func validateSchemaAttributeCache(schemaName string, cache forma.SchemaAttribute
 			continue
 		}
 		if existingAttr, exists := seenBindings[meta.ColumnBinding.ColumnName]; exists {
-			return fmt.Errorf("schema %s has duplicate column binding %s for %s and %s", schemaName, meta.ColumnBinding.ColumnName, existingAttr, attrName)
+			return bindingCollisionError(schemaName, cache, meta.ColumnBinding.ColumnName, existingAttr, attrName)
 		}
 		seenBindings[meta.ColumnBinding.ColumnName] = attrName
 	}
@@ -43,9 +43,47 @@ func validateSchemaAttributeCache(schemaName string, cache forma.SchemaAttribute
 	// Reject attribute names whose folded parquet columns land on a CDC/read
 	// system column or collide with each other — such a schema would accept
 	// hot-tier writes it can never flush or read back federated (#260,
-	// PR #273 review).
+	// PR #273 review). Retired entries stay in scope: their folded columns
+	// still exist in flushed parquet files (#342).
 	if err := sqlgen.ValidateParquetAttrColumns(cache); err != nil {
 		return fmt.Errorf("schema %s: %w", schemaName, err)
 	}
 	return nil
+}
+
+// attrIDCollisionError names the retired side of an attributeID collision.
+// AttributeIDs are physical EAV keys: an id freed by attribute removal is
+// still bound to preserved rows, so rebinding it to a different attribute
+// would surface old values under the new name or make rows unreadable (#342).
+func attrIDCollisionError(schemaName string, cache forma.SchemaAttributeCache, id int16, a, b string) error {
+	if retiredName, activeName, ok := splitRetiredPair(cache, a, b); ok {
+		return fmt.Errorf(
+			"schema %s reuses attribute id %d: retired attribute %s (valueType %s) still owns preserved EAV rows and cannot be rebound to %s; re-add the original name and valueType to restore it, or assign a new id",
+			schemaName, id, retiredName, cache[retiredName].ValueType, activeName)
+	}
+	return fmt.Errorf("schema %s has duplicate attribute id %d for %s and %s", schemaName, id, a, b)
+}
+
+// bindingCollisionError is the main-table analogue: a retired attribute's hot
+// column still holds its historical values.
+func bindingCollisionError(schemaName string, cache forma.SchemaAttributeCache, col forma.MainColumn, a, b string) error {
+	if retiredName, activeName, ok := splitRetiredPair(cache, a, b); ok {
+		return fmt.Errorf(
+			"schema %s reuses main column %s: retired attribute %s (valueType %s) still owns its stored values and cannot share the column with %s; keep the binding retired or assign a new column",
+			schemaName, col, retiredName, cache[retiredName].ValueType, activeName)
+	}
+	return fmt.Errorf("schema %s has duplicate column binding %s for %s and %s", schemaName, col, a, b)
+}
+
+// splitRetiredPair returns (retired, active, true) when exactly one of the two
+// colliding attributes is retired — the reuse case #342 guards against.
+func splitRetiredPair(cache forma.SchemaAttributeCache, a, b string) (string, string, bool) {
+	aRetired, bRetired := cache[a].Retired, cache[b].Retired
+	if aRetired == bRetired {
+		return "", "", false
+	}
+	if aRetired {
+		return a, b, true
+	}
+	return b, a, true
 }

--- a/internal/schemameta/validation.go
+++ b/internal/schemameta/validation.go
@@ -51,6 +51,23 @@ func validateSchemaAttributeCache(schemaName string, cache forma.SchemaAttribute
 	return nil
 }
 
+// activeAttributeCache returns cache without retired entries. Retired entries
+// exist only as the attributeID ledger (#342): they take part in validation
+// above, but no consumer may see them — a retired attribute reads, writes,
+// flushes, and projects exactly as if its entry were absent (#294 skip).
+// Callers must invoke this strictly after validateSchemaAttributeCache, so the
+// guard always sees the full ledger.
+func activeAttributeCache(cache forma.SchemaAttributeCache) forma.SchemaAttributeCache {
+	active := make(forma.SchemaAttributeCache, len(cache))
+	for name, meta := range cache {
+		if meta.Retired {
+			continue
+		}
+		active[name] = meta
+	}
+	return active
+}
+
 // attrIDCollisionError names the retired side of an attributeID collision.
 // AttributeIDs are physical EAV keys: an id freed by attribute removal is
 // still bound to preserved rows, so rebinding it to a different attribute

--- a/internal/schemameta/validation.go
+++ b/internal/schemameta/validation.go
@@ -22,6 +22,11 @@ func parseAttributeID(raw any, attrName, source string) (int16, error) {
 	return int16(id), nil
 }
 
+// validateSchemaAttributeCache rejects attributeID, main-column, and folded
+// parquet-column collisions across the FULL cache, retired entries included.
+// Every error it returns begins with "schema <name>", so callers wrap it with
+// what it cannot know — the location the metadata came from (attributes file or
+// schema directory), or the numeric schema id — never with the name again.
 func validateSchemaAttributeCache(schemaName string, cache forma.SchemaAttributeCache) error {
 	seenAttrIDs := make(map[int16]string, len(cache))
 	seenBindings := make(map[forma.MainColumn]string)

--- a/internal/schemameta/validation.go
+++ b/internal/schemameta/validation.go
@@ -25,8 +25,8 @@ func parseAttributeID(raw any, attrName, source string) (int16, error) {
 // validateSchemaAttributeCache rejects attributeID, main-column, and folded
 // parquet-column collisions across the FULL cache, retired entries included.
 // Every error it returns begins with "schema <name>", so callers wrap it with
-// what it cannot know — the location the metadata came from (attributes file or
-// schema directory), or the numeric schema id — never with the name again.
+// what it cannot know — the attributes file the metadata came from, or the
+// numeric schema id — never with the name again.
 func validateSchemaAttributeCache(schemaName string, cache forma.SchemaAttributeCache) error {
 	seenAttrIDs := make(map[int16]string, len(cache))
 	seenBindings := make(map[forma.MainColumn]string)

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -141,6 +141,12 @@ type AttributeMetadata struct {
 	// New code should use RequiredPolicy.
 	Required      bool               `json:"required,omitempty"`
 	ColumnBinding *MainColumnBinding `json:"column_binding,omitempty"`
+	// Retired marks an attribute removed from the schema whose entry stays in
+	// the attributes file as the attributeID ledger (#342). Retired attributes
+	// are excluded from every active cache — reads skip their EAV rows (#294),
+	// writes preserve them — but their (id, name, valueType) still guards
+	// against rebinding the freed id to a different attribute.
+	Retired bool `json:"retired,omitempty"`
 }
 
 // EffectiveRequiredPolicy returns the policy used at runtime.


### PR DESCRIPTION
Closes #342.

Formalizes `<schema>_attributes.json` as the **attributeID ledger** so an id freed by attribute removal can never be rebound to a different attribute — closing the trap #294's tolerate-and-preserve contract invited (same valueType → preserved values silently surface under the new name; different valueType → storage-type mismatch → row unreadable/500).

## ⚠️ Breaking change — read before merging

Two shipped ledgers carried pre-existing removal residue that the new generator behavior retires. **The two are not symmetric:**

| Attribute | Schema | Impact |
|---|---|---|
| `logs` (attrID 29) | `visit_full` | **Write-breaking.** `visit_full.json` declares no `logs` and no `additionalProperties`, so on `main` a client *can* write `logs` (array or scalar) and read it back. After this PR writes fail 400 `attribute 'logs' is not defined for this schema`, and existing values disappear from reads. Attribute 29 is effectively **unrestorable under its original array shape** — the docs now say so and give the workable alternative (new name, fresh id) instead of the remedy that does not work. |
| `contactSnapshot` (attrID 25) | `visit` | **Practically inert.** A pre-#315 `$ref`-collapse leftover; an object payload recurses per key and never reaches the bare leaf, so rows under id 25 could only exist if a client once sent it as a scalar (which #314 validation now rejects). |

EAV rows for both are preserved per #294 and both ids stay reserved. Retiring them is what the ledger contract requires; the alternative — leaving them unmarked — makes `TestShippedAttributesRegenerateByteIdentical` permanently red.

**Please confirm no client writes `visit_full.logs` before merging.** The remedy is cheap beforehand and awkward after (see the flush caveat below).

## Approach (per the rulings recorded on #342)

- **Mechanism: file ledger**, not a Postgres history table and not an EAV storage probe. The EAV table stores only `value_text`/`value_numeric` — no name, no type — so a storage probe could catch a cross-column type change but never a same-type silent rename. The ledger catches both.
- **Severity: hard error** at registration/startup, matching #314's fail-closed precedent.
- **Scope: guard only.** #341 (validator classification) and #343 (Warn demotion) stay separate; the retired marker is exactly the signal #341 needs.

## What changed

1. **`forma.AttributeMetadata.Retired bool`** + parser support for `"retired": true|false` (non-bool rejected).
2. **`generate-attributes`** marks schema-absent entries `"retired": true` and forces optional policy, instead of relying on humans never to hand-delete. Re-add of the same name with the same valueType+items_type clears the marker (values restore); a different type is a hard error naming attribute, old type/items, new type/items. `maxID` still scans retired entries, so freed ids are never reissued.
3. **`validateSchemaAttributeCache`** runs on the **full** cache at every registration path and emits reuse-specific errors when an attributeID or main-column collision involves exactly one retired entry. Retired entries also keep their folded parquet columns reserved (`sqlgen.ValidateParquetAttrColumns` still sees them) — those columns exist in already-flushed files.
4. **Retired entries are stripped from active caches** strictly *after* validation, at all four storage points. Downstream (transform, sqlgen, repositories, CDC) needs no changes: a retired attribute reads, writes, flushes and projects exactly as if its entry were absent, so #294 skip-on-read / preserve-on-write is unchanged.
5. **`MetadataCache.RegisterSchema` now validates** before snapshot+strip (ruled mid-flight): it was the only unvalidated registration door, and the strip would have silently swallowed a collision there. Consequence: #294's `TestReplaceEAVAttributes_DeleteScopedToCurrentSchemaAttrIDs` deliberately registered two names sharing attrID 12 to cover `knownAttrIDs`' `slices.Compact`; that state is now unconstructible through any path, so the test uses distinct ids (sort-determinism coverage preserved) and `slices.Compact` stays as belt-and-suspenders with an updated comment.
6. **Production e2e** `TestRetiredMarkerRemovalWorkflow` proves the retired-marker generation behaves identically to the hand-deleted one; the legacy `TestUpdateAfterAttributeRemoval` is untouched and still pins that old-style files are tolerated.
7. **Docs** — `docs/error-handling.md` and `docs/schema-consistency-migration.md` carry the blessed removal workflow, the guard's exact error shapes, re-add semantics, the rollback caveat, and the residual gaps.

## Operator caveat the docs now carry (inherited #294 semantics, previously over-promised)

Un-retiring restores values **only for rows not yet flushed to the lakehouse**. CDC derives its EAV pull from the active cache (`internal/cdc/export_sql_builder.go`), so a retired attribute's rows never reach parquet; a row flushed during the retired window reads NULL forever. The Postgres EAV row survives, so an unrelated later update makes the row hot again and the next flush *resurrects* the value — a value that read NULL yesterday reappears tomorrow. On CDC-enabled deployments treat retirement as effectively irreversible for flushed rows.

## Residual gaps (documented, not closed)

- **Live attribute type change is the same damage class, unguarded**: `generate-attributes` silently refreshes `valueType` for a still-present attribute, stranding existing EAV rows in the wrong physical column. Documented; follow-up candidate.
- **Hand-deleted ledger entries** (before or after #342) have no entry to guard; the rule stays "never hand-delete", which is convention, not enforcement.
- **Retired-in-ledger but still declared in `<schema>.json`** (old `tools` binary, or forgetting to regenerate) renders the attribute silently invisible at runtime; no cross-check today.
- **Rollback**: pre-#342 binaries ignore the `retired` key and load the entry as active — retired values become visible again, and the scoped DELETE resumes including those ids, so the next update of such a row destroys the preserved rows.

## Verification

`make test` green module-wide · `make lint` (golangci-lint v1.64.8) exit 0 · `gofmt` clean · e2e infra smoke green · both production removal e2e tests green under Docker · shipped-schema byte-identical regeneration guards green (12/12) · the `items_type` guard leg mutation-verified (deleting the leg reddens exactly the new test, nothing else).

Reviewed per task (spec + quality) plus a whole-branch review; findings, rulings and the deferred-minor triage are recorded on #342.

请不要自动合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
