### PR TITLE
fix: #355 bind batch attr-value operands int64-first and unify the numeric-family parse rule

### DIFF
--- a/internal/e2e_harness/production/eav_numeric_batch_lookup_e2e_test.go
+++ b/internal/e2e_harness/production/eav_numeric_batch_lookup_e2e_test.go
@@ -1,0 +1,88 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma/internal"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// TestBatchAttrValueLookupBindsEAVNumericExactly is the real-Postgres half of
+// the #355 verification. It calls the batch anchor directly rather than through
+// relation enrichment for a reason recorded in the design: fetchParents derives
+// its operands from stored child records, which have already been through the
+// write path's float64 hop, so no non-float64-exact operand can ever reach the
+// anchor that way and the contract difference is invisible end to end.
+//
+// The contract mirrors TestEAVBigintFilterBoundaryBothDialects: the write path
+// rounded 2^53+1 down to 2^53 (#205 ceiling), so an exact operand of 2^53+1
+// must NOT find the row by colliding with that same rounding error, while the
+// value actually stored must stay addressable. The mixed integral/fractional
+// probe additionally proves what pgxmock structurally cannot: that pgx encodes
+// a per-element-typed []any into numeric[].
+func TestBatchAttrValueLookupBindsEAVNumericExactly(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	// total (attr 15) is EAV-only bigint; ratio (attr 16) is EAV-only numeric.
+	aboveCeiling := CreateEvent(wide, map[string]any{
+		"title": "batch-2p53p1", "total": int64(1)<<53 + 1, "ratio": 2.5,
+	})
+	small := CreateEvent(wide, map[string]any{
+		"title": "batch-small", "total": int64(7), "ratio": float64(8),
+	})
+	mustApplyEvents(ctx, t, env, "batch anchor seed", aboveCeiling, small)
+
+	repo := internal.NewDBPersistentRecordRepository(env.Pool, env.Metadata)
+
+	lookup := func(t *testing.T, attr string, values []string) []*model.PersistentRecord {
+		t.Helper()
+		page, err := repo.QueryPersistentRecordsByAttrValues(
+			ctx, env.Tables, wide.ID, attr, values, len(values))
+		if err != nil {
+			t.Fatalf("batch lookup on %s%v: %v", attr, values, err)
+		}
+		return page.Records
+	}
+
+	t.Run("exact_operand_above_ceiling_matches_nothing", func(t *testing.T) {
+		// 9007199254740993 was never stored — the write rounded it to 2^53.
+		// Pre-fix, ParseFloat rounded the operand the same way and "found" the
+		// row anyway. No groups means: the result must be empty.
+		assertRowIDSet(t, "total=2^53+1",
+			lookup(t, "total", []string{"9007199254740993"}))
+	})
+
+	t.Run("stored_rounded_value_stays_addressable", func(t *testing.T) {
+		assertRowIDSet(t, "total=2^53",
+			lookup(t, "total", []string{"9007199254740992"}),
+			[]uuid.UUID{aboveCeiling.RowID})
+	})
+
+	t.Run("exponent_spelling_addresses_the_same_row", func(t *testing.T) {
+		assertRowIDSet(t, "total=9.007199254740992e15",
+			lookup(t, "total", []string{"9.007199254740992e15"}),
+			[]uuid.UUID{aboveCeiling.RowID})
+	})
+
+	t.Run("multi_operand_integral_set", func(t *testing.T) {
+		assertRowIDSet(t, "total IN (2^53, 7)",
+			lookup(t, "total", []string{"9007199254740992", "7"}),
+			[]uuid.UUID{aboveCeiling.RowID, small.RowID})
+	})
+
+	t.Run("mixed_integral_and_fractional_operands_encode", func(t *testing.T) {
+		// The []any carries an int64 and a float64 in one array. If pgx cannot
+		// encode that into numeric[], this is where it fails — loudly, with an
+		// encode error rather than a wrong row set.
+		assertRowIDSet(t, "ratio IN (2.5, 8)",
+			lookup(t, "ratio", []string{"2.5", "8"}),
+			[]uuid.UUID{aboveCeiling.RowID, small.RowID})
+	})
+}

--- a/internal/postgres_persistent_repository_by_attr_values.go
+++ b/internal/postgres_persistent_repository_by_attr_values.go
@@ -3,10 +3,10 @@ package internal
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/numutil"
 )
 
 // QueryPersistentRecordsByAttrValues fetches full records whose attribute
@@ -85,17 +85,29 @@ func buildAttrValuesAnchor(attr string, meta forma.AttributeMetadata, values []s
 
 	switch meta.ValueType {
 	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
-		numeric := make([]float64, 0, len(values))
+		// Per-element typing, mirroring ConvertPgMainValue and
+		// parseDuckDBRawParam (#281, #357): one literal must mean one Go value
+		// on every binder, or the same operand can match under a filter and
+		// miss under relation enrichment (#355). Integral literals in any
+		// accepted spelling bind as exact int64; genuinely fractional ones stay
+		// float64, which is what the write path's own float64 hop stored.
+		// Collapsing the slice to a single element type is not equivalent:
+		// []float64 loses exactness above 2^53, and rendering exact decimals
+		// into a ::numeric[] cast would stop matching stored fractional values.
+		operands := make([]any, 0, len(values))
 		for _, v := range values {
-			parsed, err := strconv.ParseFloat(v, 64)
-			if err != nil {
+			switch parsed := numutil.TryParseNumber(v).(type) {
+			case int64:
+				operands = append(operands, parsed)
+			case float64:
+				operands = append(operands, parsed)
+			default:
 				return "", nil, false, fmt.Errorf(
-					"invalid value %q for %s attribute %q: not parseable as float64 (expected a decimal value_numeric operand): %w",
-					v, meta.ValueType, attr, err)
+					"invalid value %q for %s attribute %q: not a numeric-family literal (expected a decimal value_numeric operand)",
+					v, meta.ValueType, attr)
 			}
-			numeric = append(numeric, parsed)
 		}
-		return "t.attr_id = $2 AND t.value_numeric = ANY($3)", []any{meta.AttributeID, numeric}, false, nil
+		return "t.attr_id = $2 AND t.value_numeric = ANY($3)", []any{meta.AttributeID, operands}, false, nil
 	default:
 		return "", nil, false, fmt.Errorf(
 			"unsupported value_type %s for attribute %q: no batch value column (expected text, uuid, or a numeric family type)",

--- a/internal/postgres_persistent_repository_by_attr_values_test.go
+++ b/internal/postgres_persistent_repository_by_attr_values_test.go
@@ -31,6 +31,14 @@ func newByAttrValuesTestCache(t *testing.T) *schemameta.MetadataCache {
 			AttributeID: 31,
 			ValueType:   forma.ValueTypeInteger,
 		},
+		"total": {
+			AttributeID: 32,
+			ValueType:   forma.ValueTypeBigInt,
+		},
+		"ratio": {
+			AttributeID: 33,
+			ValueType:   forma.ValueTypeNumeric,
+		},
 	}))
 	return cache
 }
@@ -126,7 +134,7 @@ func TestQueryPersistentRecordsByAttrValuesNumericValues(t *testing.T) {
 	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(1))
 
 	mock.ExpectQuery(`t\.attr_id = \$2 AND t\.value_numeric = ANY\(\$3\)`).
-		WithArgs(int16(1), int16(31), []float64{7, 9}, 2, 0).
+		WithArgs(int16(1), int16(31), []any{int64(7), int64(9)}, 2, 0).
 		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
 
 	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "rank", []string{"7", "9"}, 2)
@@ -150,6 +158,88 @@ func TestQueryPersistentRecordsByAttrValuesUnknownAttr(t *testing.T) {
 	_, err = repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "missing", []string{"x"}, 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryPersistentRecordsByAttrValuesBindsIntegralOperandsExactly pins the
+// #355 fix: the batch anchor must reach the same verdict as the predicate
+// binders (#281, #357) on the same literal. 2^53+1 is not representable as
+// float64 — strconv.ParseFloat rounds it down to 2^53, so the pre-fix bind
+// silently addressed a *different* value than the caller named. Both accepted
+// spellings of an integral literal must arrive as exact int64.
+func TestQueryPersistentRecordsByAttrValuesBindsIntegralOperandsExactly(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	rowID := uuid.MustParse("55555555-5555-5555-5555-555555555555")
+	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(1))
+
+	mock.ExpectQuery(`t\.attr_id = \$2 AND t\.value_numeric = ANY\(\$3\)`).
+		WithArgs(int16(1), int16(32),
+			[]any{int64(9007199254740993), int64(9007199254740992)}, 2, 0).
+		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
+
+	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "total",
+		[]string{"9007199254740993", "9.007199254740992e15"}, 2)
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryPersistentRecordsByAttrValuesKeepsFractionalOperandsFloat64 pins the
+// other half of the contract. A genuinely fractional operand must stay float64:
+// EAV storage holds what the write path's float64 hop produced, so binding an
+// exact decimal instead would stop matching the value that was actually stored.
+// A mixed list must be typed per element, not collapsed to one array type.
+func TestQueryPersistentRecordsByAttrValuesKeepsFractionalOperandsFloat64(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	rowID := uuid.MustParse("66666666-6666-6666-6666-666666666666")
+	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(1))
+
+	mock.ExpectQuery(`t\.attr_id = \$2 AND t\.value_numeric = ANY\(\$3\)`).
+		WithArgs(int16(1), int16(33), []any{9.5, int64(8)}, 2, 0).
+		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
+
+	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "ratio",
+		[]string{"9.5", "8"}, 2)
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryPersistentRecordsByAttrValuesRejectsNonNumericOperand asserts the
+// error names the numeric family and the offending value, and no longer claims
+// "float64" — the parse is no longer a strconv.ParseFloat call.
+func TestQueryPersistentRecordsByAttrValuesRejectsNonNumericOperand(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	_, err = repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "total",
+		[]string{"not-a-number"}, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `invalid value "not-a-number"`)
+	require.Contains(t, err.Error(), "bigint")
+	require.NotContains(t, err.Error(), "float64")
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -134,10 +134,12 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		// it miss on every tier alike — tier parity preserved.
 		//
 		// integer/smallint joined this arm in #355 purely to end the binder
-		// divergence: it changes no query result. Below 2^31, int64 and float64
-		// denote the same number, so comparisons are identical. Above it, both
-		// parameter types raise the same conversion error from CAST(? AS
-		// INTEGER), so queries fail identically either way. On the column side
+		// divergence: it changes no query result. Below the bound of the arm's
+		// own cast — 2^31 for CAST(? AS INTEGER), 2^15 for CAST(? AS SMALLINT) —
+		// int64 and float64 denote the same number, so comparisons are identical.
+		// Above it, both parameter types raise the same class of conversion error
+		// from that cast (DuckDB words the int64 and the float64 case
+		// differently), so queries fail either way. On the column side
 		// (independent of the parameter), an EAV-only integer attribute's stored
 		// value outside the 32-bit range is projected to NULL on every DuckDB tier
 		// via TRY_CAST; that is a separate defect tracked in #384.

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -121,16 +121,26 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		}
 		return valStr, nil
 
-	case forma.ValueTypeNumeric, forma.ValueTypeBigInt:
+	case forma.ValueTypeNumeric, forma.ValueTypeBigInt,
+		forma.ValueTypeSmallInt, forma.ValueTypeInteger:
 		// Integral literals in ANY accepted spelling — bare, decimal or
 		// exponent — bind as exact int64 (#281, #357) via the same
-		// TryParseNumber the two Postgres predicate paths use, so all three
-		// emitters agree on the value. ToDuckDBParam renders int64 via %d, so
-		// a bigint predicate above 2^53 — legal column state since #205 —
+		// TryParseNumber the two Postgres predicate paths and the batch
+		// attr-value anchor use (#355), so every emitter agrees on the value.
+		// A bigint predicate above 2^53 — legal column state since #205 —
 		// compares exactly instead of riding float64 + %.15g. Fractional
 		// literals keep float64, the numeric family's storage contract.
 		// EAV-only bigints round at write (2^53 ceiling), so exact binds above
 		// it miss on every tier alike — tier parity preserved.
+		//
+		// integer/smallint joined this arm in #355 purely to end the binder
+		// divergence: it changes no query result. Below 2^31, int64 and float64
+		// denote the same number, so comparisons are identical. Above it, both
+		// parameter types raise the same conversion error from CAST(? AS
+		// INTEGER), so queries fail identically either way. On the column side
+		// (independent of the parameter), an EAV-only integer attribute's stored
+		// value outside the 32-bit range is projected to NULL on every DuckDB tier
+		// via TRY_CAST; that is a separate defect tracked in #384.
 		switch v := numutil.TryParseNumber(valStr).(type) {
 		case int64:
 			return v, nil
@@ -139,14 +149,6 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		default:
 			return nil, forma.InvalidInputf("invalid numeric literal for %s: %s", attr, valStr)
 		}
-
-	case forma.ValueTypeSmallInt, forma.ValueTypeInteger:
-		// Stays float64: INTEGER/SMALLINT ranges end at 2^31/2^15, float64 is
-		// exact through 2^53, and ToDuckDBParam's integer arm takes float64.
-		if f, e := strconv.ParseFloat(valStr, 64); e == nil {
-			return f, nil
-		}
-		return nil, forma.InvalidInputf("invalid numeric literal for %s: %s", attr, valStr)
 
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
 		// Epoch-ms int64: date columns in the federated CTEs are BIGINT (#200).

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -68,9 +68,13 @@ func CastExpression(columnOrExpr string, v forma.ValueType) string {
 
 // ToDuckDBParam converts a Go value to the form expected by DuckDB drivers for the given value type.
 // Examples:
+// Three binders depend on this contract, so state each numeric arm exactly:
 //   - uuid.UUID -> string
 //   - time.Time -> int64 epoch-ms (BIGINT)
-//   - numeric types -> float64
+//   - smallint/integer -> an int64 passes through unchanged (#355); every other
+//     accepted input widens to float64
+//   - bigint/numeric -> an exact-precision decimal string, never a number
+//     (see toDuckDBDecimalParam)
 func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 	if value == nil {
 		return nil, nil

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -121,6 +121,14 @@ func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 			return nil, fmt.Errorf("cannot convert %T to BOOLEAN param", value)
 		}
 	case forma.ValueTypeSmallInt, forma.ValueTypeInteger:
+		// An exact int64 from parseDuckDBRawParam binds through unchanged
+		// (#355). Without this the float64 funnel below would undo the
+		// int64-first parse one call later, at predicate_normalizer.go's
+		// ToDuckDBParam hop. Everything else keeps the funnel: INTEGER and
+		// SMALLINT ranges end at 2^31/2^15 and float64 is exact well past both.
+		if exact, ok := value.(int64); ok {
+			return exact, nil
+		}
 		numeric, isNil, err := toOptionalFloat64Param(value)
 		if err != nil {
 			return nil, fmt.Errorf("cannot convert %T to numeric param", value)

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -66,15 +66,16 @@ func CastExpression(columnOrExpr string, v forma.ValueType) string {
 	return fmt.Sprintf("CAST(%s AS %s)", columnOrExpr, MapValueTypeToDuckDBType(v))
 }
 
-// ToDuckDBParam converts a Go value to the form expected by DuckDB drivers for the given value type.
-// Examples:
-// Three binders depend on this contract, so state each numeric arm exactly:
+// ToDuckDBParam converts a Go value to the form expected by DuckDB drivers for
+// the given value type. The predicate normalizer binds this result, not
+// parseDuckDBRawParam's, so each numeric arm's output type is load-bearing:
 //   - uuid.UUID -> string
 //   - time.Time -> int64 epoch-ms (BIGINT)
 //   - smallint/integer -> an int64 passes through unchanged (#355); every other
 //     accepted input widens to float64
-//   - bigint/numeric -> an exact-precision decimal string, never a number
-//     (see toDuckDBDecimalParam)
+//   - bigint/numeric -> a decimal string, never a number (see
+//     toDuckDBDecimalParam): exact for int/int64/string inputs, while a float64
+//     input is rendered by decimalString's %.15g
 func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 	if value == nil {
 		return nil, nil

--- a/internal/sqlgen/numeric_bind_parity_test.go
+++ b/internal/sqlgen/numeric_bind_parity_test.go
@@ -7,16 +7,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNumericBinderTypeParity pins the invariant #355 establishes: for the
-// whole numeric family, one literal yields one Go type on every binder. Before
-// this, the integer/smallint arm of parseDuckDBRawParam kept float64 while
-// ConvertPgMainValue went int64-first, so the two Postgres/DuckDB legs of the
-// same predicate carried different values for the same input string.
+// TestNumericBinderTypeParity pins the invariant #355 establishes on the two
+// binders this table exercises — ConvertPgMainValue and parseDuckDBRawParam:
+// across the whole numeric family, one literal parses to one Go type on both.
+// The package's third numeric binder, parsePgEavValue, is pinned by the
+// characterization matrix's PgArgs expectations in
+// predicate_characterization_test.go. The claim is about the parse rule only:
+// for bigint/numeric the value ultimately bound to DuckDB is an exact decimal
+// string, produced downstream by ToDuckDBParam's toDuckDBDecimalParam.
 //
-// This changes no query result. Below 2^31, int64 and float64 denote the same
-// number so comparisons are identical. Above it, both parameter types raise the
-// same conversion error from CAST(? AS INTEGER), so queries fail identically
-// either way. What is fixed here is the divergence itself.
+// Before this, the integer/smallint arm of parseDuckDBRawParam kept float64
+// while ConvertPgMainValue went int64-first, so the two Postgres/DuckDB legs of
+// the same predicate carried different values for the same input string.
+//
+// This changes no query result. Below the bound of the arm's own cast — 2^31
+// for CAST(? AS INTEGER), 2^15 for CAST(? AS SMALLINT) — int64 and float64
+// denote the same number so comparisons are identical. Above it, both parameter
+// types raise the same class of conversion error from that cast (DuckDB words
+// the int64 and the float64 case differently), so queries fail either way. What
+// is fixed here is the divergence itself.
 func TestNumericBinderTypeParity(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -55,24 +64,14 @@ func TestNumericBinderTypeParity(t *testing.T) {
 // so an exact int64 was converted straight back to float64 one call later
 // (predicate_normalizer.go binds the result of ToDuckDBParam, not of
 // parseDuckDBRawParam). The bigint/numeric arm never hit this because it exits
-// through toDuckDBDecimalParam instead.
+// through toDuckDBDecimalParam instead. The passthrough is deliberately narrow —
+// int, int16 and int32 still take the float64 funnel, which the pre-existing
+// TestToDuckDBParam_Numeric_FromInt, _FromInt16 and _FromInt32 in
+// duckdb_type_mapper_test.go pin.
 func TestToDuckDBParamIntegerArmPassesInt64Through(t *testing.T) {
 	for _, vt := range []forma.ValueType{forma.ValueTypeInteger, forma.ValueTypeSmallInt} {
 		got, err := ToDuckDBParam(int64(9007199254740993), vt)
 		require.NoError(t, err)
 		require.Equal(t, int64(9007199254740993), got, "value type %s", vt)
 	}
-}
-
-// TestToDuckDBParamIntegerArmStillWidensOtherIntegerTypes pins that the
-// passthrough is narrow: int/int16/int32 and float64 inputs keep the existing
-// float64 conversion, which callers other than the predicate path rely on.
-func TestToDuckDBParamIntegerArmStillWidensOtherIntegerTypes(t *testing.T) {
-	got, err := ToDuckDBParam(int32(42), forma.ValueTypeInteger)
-	require.NoError(t, err)
-	require.Equal(t, float64(42), got)
-
-	got, err = ToDuckDBParam(int16(7), forma.ValueTypeSmallInt)
-	require.NoError(t, err)
-	require.Equal(t, float64(7), got)
 }

--- a/internal/sqlgen/numeric_bind_parity_test.go
+++ b/internal/sqlgen/numeric_bind_parity_test.go
@@ -1,0 +1,78 @@
+package sqlgen
+
+import (
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNumericBinderTypeParity pins the invariant #355 establishes: for the
+// whole numeric family, one literal yields one Go type on every binder. Before
+// this, the integer/smallint arm of parseDuckDBRawParam kept float64 while
+// ConvertPgMainValue went int64-first, so the two Postgres/DuckDB legs of the
+// same predicate carried different values for the same input string.
+//
+// This changes no query result. Below 2^31, int64 and float64 denote the same
+// number so comparisons are identical. Above it, both parameter types raise the
+// same conversion error from CAST(? AS INTEGER), so queries fail identically
+// either way. What is fixed here is the divergence itself.
+func TestNumericBinderTypeParity(t *testing.T) {
+	cases := []struct {
+		name      string
+		valueType forma.ValueType
+		literal   string
+		want      any
+	}{
+		{"bigint_bare_integral", forma.ValueTypeBigInt, "9007199254740993", int64(9007199254740993)},
+		{"integer_bare_integral", forma.ValueTypeInteger, "42", int64(42)},
+		{"integer_decimal_spelling", forma.ValueTypeInteger, "42.0", int64(42)},
+		{"integer_exponent_spelling", forma.ValueTypeInteger, "4.2e1", int64(42)},
+		{"smallint_bare_integral", forma.ValueTypeSmallInt, "7", int64(7)},
+		{"smallint_negative_integral", forma.ValueTypeSmallInt, "-7", int64(-7)},
+		{"numeric_fraction_stays_float", forma.ValueTypeNumeric, "2.5", 2.5},
+		{"integer_fraction_stays_float", forma.ValueTypeInteger, "2.5", 2.5},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := forma.AttributeMetadata{ValueType: tc.valueType}
+
+			pgValue, err := ConvertPgMainValue(tc.literal, "probe", meta)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, pgValue, "ConvertPgMainValue")
+
+			duckRaw, err := parseDuckDBRawParam(tc.literal, "probe", tc.valueType)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, duckRaw, "parseDuckDBRawParam")
+		})
+	}
+}
+
+// TestToDuckDBParamIntegerArmPassesInt64Through guards the hop that would
+// otherwise make the parseDuckDBRawParam change a no-op: ToDuckDBParam's
+// smallint/integer arm funnelled everything through toOptionalFloat64Param,
+// so an exact int64 was converted straight back to float64 one call later
+// (predicate_normalizer.go binds the result of ToDuckDBParam, not of
+// parseDuckDBRawParam). The bigint/numeric arm never hit this because it exits
+// through toDuckDBDecimalParam instead.
+func TestToDuckDBParamIntegerArmPassesInt64Through(t *testing.T) {
+	for _, vt := range []forma.ValueType{forma.ValueTypeInteger, forma.ValueTypeSmallInt} {
+		got, err := ToDuckDBParam(int64(9007199254740993), vt)
+		require.NoError(t, err)
+		require.Equal(t, int64(9007199254740993), got, "value type %s", vt)
+	}
+}
+
+// TestToDuckDBParamIntegerArmStillWidensOtherIntegerTypes pins that the
+// passthrough is narrow: int/int16/int32 and float64 inputs keep the existing
+// float64 conversion, which callers other than the predicate path rely on.
+func TestToDuckDBParamIntegerArmStillWidensOtherIntegerTypes(t *testing.T) {
+	got, err := ToDuckDBParam(int32(42), forma.ValueTypeInteger)
+	require.NoError(t, err)
+	require.Equal(t, float64(42), got)
+
+	got, err = ToDuckDBParam(int16(7), forma.ValueTypeSmallInt)
+	require.NoError(t, err)
+	require.Equal(t, float64(7), got)
+}

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -119,18 +119,18 @@ func buildCharTextCases() []charCase {
 }
 
 // buildCharNumericBoolCases covers the numeric and boolean storage classes, including
-// the >2^53 precision split between the exact int64 pg binds and the duck INTEGER
-// arm's deliberate float64 (#281) and the bool-int / bool-text / unbound-bool
-// encodings. The bigint storage class lives in predicate_characterization_bigint_test.go.
+// the >2^31 range limit test where all three emitters now bind integer/smallint as int64
+// (#355), and the bool-int / bool-text / unbound-bool encodings. The bigint storage class
+// lives in predicate_characterization_bigint_test.go.
 func buildCharNumericBoolCases() []charCase {
 	return []charCase{
 		{
-			name: "integer gt: main/eav int64, duck float64",
+			name: "integer gt: main/eav/duck all int64",
 			cond: charKv("age", "gt:30"),
 			want: DualClauses{
 				PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(30)},
 				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), int64(30)},
-				DuckClause: "age > CAST(? AS INTEGER)", DuckArgs: []any{float64(30)},
+				DuckClause: "age > CAST(? AS INTEGER)", DuckArgs: []any{int64(30)},
 			},
 			span: 3,
 		},
@@ -145,12 +145,12 @@ func buildCharNumericBoolCases() []charCase {
 			span: 2,
 		},
 		{
-			name: "integer above 2^53: main/eav exact int64, duck float64 by design (INTEGER caps at 2^31)",
+			name: "integer above 2^31: main/eav/duck all int64 (CAST raises conversion error identically on both types)",
 			cond: charKv("age", "equals:9007199254740993"),
 			want: DualClauses{
 				PgMainClause: "m.integer_01 = ?", PgMainArgs: []any{int64(9007199254740993)},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), int64(9007199254740993)},
-				DuckClause: "age = CAST(? AS INTEGER)", DuckArgs: []any{float64(9007199254740992)},
+				DuckClause: "age = CAST(? AS INTEGER)", DuckArgs: []any{int64(9007199254740993)},
 			},
 			span: 3,
 		},
@@ -250,7 +250,7 @@ func buildCharCompositeCases() []charCase {
 					charEavClause("$6", "value_text", "=", "$7") + "))))",
 				PgArgs:     []any{int16(1), "Alice", int16(2), int64(18), int16(4), "x"},
 				DuckClause: "(username = ?) AND ((age > CAST(? AS INTEGER)) OR (tag = ?))",
-				DuckArgs:   []any{"Alice", float64(18), "x"},
+				DuckArgs:   []any{"Alice", int64(18), "x"},
 			},
 			span: 7,
 		},
@@ -263,7 +263,7 @@ func buildCharCompositeCases() []charCase {
 					charEavClause("$5", "value_numeric", ">", "$6") + "))",
 				PgArgs:     []any{int16(1), "A", int16(2), int64(5)},
 				DuckClause: "(username = ?) OR (age > CAST(? AS INTEGER))",
-				DuckArgs:   []any{"A", float64(5)},
+				DuckArgs:   []any{"A", int64(5)},
 			},
 			span: 6,
 		},
@@ -276,7 +276,7 @@ func buildCharCompositeCases() []charCase {
 					charEavClause("$5", "value_numeric", "<", "$6") + "))",
 				PgArgs:     []any{int16(2), int64(10), int16(2), int64(90)},
 				DuckClause: "(age > CAST(? AS INTEGER)) AND (age < CAST(? AS INTEGER))",
-				DuckArgs:   []any{float64(10), float64(90)},
+				DuckArgs:   []any{int64(10), int64(90)},
 			},
 			span: 6,
 		},


### PR DESCRIPTION
Closes #355.

Approved design: https://github.com/Lychee-Technology/forma/issues/355#issuecomment-5229859768 · Implementation plan: https://github.com/Lychee-Technology/forma/issues/355#issuecomment-5229990260

## What this fixes

`buildAttrValuesAnchor` — the builder behind the batch `value_numeric = ANY($n)` lookup that relation enrichment uses — parsed every numeric operand with `strconv.ParseFloat` and bound `[]float64`. Since #281/#357 the predicate binders (`ConvertPgMainValue`, `parsePgEavValue`, `parseDuckDBRawParam`) go int64-first, and that contract is pinned by e2e (`TestEAVBigintFilterBoundaryBothDialects`): an operand the write path rounded away must **not** find a row by colliding with the same rounding error, while the value actually stored must stay addressable.

This anchor was the only numeric binder that disagreed. Same attribute, same operand: a filter said "no match", relation enrichment said "match".

## Audit — the issue's scope changed

Three of the filed issue's premises did not survive checking against `main`:

1. **The numeric arm is reachable only for EAV-only attributes, through one production caller.** `QueryPersistentRecordsByAttrValues` is called only by `entityRelationService.fetchParents`, and the anchor's first arm rejects any non-text column binding, so a column-bound bigint never reaches the numeric arm.
2. **"This may end up document-only" no longer held.** That hedge predated #357. Once the predicate path pinned the opposite contract, leaving this binder alone meant shipping a documented fork.
3. **The filed "latent edge" is real but the bind is not the load-bearing part.** For an EAV-only integer attribute the divergence starts at **2^31**, not 2^53, and no parameter type affects it — filed separately as #384.

## The three changes

**1. `buildAttrValuesAnchor` binds per element** (`dfa2243`). `numutil.TryParseNumber` per operand: integral literals in any accepted spelling → exact `int64`, genuine fractions → `float64`, bound as `[]any`. Per-element typing is the point — parity with `ConvertPgMainValue` is guaranteed *by construction* only when the same input string yields the same Go type on both paths. Two tempting alternatives were rejected in the design: collapsing to one array type loses exactness for the integral members of a mixed set, and rendering exact decimals into a `::numeric[]` cast is a net regression, because a fractional operand would become an exact `NUMERIC` and stop matching the float64 value the write path stored. The error message no longer claims "not parseable as float64" and names the numeric family instead; it stays a plain read-path error.

**2. A real-Postgres probe** (`d2ba313`). `pgxmock` cannot see pgx's wire encoding, so the unit tests cannot prove a per-element-typed `[]any` reaches Postgres as `numeric[]`. The probe calls the repository directly against the harness cluster and asserts the same contract the predicate path pins. **Empirical result: pgx encodes the mixed `int64`/`float64` slice into `numeric[]` with no error**, so the design's documented fallback was not needed.

**3. Integer/smallint join the numeric family's parse rule** (`63faf4c`). `parseDuckDBRawParam`'s integer/smallint arm merges into its numeric/bigint sibling, **and** `ToDuckDBParam` gains a matching `int64` passthrough — without the second edit the first is a no-op, because `toOptionalFloat64Param` converts the exact `int64` straight back to `float64` one call later at the hop that actually binds. The bigint/numeric arm never hit this because it exits through `toDuckDBDecimalParam`.

**Change 3 alters no query result.** It removes a divergence, nothing more. Below the arm's own cast bound (2^31 for `CAST(? AS INTEGER)`, 2^15 for `CAST(? AS SMALLINT)`) `int64` and `float64` denote the same number; above it both parameter types raise the same class of conversion error, so the query fails identically either way. *(Note: the design originally justified this with the column-side `TRY_CAST(… AS INTEGER)` → NULL projection. Review showed that reasoning is wrong on the parameter side — the parameter cast is a strict `CAST`, so the query errors before the column's NULL-ness is ever reached. The conclusion stands; the mechanism in the code comments has been corrected, and #384 has been updated.)*

## Behaviour change, stated plainly

The anchor change is user-visible in one narrow case: a child FK carrying an exact integer above 2^53 — e.g. a text-typed FK attribute — pointing at a bigint parent-ID attribute whose stored value was rounded at write will now stop enriching, where the old `[]float64` bind found the parent by sharing the write path's rounding error. That is the intended contract and it is what the equivalent filter already does, but it is a behaviour change rather than pure hygiene.

## Verification

- **Mutation-verified.** With the anchor's `int64` arm reverted to append `float64(parsed)`, `exact_operand_above_ceiling_matches_nothing` fails with `unexpected row`; restored, it passes. The DuckDB half was mutation-checked the same way via `go test -overlay`: deleting the `ToDuckDBParam` passthrough fails its own test plus five characterization rows.
- `make fmt-check && make lint && make test` green.
- `make test-e2e-production`: 231 PASS / 0 FAIL.
- Federated e2e smoke green.

**What the e2e deliberately does not cover.** The probe calls the repository rather than relation enrichment, because enrichment cannot exhibit the contract difference: `fetchParents` derives its operands from stored child records, which have already been through the write path's float64 hop, so no non-float64-exact operand can reach the anchor that way.

## Follow-ups (none closed by this PR)

- **#384** — EAV-only integer/smallint above 2^31: NULL on every DuckDB tier vs matched in Postgres; updated during this work with the corrected mechanism (the predicate side *errors* rather than silently diverging).
- **#385** — CI provisions a Postgres service the `internal` integration suite never connects to; the suite silently skips.
- **#386** — `conditionexpr.ParseNumeric` is a dead fifth numeric parse rule that diverges from `TryParseNumber` on `"42.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
