### PR TITLE
fix(tools): #341 classify #294-preserved EAV rows as informational

### DIFF
--- a/cmd/tools/validate_schema_consistency.go
+++ b/cmd/tools/validate_schema_consistency.go
@@ -26,9 +26,20 @@ type schemaConsistencyValidator struct {
 	out         io.Writer
 }
 
+// issueSeverity separates findings that must block a pre-flight from findings
+// the operator only needs to know about. severityError is the zero value, so
+// every existing construction site stays a failure by default.
+type issueSeverity int
+
+const (
+	severityError issueSeverity = iota
+	severityInfo
+)
+
 type validationIssue struct {
 	category string
 	details  string
+	severity issueSeverity
 }
 
 func runValidateSchemaConsistency(ctx context.Context, args []string) error {
@@ -113,15 +124,49 @@ func (v schemaConsistencyValidator) run(ctx context.Context) error {
 		return err
 	}
 
-	if len(issues) == 0 {
-		fmt.Fprintf(v.out, "schema consistency checks passed for %d schema(s)\n", len(cache.ListSchemas()))
+	failures, notices := partitionIssues(issues)
+	v.report(failures, notices, len(cache.ListSchemas()))
+	if len(failures) == 0 {
 		return nil
 	}
+	return fmt.Errorf("schema consistency validation failed with %d issue(s)", len(failures))
+}
 
+// partitionIssues splits collectIssues' sorted output into the two report
+// blocks while preserving order inside each.
+func partitionIssues(issues []validationIssue) (failures, notices []validationIssue) {
 	for _, issue := range issues {
+		if issue.severity == severityInfo {
+			notices = append(notices, issue)
+			continue
+		}
+		failures = append(failures, issue)
+	}
+	return failures, notices
+}
+
+// report prints failures first, then the informational block. Informational
+// findings are EAV rows #294 preserves under a retired attribute: a supported
+// steady state, so they are surfaced for awareness and never gate the exit
+// code (#341).
+func (v schemaConsistencyValidator) report(failures, notices []validationIssue, schemaCount int) {
+	if len(failures) == 0 {
+		fmt.Fprintf(v.out, "schema consistency checks passed for %d schema(s)", schemaCount)
+		if len(notices) > 0 {
+			fmt.Fprintf(v.out, ", %d informational finding(s)", len(notices))
+		}
+		fmt.Fprintln(v.out)
+	}
+	for _, issue := range failures {
 		fmt.Fprintf(v.out, "- %s: %s\n", issue.category, issue.details)
 	}
-	return fmt.Errorf("schema consistency validation failed with %d issue(s)", len(issues))
+	if len(notices) == 0 {
+		return
+	}
+	fmt.Fprintln(v.out, "informational (not a failure):")
+	for _, issue := range notices {
+		fmt.Fprintf(v.out, "- %s: %s\n", issue.category, issue.details)
+	}
 }
 
 func (v schemaConsistencyValidator) collectIssues(ctx context.Context, cache *schemameta.MetadataCache) ([]validationIssue, error) {
@@ -148,8 +193,17 @@ func (v schemaConsistencyValidator) collectIssues(ctx context.Context, cache *sc
 	return issues, nil
 }
 
-func (v schemaConsistencyValidator) checkUnknownAttributeIDs(ctx context.Context, cache *schemameta.MetadataCache) ([]validationIssue, error) {
-	knownAttrIDs := make(map[int16]map[int16]struct{})
+// schemaLedger is the per-schema view checkUnknownAttributeIDs classifies
+// against: the active attributeIDs, the retired ledger #342 records, and the
+// schema name for the report line.
+type schemaLedger struct {
+	name    string
+	active  map[int16]struct{}
+	retired map[int16]string
+}
+
+func buildSchemaLedgers(cache *schemameta.MetadataCache) map[int16]schemaLedger {
+	ledgers := make(map[int16]schemaLedger)
 	for _, schemaName := range cache.ListSchemas() {
 		schemaID, ok := cache.GetSchemaID(schemaName)
 		if !ok {
@@ -159,12 +213,21 @@ func (v schemaConsistencyValidator) checkUnknownAttributeIDs(ctx context.Context
 		if !ok {
 			continue
 		}
-		ids := make(map[int16]struct{}, len(schemaCache))
+		active := make(map[int16]struct{}, len(schemaCache))
 		for _, meta := range schemaCache {
-			ids[meta.AttributeID] = struct{}{}
+			active[meta.AttributeID] = struct{}{}
 		}
-		knownAttrIDs[schemaID] = ids
+		ledgers[schemaID] = schemaLedger{
+			name:    schemaName,
+			active:  active,
+			retired: cache.RetiredAttributeIDs(schemaID),
+		}
 	}
+	return ledgers
+}
+
+func (v schemaConsistencyValidator) checkUnknownAttributeIDs(ctx context.Context, cache *schemameta.MetadataCache) ([]validationIssue, error) {
+	ledgers := buildSchemaLedgers(cache)
 
 	query := fmt.Sprintf(`
 SELECT e.schema_id, e.attr_id, COUNT(*) AS record_count
@@ -185,20 +248,38 @@ ORDER BY e.schema_id, e.attr_id`, quoteIdentifier(v.eavTable))
 		if err := rows.Scan(&schemaID, &attrID, &count); err != nil {
 			return nil, fmt.Errorf("scan unknown attribute ids: %w", err)
 		}
-		if ids, ok := knownAttrIDs[schemaID]; ok {
-			if _, exists := ids[attrID]; exists {
-				continue
-			}
+		// A schema_id absent from the registry yields the zero ledger: both maps
+		// are nil, so the row falls through to the failure branch as before.
+		ledger := ledgers[schemaID]
+		if _, exists := ledger.active[attrID]; exists {
+			continue
 		}
-		issues = append(issues, validationIssue{
-			category: "unknown attribute IDs in " + v.eavTable,
-			details:  fmt.Sprintf("schema_id=%d attr_id=%d rows=%d", schemaID, attrID, count),
-		})
+		issues = append(issues, classifyUndecodableRows(v.eavTable, ledger, schemaID, attrID, count))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate unknown attribute ids: %w", err)
 	}
 	return issues, nil
+}
+
+// classifyUndecodableRows splits EAV rows current metadata cannot decode into
+// the two cases the migration guide names. Rows under a retired ledger entry
+// were preserved by an attribute removal (#294) — an expected, supported steady
+// state, reported informationally. Everything else is genuinely orphaned and
+// still fails the pre-flight (#341).
+func classifyUndecodableRows(eavTable string, ledger schemaLedger, schemaID, attrID int16, count int64) validationIssue {
+	if attrName, ok := ledger.retired[attrID]; ok {
+		return validationIssue{
+			category: "preserved EAV rows for retired attributes in " + eavTable,
+			details: fmt.Sprintf("schema=%s schema_id=%d attr_id=%d attribute=%s rows=%d",
+				ledger.name, schemaID, attrID, attrName, count),
+			severity: severityInfo,
+		}
+	}
+	return validationIssue{
+		category: "unknown attribute IDs in " + eavTable,
+		details:  fmt.Sprintf("schema_id=%d attr_id=%d rows=%d", schemaID, attrID, count),
+	}
 }
 
 func (v schemaConsistencyValidator) checkStorageMismatches(ctx context.Context, cache *schemameta.MetadataCache) ([]validationIssue, error) {

--- a/cmd/tools/validate_schema_consistency_test.go
+++ b/cmd/tools/validate_schema_consistency_test.go
@@ -203,3 +203,176 @@ func writeSchemaConsistencyArtifacts(t *testing.T, dir, schemaName, schemaJSON, 
 		t.Fatalf("write attrs: %v", err)
 	}
 }
+
+// newSchemaConsistencyMock wires the four queries validator.run issues, in
+// order: the schema registry, the attr_id census, then the two storage-column
+// censuses. Only the attr_id census varies across the #341 classification
+// tests, so the rest is fixed here.
+func newSchemaConsistencyMock(t *testing.T, attrCensus *pgxmock.Rows) pgxmock.PgxPoolIface {
+	t.Helper()
+	mock, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("create mock pool: %v", err)
+	}
+	t.Cleanup(mock.Close)
+
+	mock.ExpectQuery(`SELECT schema_name, schema_id FROM "schema_registry_dev"`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_name", "schema_id"}).AddRow("contact", int16(100)))
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e`).
+		WillReturnRows(attrCensus)
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e WHERE e\.value_text IS NOT NULL`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}))
+	mock.ExpectQuery(`SELECT e\.schema_id, e\.attr_id, COUNT\(\*\) AS record_count FROM "eav_data_dev" AS e WHERE e\.value_numeric IS NOT NULL`).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}))
+	return mock
+}
+
+// retiredLedgerSchemaDir writes a contact schema whose ledger has one active
+// attribute (id 1) and one retired entry, legacy (id 9) — the #342 shape.
+func retiredLedgerSchemaDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeSchemaConsistencyArtifacts(t, dir, "contact",
+		`{"type":"object","properties":{"id":{"type":"string"}}}`,
+		`{"id":{"attributeID":1,"valueType":"text"},"legacy":{"attributeID":9,"valueType":"text","retired":true}}`)
+	return dir
+}
+
+func attrCensusRows() *pgxmock.Rows {
+	return pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"})
+}
+
+// TestValidateSchemaConsistencyClassifiesRetiredAttrRows pins the #341
+// contract: EAV rows whose attr_id belongs to a retired ledger entry are the
+// #294 tolerate-and-preserve steady state, so they report as informational and
+// leave the pre-flight green.
+func TestValidateSchemaConsistencyClassifiesRetiredAttrRows(t *testing.T) {
+	mock := newSchemaConsistencyMock(t, attrCensusRows().AddRow(int16(100), int16(9), int64(12)))
+
+	var out strings.Builder
+	validator := schemaConsistencyValidator{
+		pool:        mock,
+		schemaDir:   retiredLedgerSchemaDir(t),
+		schemaTable: "schema_registry_dev",
+		eavTable:    "eav_data_dev",
+		out:         &out,
+	}
+
+	if err := validator.run(context.Background()); err != nil {
+		t.Fatalf("preserved rows must not fail the run: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "unknown attribute IDs") {
+		t.Fatalf("preserved rows must not be reported as unknown attribute IDs, got %q", got)
+	}
+	for _, want := range []string{
+		"informational (not a failure):",
+		"preserved EAV rows for retired attributes in eav_data_dev",
+		"schema=contact", "attr_id=9", "attribute=legacy", "rows=12",
+		"schema consistency checks passed for 1 schema(s), 1 informational finding(s)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q, got %q", want, got)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}
+
+// TestValidateSchemaConsistencyFailsUnledgeredAttrID pins that classification
+// is per attributeID, not a per-schema amnesty: a schema that owns a retired
+// entry still fails for a different, unledgered id.
+func TestValidateSchemaConsistencyFailsUnledgeredAttrID(t *testing.T) {
+	mock := newSchemaConsistencyMock(t, attrCensusRows().AddRow(int16(100), int16(99), int64(2)))
+
+	var out strings.Builder
+	validator := schemaConsistencyValidator{
+		pool:        mock,
+		schemaDir:   retiredLedgerSchemaDir(t),
+		schemaTable: "schema_registry_dev",
+		eavTable:    "eav_data_dev",
+		out:         &out,
+	}
+
+	err := validator.run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "1 issue(s)") {
+		t.Fatalf("expected one failure for the unledgered attr_id, got %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "unknown attribute IDs in eav_data_dev: schema_id=100 attr_id=99 rows=2") {
+		t.Fatalf("expected the orphan finding, got %q", got)
+	}
+	if strings.Contains(got, "informational") {
+		t.Fatalf("an unledgered attr_id must not be softened to informational, got %q", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}
+
+// TestValidateSchemaConsistencyFailsUnknownSchemaID pins that the ledger lookup
+// is scoped per schema: attr_id 9 is retired on schema 100, and that must not
+// excuse rows carrying schema_id 200, which the registry does not know at all.
+func TestValidateSchemaConsistencyFailsUnknownSchemaID(t *testing.T) {
+	mock := newSchemaConsistencyMock(t, attrCensusRows().AddRow(int16(200), int16(9), int64(4)))
+
+	var out strings.Builder
+	validator := schemaConsistencyValidator{
+		pool:        mock,
+		schemaDir:   retiredLedgerSchemaDir(t),
+		schemaTable: "schema_registry_dev",
+		eavTable:    "eav_data_dev",
+		out:         &out,
+	}
+
+	err := validator.run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "1 issue(s)") {
+		t.Fatalf("expected a failure for the unknown schema_id, got %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "schema_id=200 attr_id=9 rows=4") ||
+		strings.Contains(got, "informational") {
+		t.Fatalf("unknown schema_id must stay a failure, got %q", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}
+
+// TestValidateSchemaConsistencyReportsBothBlocks pins that a run carrying both
+// kinds prints both, counts only the failure, and still exits non-zero.
+func TestValidateSchemaConsistencyReportsBothBlocks(t *testing.T) {
+	mock := newSchemaConsistencyMock(t, attrCensusRows().
+		AddRow(int16(100), int16(9), int64(12)).
+		AddRow(int16(100), int16(99), int64(2)))
+
+	var out strings.Builder
+	validator := schemaConsistencyValidator{
+		pool:        mock,
+		schemaDir:   retiredLedgerSchemaDir(t),
+		schemaTable: "schema_registry_dev",
+		eavTable:    "eav_data_dev",
+		out:         &out,
+	}
+
+	err := validator.run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "1 issue(s)") {
+		t.Fatalf("the error count must exclude informational findings, got %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "schema consistency checks passed") {
+		t.Fatalf("a failing run must not print the success line, got %q", got)
+	}
+	for _, want := range []string{
+		"unknown attribute IDs in eav_data_dev: schema_id=100 attr_id=99 rows=2",
+		"informational (not a failure):",
+		"attribute=legacy",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q, got %q", want, got)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet db expectations: %v", err)
+	}
+}

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -326,7 +326,10 @@ a retired attributeID, a retired main-column binding, or a retired attribute's
 folded parquet column. `MetadataCache.RegisterSchema` applies the same
 validation but has no production callers; it is defence in depth for
 programmatic registration. Retired entries are stripped only after that check
-and never reach a consumer, so a retired attribute reads, writes, flushes, and
+and never reach a consumer — with one sanctioned exception,
+`schemameta.MetadataCache.RetiredAttributeIDs`, which hands validation tooling
+attributeID → attribute name only (no `forma.AttributeMetadata`, and not the
+live attribute map), so a retired attribute still reads, writes, flushes, and
 projects exactly as if its entry were absent — the #294 skip-and-preserve
 behavior above is unchanged. Re-adding the same name with the same `valueType`
 and `items_type` clears the marker and restores the preserved values **for rows

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -6,18 +6,22 @@ This guide covers the upgrade to the schema/metadata consistency hardening intro
 
 Older releases tolerated several schema and metadata inconsistencies by logging warnings or silently skipping bad records. The hardened release turns those cases into startup or request-time errors.
 
-The new checks fail on:
+The checks `#121` introduced fail on:
 
 - duplicate `schema_id` values in the schema registry table
 - duplicate `attributeID` values inside a single `<schema>_attributes.json`
 - duplicate hot-column bindings inside a single `<schema>_attributes.json`
-- EAV rows whose `attr_id` is not present in metadata for that schema — as
-  originally shipped in `#121`. Since `#294` the runtime path no longer errors
-  on these: it skips them on read and preserves them on write. See
-  [Unknown attribute IDs in EAV](#unknown-attribute-ids-in-eav) for what the
-  validator does with them today.
+- EAV rows whose `attr_id` is not present in metadata for that schema — **since
+  superseded, see below**
 - EAV rows whose value is stored in the wrong physical column (`value_text` vs `value_numeric`)
 - writes that reference attributes not defined in schema metadata
+
+**Superseded since `#294`.** The runtime path no longer errors on EAV rows whose
+`attr_id` is absent from metadata: it skips them on read and preserves them on
+write. Since `#341` the validator likewise reports the ones a `retired` ledger
+entry accounts for as informational rather than as failures. Only that one
+bullet changed; the rest of the list still fails as written. See
+[Unknown attribute IDs in EAV](#unknown-attribute-ids-in-eav).
 
 A later release (`#314`) adds one more startup check and one more request-time check:
 
@@ -197,8 +201,10 @@ that should describe it is simply missing. The determination is yours whenever
 the validator reports a **failure** rather than an informational finding, and
 three possibilities remain at that point: the rows were never legitimate (case
 (i)), the attribute was retired **before** `#342` so no `retired` entry records
-it and the validator can only see an unledgered id (case (ii)), or legitimate
-metadata was lost by accident and must be restored (case (iii)).
+it and the validator can only see an unledgered id (case (ii), *unledgered
+variant* — the ledgered majority of case (ii) never reaches you as a failure at
+all), or legitimate metadata was lost by accident and must be restored
+(case (iii)).
 
 **Case (i) — never legitimate.** The rows came from a bad deployment, a
 mis-mapped import, or leftover test data: no schema generation ever defined that

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -11,7 +11,11 @@ The new checks fail on:
 - duplicate `schema_id` values in the schema registry table
 - duplicate `attributeID` values inside a single `<schema>_attributes.json`
 - duplicate hot-column bindings inside a single `<schema>_attributes.json`
-- EAV rows whose `attr_id` is not present in metadata for that schema
+- EAV rows whose `attr_id` is not present in metadata for that schema — as
+  originally shipped in `#121`. Since `#294` the runtime path no longer errors
+  on these: it skips them on read and preserves them on write. See
+  [Unknown attribute IDs in EAV](#unknown-attribute-ids-in-eav) for what the
+  validator does with them today.
 - EAV rows whose value is stored in the wrong physical column (`value_text` vs `value_numeric`)
 - writes that reference attributes not defined in schema metadata
 
@@ -108,7 +112,10 @@ It validates:
 - every referenced `<schema>_attributes.json` parses successfully
 - each schema’s metadata has unique `attributeID` values
 - each schema’s metadata has unique `column_binding.col_name` values
-- `eav_data.attr_id` values all map to known metadata IDs for the same `schema_id`
+- `eav_data.attr_id` values all map to known metadata IDs for the same
+  `schema_id` — ids belonging to a `retired` ledger entry (`#342`) are reported
+  as informational rather than as failures, because those rows are the `#294`
+  preserved state (`#341`)
 - numeric/date/bool values are not incorrectly stored in `value_text`
 - text/uuid/list values are not incorrectly stored in `value_numeric`
 
@@ -160,14 +167,37 @@ Example validator output:
 
 That means the table contains rows that current metadata cannot decode. There are two very different reasons this can happen, and they call for opposite actions. **Determine which case you are in before touching any row**: check whether that `attr_id` was ever a legitimate attribute in an earlier generation of the schema's `<schema>_attributes.json` (version control on the schema files is the record) and was later removed.
 
-**Case (i) — never legitimate.** The rows came from a bad deployment, a mis-mapped import, or leftover test data: no schema generation ever defined that `attr_id`. Fix by either:
+Three things can put an `attr_id` in this state, and the third one is neither of
+the two cases below: the metadata may have been **lost by accident** — a partial
+deploy, a rollback that reverted the attributes file but not the data, or a
+ledger entry hand-deleted before `#342`. If the values are legitimate and the
+attribute genuinely belongs to the schema, the fix is to restore the metadata,
+not to touch the rows. See
+[Removing an attribute](#removing-an-attribute-342) for how to rebuild a missing
+ledger entry.
 
-1. restoring the missing attribute metadata if the data is legitimate, or
-2. deleting the orphaned EAV rows.
+**Case (i) — never legitimate.** The rows came from a bad deployment, a
+mis-mapped import, or leftover test data: no schema generation ever defined that
+`attr_id`, and no metadata is missing. Fix by deleting the orphaned EAV rows.
 
 **Case (ii) — preserved by attribute removal (`#294`).** The attribute did exist and was removed from the schema. Since `#294` (tolerate-and-preserve) these rows are the **expected** state: the read path skips them and the write path preserves them untouched, so removing an attribute is non-destructive and re-adding it (same `attributeID`) restores the stored values. **Do not delete them.** Deletion is destructive and irreversible — it permanently forfeits the re-add restore path — and nothing else in the system is asking you to do it. Leave the rows in place and treat the validator finding as informational.
 
 If you cannot establish which case applies, treat the rows as case (ii) and leave them alone; keeping undecodable rows costs storage, deleting recoverable ones costs the data.
+
+Since `#341` the validator makes this split for you whenever the ledger carries
+the retired entry. Case (ii) rows are reported in a separate block and do not
+fail the run:
+
+```text
+schema consistency checks passed for 3 schema(s), 1 informational finding(s)
+informational (not a failure):
+- preserved EAV rows for retired attributes in eav_data_dev: schema=visit schema_id=1 attr_id=25 attribute=contactSnapshot rows=12
+```
+
+The manual determination above is still yours to make in exactly one situation:
+the attribute was removed **before** `#342`, so no `retired` entry records it and
+the validator can only see an unledgered id. That is a failure until you rebuild
+the ledger entry — see [Removing an attribute](#removing-an-attribute-342).
 
 Whichever case applies, an `attributeID` freed by removing an attribute must never be reused for a different attribute: the preserved rows would silently bind to the new attribute's name, or make the row unreadable with a storage type mismatch. Since `#342` that is enforced at startup rather than left to convention — see [Removing an attribute](#removing-an-attribute-342) below.
 
@@ -316,6 +346,29 @@ two is not symmetric**, so assess them separately:
 documentation-only: check the schema files' version history before assigning any
 `attributeID` that no current entry claims.
 
+**Rebuilding a lost ledger entry.** Hand-add the entry back to
+`<schema>_attributes.json` under its original name, with its original
+`attributeID` and `valueType` (and `items_type`, for a list), marked retired:
+
+```json
+"legacy_field": { "attributeID": 9, "valueType": "text", "retired": true }
+```
+
+This is the one hand-edit the ledger sanctions, and it is not the unsupported
+case described above: the schema no longer declares the property, so the next
+`generate-attributes` run finds nothing to re-add and keeps the marker. Once the
+entry exists, the reuse guard protects the id and
+`validate-schema-consistency` reclassifies its preserved rows as informational
+(`#341`).
+
+Two things to expect. The entry is now subject to full-ledger validation, so if
+that `attributeID` was already handed to a different attribute during the
+pre-`#342` era, startup will fail naming both — that is pre-existing corruption
+surfacing, not a regression, and the fix is to give the *newer* attribute an
+unused id. And the `valueType` you record must be the one the stored rows
+actually carry: get it wrong and a future re-add restores values through the
+wrong physical column.
+
 ### Storage-column mismatches
 
 Example validator output:
@@ -400,18 +453,16 @@ LIMIT 50;
 
 - database backup taken
 - `scripts/validate_schema_consistency.sql` returns no duplicate schema IDs
-- `make validate-schema-consistency` returns success — except that on deployments
-  whose schemas have had attributes **retired**, unknown-attrID findings for
-  exactly those attributes are **expected** (`#294` tolerate-and-preserve) and
-  are **not** a deployment blocker. With the shipped ledgers this now includes
-  `attr_id` 25 on the `visit` schema and `attr_id` 29 on `visit_full`, which the
-  validator will flag on **every** deployment that holds rows under those ids.
-  The tool does not yet classify preserved rows separately
-  from genuinely orphaned ones, so confirm the reported `attr_id`s against the
-  retired entries in `<schema>_attributes.json` — and, for ledgers generated
-  before `#342`, against the attributes removed in the schema files' version
-  history, since a hand-deleted entry left no retired marker to cross-check —
-  then proceed (follow-up tracked on the PR).
+- `make validate-schema-consistency` returns success. Deployments whose schemas
+  have had attributes **retired** will see those rows listed in the
+  informational block — expected `#294` tolerate-and-preserve state, not a
+  deployment blocker, and not part of the exit code (`#341`). With the shipped
+  ledgers this covers `attr_id` 25 on `visit` and `attr_id` 29 on `visit_full`.
+  A remaining `unknown attribute IDs` **failure** means one of two things: rows
+  that were never legitimate, or an attribute retired before `#342` whose ledger
+  entry is missing. Resolve it with
+  [Unknown attribute IDs in EAV](#unknown-attribute-ids-in-eav) — do not wave it
+  through.
 - every schema name in `schema_registry` has a resolvable `<name>.json` in `SCHEMA_DIR` (`#314` startup check)
 - no active attribute reuses a `retired` attributeID, main-column binding, or folded parquet column (`#342` startup check)
 - hardened release deployed
@@ -424,7 +475,10 @@ If deploy fails because of newly enforced checks:
 
 1. restore the previous server binary or image
 2. keep the database unchanged unless you already applied manual cleanup SQL
-3. fix the reported metadata or EAV inconsistencies
+3. fix the reported metadata or EAV inconsistencies — this never includes
+   deleting EAV rows the validator reports in the informational block. Those are
+   `#294`-preserved rows; deleting them is irreversible. See
+   [Unknown attribute IDs in EAV](#unknown-attribute-ids-in-eav).
 4. re-run the validator
 5. retry the upgrade
 

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -37,7 +37,10 @@ All three are covered below.
 2. Back up the database.
 3. Run the checked-in SQL script for DB-level sanity checks.
 4. Run the checked-in Go validator for full metadata-aware validation.
-5. Fix all reported issues.
+5. Fix all reported issues — never by deleting EAV rows the validator reports in
+   the informational block. Those are `#294`-preserved rows; deleting them is
+   irreversible. See
+   [Unknown attribute IDs in EAV](#unknown-attribute-ids-in-eav).
 6. Deploy the hardened release.
 7. Run the validator again after deploy.
 
@@ -165,28 +168,17 @@ Example validator output:
 - unknown attribute IDs in eav_data_dev: schema_id=100 attr_id=99 rows=12
 ```
 
-That means the table contains rows that current metadata cannot decode. There are two very different reasons this can happen, and they call for opposite actions. **Determine which case you are in before touching any row**: check whether that `attr_id` was ever a legitimate attribute in an earlier generation of the schema's `<schema>_attributes.json` (version control on the schema files is the record) and was later removed.
+That means the table contains rows that current metadata cannot decode. **Three**
+different things can put an `attr_id` in this state, and they call for opposite
+actions: the rows were **never legitimate** (case (i)), they are **preserved by
+attribute removal** (`#294`, case (ii)), or the attribute is still legitimate and
+its **metadata was lost by accident** (case (iii)). Since `#341` the validator
+classifies case (ii) for you whenever the ledger carries the retired entry, so
+the manual determination below is only needed for what the validator still
+reports as a **failure**.
 
-Three things can put an `attr_id` in this state, and the third one is neither of
-the two cases below: the metadata may have been **lost by accident** — a partial
-deploy, a rollback that reverted the attributes file but not the data, or a
-ledger entry hand-deleted before `#342`. If the values are legitimate and the
-attribute genuinely belongs to the schema, the fix is to restore the metadata,
-not to touch the rows. See
-[Removing an attribute](#removing-an-attribute-342) for how to rebuild a missing
-ledger entry.
-
-**Case (i) — never legitimate.** The rows came from a bad deployment, a
-mis-mapped import, or leftover test data: no schema generation ever defined that
-`attr_id`, and no metadata is missing. Fix by deleting the orphaned EAV rows.
-
-**Case (ii) — preserved by attribute removal (`#294`).** The attribute did exist and was removed from the schema. Since `#294` (tolerate-and-preserve) these rows are the **expected** state: the read path skips them and the write path preserves them untouched, so removing an attribute is non-destructive and re-adding it (same `attributeID`) restores the stored values. **Do not delete them.** Deletion is destructive and irreversible — it permanently forfeits the re-add restore path — and nothing else in the system is asking you to do it. Leave the rows in place and treat the validator finding as informational.
-
-If you cannot establish which case applies, treat the rows as case (ii) and leave them alone; keeping undecodable rows costs storage, deleting recoverable ones costs the data.
-
-Since `#341` the validator makes this split for you whenever the ledger carries
-the retired entry. Case (ii) rows are reported in a separate block and do not
-fail the run:
+Concretely: rows whose `attr_id` matches a `retired` ledger entry are reported in
+a separate informational block and do not fail the run.
 
 ```text
 schema consistency checks passed for 3 schema(s), 1 informational finding(s)
@@ -194,10 +186,43 @@ informational (not a failure):
 - preserved EAV rows for retired attributes in eav_data_dev: schema=visit schema_id=1 attr_id=25 attribute=contactSnapshot rows=12
 ```
 
-The manual determination above is still yours to make in exactly one situation:
-the attribute was removed **before** `#342`, so no `retired` entry records it and
-the validator can only see an unledgered id. That is a failure until you rebuild
-the ledger entry — see [Removing an attribute](#removing-an-attribute-342).
+Everything else still comes out as an `unknown attribute IDs` **failure**, and
+that is what the rest of this section is for.
+
+**Determine which case you are in before touching any row.** Version control on
+the schema files is the record: check whether that `attr_id` was ever a
+legitimate attribute in an earlier generation of the schema's
+`<schema>_attributes.json`, whether it was later removed, and whether the entry
+that should describe it is simply missing. The determination is yours whenever
+the validator reports a **failure** rather than an informational finding, and
+three possibilities remain at that point: the rows were never legitimate (case
+(i)), the attribute was retired **before** `#342` so no `retired` entry records
+it and the validator can only see an unledgered id (case (ii)), or legitimate
+metadata was lost by accident and must be restored (case (iii)).
+
+**Case (i) — never legitimate.** The rows came from a bad deployment, a
+mis-mapped import, or leftover test data: no schema generation ever defined that
+`attr_id`, and no metadata is missing. Fix by deleting the orphaned EAV rows.
+
+**Case (ii) — preserved by attribute removal (`#294`).** The attribute did exist and was removed from the schema. Since `#294` (tolerate-and-preserve) these rows are the **expected** state: the read path skips them and the write path preserves them untouched, so removing an attribute is non-destructive and re-adding it (same `attributeID`) restores the stored values. **Do not delete them.** Deletion is destructive and irreversible — it permanently forfeits the re-add restore path — and nothing else in the system is asking you to do it. Leave the rows in place and treat the validator finding as informational.
+
+This case reaches you as a *failure* only when the attribute was removed before
+`#342`, so the ledger carries no `retired` entry to classify it against. The
+repair is to rebuild that entry, not to delete the rows — see
+[Removing an attribute](#removing-an-attribute-342).
+
+**Case (iii) — metadata lost by accident.** The attribute is still legitimate and
+genuinely belongs to the schema, but its metadata is gone — a partial deploy, a
+rollback that reverted the attributes file but not the data, or a ledger entry
+hand-deleted before `#342`. The fix is to **restore the metadata, not to touch
+the rows**: put the property back into `<schema>.json` and re-run
+`generate-attributes` (or restore the attributes file from version history),
+keeping the original `attributeID`. Once metadata describes the id again the
+rows decode as they always did. If the attribute is not wanted back, retire it
+properly instead — see
+[Removing an attribute](#removing-an-attribute-342).
+
+If you cannot establish which case applies, treat the rows as case (ii) and leave them alone; keeping undecodable rows costs storage, deleting recoverable ones costs the data.
 
 Whichever case applies, an `attributeID` freed by removing an attribute must never be reused for a different attribute: the preserved rows would silently bind to the new attribute's name, or make the row unreadable with a storage type mismatch. Since `#342` that is enforced at startup rather than left to convention — see [Removing an attribute](#removing-an-attribute-342) below.
 
@@ -348,25 +373,41 @@ documentation-only: check the schema files' version history before assigning any
 
 **Rebuilding a lost ledger entry.** Hand-add the entry back to
 `<schema>_attributes.json` under its original name, with its original
-`attributeID` and `valueType` (and `items_type`, for a list), marked retired:
+`attributeID`, its original `valueType` (and `items_type`, for a list), **and its
+original `column_binding.col_name` if the attribute had a hot column**, marked
+retired:
 
 ```json
-"legacy_field": { "attributeID": 9, "valueType": "text", "retired": true }
+"legacy_field": {
+  "attributeID": 9,
+  "valueType": "text",
+  "column_binding": {"col_name":"text_01"},
+  "retired": true
+}
 ```
+
+The `column_binding` matters as much as the id, and like `valueType` it has to be
+recovered from the schema files' version history — nothing derives it. Omit it
+and the entry reserves only the id: a later attribute can bind that main-table
+column with the guard silent, and reads then serve the retired attribute's stale
+values out of `text_01`. The third reserved resource, the folded parquet column,
+needs no separate field — it is derived from the attribute name, which this
+recipe already requires you to restore.
 
 This is the one hand-edit the ledger sanctions, and it is not the unsupported
 case described above: the schema no longer declares the property, so the next
 `generate-attributes` run finds nothing to re-add and keeps the marker. Once the
-entry exists, the reuse guard protects the id and
-`validate-schema-consistency` reclassifies its preserved rows as informational
-(`#341`).
+entry exists, the reuse guard protects the id, the main column and the folded
+parquet column, and `validate-schema-consistency` reclassifies its preserved rows
+as informational (`#341`).
 
 Two things to expect. The entry is now subject to full-ledger validation, so if
-that `attributeID` was already handed to a different attribute during the
+that `attributeID`, that `column_binding.col_name`, or that attribute name's
+folded parquet column was already handed to a different attribute during the
 pre-`#342` era, startup will fail naming both — that is pre-existing corruption
 surfacing, not a regression, and the fix is to give the *newer* attribute an
-unused id. And the `valueType` you record must be the one the stored rows
-actually carry: get it wrong and a future re-add restores values through the
+unused id/column/name. And the `valueType` you record must be the one the stored
+rows actually carry: get it wrong and a future re-add restores values through the
 wrong physical column.
 
 ### Storage-column mismatches
@@ -458,9 +499,11 @@ LIMIT 50;
   informational block — expected `#294` tolerate-and-preserve state, not a
   deployment blocker, and not part of the exit code (`#341`). With the shipped
   ledgers this covers `attr_id` 25 on `visit` and `attr_id` 29 on `visit_full`.
-  A remaining `unknown attribute IDs` **failure** means one of two things: rows
-  that were never legitimate, or an attribute retired before `#342` whose ledger
-  entry is missing. Resolve it with
+  A remaining `unknown attribute IDs` **failure** means one of three things: rows
+  that were never legitimate (delete them), an attribute retired before `#342`
+  whose ledger entry is missing (rebuild the entry), or metadata lost by accident
+  for an attribute that is still legitimate (restore the metadata — do **not**
+  touch the rows). Resolve it with
   [Unknown attribute IDs in EAV](#unknown-attribute-ids-in-eav) — do not wave it
   through.
 - every schema name in `schema_registry` has a resolvable `<name>.json` in `SCHEMA_DIR` (`#314` startup check)

--- a/internal/schemameta/loader.go
+++ b/internal/schemameta/loader.go
@@ -45,6 +45,12 @@ type MetadataCache struct {
 	// registration; plan caches key on it so metadata content changes orphan
 	// stale entries (#142).
 	fingerprints map[int16]string
+
+	// retiredAttrIDs is the ledger view the strip above discards: schema id →
+	// attributeID → attribute name for entries marked retired (#342). Nothing on
+	// the read/write path consults it; RetiredAttributeIDs is its only reader,
+	// and exists for validation tooling alone (#341).
+	retiredAttrIDs map[int16]map[int16]string
 }
 
 // NewMetadataCache creates a new metadata cache
@@ -55,6 +61,7 @@ func NewMetadataCache() *MetadataCache {
 		attributeMetadata: make(map[int16]map[string]forma.AttributeMetadata),
 		schemaCaches:      make(map[int16]forma.SchemaAttributeCache),
 		fingerprints:      make(map[int16]string),
+		retiredAttrIDs:    make(map[int16]map[int16]string),
 	}
 }
 
@@ -87,6 +94,7 @@ func (mc *MetadataCache) RegisterSchema(schemaName string, schemaID int16, cache
 	// on MetadataCache's field declarations.
 	mc.attributeMetadata[schemaID] = map[string]forma.AttributeMetadata(copySchemaAttributeCache(snapshot))
 	mc.fingerprints[schemaID] = fingerprintSchema(schemaName, snapshot)
+	mc.retiredAttrIDs[schemaID] = retiredAttributeIDs(cache)
 	return nil
 }
 
@@ -187,6 +195,26 @@ func (mc *MetadataCache) GetSchemaCacheByID(schemaID int16) (forma.SchemaAttribu
 	defer mc.mu.RUnlock()
 	cache, ok := mc.schemaCaches[schemaID]
 	return cache, ok
+}
+
+// RetiredAttributeIDs returns the schema's retired ledger entries as
+// attributeID → attribute name (#341). Validation tooling only: it hands back
+// neither forma.AttributeMetadata nor the live map, so it cannot become a read,
+// write, flush, or projection path for a retired attribute — the invariant
+// activeAttributeCache states. Returns nil for an unknown schema or one with no
+// retired entries.
+func (mc *MetadataCache) RetiredAttributeIDs(schemaID int16) map[int16]string {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+	retired := mc.retiredAttrIDs[schemaID]
+	if len(retired) == 0 {
+		return nil
+	}
+	out := make(map[int16]string, len(retired))
+	for id, name := range retired {
+		out[id] = name
+	}
+	return out
 }
 
 // ListSchemas returns all schema names (thread-safe)
@@ -338,6 +366,7 @@ func (ml *MetadataLoader) loadAttributeMetadataFromFiles(cache *MetadataCache) e
 		// MetadataCache's field declarations.
 		cache.attributeMetadata[schemaID] = map[string]forma.AttributeMetadata(copySchemaAttributeCache(active))
 		cache.schemaCaches[schemaID] = active
+		cache.retiredAttrIDs[schemaID] = retiredAttributeIDs(schemaCache)
 
 		zap.S().Infow("Loaded attributes for schema", "count", len(active), "schema", schemaName)
 	}

--- a/internal/schemameta/retired_guard_test.go
+++ b/internal/schemameta/retired_guard_test.go
@@ -187,3 +187,64 @@ func TestLoadMetadata_StripsRetiredFromFileCache(t *testing.T) {
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// TestMetadataCacheRetiredAttributeIDs_LedgerVisibleToTooling pins #341: the
+// retired ledger stays reachable for validation tooling while remaining absent
+// from every consumer-facing cache. The accessor is the single sanctioned
+// exception to activeAttributeCache's "no consumer may see them".
+func TestMetadataCacheRetiredAttributeIDs_LedgerVisibleToTooling(t *testing.T) {
+	mc := NewMetadataCache()
+	require.NoError(t, mc.RegisterSchema("user", 100, forma.SchemaAttributeCache{
+		"name":    {AttributeName: "name", AttributeID: 1, ValueType: forma.ValueTypeText},
+		"old_col": {AttributeName: "old_col", AttributeID: 3, ValueType: forma.ValueTypeText, Retired: true},
+	}), "RegisterSchema")
+
+	assert.Equal(t, map[int16]string{3: "old_col"}, mc.RetiredAttributeIDs(100),
+		"retired ledger must expose attribute id 3")
+
+	cache, ok := mc.GetSchemaCacheByID(100)
+	require.True(t, ok, "GetSchemaCacheByID")
+	assert.NotContains(t, cache, "old_col",
+		"the ledger accessor must not re-expose retired entries to consumers")
+
+	// Copy-on-read: a tooling-side mutation must not corrupt the registry ledger.
+	tampered := mc.RetiredAttributeIDs(100)
+	tampered[3] = "tampered"
+	assert.Equal(t, "old_col", mc.RetiredAttributeIDs(100)[3], "accessor must return a copy")
+
+	assert.Nil(t, mc.RetiredAttributeIDs(999), "unknown schema id has no ledger")
+	assert.NotContains(t, mc.RetiredAttributeIDs(100), int16(1), "an active attribute id is not in the ledger")
+}
+
+// TestLoadMetadata_RetiredLedgerPopulatedFromFiles covers the path
+// validate-schema-consistency actually uses: attribute metadata read from
+// <schema>_attributes.json must record the ledger even though the active cache
+// strips it (#341). Its sibling TestLoadMetadata_StripsRetiredFromFileCache
+// pins the strip; this pins that the strip is no longer lossy for tooling.
+func TestLoadMetadata_RetiredLedgerPopulatedFromFiles(t *testing.T) {
+	ctx := context.Background()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	dir := t.TempDir()
+	rows := pgxmock.NewRows([]string{"schema_name", "schema_id"}).AddRow("user", int16(7))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT schema_name, schema_id FROM ` + sanitizeIdentifier("test_registry"))).WillReturnRows(rows)
+
+	writeJSONFile(t, filepath.Join(dir, "user_attributes.json"), map[string]any{
+		"name":    map[string]any{"attributeID": float64(1), "valueType": "text"},
+		"old_col": map[string]any{"attributeID": float64(3), "valueType": "text", "retired": true},
+	})
+
+	cache, err := NewMetadataLoader(mock, "test_registry", dir).LoadMetadata(ctx)
+	require.NoError(t, err, "LoadMetadata")
+
+	assert.Equal(t, map[int16]string{3: "old_col"}, cache.RetiredAttributeIDs(7),
+		"file-loaded metadata must record the retired ledger")
+	active, ok := cache.GetSchemaCache("user")
+	require.True(t, ok, "GetSchemaCache")
+	assert.NotContains(t, active, "old_col", "the active cache must still strip retired entries")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/schemameta/validation.go
+++ b/internal/schemameta/validation.go
@@ -73,6 +73,27 @@ func activeAttributeCache(cache forma.SchemaAttributeCache) forma.SchemaAttribut
 	return active
 }
 
+// retiredAttributeIDs is activeAttributeCache's counterpart: it keeps the books
+// the strip discards. The result is the attributeID ledger of removed
+// attributes (#342) — id → name — which validation tooling needs to tell an EAV
+// row #294 preserved from a genuinely orphaned one (#341). Like its
+// counterpart, callers must invoke it strictly after
+// validateSchemaAttributeCache, which is what makes the id key unambiguous:
+// that guard has already rejected any duplicate attributeID in the file.
+func retiredAttributeIDs(cache forma.SchemaAttributeCache) map[int16]string {
+	var retired map[int16]string
+	for name, meta := range cache {
+		if !meta.Retired {
+			continue
+		}
+		if retired == nil {
+			retired = make(map[int16]string)
+		}
+		retired[meta.AttributeID] = name
+	}
+	return retired
+}
+
 // attrIDCollisionError names the retired side of an attributeID collision.
 // AttributeIDs are physical EAV keys: an id freed by attribute removal is
 // still bound to preserved rows, so rebinding it to a different attribute


### PR DESCRIPTION
Closes #341.

Spec: https://github.com/Lychee-Technology/forma/issues/341#issuecomment-5226173089

## The problem

`validate-schema-consistency` reported **every** EAV row whose `attr_id` is absent from current metadata as a failure and exited non-zero. Since #294 those rows are a supported steady state — skipped on read, preserved on update, restored on re-add — so any deployment that ever retired an attribute could never get a green pre-flight. The ledgers shipped by #342/#376 made this universal: `visit` `attr_id` 25 and `visit_full` `attr_id` 29 are retired, so every deployment holding rows under them was flagged on every run.

The signal to fix it already existed (#342's `"retired": true` marker) but the validator could not see it: `MetadataCache` strips retired entries before any consumer reaches them (`activeAttributeCache`).

## What changed

**`internal/schemameta`** — `MetadataCache` now records the retired ledger it previously discarded, at both registration points, reading the un-stripped cache strictly after `validateSchemaAttributeCache` (which is what makes the attributeID key unambiguous). Exposed through:

```go
func (mc *MetadataCache) RetiredAttributeIDs(schemaID int16) map[int16]string
```

Ids and names only, copy-on-read. It deliberately returns neither `forma.AttributeMetadata` nor the live map, so it cannot become a read, write, flush, or projection path for a retired attribute — the narrow return type, not convention, is what preserves `activeAttributeCache`'s invariant. Existing strip guards stay green.

**`cmd/tools/validate_schema_consistency.go`** — undecodable EAV rows are now classified three ways:

| Condition | Result |
| --- | --- |
| `schema_id` absent from the registry | failure (unchanged) |
| `attr_id` in that schema's retired ledger | informational |
| otherwise | failure (unchanged) |

Classification is per attributeID, not a per-schema amnesty, and the ledger lookup is scoped per schema. Only failures reach the exit code and the `%d issue(s)` count.

**`docs/schema-consistency-migration.md`** — the three residues #341 names (front-matter bullet, case (i) carrying an option that belongs to a third cause, rollback step 3 readable as licence to delete preserved rows), plus the Go Validator checklist, the Deployment Checklist, a ledger-reconstruction recipe for attributes retired before #342, and a rewrite of `### Unknown attribute IDs in EAV` so the lead-in, the cases, and the checklist all state the same three-way taxonomy and lead with what the tool now decides for you. `docs/error-handling.md` gains one clause naming the accessor as the sanctioned exception to "retired entries never reach a consumer".

## Verification

`make lint` (golangci-lint v1.64.8) and `make test` both clean. Nine unit tests added across the two packages, including per-id-not-per-schema and unknown-`schema_id` pins.

End-to-end against real Postgres and the **shipped** ledgers, with probe rows under `visit`/25, `visit_full`/29 and an unledgered id 199:

```text
- unknown attribute IDs in eav_data_dev: schema_id=110 attr_id=199 rows=1
informational (not a failure):
- preserved EAV rows for retired attributes in eav_data_dev: schema=visit schema_id=110 attr_id=25 attribute=contactSnapshot rows=1
- preserved EAV rows for retired attributes in eav_data_dev: schema=visit_full schema_id=111 attr_id=29 attribute=logs rows=1
validate-schema-consistency: schema consistency validation failed with 1 issue(s)
```

With the orphan removed, exit code 0:

```text
schema consistency checks passed for 12 schema(s), 2 informational finding(s)
informational (not a failure):
- preserved EAV rows for retired attributes in eav_data_dev: schema=visit schema_id=110 attr_id=25 attribute=contactSnapshot rows=1
- preserved EAV rows for retired attributes in eav_data_dev: schema=visit_full schema_id=111 attr_id=29 attribute=logs rows=1
```

## Exit-code change

This changes an operator-facing pre-flight tool's exit semantics — deliberately, and that is the issue. Nothing in CI gates on it: the in-repo callers are the `validate-schema-consistency` Makefile target, a hint echoed by `scripts/validate_schema_consistency.sql`, and the migration guide. `.github/workflows/ci.yml` never invokes it.

## Not in scope

Per the spec's decision record: retired attributes are **not** folded into the storage-column mismatch check (those rows are unreadable until re-add, and including them would create new failures for existing deployments); no `--fail-on-retired` mode; no `--allow-attr-ids` escape hatch. Deployments that retired an attribute before #342 have no ledger entry and still fail — the remedy is the documented hand-rebuild recipe, not code.

## Known residue

One-word polish left open: `docs/schema-consistency-migration.md` "startup will fail naming both" now follows a three-item antecedent. The claim is accurate (every guard message names two attributes), so it reads as imprecise rather than wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
