### PR TITLE
fix: #276 deterministic clock ordering for the remaining LWW guard, export error wraps, and a real gofmt gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Check gofmt
+        run: make fmt-check
+
       - name: Run golangci-lint
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Forma is a general-purpose data management system on PostgreSQL. Entities are de
 
 ```bash
 make test          # unit tests (wraps: go test . ./cdc ./cmd/... ./factory ./internal/...)
+make fmt-check     # gofmt gate over git-listed Go files — CI runs it ahead of the linter
 make lint          # golangci-lint, pinned to v1.64.8 — same as CI; do not upgrade the pin
 make coverage      # unit tests + coverage report in build/
 make build-all     # build server/tools/sample into build/ with platform symlinks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,9 @@ Error messages must name the logical value type, the offending column/attribute,
 
 ## Specs and Design Docs
 
-Planning artifacts — specs, design docs, implementation plans — are not committed to the repo (`docs/superpowers/` is gitignored). Post them to the GitHub issue they serve instead: once a spec or design is approved, add its full content as a comment on the relevant issue so the issue carries the complete decision record. This covers per-issue planning artifacts only; reference designs that document the system itself (e.g. `docs/federated-query/design.md`) live in `docs/` as before.
+Every non-code artifact produced while working an issue goes to that issue as a comment — never into the repo (`docs/superpowers/` is gitignored). This covers design drafts, specs, implementation plans, investigation and verification notes, and rulings made mid-execution. Post the full content, not a summary, and post it when it is produced: a design draft goes up as a draft (say so), a plan goes up when written, a mid-execution decision goes up at the moment it is taken. The issue is the complete decision record; nothing load-bearing may live only in a chat transcript or a local file.
+
+Scope: per-issue artifacts only. Reference documentation of the system itself (e.g. `docs/federated-query/design.md`) lives in `docs/` and is committed as before. Review artifacts belong on the PR — see Pull Request Rules.
 
 ## Pull Request Rules
 

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,22 @@ test-e2e-production:
 # //go:build e2e harness files, where 3 of this issue's 7 drifted files lived.
 # gofmt -l is purely syntactic and therefore tag-agnostic, so it is the only
 # check that covers the whole tree. CI runs this exact target.
+#
+# The file list comes from git, not a directory walk: tracked files plus
+# untracked ones git would not ignore. Walking the checkout would also inspect
+# gitignored directories (docs/superpowers/, build/, .gocache/), so a local run
+# could fail on scratch files that do not exist in CI's fresh checkout —
+# breaking the local/CI parity this gate exists to protect. Untracked-but-not-
+# ignored files stay in scope so a new file is caught before it is committed;
+# CI has none, so the two runs see the same set.
 fmt-check:
 	@echo "Checking gofmt..."
-	@unformatted=$$(gofmt -l .); \
+	@files=$$(git ls-files --cached --others --exclude-standard '*.go'); \
+	if [ -z "$$files" ]; then \
+		echo "fmt-check found no Go files — not a git checkout?"; \
+		exit 1; \
+	fi; \
+	unformatted=$$(gofmt -l $$files); \
 	if [ -n "$$unformatted" ]; then \
 		echo "Not gofmt-clean:"; \
 		echo "$$unformatted"; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit test-e2e-production lint coverage build build-tools build-benchmark benchmark-smoke benchmark-regression benchmark-heavy benchmark-heavy-live build-all build-lambda clean all create-build-dir link validate-schema-consistency
+.PHONY: test test-unit test-e2e-production fmt-check lint coverage build build-tools build-benchmark benchmark-smoke benchmark-regression benchmark-heavy benchmark-heavy-live build-all build-lambda clean all create-build-dir link validate-schema-consistency
 
 # Binary names
 BINARY_SERVER=server
@@ -48,6 +48,21 @@ test-unit:
 test-e2e-production:
 	@echo "Running production E2E harness tests..."
 	@$(GOENV) go test -v ./internal/e2e_harness/production/ -tags=e2e -timeout=10m
+
+# Formatter gate (#276). golangci-lint's default linter set carries no
+# formatter, and its gofmt linter is build-tag scoped: it never loads the
+# //go:build e2e harness files, where 3 of this issue's 7 drifted files lived.
+# gofmt -l is purely syntactic and therefore tag-agnostic, so it is the only
+# check that covers the whole tree. CI runs this exact target.
+fmt-check:
+	@echo "Checking gofmt..."
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then \
+		echo "Not gofmt-clean:"; \
+		echo "$$unformatted"; \
+		echo "Fix with: gofmt -w ."; \
+		exit 1; \
+	fi
 
 # Run linter (same as CI lint job)
 lint:

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -80,7 +80,7 @@ func NewDuckExporter(ctx context.Context, cfg CDCConfig, s3AccessKey, s3Secret, 
 func (e *DuckExporter) ExportSnapshotToTmp(ctx context.Context, cfg CDCConfig, pgConnStr string, s3TmpPath string, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
 	sql, clQuery, mQuery, eQuery, err := buildExportSQL(pgConnStr, s3TmpPath, cfg, schemaID, snapshotTS, rowIDs, attrCache)
 	if err != nil {
-		return err
+		return fmt.Errorf("export snapshot to tmp for schema %d: %w", schemaID, err)
 	}
 
 	return e.executeExportSQL(ctx, cfg, "duckdb export sql", "duckdb copy exec", sql, clQuery, mQuery, eQuery)

--- a/internal/cdc/duckdb_exporter_sql_test.go
+++ b/internal/cdc/duckdb_exporter_sql_test.go
@@ -1,6 +1,7 @@
 package cdc
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -208,4 +209,30 @@ func TestBuildExportSQL_UsesCustomTableNames(t *testing.T) {
 		t.Fatalf("eav query not using custom table name: %s", eQuery)
 	}
 	_ = sql
+}
+
+// TestExportToTmpWrapsPlanErrors pins the caller-side context on both export
+// entry points: a plan failure must name the operation the caller was
+// performing, not arrive as a bare pass-through (#276, coding-standard.md).
+// Empty rowIDs is the cheapest plan failure — it returns before any DB or S3
+// use, so a zero-value DuckExporter is enough.
+func TestExportToTmpWrapsPlanErrors(t *testing.T) {
+	exporter := &DuckExporter{}
+	cfg := CDCConfig{}
+
+	t.Run("snapshot export", func(t *testing.T) {
+		err := exporter.ExportSnapshotToTmp(context.Background(), cfg,
+			"postgres://user@host/db", "s3://bucket/7/_tmp/f.parquet", 7, 0, nil, testAttrCache())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "export snapshot to tmp for schema 7")
+		require.Contains(t, err.Error(), "no row ids provided")
+	})
+
+	t.Run("base export", func(t *testing.T) {
+		err := exporter.ExportBaseFileToTmp(context.Background(), cfg,
+			"postgres://user@host/db", "s3://bucket/base/7/_tmp/f.parquet", 7, nil, testAttrCache())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "export base file to tmp for schema 7")
+		require.Contains(t, err.Error(), "no row ids provided")
+	})
 }

--- a/internal/cdc/init_exporter.go
+++ b/internal/cdc/init_exporter.go
@@ -14,7 +14,7 @@ import (
 func (e *DuckExporter) ExportBaseFileToTmp(ctx context.Context, cfg CDCConfig, pgConnStr string, s3TmpPath string, schemaID int16, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) error {
 	sql, mQuery, eQuery, err := buildBaseExportSQL(pgConnStr, s3TmpPath, cfg, schemaID, rowIDs, attrCache)
 	if err != nil {
-		return err
+		return fmt.Errorf("export base file to tmp for schema %d: %w", schemaID, err)
 	}
 
 	return e.executeExportSQL(ctx, cfg, "duckdb base export sql", "duckdb base copy exec", sql, "", mQuery, eQuery)

--- a/internal/cdc/redact_test.go
+++ b/internal/cdc/redact_test.go
@@ -73,8 +73,12 @@ func TestRedactConnStr_HostilePasswordEscapedQuoted(t *testing.T) {
 	require.Contains(t, redacted, "sslmode=''")
 }
 
-// TestRedactConnStr_EmptyPasswordRawQuoted pins that an empty password (raw
-// password='') does not derail redaction of surrounding keys.
+// TestRedactConnStr_EmptyPasswordRawQuoted pins that an empty password does
+// not derail redaction of surrounding keys. The raw-quoted form is (kept in a
+// code block because gofmt rewrites doubled single quotes into a typographic
+// quote when they sit in comment prose, #276):
+//
+//	password=''
 func TestRedactConnStr_EmptyPasswordRawQuoted(t *testing.T) {
 	p := redactTestParams()
 	p.Password = ""
@@ -84,8 +88,10 @@ func TestRedactConnStr_EmptyPasswordRawQuoted(t *testing.T) {
 	require.Contains(t, redacted, "sslmode=")
 }
 
-// TestRedactConnStr_EmptyPasswordEscapedQuoted pins the doubled-quote empty form
-// (password='''') — the branch-1 fallback must not swallow the trailing keys.
+// TestRedactConnStr_EmptyPasswordEscapedQuoted pins the doubled-quote empty
+// form — the branch-1 fallback must not swallow the trailing keys:
+//
+//	password=''''
 func TestRedactConnStr_EmptyPasswordEscapedQuoted(t *testing.T) {
 	p := redactTestParams()
 	p.Password = ""
@@ -98,8 +104,10 @@ func TestRedactConnStr_EmptyPasswordEscapedQuoted(t *testing.T) {
 // TestRedactConnStr_EscapedQuotedDSN pins the #290 regression: the flusher/init
 // feed BuildPGDSN's quoted DSN through sqlutil.EscapeLiteral (doubling single quotes)
 // into a DuckDB ATTACH literal, then log it via redactConnStr. The doubled-quote
-// form (password=''secret'') must still be fully redacted — the old regex
-// matched the empty string between the doubled quotes and leaked the password.
+// form must still be fully redacted — the old regex matched the empty string
+// between the doubled quotes and leaked the password:
+//
+//	password=''secret''
 func TestRedactConnStr_EscapedQuotedDSN(t *testing.T) {
 	sqlLiteral := sqlutil.EscapeLiteral(BuildPGDSN(redactTestParams()))
 	require.Contains(t, sqlLiteral, "password=''"+redactSecret+"''",

--- a/internal/e2e_harness/production/boundary_roundtrip_e2e_test.go
+++ b/internal/e2e_harness/production/boundary_roundtrip_e2e_test.go
@@ -173,7 +173,7 @@ func buildBoundaryEvents(wide SchemaRef) (nullRow, zeroRow, maxRow, minRow *Even
 		"ref": maxUUID, "token": maxUUID,
 		"rank": float64(32767), "count": float64(2147483647),
 		"amount": maxBoundBigint,
-		"score": math.MaxFloat64, "level": float64(32767),
+		"score":  math.MaxFloat64, "level": float64(32767),
 		"qty": float64(2147483647), "total": maxEAVInt,
 		"ratio": float64(1048576.25), "active": true,
 		"born": "9999-12-31", "joined": "9999-12-31",
@@ -183,7 +183,7 @@ func buildBoundaryEvents(wide SchemaRef) (nullRow, zeroRow, maxRow, minRow *Even
 		"title": "b-min", "note": "b-min",
 		"rank": float64(-32768), "count": float64(-2147483648),
 		"amount": -maxBoundBigint,
-		"score": -math.MaxFloat64, "level": float64(-32768),
+		"score":  -math.MaxFloat64, "level": float64(-32768),
 		"qty": float64(-2147483648), "total": -maxEAVInt,
 		"ratio": float64(-1048576.25), "active": false,
 		// pre-epoch: negative epoch-ms must survive every tier

--- a/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_concurrent_flush_e2e_test.go
@@ -174,6 +174,13 @@ func testUpdateBeforeExport(ctx context.Context, t *testing.T) {
 	cfg.BeforeExportHook = func(hctx context.Context, _ int16, ids []uuid.UUID, snapshot int64) error {
 		hookSnapshot = snapshot
 		hookBatch = len(ids)
+		// The snapshot is an independent clock read, so #274's per-row
+		// monotonicity does not order the mutation against it: without this
+		// wait the update can land inside the snapshot millisecond, the
+		// mark-flushed guard (changed_at <= snapshot) then marks the row
+		// flushed, and both halves of the scenario collapse. Observed flaking
+		// in CI on PR #280 (actions run 29606517056) — #276.
+		waitClockPastMillis(snapshot)
 		update = UpdateEvent(wide, victim.RowID, map[string]any{
 			"title": "hot-00",
 			"count": float64(900000),

--- a/internal/e2e_harness/production/clock_guard_test.go
+++ b/internal/e2e_harness/production/clock_guard_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+
+package production
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWaitClockPastMillis pins the mechanism every clock-ordering guard in this
+// package leans on (#276): the helper must not return until the process clock
+// is STRICTLY past its anchor, and must not spin when the anchor is already
+// behind. It touches no cluster — SharedCluster starts lazily — so it runs in
+// milliseconds without docker.
+func TestWaitClockPastMillis(t *testing.T) {
+	t.Run("waits past a future anchor", func(t *testing.T) {
+		anchor := time.Now().UnixMilli() + 5
+		waitClockPastMillis(anchor)
+		if got := time.Now().UnixMilli(); got <= anchor {
+			t.Fatalf("returned at %d, want strictly past anchor %d", got, anchor)
+		}
+	})
+
+	t.Run("returns immediately for a past anchor", func(t *testing.T) {
+		start := time.Now()
+		waitClockPastMillis(time.Now().UnixMilli() - 10)
+		if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+			t.Fatalf("returned after %s, want an immediate return for a past anchor", elapsed)
+		}
+	})
+}

--- a/internal/e2e_harness/production/filter_lww_helpers_test.go
+++ b/internal/e2e_harness/production/filter_lww_helpers_test.go
@@ -68,9 +68,18 @@ func assertRowCount(ctx context.Context, t *testing.T, env *Env, name string, q 
 func waitClockPast(t *testing.T, evs ...*Event) {
 	t.Helper()
 	for _, ev := range evs {
-		for time.Now().UnixMilli() <= ev.ChangedAt {
-			time.Sleep(time.Millisecond)
-		}
+		waitClockPastMillis(ev.ChangedAt)
+	}
+}
+
+// waitClockPastMillis is waitClockPast against a bare millisecond anchor: a
+// flush snapshot (SelectBatchRowIDs' snapshot := time.Now().UnixMilli()) or any
+// other timestamp not carried by an Event. It takes no *testing.T so CDC hooks
+// can call it — a hook reports failure through the flush error, never through
+// t.* (#276).
+func waitClockPastMillis(ms int64) {
+	for time.Now().UnixMilli() <= ms {
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -78,6 +87,20 @@ func waitClockPast(t *testing.T, evs ...*Event) {
 // strictly after its predecessor's at millisecond resolution — otherwise an
 // LWW probe degrades into an undefined equal-ver_ts tie (#210 fixed the init
 // stamp; equal-timestamp DIVERGENT versions of a row remain unranked).
+//
+// Since #274 the write path guarantees this for pairs on the SAME row_id:
+// ltbase_updated_at = GREATEST($now, ltbase_updated_at + 1) with RETURNING
+// (postgres_persistent_repository_main_table.go), computeTombstoneStamp for
+// deletes and nextRowVersion for recreates each raise the successor above the
+// row's previous version even inside one millisecond, and change_log is stamped
+// from that same effective value. For same-row pairs this guard is therefore a
+// cheap redundant assertion, and no wait is needed before the later write.
+//
+// It stays load-bearing for pairs the write path cannot order, and those are the
+// only sites that need waitClockPast / waitClockPastMillis first (#276): pairs
+// on DIFFERENT row_ids (each write takes its own clock read, including two
+// writes inside one ApplyEvents batch), and comparisons against an independent
+// anchor such as a flush snapshot.
 func assertStrictlyNewer(t *testing.T, olds, news []*Event) {
 	t.Helper()
 	for i := range olds {

--- a/internal/e2e_harness/production/full_type_parquet_e2e_test.go
+++ b/internal/e2e_harness/production/full_type_parquet_e2e_test.go
@@ -342,7 +342,7 @@ func assertWideParquetValues(ctx context.Context, t *testing.T, env *Env, key, t
 
 // systemCols is one parquet row's scanned system columns.
 type systemCols struct {
-	schema                                                     sql.NullInt16
+	schema                                                      sql.NullInt16
 	changedAt, deletedAt, createdAt, updatedAt, ltbaseDeletedAt sql.NullInt64
 }
 

--- a/internal/e2e_harness/production/keyset_lww_e2e_test.go
+++ b/internal/e2e_harness/production/keyset_lww_e2e_test.go
@@ -119,11 +119,24 @@ func testKeysetCreatedAtCursorResurrection(ctx context.Context, t *testing.T, en
 	}
 	mustFlush(ctx, t, env) // delta #1: A@t1
 
+	// t1 < t2 < t3 < t4 must hold STRICTLY, and every leg here is CROSS-ROW,
+	// which #274's per-row monotonicity cannot order: b and c are different rows
+	// (applied one per ApplyEvents call precisely so each lands on its own
+	// millisecond — one batch would let two independent clock reads tie), and
+	// upd is compared against c. The cursor below is pinned to c.ChangedAt with
+	// B expected to qualify strictly below it, so a tie does not merely weaken
+	// the probe, it changes what it asserts (#276).
+	waitClockPast(t, a)
 	b := CreateEvent(wide, map[string]any{"title": "ca-b", "count": float64(400)})
-	c := CreateEvent(wide, map[string]any{"title": "ca-c", "count": float64(600)})
-	if err := env.ApplyEvents(ctx, b, c); err != nil {
-		t.Fatalf("apply creates b, c: %v", err)
+	if err := env.ApplyEvents(ctx, b); err != nil {
+		t.Fatalf("apply create b: %v", err)
 	}
+	waitClockPast(t, b)
+	c := CreateEvent(wide, map[string]any{"title": "ca-c", "count": float64(600)})
+	if err := env.ApplyEvents(ctx, c); err != nil {
+		t.Fatalf("apply create c: %v", err)
+	}
+	waitClockPast(t, c)
 	upd := UpdateEvent(wide, a.RowID, map[string]any{"count": float64(100)})
 	if err := env.ApplyEvents(ctx, upd); err != nil {
 		t.Fatalf("apply update: %v", err)

--- a/internal/e2e_harness/production/list_roundtrip_e2e_test.go
+++ b/internal/e2e_harness/production/list_roundtrip_e2e_test.go
@@ -129,9 +129,10 @@ func runListRoundTripSpec(ctx context.Context, t *testing.T, cluster *Cluster) {
 }
 
 // TestEmptyListRoundTrip pins the #204 empty-list contract across tiers: an
-// explicit `"tags": []` persists a single marker EAV row (array_indices '',
-// both value columns NULL), exports as an empty (non-NULL) parquet LIST, and
-// survives the federated read as the marker — distinguishable at every hop
+// explicit `"tags": []` persists a single marker EAV row (array_indices the
+// empty string, both value columns NULL), exports as an empty (non-NULL)
+// parquet LIST, and survives the federated read as the marker —
+// distinguishable at every hop
 // from an absent attribute. Under merge-update semantics `"tags": []` is the
 // only way to clear a list (omit preserves, null is rejected), so the clear
 // gesture must not be lossy.
@@ -224,8 +225,8 @@ func TestEmptyListRoundTrip(t *testing.T) {
 	}
 }
 
-// assertEmptyListMarker requires exactly one marker row: array_indices ''
-// with both value columns NULL.
+// assertEmptyListMarker requires exactly one marker row: array_indices the
+// empty string with both value columns NULL.
 func assertEmptyListMarker(t *testing.T, label string, rows []eavRow) {
 	t.Helper()
 	if len(rows) != 1 {

--- a/internal/sqlgen/duckdb_benchmark_list_test.go
+++ b/internal/sqlgen/duckdb_benchmark_list_test.go
@@ -23,7 +23,7 @@ func TestBenchmarkEAVJSONArrayScalarShapeUnchanged(t *testing.T) {
 // TestBenchmarkEAVJSONArrayListAttrPositionalIndices: if a benchmark shape
 // ever declares a list attribute, it must reconstruct positional
 // array_indices exactly like the production projection (#204) instead of the
-// hardcoded ''.
+// hardcoded empty string.
 func TestBenchmarkEAVJSONArrayListAttrPositionalIndices(t *testing.T) {
 	got := benchmarkEAVJSONArray(102, 102, "",
 		eavJSONAttr{id: 8, name: "exchange", type_: "text"},

--- a/internal/sqlgen/duckdb_benchmark_projection.go
+++ b/internal/sqlgen/duckdb_benchmark_projection.go
@@ -304,7 +304,8 @@ func benchmarkEAVJSONArray(schemaID, targetSchemaID int16, extra string, attrs .
 }
 
 // benchmarkScalarJSONObject renders the single json_object for one scalar
-// benchmark EAV attribute (array_indices '' — scalars carry no position).
+// benchmark EAV attribute (array_indices is the empty string — scalars carry
+// no position).
 func benchmarkScalarJSONObject(targetSchemaID int16, a eavJSONAttr) string {
 	valColumn := "value_text"
 	nullColumn := "value_numeric"

--- a/internal/sqlgen/duckdb_schema_projection_json.go
+++ b/internal/sqlgen/duckdb_schema_projection_json.go
@@ -64,7 +64,8 @@ func (sp *SchemaProjection) buildAttributesJSONExpr(schemaID int16, sortedAttrs 
 }
 
 // scalarEAVJSONObject renders the single CASE ... END object for one scalar
-// EAV attribute (array_indices is '' — scalars have no element position).
+// EAV attribute (array_indices is the empty string — scalars have no element
+// position).
 func (sp *SchemaProjection) scalarEAVJSONObject(schemaID int16, attr string) string {
 	unified := ParquetAttrColumn(attr)
 	valueText, valueNumeric := "NULL", "NULL"
@@ -87,8 +88,9 @@ func (sp *SchemaProjection) scalarEAVJSONObject(schemaID int16, attr string) str
 // element. The 1-based lambda index i becomes the 0-based array_indices, so
 // the parquet LIST position round-trips the original element index. An
 // explicit empty list ([] column, non-NULL) emits the marker object —
-// array_indices '' with both value columns NULL — which the transform layer
-// materializes back into an empty array; NULL (absent) emits nothing (#204).
+// array_indices the empty string with both value columns NULL — which the
+// transform layer materializes back into an empty array; NULL (absent) emits
+// nothing (#204).
 func (sp *SchemaProjection) listEAVJSONPart(schemaID int16, attr string) string {
 	unified := ParquetAttrColumn(attr)
 	itemsVT := sp.itemsTypes[attr]


### PR DESCRIPTION
Closes #276. Refs #204, #210, #274, #275, #280, #290; follow-up #379.

Design, plan, and the mid-execution gofmt finding are on the issue: [design](https://github.com/Lychee-Technology/forma/issues/276#issuecomment-5227915070), [plan](https://github.com/Lychee-Technology/forma/issues/276#issuecomment-5227947663), [finding](https://github.com/Lychee-Technology/forma/issues/276#issuecomment-5228378227).

## Why this is smaller than the filed checklist

The issue was filed 2026-07-17. `#274` has landed since and made row versions **strictly monotonic per row in the write path** — `ltbase_updated_at = GREATEST($now, ltbase_updated_at + 1)` with `RETURNING` (`postgres_persistent_repository_main_table.go:133`), `computeTombstoneStamp` for deletes, `nextRowVersion` for recreates, and `change_log.changed_at` stamped from that same effective value. A successor version of the **same** `row_id` therefore cannot tie its predecessor regardless of clock resolution.

Auditing the eight listed `assertStrictlyNewer` call sites against that (line numbers had drifted):

| Site | Guard compares | Disposition |
| --- | --- | --- |
| `filter_lww_e2e_test.go:59,107` | same row, v1 → v2 | no change — `#274` guarantees it |
| `filter_lww_matrix_e2e_test.go:93` | same row, v1 → v2 | no change |
| `filter_lww_tombstone_e2e_test.go:32` | same rows, live → tombstone | no change (`computeTombstoneStamp`) |
| `filter_lww_tombstone_e2e_test.go:86` | same row, v1 → v2 | no change |
| `keyset_lww_e2e_test.go:75,222` | same row, v1 → v2 | no change |
| `keyset_lww_e2e_test.go:132` | `[a,b,c]` vs `[b,c,upd]` — **cross-row**, and `b`/`c` shared one `ApplyEvents` batch | **fixed** |
| `sort_stability_e2e_test.go:110` (issue omitted it) | same rows, reverse-order updates | no change; kept in the regression set as evidence |

Rather than edit seven sites the write path already covers, the invariant is now written into `assertStrictlyNewer`'s doc comment: which pairs are ordered by construction, and which two shapes (different `row_id`s; comparison against an independent anchor) still need an explicit wait.

Item 3 of the checklist was already fixed by `#274`'s review commit `c04a5b1`.

## What changed

**1. `keyset_lww_e2e_test.go` — the one real race.** `testKeysetCreatedAtCursorResurrection` needs `t1 < t2 < t3 < t4` across four writes on three rows, and its cursor boundary is literally `c.ChangedAt` with `B` expected to qualify strictly below it. `b` and `c` were created in one `ApplyEvents` call, where each `Create` takes its own clock read. They are now applied one per call with `waitClockPast` between, so a tie cannot silently change what the probe asserts.

**2. `cdc_concurrent_flush_e2e_test.go` — the observed CI flake.** `testUpdateBeforeExport`'s hook mutates a row and then asserts `update.ChangedAt > hookSnapshot`, where the snapshot is the flush's own independent clock read — nothing in `#274` orders a write against it. The hook now waits past the snapshot first. New `waitClockPastMillis(ms int64)` takes no `*testing.T` because a CDC hook reports failure through the flush error.

The `runPausedFlush` siblings (`:257`, `:310`, `:360`) are deliberately untouched: their pause point is the first `CopyObject`, i.e. after a full DuckDB export plus S3 tmp `PUT`, and their guard legs are same-row.

**3. Both `Export*ToTmp` entry points** now wrap their plan errors (`export snapshot to tmp for schema %d` / `export base file to tmp for schema %d`). The issue named only the delta side; wrapping one caller while leaving its byte-identical twin bare would rebuild the asymmetry this issue exists to clear. The seven remaining bare returns in `internal/cdc` (`flusher.go:65,71,91,117`, `flush_batch.go:212`, `init.go:318`, `runner.go:166`) are #379; repo-wide the count is 92, which needs its own decision.

**4. gofmt gate — and the item was not cosmetic.** The issue called the drift "comment-alignment"; that holds for only 2 of the 7 files. For the other 5, gofmt's doc-comment printer rewrites `''` into a typographic quote, corrupting documentation about SQL literals: the doubled-quote DSN forms `redact_test.go` exists to pin (#290) and the empty-string `array_indices` marker (#204). Those files could never have been gofmt-clean without editing prose — which is why the drift survived. The nine sites now keep the literal in a doc-comment code block (verified preserved) or name it in prose, so the tree is a genuine gofmt fixed point.

The gate is `make fmt-check` (`gofmt -l`), **not** golangci's `gofmt` linter, because that linter is build-tag scoped: it never loads `//go:build e2e` files, where 3 of the 7 drifted files lived. Pulling them in with `--build-tags=e2e` surfaces 6 unrelated pre-existing findings (`federated/cdc_flush_test.go` errcheck ×3, `suite_test.go` unused ×2, `consistency_test.go` staticcheck SA4010 ×1). `gofmt -l` is purely syntactic and therefore tag-agnostic. CI runs the same make target; the v1.64.8 pin and local/CI parity are untouched.

**5. `AGENTS.md`** — the Specs and Design Docs rule now covers every non-code artifact of an issue (drafts, investigation and verification notes, mid-execution rulings), posted when produced rather than after approval.

## Verification

- `make fmt-check && make lint && make test` — all pass.
- `go test -tags=e2e -run 'TestFilterLWW|TestKeysetLWW|TestConcurrentFlushSnapshot|TestSortStability|TestWaitClockPastMillis' ./internal/e2e_harness/production` — 19/19 pass, including the untouched suites that the audit claims need no wait.
- `make test-e2e-production` — 125 pass, 0 fail.

**Mutation verification (item 2).** A green run proves nothing about a race, so the guard was driven red on purpose: with the hook's anchor moved to `snapshot + 50` and the wait removed, `TestConcurrentFlushSnapshot/UpdateBeforeExport` fails at `cdc_concurrent_flush_e2e_test.go:207` — `concurrent update changed_at 1786226477115 must be > snapshot 1786226477164`, 49ms behind. Restoring the wait alone, same anchor, turns it green. Both probe lines were then reverted.

**Measurement (item 1).** Instrumenting the chain on the *unfixed* code across 5 runs gave `b→c` gaps of 2–3ms and `c→upd` gaps of 3–4ms — the ordering held entirely on per-event transaction latency, not by construction. No zero gap reproduced locally, and the post-fix gaps are unchanged (2–4ms) because the waits are inert whenever the clock has already advanced. The value of the change is removing the dependence on that margin, not widening it; under a loaded CI runner the margin is what closes.

**Helper mechanism** is pinned directly by `TestWaitClockPastMillis` (`clock_guard_test.go`): returns only once the clock is strictly past the anchor, and returns immediately for a past one. It starts no container (the shared cluster is lazy) and runs in ~10ms.
