### PR TITLE
fix: #322 classify non-finite payload numbers as invalid input and reject them at transform

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -135,11 +135,13 @@ payload.
   it at `Warn` and proceeding — safely even for the marshal case, because the
   transform layer independently rejects non-finite numbers with the attribute
   name before anything reaches storage.
-- **Everything else is returned regardless of enforcement** — in practice a
-  missing resolved schema. That is a plain error, therefore `500`, therefore
-  operator-visible. Absorbing it into report-only would write the document with
-  *zero* validation while a log line claimed it had merely failed a check, and
-  would blame the caller for a server fault.
+- **Everything else is returned regardless of enforcement** — a missing
+  resolved schema, plus the one caller-input case misfiled here (#402), both
+  enumerated under "Public HTTP error surface". Those are plain errors,
+  therefore `500`, therefore operator-visible. Absorbing them into report-only
+  would write the document with *zero* validation while a log line claimed it
+  had merely failed a check — and, for the missing schema, would blame the
+  caller for a server fault.
 
 ### Startup fails closed
 
@@ -805,9 +807,11 @@ Since #314 there is a **second** write-path validator on the same footing,
 for a payload `json.Marshal` refuses to encode (`NaN`/`Inf` from a Go
 embedder), which is caller input just the same. It is independent of the
 `required_policy` row above: the two check different things and both run. Its
-*remaining* errors deliberately stay plain, so a `500` — a missing resolved
-schema, and a numeric literal that fits neither `int64` nor `float64`; see
-"JSON Schema enforcement on write" for the split.
+*remaining* errors currently stay plain, so a `500` — a missing resolved
+schema, and a numeric literal that fits neither `int64` nor `float64`. Only the
+first of those is a deliberate `500`; the numeric literal is caller input
+misfiled on the operator side, a known gap tracked in #402. See "JSON Schema
+enforcement on write" for the split.
 
 Its published message deliberately includes the third-party `jsonschema-go`
 violation prose (decision recorded at the wrap site, `validator.go`): that text

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -129,14 +129,17 @@ payload.
 
 `validateWritePayload` splits on sentinel evidence, not on the enforce flag:
 
-- A genuine violation wraps `forma.ErrInvalidInput` → `400`. Report-only mode
-  absorbs exactly this case, logging it at `Warn` and proceeding.
-- **Everything else is returned regardless of enforcement** — a missing resolved
-  schema, or a payload that will not marshal (`NaN`/`Inf`). Those are plain
-  errors, therefore `500`, therefore operator-visible. Absorbing them into
-  report-only would write the document with *zero* validation while a log line
-  claimed it had merely failed a check, and would blame the caller for a server
-  fault.
+- A genuine violation wraps `forma.ErrInvalidInput` → `400`. So does a payload
+  `json.Marshal` refuses — `NaN`/`Inf` from a Go embedder (#322); no HTTP body
+  can encode one. Report-only mode absorbs exactly this carrier class, logging
+  it at `Warn` and proceeding — safely even for the marshal case, because the
+  transform layer independently rejects non-finite numbers with the attribute
+  name before anything reaches storage.
+- **Everything else is returned regardless of enforcement** — in practice a
+  missing resolved schema. That is a plain error, therefore `500`, therefore
+  operator-visible. Absorbing it into report-only would write the document with
+  *zero* validation while a log line claimed it had merely failed a check, and
+  would blame the caller for a server fault.
 
 ### Startup fails closed
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -801,10 +801,13 @@ stay in `Error()` and in the chain for `errors.Is`/`As`, and never in
 Since #314 there is a **second** write-path validator on the same footing,
 `internal/schemavalidate`'s `Validator.Validate`, which builds an
 `InvalidInputf` carrier for a JSON Schema violation — `enum`, `pattern`,
-`type`, `minimum`/`maximum`, and the schema's own `required`. It is independent
-of the `required_policy` row above: the two check different things and both
-run. Its *non*-violation errors deliberately stay plain, so a `500`; see "JSON
-Schema enforcement on write" for the split.
+`type`, `minimum`/`maximum`, and the schema's own `required` — and, since #322,
+for a payload `json.Marshal` refuses to encode (`NaN`/`Inf` from a Go
+embedder), which is caller input just the same. It is independent of the
+`required_policy` row above: the two check different things and both run. Its
+*remaining* errors deliberately stay plain, so a `500` — a missing resolved
+schema, and a numeric literal that fits neither `int64` nor `float64`; see
+"JSON Schema enforcement on write" for the split.
 
 Its published message deliberately includes the third-party `jsonschema-go`
 violation prose (decision recorded at the wrap site, `validator.go`): that text

--- a/internal/entity_write_nonfinite_test.go
+++ b/internal/entity_write_nonfinite_test.go
@@ -1,0 +1,114 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/schemavalidate"
+	"github.com/lychee-technology/forma/internal/transform"
+	"github.com/stretchr/testify/require"
+)
+
+// numericValidationRegistry mirrors validationRegistry but declares a numeric
+// attribute, which the shared fixture deliberately lacks. File-local so the
+// shared fixture's assertions stay untouched.
+type numericValidationRegistry struct{}
+
+const numericSchemaJSON = `{
+  "type": "object",
+  "properties": {
+    "name":  {"type": "string"},
+    "score": {"type": "number"}
+  },
+  "required": ["name"]
+}`
+
+func (numericValidationRegistry) GetSchemaAttributeCacheByName(name string) (int16, forma.SchemaAttributeCache, error) {
+	if name != "test" {
+		return 0, nil, fmt.Errorf("schema %s not found", name)
+	}
+	return 100, forma.SchemaAttributeCache{
+		"name":  {AttributeID: 1, ValueType: forma.ValueTypeText},
+		"score": {AttributeID: 2, ValueType: forma.ValueTypeNumeric},
+	}, nil
+}
+
+func (r numericValidationRegistry) GetSchemaAttributeCacheByID(int16) (string, forma.SchemaAttributeCache, error) {
+	_, cache, err := r.GetSchemaAttributeCacheByName("test")
+	return "test", cache, err
+}
+
+func (numericValidationRegistry) ListSchemas() []string { return []string{"test"} }
+
+func (numericValidationRegistry) GetSchemaByName(string) (int16, forma.JSONSchema, error) {
+	return 100, forma.JSONSchema{ID: 100, Name: "test", Schema: numericSchemaJSON}, nil
+}
+
+func (numericValidationRegistry) GetSchemaByID(int16) (string, forma.JSONSchema, error) {
+	return "test", forma.JSONSchema{ID: 100, Name: "test", Schema: numericSchemaJSON}, nil
+}
+
+func newNumericValidatingManager(t *testing.T, strict bool) (forma.EntityManager, *mockPersistentRecordRepository) {
+	t.Helper()
+	registry := numericValidationRegistry{}
+
+	validator, err := schemavalidate.New(registry, t.TempDir())
+	require.NoError(t, err)
+
+	config := createTestConfig()
+	config.Entity.ValidateUpdatesStrict = strict
+
+	transformer := transform.NewPersistentRecordTransformer(registry)
+	repo := newMockPersistentRecordRepository()
+	manager := mustNewEntityManager(t, transformer, repo, nil, registry, config, validator)
+	return manager, repo
+}
+
+// TestCreateClassifiesEmbedderNaNAsInvalidInput is issue #322's headline: a Go
+// embedder handing math.NaN() to Create gets invalid input (4xx), not an
+// operator fault (5xx). The validator's marshal step fires first on create, so
+// this exercises the schemavalidate reclassification end to end.
+func TestCreateClassifiesEmbedderNaNAsInvalidInput(t *testing.T) {
+	manager, _ := newNumericValidatingManager(t, false)
+
+	_, err := manager.Create(context.Background(),
+		createOp(map[string]any{"name": "x", "score": math.NaN()}))
+
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}
+
+// TestReportOnlyUpdateStillRejectsNonFinite pins the interaction that makes
+// #322's reclassification safe. Report-only mode now absorbs the validator's
+// marshal carrier like any violation, so the transform guard is all that
+// stands between an absorbed NaN and a stored row that 500s on every
+// subsequent read (the response json.Marshal cannot represent it). The string
+// spelling is the HTTP-reachable shape: strconv.ParseFloat accepts "NaN", so
+// before the guard a report-only update could poison a row over HTTP.
+func TestReportOnlyUpdateStillRejectsNonFinite(t *testing.T) {
+	manager, repo := newNumericValidatingManager(t, false)
+	created, err := manager.Create(context.Background(),
+		createOp(map[string]any{"name": "x", "score": 1.5}))
+	require.NoError(t, err)
+
+	for name, value := range map[string]any{
+		"embedder float64": math.NaN(),
+		"HTTP string":      "NaN",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := manager.Update(context.Background(),
+				updateOp(created.RowID, map[string]any{"score": value}))
+
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			require.Contains(t, err.Error(), "score",
+				"the transform rejection names the attribute; a marshal error cannot")
+		})
+	}
+
+	stored, err := transform.NewPersistentRecordTransformer(numericValidationRegistry{}).
+		FromPersistentRecord(context.Background(), repo.records[100][created.RowID])
+	require.NoError(t, err)
+	require.EqualValues(t, 1.5, stored["score"], "the finite value must have survived both rejected updates")
+}

--- a/internal/entity_write_nonfinite_test.go
+++ b/internal/entity_write_nonfinite_test.go
@@ -20,8 +20,9 @@ type numericValidationRegistry struct{}
 const numericSchemaJSON = `{
   "type": "object",
   "properties": {
-    "name":  {"type": "string"},
-    "score": {"type": "number"}
+    "name":   {"type": "string"},
+    "score":  {"type": "number"},
+    "active": {"type": "boolean"}
   },
   "required": ["name"]
 }`
@@ -31,8 +32,9 @@ func (numericValidationRegistry) GetSchemaAttributeCacheByName(name string) (int
 		return 0, nil, fmt.Errorf("schema %s not found", name)
 	}
 	return 100, forma.SchemaAttributeCache{
-		"name":  {AttributeID: 1, ValueType: forma.ValueTypeText},
-		"score": {AttributeID: 2, ValueType: forma.ValueTypeNumeric},
+		"name":   {AttributeID: 1, ValueType: forma.ValueTypeText},
+		"score":  {AttributeID: 2, ValueType: forma.ValueTypeNumeric},
+		"active": {AttributeID: 3, ValueType: forma.ValueTypeBool},
 	}, nil
 }
 
@@ -114,4 +116,26 @@ func TestReportOnlyUpdateStillRejectsNonFinite(t *testing.T) {
 		FromPersistentRecord(context.Background(), repo.records[100][created.RowID])
 	require.NoError(t, err)
 	require.EqualValues(t, 1.5, stored["score"], "the finite value must have survived both rejected updates")
+}
+
+// TestReportOnlyUpdateRejectsNonFiniteBool pins the P1 from PR #403's review:
+// a bool attribute's converter must not silently coerce an absorbed non-finite
+// (pre-#322 this write failed as a plain error; the reclassification made it
+// absorbable, so the transform guard has to cover bool funnels too).
+func TestReportOnlyUpdateRejectsNonFiniteBool(t *testing.T) {
+	manager, repo := newNumericValidatingManager(t, false)
+	created, err := manager.Create(context.Background(),
+		createOp(map[string]any{"name": "x", "active": true}))
+	require.NoError(t, err)
+
+	_, err = manager.Update(context.Background(),
+		updateOp(created.RowID, map[string]any{"active": math.NaN()}))
+
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	require.Contains(t, err.Error(), "active")
+
+	stored, err := transform.NewPersistentRecordTransformer(numericValidationRegistry{}).
+		FromPersistentRecord(context.Background(), repo.records[100][created.RowID])
+	require.NoError(t, err)
+	require.Equal(t, true, stored["active"], "the stored bool must be untouched")
 }

--- a/internal/entity_write_nonfinite_test.go
+++ b/internal/entity_write_nonfinite_test.go
@@ -78,6 +78,9 @@ func TestCreateClassifiesEmbedderNaNAsInvalidInput(t *testing.T) {
 		createOp(map[string]any{"name": "x", "score": math.NaN()}))
 
 	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	// Pins the mechanism, not just the class: the 4xx must come from the
+	// validator's marshal step, which is the reclassification #322 made.
+	require.ErrorContains(t, err, "cannot be encoded as JSON")
 }
 
 // TestReportOnlyUpdateStillRejectsNonFinite pins the interaction that makes

--- a/internal/entity_write_relation_diagnosis_test.go
+++ b/internal/entity_write_relation_diagnosis_test.go
@@ -171,7 +171,7 @@ func TestWriteDiagnosisIsSilentWithoutRelationRoots(t *testing.T) {
 // gate, and it is not a special case in the code: forma.WithOperatorDetail
 // returns its input unchanged when that input publishes nothing
 // (client_error.go), and schemavalidate.Validate returns a plain error rather
-// than an ErrInvalidInput carrier for everything that is not a caller violation.
+// than an ErrInvalidInput carrier for everything that is not caller input.
 //
 // So a missing resolved schema — an operator fault that must surface as a 500,
 // not a 4xx — cannot pick up a diagnosis about relation roots on its way out.

--- a/internal/entity_write_relation_diagnosis_test.go
+++ b/internal/entity_write_relation_diagnosis_test.go
@@ -171,7 +171,7 @@ func TestWriteDiagnosisIsSilentWithoutRelationRoots(t *testing.T) {
 // gate, and it is not a special case in the code: forma.WithOperatorDetail
 // returns its input unchanged when that input publishes nothing
 // (client_error.go), and schemavalidate.Validate returns a plain error rather
-// than an ErrInvalidInput carrier for everything that is not caller input.
+// than an ErrInvalidInput carrier for every error outside the sentinel class.
 //
 // So a missing resolved schema — an operator fault that must surface as a 500,
 // not a 4xx — cannot pick up a diagnosis about relation roots on its way out.

--- a/internal/entity_write_validation.go
+++ b/internal/entity_write_validation.go
@@ -72,12 +72,13 @@ type writeValidation struct {
 // Anything that is not caller input is returned regardless of enforce. Validate
 // distinguishes the two by wrapping forma.ErrInvalidInput for caller input —
 // a genuine violation, or a payload json.Marshal refuses (NaN/Inf, #322) — and
-// returning a plain error otherwise, i.e. a missing resolved schema. The plain
-// case must not be absorbed by report-only mode: the document would be written
-// with *zero* validation while a log line claimed it had been checked and
-// merely failed (docs/error-handling.md). The absorbed marshal case cannot
-// write a non-finite row: transform's finiteForEAV independently rejects
-// NaN/Inf with the attribute name before anything is staged for storage.
+// returning a plain error otherwise: a missing resolved schema, or a numeric
+// literal that fits neither int64 nor float64. Those must not be absorbed by
+// report-only mode: the document would be written with *zero* validation while
+// a log line claimed it had been checked and merely failed
+// (docs/error-handling.md). The absorbed marshal case cannot write a
+// non-finite row: transform's finiteForEAV independently rejects NaN/Inf with
+// the attribute name before anything is staged for storage.
 //
 // A nil validator means validation is unconfigured and both steps are skipped.
 // Validate on a nil validator returns an error rather than doing nothing, so

--- a/internal/entity_write_validation.go
+++ b/internal/entity_write_validation.go
@@ -64,19 +64,22 @@ type writeValidation struct {
 // map it built.
 //
 // enforce is true on create and follows Entity.ValidateUpdatesStrict on update.
-// It governs *caller input only*. With enforcement off a violation is logged
-// and the write proceeds: rows written before #314 may already violate their
-// schema, and rejecting on update would leave them un-updatable over an
-// unrelated field.
+// It governs *sentinel carriers only* — the split is on sentinel evidence, not
+// on the enforce flag (docs/error-handling.md). With enforcement off a
+// violation is logged and the write proceeds: rows written before #314 may
+// already violate their schema, and rejecting on update would leave them
+// un-updatable over an unrelated field.
 //
-// Anything that is not caller input is returned regardless of enforce. Validate
-// distinguishes the two by wrapping forma.ErrInvalidInput for caller input —
-// a genuine violation, or a payload json.Marshal refuses (NaN/Inf, #322) — and
-// returning a plain error otherwise: a missing resolved schema, or a numeric
-// literal that fits neither int64 nor float64. Those must not be absorbed by
-// report-only mode: the document would be written with *zero* validation while
-// a log line claimed it had been checked and merely failed
-// (docs/error-handling.md). The absorbed marshal case cannot write a
+// Anything without the sentinel is returned regardless of enforce. Validate
+// decides that by wrapping forma.ErrInvalidInput for the caller input it
+// recognises — a genuine violation, or a payload json.Marshal refuses (NaN/Inf,
+// #322) — and returning a plain error otherwise: a missing resolved schema, or
+// a numeric literal that fits neither int64 nor float64. That last one is
+// caller input too and still answers a 500 for want of the sentinel: a known
+// gap, tracked in #402, not a claim that it belongs on this side. Those must
+// not be absorbed by report-only mode: the document would be written with
+// *zero* validation while a log line claimed it had been checked and merely
+// failed (docs/error-handling.md). The absorbed marshal case cannot write a
 // non-finite row: transform's finiteForEAV independently rejects NaN/Inf with
 // the attribute name before anything is staged for storage.
 //
@@ -195,8 +198,8 @@ func validateWritePayload(v writeValidation) error {
 // One narrowing does come for free, and is not a special case here:
 // forma.WithOperatorDetail returns its input unchanged when that input publishes
 // nothing (client_error.go), and schemavalidate.Validate answers a plain error
-// rather than an ErrInvalidInput carrier for everything that is not caller
-// input — a missing resolved schema — and it passes through untouched,
+// rather than an ErrInvalidInput carrier for every error outside the sentinel
+// class — a missing resolved schema — and it passes through untouched,
 // which is the surviving require.Same in
 // TestExplainStrippedRelationRootsNamesEveryRootOnce.
 func explainStrippedRelationRoots(err error, schemaName string, relationRoots []string) error {

--- a/internal/entity_write_validation.go
+++ b/internal/entity_write_validation.go
@@ -64,18 +64,20 @@ type writeValidation struct {
 // map it built.
 //
 // enforce is true on create and follows Entity.ValidateUpdatesStrict on update.
-// It governs *violations only*. With enforcement off a violation is logged and
-// the write proceeds: rows written before #314 may already violate their schema,
-// and rejecting on update would leave them un-updatable over an unrelated field.
+// It governs *caller input only*. With enforcement off a violation is logged
+// and the write proceeds: rows written before #314 may already violate their
+// schema, and rejecting on update would leave them un-updatable over an
+// unrelated field.
 //
-// Anything that is not a violation is returned regardless of enforce. Validate
-// distinguishes the two by wrapping forma.ErrInvalidInput for a genuine
-// violation (→4xx) and returning a plain error otherwise — a missing resolved
-// schema, or a payload that will not marshal (NaN/Inf). Those must not be
-// absorbed by report-only mode: the document would be written with *zero*
-// validation while a log line claimed it had been checked and merely failed, and
-// the message would blame a caller violation for what is an operator fault
-// (docs/error-handling.md).
+// Anything that is not caller input is returned regardless of enforce. Validate
+// distinguishes the two by wrapping forma.ErrInvalidInput for caller input —
+// a genuine violation, or a payload json.Marshal refuses (NaN/Inf, #322) — and
+// returning a plain error otherwise, i.e. a missing resolved schema. The plain
+// case must not be absorbed by report-only mode: the document would be written
+// with *zero* validation while a log line claimed it had been checked and
+// merely failed (docs/error-handling.md). The absorbed marshal case cannot
+// write a non-finite row: transform's finiteForEAV independently rejects
+// NaN/Inf with the attribute name before anything is staged for storage.
 //
 // A nil validator means validation is unconfigured and both steps are skipped.
 // Validate on a nil validator returns an error rather than doing nothing, so
@@ -192,10 +194,9 @@ func validateWritePayload(v writeValidation) error {
 // One narrowing does come for free, and is not a special case here:
 // forma.WithOperatorDetail returns its input unchanged when that input publishes
 // nothing (client_error.go), and schemavalidate.Validate answers a plain error
-// rather than an ErrInvalidInput carrier for everything that is not a caller
-// violation — a missing resolved schema, a payload that will not marshal. Those
-// are operator faults bound for a 500 and they pass through untouched, which is
-// the surviving require.Same in
+// rather than an ErrInvalidInput carrier for everything that is not caller
+// input — a missing resolved schema — and it passes through untouched,
+// which is the surviving require.Same in
 // TestExplainStrippedRelationRootsNamesEveryRootOnce.
 func explainStrippedRelationRoots(err error, schemaName string, relationRoots []string) error {
 	return forma.WithOperatorDetail(err, fmt.Errorf(

--- a/internal/schemavalidate/nonfinite_paths.go
+++ b/internal/schemavalidate/nonfinite_paths.go
@@ -1,0 +1,103 @@
+package schemavalidate
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+
+	"github.com/lychee-technology/forma"
+)
+
+// nonFinitePath is one non-finite float found in a payload, with the dotted
+// path it sits at.
+type nonFinitePath struct {
+	path  string
+	value float64
+}
+
+// marshalRefusalError classifies a json.Marshal refusal of the caller's own
+// payload (#322): caller input, so it carries forma.ErrInvalidInput and
+// publishes.
+//
+// encoding/json's own text names the offending value ("json: unsupported
+// value: NaN") but never where it sits, and an error the caller cannot locate
+// in their payload is barely actionable. So the payload is walked here to
+// derive the path. Only the first offender is named — alphabetically first, so
+// the same payload always produces the same message — with a count of the
+// rest, matching the precedent in transform's missing-required error.
+//
+// If the walk finds nothing the refusal came from something else (a cycle, a
+// failing json.Marshaler, an unsupported type such as a channel or func), and
+// the library's text is published unchanged: it is the only description of the
+// fault that exists.
+func marshalRefusalError(doc any, marshalErr error) error {
+	found := nonFinitePaths(doc)
+	if len(found) == 0 {
+		return forma.InvalidInputf("payload cannot be encoded as JSON: %v", marshalErr)
+	}
+	more := ""
+	if len(found) > 1 {
+		more = fmt.Sprintf(" (and %d more)", len(found)-1)
+	}
+	return forma.InvalidInputf(
+		"payload cannot be encoded as JSON: attribute %q holds non-finite number %v; a finite number is required%s",
+		found[0].path, found[0].value, more)
+}
+
+// nonFinitePaths walks a document and returns every non-finite float in it,
+// sorted by path. It exists for one error path — json.Marshal has just refused
+// the payload — and is never on a successful write.
+//
+// Only the shapes a payload is made of are walked: map[string]any, []any,
+// float64 and float32. Anything else either cannot hold the non-finite that
+// made Marshal fail, or is exotic enough (a custom Marshaler, a struct) that
+// the caller is better served by the library's own text, which the empty
+// result falls back to. A non-finite at the document root is likewise left to
+// the library: there is no attribute to name.
+func nonFinitePaths(doc any) []nonFinitePath {
+	var found []nonFinitePath
+	collectNonFinite("", doc, &found)
+	slices.SortFunc(found, func(a, b nonFinitePath) int {
+		return strings.Compare(a.path, b.path)
+	})
+	return found
+}
+
+func collectNonFinite(path string, node any, found *[]nonFinitePath) {
+	switch v := node.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+		for _, key := range keys {
+			collectNonFinite(joinAttributePath(path, key), v[key], found)
+		}
+	case []any:
+		for i, elem := range v {
+			collectNonFinite(fmt.Sprintf("%s[%d]", path, i), elem, found)
+		}
+	case float64:
+		appendIfNonFinite(path, v, found)
+	case float32:
+		appendIfNonFinite(path, float64(v), found)
+	}
+}
+
+func appendIfNonFinite(path string, value float64, found *[]nonFinitePath) {
+	if path == "" {
+		return
+	}
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		*found = append(*found, nonFinitePath{path: path, value: value})
+	}
+}
+
+func joinAttributePath(prefix, key string) string {
+	if prefix == "" {
+		return key
+	}
+	return prefix + "." + key
+}

--- a/internal/schemavalidate/nonfinite_paths.go
+++ b/internal/schemavalidate/nonfinite_paths.go
@@ -33,9 +33,10 @@ type nonFinitePath struct {
 // is then the only description of the fault that exists. That covers a failing
 // json.Marshaler and an unsupported type such as a channel or func — and a
 // cycle, which reaches this branch because the walk is depth-capped and gives
-// up on one rather than following it (see nonFinitePaths). Publishing "json:
-// unsupported value: encountered a cycle" is the honest answer there: no single
-// attribute is at fault.
+// up on one rather than following it (see nonFinitePaths). There the library's
+// text begins "json: unsupported value: encountered a cycle" and goes on to
+// name the type it was found via; publishing it is the honest answer, because
+// no single attribute is at fault.
 func marshalRefusalError(doc any, marshalErr error) error {
 	found := nonFinitePaths(doc)
 	if len(found) == 0 {
@@ -50,10 +51,20 @@ func marshalRefusalError(doc any, marshalErr error) error {
 		found[0].path, found[0].value, more)
 }
 
-// maxNonFiniteWalkDepth bounds the recursion below. Any real payload is far
-// shallower — an HTTP-decoded document is bounded by encoding/json's own
-// nesting limit long before this — so the cap only ever fires on a payload that
-// is pathological, which on this code path means a cyclic one.
+// maxNonFiniteWalkDepth bounds the recursion below. Nothing upstream enforces a
+// shallower limit: encoding/json's decoder refuses nesting past 10000, ten times
+// this cap, so a decoded document can sit well beyond it.
+//
+// The cap therefore fires on two kinds of payload — a cyclic one, which has no
+// bottom to reach, and any acyclic payload nested deeper than 1000. Both are
+// treated identically: the walk abandons and the caller publishes the library's
+// text. That is a safe degradation rather than a wrong answer, and both cases
+// are pinned.
+//
+// What limits the cost of that degradation is the payload's provenance, not its
+// depth: JSON has no syntax for a non-finite, so an HTTP request can never
+// produce the refusal this walk exists to explain. Only a Go embedder can, which
+// makes a message degraded by this cap an embedder-only outcome.
 const maxNonFiniteWalkDepth = 1000
 
 // nonFinitePaths walks a document and returns every non-finite float in it,
@@ -62,11 +73,15 @@ const maxNonFiniteWalkDepth = 1000
 //
 // The walk is depth-capped, and exceeding the cap abandons it entirely: nil
 // comes back, and the caller publishes the library's text. That is what makes
-// a cyclic payload safe here. json.Marshal detects a cycle and refuses, so this
-// walk runs precisely when a cycle is possible, and following one has no
-// natural end — the cap is the end. Abandoning rather than truncating is
-// deliberate: a partial walk cannot tell "no non-finite in this payload" from
-// "stopped looking", and only the first answer may be published.
+// a cyclic payload safe here — json.Marshal detects a cycle and refuses, so
+// this walk runs precisely when a cycle is possible, and following one has no
+// natural end, so the cap is the end. A merely deep acyclic payload hits the
+// same cap and gets the same treatment (see maxNonFiniteWalkDepth).
+//
+// Abandoning rather than truncating is deliberate: a partial walk cannot tell
+// "no non-finite in this payload" from "stopped looking", and only the first
+// answer may be published. A payload with a shallow non-finite and a too-deep
+// branch is what distinguishes them, and is pinned.
 //
 // Only the shapes a payload is made of are walked: map[string]any, []any,
 // float64, float32, *float64, *float32 and json.Number. Every one of them can
@@ -82,9 +97,13 @@ const maxNonFiniteWalkDepth = 1000
 // such as "abc", which does cause one but is already named by the library's
 // own "invalid number literal" text.
 //
-// Everything else — structs, custom Marshalers, channels — yields nothing and
-// falls back to that library text. A non-finite at the document root is
-// likewise left to the library: there is no attribute to name.
+// Everything else yields nothing and falls back to that library text. That
+// includes shapes which do refuse and which an embedder could plausibly hand
+// in — a []float64 or map[string]float64 holding a non-finite refuses exactly
+// like []any would, but is not walked, because type-switching every concrete
+// numeric container is a losing game against a caller who can name any type.
+// Structs, custom Marshalers and channels land here too. A non-finite at the
+// document root is likewise left to the library: there is no attribute to name.
 func nonFinitePaths(doc any) []nonFinitePath {
 	var walker nonFiniteWalker
 	walker.walk("", doc, 0)

--- a/internal/schemavalidate/nonfinite_paths.go
+++ b/internal/schemavalidate/nonfinite_paths.go
@@ -47,7 +47,7 @@ func marshalRefusalError(doc any, marshalErr error) error {
 		more = fmt.Sprintf(" (and %d more)", len(found)-1)
 	}
 	return forma.InvalidInputf(
-		"payload cannot be encoded as JSON: attribute %q holds non-finite number %v; a finite number is required%s",
+		"payload cannot be encoded as JSON: attribute %q holds non-finite number %v; a finite value is required%s",
 		found[0].path, found[0].value, more)
 }
 

--- a/internal/schemavalidate/nonfinite_paths.go
+++ b/internal/schemavalidate/nonfinite_paths.go
@@ -27,10 +27,13 @@ type nonFinitePath struct {
 // the same payload always produces the same message — with a count of the
 // rest, matching the precedent in transform's missing-required error.
 //
-// If the walk finds nothing the refusal came from something else (a cycle, a
-// failing json.Marshaler, an unsupported type such as a channel or func), and
-// the library's text is published unchanged: it is the only description of the
-// fault that exists.
+// If the walk comes back empty, the library's text is published unchanged: it
+// is then the only description of the fault that exists. That covers a failing
+// json.Marshaler and an unsupported type such as a channel or func — and a
+// cycle, which reaches this branch because the walk is depth-capped and gives
+// up on one rather than following it (see nonFinitePaths). Publishing "json:
+// unsupported value: encountered a cycle" is the honest answer there: no single
+// attribute is at fault.
 func marshalRefusalError(doc any, marshalErr error) error {
 	found := nonFinitePaths(doc)
 	if len(found) == 0 {
@@ -45,9 +48,23 @@ func marshalRefusalError(doc any, marshalErr error) error {
 		found[0].path, found[0].value, more)
 }
 
+// maxNonFiniteWalkDepth bounds the recursion below. Any real payload is far
+// shallower — an HTTP-decoded document is bounded by encoding/json's own
+// nesting limit long before this — so the cap only ever fires on a payload that
+// is pathological, which on this code path means a cyclic one.
+const maxNonFiniteWalkDepth = 1000
+
 // nonFinitePaths walks a document and returns every non-finite float in it,
 // sorted by path. It exists for one error path — json.Marshal has just refused
 // the payload — and is never on a successful write.
+//
+// The walk is depth-capped, and exceeding the cap abandons it entirely: nil
+// comes back, and the caller publishes the library's text. That is what makes
+// a cyclic payload safe here. json.Marshal detects a cycle and refuses, so this
+// walk runs precisely when a cycle is possible, and following one has no
+// natural end — the cap is the end. Abandoning rather than truncating is
+// deliberate: a partial walk cannot tell "no non-finite in this payload" from
+// "stopped looking", and only the first answer may be published.
 //
 // Only the shapes a payload is made of are walked: map[string]any, []any,
 // float64 and float32. Anything else either cannot hold the non-finite that
@@ -56,15 +73,33 @@ func marshalRefusalError(doc any, marshalErr error) error {
 // result falls back to. A non-finite at the document root is likewise left to
 // the library: there is no attribute to name.
 func nonFinitePaths(doc any) []nonFinitePath {
-	var found []nonFinitePath
-	collectNonFinite("", doc, &found)
-	slices.SortFunc(found, func(a, b nonFinitePath) int {
+	var walker nonFiniteWalker
+	walker.walk("", doc, 0)
+	if walker.aborted {
+		return nil
+	}
+	slices.SortFunc(walker.found, func(a, b nonFinitePath) int {
 		return strings.Compare(a.path, b.path)
 	})
-	return found
+	return walker.found
 }
 
-func collectNonFinite(path string, node any, found *[]nonFinitePath) {
+// nonFiniteWalker carries the walk's accumulated findings and its abort flag.
+// Once aborted, every pending frame returns without doing further work.
+type nonFiniteWalker struct {
+	found   []nonFinitePath
+	aborted bool
+}
+
+func (w *nonFiniteWalker) walk(path string, node any, depth int) {
+	if w.aborted {
+		return
+	}
+	if depth > maxNonFiniteWalkDepth {
+		w.aborted = true
+		return
+	}
+
 	switch v := node.(type) {
 	case map[string]any:
 		keys := make([]string, 0, len(v))
@@ -73,25 +108,25 @@ func collectNonFinite(path string, node any, found *[]nonFinitePath) {
 		}
 		slices.Sort(keys)
 		for _, key := range keys {
-			collectNonFinite(joinAttributePath(path, key), v[key], found)
+			w.walk(joinAttributePath(path, key), v[key], depth+1)
 		}
 	case []any:
 		for i, elem := range v {
-			collectNonFinite(fmt.Sprintf("%s[%d]", path, i), elem, found)
+			w.walk(fmt.Sprintf("%s[%d]", path, i), elem, depth+1)
 		}
 	case float64:
-		appendIfNonFinite(path, v, found)
+		w.appendIfNonFinite(path, v)
 	case float32:
-		appendIfNonFinite(path, float64(v), found)
+		w.appendIfNonFinite(path, float64(v))
 	}
 }
 
-func appendIfNonFinite(path string, value float64, found *[]nonFinitePath) {
+func (w *nonFiniteWalker) appendIfNonFinite(path string, value float64) {
 	if path == "" {
 		return
 	}
 	if math.IsNaN(value) || math.IsInf(value, 0) {
-		*found = append(*found, nonFinitePath{path: path, value: value})
+		w.found = append(w.found, nonFinitePath{path: path, value: value})
 	}
 }
 

--- a/internal/schemavalidate/nonfinite_paths.go
+++ b/internal/schemavalidate/nonfinite_paths.go
@@ -1,9 +1,11 @@
 package schemavalidate
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/lychee-technology/forma"
@@ -67,11 +69,22 @@ const maxNonFiniteWalkDepth = 1000
 // "stopped looking", and only the first answer may be published.
 //
 // Only the shapes a payload is made of are walked: map[string]any, []any,
-// float64 and float32. Anything else either cannot hold the non-finite that
-// made Marshal fail, or is exotic enough (a custom Marshaler, a struct) that
-// the caller is better served by the library's own text, which the empty
-// result falls back to. A non-finite at the document root is likewise left to
-// the library: there is no attribute to name.
+// float64, float32, *float64, *float32 and json.Number. Every one of them can
+// be what Marshal refused — a pointer at a non-finite gives "unsupported
+// value: NaN", and a json.Number spelled "NaN"/"Inf"/"Infinity" gives "invalid
+// number literal". A nil pointer is skipped: it marshals as null, so it is
+// never the cause.
+//
+// The json.Number case counts a literal only when it parses cleanly to a
+// non-finite. That gate excludes exactly the two kinds that must not be named:
+// "1e400", which ParseFloat reports out of range but which is valid JSON
+// grammar and marshals fine (so it never causes a refusal at all), and garbage
+// such as "abc", which does cause one but is already named by the library's
+// own "invalid number literal" text.
+//
+// Everything else — structs, custom Marshalers, channels — yields nothing and
+// falls back to that library text. A non-finite at the document root is
+// likewise left to the library: there is no attribute to name.
 func nonFinitePaths(doc any) []nonFinitePath {
 	var walker nonFiniteWalker
 	walker.walk("", doc, 0)
@@ -118,6 +131,21 @@ func (w *nonFiniteWalker) walk(path string, node any, depth int) {
 		w.appendIfNonFinite(path, v)
 	case float32:
 		w.appendIfNonFinite(path, float64(v))
+	case *float64:
+		if v != nil {
+			w.appendIfNonFinite(path, *v)
+		}
+	case *float32:
+		if v != nil {
+			w.appendIfNonFinite(path, float64(*v))
+		}
+	case json.Number:
+		// A non-nil err covers both literals that must not be named: 1e400,
+		// which is out of range but valid JSON that marshals fine, and garbage
+		// such as "abc", which the library's own text already names.
+		if parsed, err := strconv.ParseFloat(string(v), 64); err == nil {
+			w.appendIfNonFinite(path, parsed)
+		}
 	}
 }
 

--- a/internal/schemavalidate/nonfinite_paths_test.go
+++ b/internal/schemavalidate/nonfinite_paths_test.go
@@ -97,7 +97,7 @@ func TestValidateNamesNonFiniteAttribute(t *testing.T) {
 			require.True(t, ok, "the carrier must publish, not earn a redacted body (#313)")
 			require.Contains(t, msg, "payload cannot be encoded as JSON")
 			require.Contains(t, msg, tc.wantPath, "the offending attribute must be named")
-			require.Contains(t, msg, "a finite number is required", "the expected state must be stated")
+			require.Contains(t, msg, "a finite value is required", "the expected state must be stated")
 			if tc.wantMore {
 				require.Contains(t, msg, "(and 1 more)")
 			} else {
@@ -274,7 +274,7 @@ func TestValidateNamesNonFinitePointerAndNumber(t *testing.T) {
 			msg, ok := forma.ResolvePublicMessage(err)
 			require.True(t, ok)
 			require.Contains(t, msg, `"score"`, "the offending attribute must be named")
-			require.Contains(t, msg, "a finite number is required")
+			require.Contains(t, msg, "a finite value is required")
 		})
 	}
 }

--- a/internal/schemavalidate/nonfinite_paths_test.go
+++ b/internal/schemavalidate/nonfinite_paths_test.go
@@ -151,6 +151,21 @@ func TestNonFinitePathsAbortsBeyondDepthCap(t *testing.T) {
 		require.Nil(t, nonFinitePaths(doc))
 	})
 
+	// Abandon, do not truncate. This is the only case that can tell the two
+	// apart: "a" is found before "z" blows the cap (keys are walked sorted), so
+	// a walk that returned what it had would publish `attribute "a"` — a
+	// confident, singular answer produced by a search that silently stopped.
+	// The whole payload must be disowned instead. Without this the abort-return
+	// in nonFinitePaths is dead weight: every other cap test aborts having found
+	// nothing, so returning the accumulated slice looks identical to nil.
+	t.Run("a partial result is discarded, not published", func(t *testing.T) {
+		doc := map[string]any{
+			"a": math.NaN(),
+			"z": nestMaps(maxNonFiniteWalkDepth+1, map[string]any{"deep": math.NaN()}),
+		}
+		require.Nil(t, nonFinitePaths(doc))
+	})
+
 	// The control: real payloads are nowhere near the cap and must still be
 	// walked in full, or the cap would have quietly disabled the feature.
 	t.Run("modest nesting is still walked", func(t *testing.T) {

--- a/internal/schemavalidate/nonfinite_paths_test.go
+++ b/internal/schemavalidate/nonfinite_paths_test.go
@@ -1,6 +1,7 @@
 package schemavalidate
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 	"testing"
@@ -190,4 +191,91 @@ func TestValidateFallsBackBeyondDepthCap(t *testing.T) {
 	require.True(t, ok)
 	require.Contains(t, msg, "unsupported value: NaN", "the library text is the fallback")
 	require.NotContains(t, msg, "attribute", "nothing may be named when the walk gave up")
+}
+
+// TestNonFinitePathsCoversPointerAndNumberSpellings pins PR #403 round-2's P2.
+// These three shapes all make json.Marshal refuse — probed, not assumed:
+// *float64/*float32 at a non-finite give "unsupported value: NaN", and a
+// json.Number carrying a non-finite spelling gives "invalid number literal".
+// The walk used to miss all three, so those refusals published the library text
+// with no attribute named.
+func TestNonFinitePathsCoversPointerAndNumberSpellings(t *testing.T) {
+	nan := math.NaN()
+	posInf32 := float32(math.Inf(1))
+
+	t.Run("*float64 NaN", func(t *testing.T) {
+		found := nonFinitePaths(map[string]any{"score": &nan})
+		require.Len(t, found, 1)
+		require.Equal(t, "score", found[0].path)
+	})
+
+	t.Run("*float32 +Inf", func(t *testing.T) {
+		found := nonFinitePaths(map[string]any{"ratio": &posInf32})
+		require.Len(t, found, 1)
+		require.Equal(t, "ratio", found[0].path)
+	})
+
+	t.Run("nested json.Number NaN", func(t *testing.T) {
+		found := nonFinitePaths(map[string]any{"a": map[string]any{"b": json.Number("NaN")}})
+		require.Len(t, found, 1)
+		require.Equal(t, "a.b", found[0].path)
+	})
+
+	// A nil pointer marshals as null, so it can never be what Marshal refused.
+	t.Run("nil pointers are skipped", func(t *testing.T) {
+		var nilFloat *float64
+		var nilFloat32 *float32
+		require.Empty(t, nonFinitePaths(map[string]any{"a": nilFloat, "b": nilFloat32}))
+	})
+}
+
+// TestNonFinitePathsIgnoresNonRefusingNumberLiterals guards the gate on the
+// json.Number case. 1e400 is the one that matters: ParseFloat reports it out of
+// range (and hands back +Inf), but it is valid JSON grammar and marshals fine,
+// so it is never the cause of a refusal and naming it would be a lie. "abc"
+// does cause a refusal, but the library's own text already names it.
+func TestNonFinitePathsIgnoresNonRefusingNumberLiterals(t *testing.T) {
+	for _, literal := range []string{"1e400", "-1e400", "abc", "", "1.5"} {
+		t.Run(literal, func(t *testing.T) {
+			require.Empty(t, nonFinitePaths(map[string]any{"score": json.Number(literal)}))
+		})
+	}
+}
+
+// TestValidateNamesNonFinitePointerAndNumber is the same coverage at the seam.
+func TestValidateNamesNonFinitePointerAndNumber(t *testing.T) {
+	const schema = `{"type":"object","properties":{"score":{"type":"number"}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), t.TempDir())
+	require.NoError(t, err)
+
+	nan := math.NaN()
+	for name, doc := range map[string]map[string]any{
+		"*float64":    {"score": &nan},
+		"json.Number": {"score": json.Number("Infinity")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := v.Validate(3, doc)
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			msg, ok := forma.ResolvePublicMessage(err)
+			require.True(t, ok)
+			require.Contains(t, msg, `"score"`, "the offending attribute must be named")
+			require.Contains(t, msg, "a finite number is required")
+		})
+	}
+}
+
+// TestValidateFallsBackOnInvalidNumberLiteral pins the boundary the json.Number
+// gate creates: a literal that is garbage rather than non-finite still refuses,
+// and must publish the library text, which already names it.
+func TestValidateFallsBackOnInvalidNumberLiteral(t *testing.T) {
+	const schema = `{"type":"object","properties":{"score":{"type":"number"}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), t.TempDir())
+	require.NoError(t, err)
+
+	err = v.Validate(3, map[string]any{"score": json.Number("abc")})
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	msg, ok := forma.ResolvePublicMessage(err)
+	require.True(t, ok)
+	require.Contains(t, msg, "invalid number literal")
+	require.NotContains(t, msg, "non-finite", "nothing may be named when the walk found nothing")
 }

--- a/internal/schemavalidate/nonfinite_paths_test.go
+++ b/internal/schemavalidate/nonfinite_paths_test.go
@@ -1,0 +1,106 @@
+package schemavalidate
+
+import (
+	"math"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonFinitePaths(t *testing.T) {
+	t.Run("flat map", func(t *testing.T) {
+		found := nonFinitePaths(map[string]any{"name": "x", "score": math.NaN()})
+		require.Len(t, found, 1)
+		require.Equal(t, "score", found[0].path)
+		require.True(t, math.IsNaN(found[0].value))
+	})
+
+	t.Run("nested map is dotted", func(t *testing.T) {
+		found := nonFinitePaths(map[string]any{"a": map[string]any{"b": math.Inf(1)}})
+		require.Len(t, found, 1)
+		require.Equal(t, "a.b", found[0].path)
+		require.Equal(t, math.Inf(1), found[0].value)
+	})
+
+	t.Run("array element is indexed", func(t *testing.T) {
+		found := nonFinitePaths(map[string]any{"scores": []any{1.0, math.Inf(-1)}})
+		require.Len(t, found, 1)
+		require.Equal(t, "scores[1]", found[0].path)
+	})
+
+	t.Run("float32 counts", func(t *testing.T) {
+		found := nonFinitePaths(map[string]any{"ratio": float32(math.Inf(1))})
+		require.Len(t, found, 1)
+		require.Equal(t, "ratio", found[0].path)
+	})
+
+	t.Run("finite payload yields nothing", func(t *testing.T) {
+		require.Empty(t, nonFinitePaths(map[string]any{
+			"a": 1.5, "b": []any{2.0, map[string]any{"c": float32(3)}}, "d": "NaN",
+		}))
+	})
+
+	// Sorted, not map-iteration order: the same payload must always name the
+	// same attribute, or the published message is nondeterministic.
+	t.Run("multiple offenders come back sorted", func(t *testing.T) {
+		found := nonFinitePaths(map[string]any{
+			"zeta": math.NaN(), "alpha": math.Inf(1), "mid": map[string]any{"x": math.NaN()},
+		})
+		require.Len(t, found, 3)
+		require.Equal(t, []string{"alpha", "mid.x", "zeta"},
+			[]string{found[0].path, found[1].path, found[2].path})
+	})
+}
+
+// TestValidateNamesNonFiniteAttribute pins PR #403's P2: the published message
+// for a marshal refusal must name the attribute, the value, and the expected
+// state. encoding/json carries no path, so the path is derived by walking the
+// payload — this test is the reason that walk exists.
+func TestValidateNamesNonFiniteAttribute(t *testing.T) {
+	const schema = `{"type":"object","properties":{"score":{"type":"number"}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), t.TempDir())
+	require.NoError(t, err)
+
+	for name, tc := range map[string]struct {
+		doc      map[string]any
+		wantPath string
+		wantMore bool
+	}{
+		"flat":     {doc: map[string]any{"score": math.NaN()}, wantPath: `"score"`},
+		"nested":   {doc: map[string]any{"a": map[string]any{"b": math.Inf(1)}}, wantPath: `"a.b"`},
+		"multiple": {doc: map[string]any{"score": math.NaN(), "other": math.NaN()}, wantPath: `"other"`, wantMore: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := v.Validate(3, tc.doc)
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			msg, ok := forma.ResolvePublicMessage(err)
+			require.True(t, ok, "the carrier must publish, not earn a redacted body (#313)")
+			require.Contains(t, msg, "payload cannot be encoded as JSON")
+			require.Contains(t, msg, tc.wantPath, "the offending attribute must be named")
+			require.Contains(t, msg, "a finite number is required", "the expected state must be stated")
+			if tc.wantMore {
+				require.Contains(t, msg, "(and 1 more)")
+			} else {
+				require.NotContains(t, msg, "more)")
+			}
+		})
+	}
+}
+
+// TestValidateFallsBackToLibraryTextWithoutNonFinite pins the other half: a
+// marshal refusal the walk cannot explain must still publish encoding/json's
+// text, which is then the only description of the fault that exists.
+func TestValidateFallsBackToLibraryTextWithoutNonFinite(t *testing.T) {
+	const schema = `{"type":"object","properties":{"score":{"type":"number"}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), t.TempDir())
+	require.NoError(t, err)
+
+	err = v.Validate(3, map[string]any{"x": make(chan int)})
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	msg, ok := forma.ResolvePublicMessage(err)
+	require.True(t, ok, "the carrier must publish, not earn a redacted body (#313)")
+	require.Contains(t, msg, "payload cannot be encoded as JSON")
+	require.Contains(t, msg, "unsupported type")
+	require.NotContains(t, msg, "non-finite")
+}

--- a/internal/schemavalidate/nonfinite_paths_test.go
+++ b/internal/schemavalidate/nonfinite_paths_test.go
@@ -2,11 +2,29 @@ package schemavalidate
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/lychee-technology/forma"
 	"github.com/stretchr/testify/require"
 )
+
+// nestMaps wraps leaf in depth levels of {"n": ...}.
+func nestMaps(depth int, leaf any) any {
+	node := leaf
+	for i := 0; i < depth; i++ {
+		node = map[string]any{"n": node}
+	}
+	return node
+}
+
+// cyclicMap returns a map that contains itself. json.Marshal refuses it safely
+// ("encountered a cycle"); an unguarded walk of it does not return.
+func cyclicMap() map[string]any {
+	m := map[string]any{"name": "x"}
+	m["self"] = m
+	return m
+}
 
 func TestNonFinitePaths(t *testing.T) {
 	t.Run("flat map", func(t *testing.T) {
@@ -103,4 +121,73 @@ func TestValidateFallsBackToLibraryTextWithoutNonFinite(t *testing.T) {
 	require.Contains(t, msg, "payload cannot be encoded as JSON")
 	require.Contains(t, msg, "unsupported type")
 	require.NotContains(t, msg, "non-finite")
+}
+
+// TestNonFinitePathsAbortsOnCycle pins PR #403 round-2's P1. json.Marshal
+// refuses a cyclic payload safely, so the walk that runs *after* that refusal
+// used to be the only thing in the process that could not survive one: it
+// recursed until the stack was exhausted and took the server down. A depth cap
+// aborts the whole walk, which returns the caller to the library's text — and
+// for a cycle that text is the only truthful description anyway.
+func TestNonFinitePathsAbortsOnCycle(t *testing.T) {
+	t.Run("cyclic map", func(t *testing.T) {
+		require.Nil(t, nonFinitePaths(cyclicMap()))
+	})
+
+	t.Run("cyclic slice", func(t *testing.T) {
+		s := []any{nil}
+		s[0] = s
+		require.Nil(t, nonFinitePaths(map[string]any{"x": s}))
+	})
+}
+
+// TestNonFinitePathsAbortsBeyondDepthCap pins the cap itself: past it the walk
+// gives up entirely rather than reporting a partial answer, because a truncated
+// walk cannot tell "no non-finite here" from "stopped looking".
+func TestNonFinitePathsAbortsBeyondDepthCap(t *testing.T) {
+	t.Run("beyond the cap the walk yields nothing", func(t *testing.T) {
+		doc := nestMaps(maxNonFiniteWalkDepth+1, map[string]any{"score": math.NaN()})
+		require.Nil(t, nonFinitePaths(doc))
+	})
+
+	// The control: real payloads are nowhere near the cap and must still be
+	// walked in full, or the cap would have quietly disabled the feature.
+	t.Run("modest nesting is still walked", func(t *testing.T) {
+		found := nonFinitePaths(nestMaps(50, map[string]any{"score": math.NaN()}))
+		require.Len(t, found, 1)
+		require.True(t, strings.HasPrefix(found[0].path, "n.n.n."), "got %q", found[0].path)
+		require.True(t, strings.HasSuffix(found[0].path, ".score"), "got %q", found[0].path)
+	})
+}
+
+// TestValidateFallsBackOnCyclicPayload is the same guarantee at the seam that
+// matters: a cyclic payload must produce a 4xx carrier, not a stack overflow.
+func TestValidateFallsBackOnCyclicPayload(t *testing.T) {
+	const schema = `{"type":"object","properties":{"name":{"type":"string"}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), t.TempDir())
+	require.NoError(t, err)
+
+	err = v.Validate(3, cyclicMap())
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	msg, ok := forma.ResolvePublicMessage(err)
+	require.True(t, ok, "the carrier must publish, not earn a redacted body (#313)")
+	require.Contains(t, msg, "payload cannot be encoded as JSON")
+	require.Contains(t, msg, "cycle", "the library's text is the only truthful description of a cycle")
+}
+
+// TestValidateFallsBackBeyondDepthCap pins the honest half of the cap: a
+// non-finite that sits deeper than the walk will go is not named, and the
+// message degrades to the library text instead of claiming the payload is fine.
+func TestValidateFallsBackBeyondDepthCap(t *testing.T) {
+	const schema = `{"type":"object","properties":{"n":{}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), t.TempDir())
+	require.NoError(t, err)
+
+	doc := nestMaps(maxNonFiniteWalkDepth+1, map[string]any{"score": math.NaN()})
+	err = v.Validate(3, doc)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	msg, ok := forma.ResolvePublicMessage(err)
+	require.True(t, ok)
+	require.Contains(t, msg, "unsupported value: NaN", "the library text is the fallback")
+	require.NotContains(t, msg, "attribute", "nothing may be named when the walk gave up")
 }

--- a/internal/schemavalidate/validator.go
+++ b/internal/schemavalidate/validator.go
@@ -278,13 +278,16 @@ func (v *Validator) Validate(schemaID int16, doc any) error {
 	if err != nil {
 		// The caller's own payload cannot be encoded as JSON — math.NaN() or
 		// math.Inf() handed in by a Go embedder; no HTTP body can produce one
-		// (#322). That is caller input, so it carries the sentinel and publishes:
-		// encoding/json's text names the offending value ("json: unsupported
-		// value: NaN") and nothing of the rest of the payload. The transform
-		// layer independently rejects non-finite floats with the attribute name
-		// (finiteForEAV), which is what keeps report-only mode — which absorbs
-		// this carrier like any violation — from writing an unreadable row.
-		return forma.InvalidInputf("payload cannot be encoded as JSON: %v", err)
+		// (#322). That is caller input, so it carries the sentinel and
+		// publishes. encoding/json's text names the offending value ("json:
+		// unsupported value: NaN") but not where it sits, so marshalRefusalError
+		// walks the payload to derive the attribute path the library does not
+		// carry, and falls back to that text when the walk explains nothing.
+		// The transform layer independently rejects non-finite floats with the
+		// attribute name (finiteForEAV), which is what keeps report-only mode —
+		// which absorbs this carrier like any violation — from writing an
+		// unreadable row.
+		return marshalRefusalError(doc, err)
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()

--- a/internal/schemavalidate/validator.go
+++ b/internal/schemavalidate/validator.go
@@ -243,9 +243,12 @@ func New(registry forma.SchemaRegistry, schemaDir string) (*Validator, error) {
 
 // Validate checks doc against the schema registered for schemaID.
 //
-// A violation wraps forma.ErrInvalidInput: it is caller input and must surface
-// as 4xx. A missing resolved schema does not — that is a server configuration
-// fault and must stay operator-visible (docs/error-handling.md).
+// A violation, or a payload json.Marshal refuses to encode, wraps
+// forma.ErrInvalidInput: both are caller input and must surface as 4xx. A
+// missing resolved schema does not — that is a server configuration fault and
+// must stay operator-visible (docs/error-handling.md). Neither does a decode
+// failure of the marshaller's own output: marshalling already succeeded, so
+// that is an internal fault, not something the caller handed in.
 //
 // doc is marshalled before validating. Native Go values do not carry their JSON
 // types: time.Time presents as an object and fails a "type":"string" property
@@ -267,7 +270,15 @@ func (v *Validator) Validate(schemaID int16, doc any) error {
 
 	raw, err := json.Marshal(doc)
 	if err != nil {
-		return fmt.Errorf("failed to marshal payload for schema %d: %w", schemaID, err)
+		// The caller's own payload cannot be encoded as JSON — math.NaN() or
+		// math.Inf() handed in by a Go embedder; no HTTP body can produce one
+		// (#322). That is caller input, so it carries the sentinel and publishes:
+		// encoding/json's text names the offending value ("json: unsupported
+		// value: NaN") and nothing of the rest of the payload. The transform
+		// layer independently rejects non-finite floats with the attribute name
+		// (finiteForEAV), which is what keeps report-only mode — which absorbs
+		// this carrier like any violation — from writing an unreadable row.
+		return forma.InvalidInputf("payload cannot be encoded as JSON: %v", err)
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()

--- a/internal/schemavalidate/validator.go
+++ b/internal/schemavalidate/validator.go
@@ -246,9 +246,15 @@ func New(registry forma.SchemaRegistry, schemaDir string) (*Validator, error) {
 // A violation, or a payload json.Marshal refuses to encode, wraps
 // forma.ErrInvalidInput: both are caller input and must surface as 4xx. A
 // missing resolved schema does not — that is a server configuration fault and
-// must stay operator-visible (docs/error-handling.md). Neither does a decode
-// failure of the marshaller's own output: marshalling already succeeded, so
+// must stay operator-visible (docs/error-handling.md). Neither does a failure
+// to decode the marshaller's own output: marshalling already succeeded, so
 // that is an internal fault, not something the caller handed in.
+//
+// exactNumberInstance is the one honest gap. A literal that fits neither int64
+// nor float64 — {"score": 1e400}, which arrives intact because httpapi decodes
+// with UseNumber and json.Marshal re-emits a json.Number verbatim — is caller
+// input, yet it answers a plain error here and so a 500. That is a known
+// misclassification, tracked in #402, not a decision this comment is defending.
 //
 // doc is marshalled before validating. Native Go values do not carry their JSON
 // types: time.Time presents as an object and fails a "type":"string" property

--- a/internal/schemavalidate/validator_test.go
+++ b/internal/schemavalidate/validator_test.go
@@ -246,7 +246,7 @@ func TestValidateUnknownSchemaIDIsNotClientError(t *testing.T) {
 // math.Inf(), reachable only from a Go embedder, since encoding/json cannot
 // decode those literals from an HTTP body — is the caller's fault, not the
 // operator's. It must carry forma.ErrInvalidInput and publish a message naming
-// the offending value, like any other fault in the caller's own input.
+// the offending value — since #403 that message is synthesized, not the library's.
 func TestValidateClassifiesUnmarshallablePayloadAsInvalidInput(t *testing.T) {
 	dir := t.TempDir()
 	schema := `{"type":"object","properties":{"score":{"type":"number"}}}`
@@ -263,7 +263,7 @@ func TestValidateClassifiesUnmarshallablePayloadAsInvalidInput(t *testing.T) {
 			require.ErrorIs(t, err, forma.ErrInvalidInput)
 			msg, ok := forma.ResolvePublicMessage(err)
 			require.True(t, ok, "the carrier must publish, not earn a redacted body (#313)")
-			require.Contains(t, msg, name, "encoding/json names the offending value; publish it")
+			require.Contains(t, msg, name, "the published message names the offending value on either marshalRefusalError branch")
 		})
 	}
 }

--- a/internal/schemavalidate/validator_test.go
+++ b/internal/schemavalidate/validator_test.go
@@ -2,6 +2,7 @@ package schemavalidate
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -238,6 +239,33 @@ func TestValidateUnknownSchemaIDIsNotClientError(t *testing.T) {
 	err = v.Validate(99, map[string]any{})
 	require.Error(t, err)
 	require.NotErrorIs(t, err, forma.ErrInvalidInput)
+}
+
+// TestValidateClassifiesUnmarshallablePayloadAsInvalidInput pins #322: a
+// payload the caller built that cannot be encoded as JSON — math.NaN()/
+// math.Inf(), reachable only from a Go embedder, since encoding/json cannot
+// decode those literals from an HTTP body — is the caller's fault, not the
+// operator's. It must carry forma.ErrInvalidInput and publish a message naming
+// the offending value, like any other fault in the caller's own input.
+func TestValidateClassifiesUnmarshallablePayloadAsInvalidInput(t *testing.T) {
+	dir := t.TempDir()
+	schema := `{"type":"object","properties":{"score":{"type":"number"}}}`
+	v, err := New(registryWith(t, "ev", schema, 3), dir)
+	require.NoError(t, err)
+
+	for name, value := range map[string]float64{
+		"NaN":  math.NaN(),
+		"+Inf": math.Inf(1),
+		"-Inf": math.Inf(-1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := v.Validate(3, map[string]any{"score": value})
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			msg, ok := forma.ResolvePublicMessage(err)
+			require.True(t, ok, "the carrier must publish, not earn a redacted body (#313)")
+			require.Contains(t, msg, name, "encoding/json names the offending value; publish it")
+		})
+	}
 }
 
 // TestValidateDoesNotReResolve pins that Validate reuses the schema resolved by

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -50,7 +50,14 @@ func (c *AttributeConverter) relationRootsFor(schemaID int16) (RelationRoots, er
 	return c.relationRoots(schemaName), nil
 }
 
-// ToEAVRecord converts an model.EntityAttribute to an model.EAVRecord
+// ToEAVRecord converts an model.EntityAttribute to an model.EAVRecord.
+//
+// Its conversion failures are plain errors and name the attribute by AttrID,
+// which is the EAV key and the only identity this layer holds — the attribute
+// name would need a metadata cache it does not take. The caller-facing carrier
+// that names the attribute and wraps forma.ErrInvalidInput is raised earlier,
+// at populateTypedValue (typed_value.go); reaching an error here on the write
+// path means the value got past it, so it is operator-visible by design.
 func (c *AttributeConverter) ToEAVRecord(attr model.EntityAttribute, rowID uuid.UUID) (model.EAVRecord, error) {
 	record := model.EAVRecord{
 		SchemaID:     attr.SchemaID,
@@ -77,7 +84,7 @@ func (c *AttributeConverter) ToEAVRecord(attr model.EntityAttribute, rowID uuid.
 			numVal, err = finiteForEAV(numVal)
 		}
 		if err != nil {
-			return record, fmt.Errorf("convert to numeric: %w", err)
+			return record, fmt.Errorf("convert to numeric for attrID %d: %w", attr.AttrID, err)
 		}
 		record.ValueNumeric = &numVal
 		if attr.ValueType == forma.ValueTypeBigInt {
@@ -107,7 +114,7 @@ func (c *AttributeConverter) ToEAVRecord(attr model.EntityAttribute, rowID uuid.
 	case forma.ValueTypeBool:
 		boolVal, err := toBoolForEAV(attr.Value)
 		if err != nil {
-			return record, fmt.Errorf("convert to bool: %w", err)
+			return record, fmt.Errorf("convert to bool for attrID %d: %w", attr.AttrID, err)
 		}
 		floatBool := boolToFloat64(boolVal)
 		record.ValueNumeric = &floatBool

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -73,6 +73,9 @@ func (c *AttributeConverter) ToEAVRecord(attr model.EntityAttribute, rowID uuid.
 
 	case forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeNumeric:
 		numVal, err := toFloat64ForEAV(attr.Value)
+		if err == nil {
+			numVal, err = finiteForEAV(numVal)
+		}
 		if err != nil {
 			return record, fmt.Errorf("convert to numeric: %w", err)
 		}
@@ -289,33 +292,9 @@ func (c *AttributeConverter) checkRequiredAttributes(
 }
 
 // Helper functions for conversion
-
-func toFloat64ForEAV(value any) (float64, error) {
-	switch v := value.(type) {
-	case *float64:
-		return requiredFloat64FromPointer(v, "float64")
-	case *float32:
-		return requiredFloat64FromPointer(v, "float32")
-	case *int:
-		return requiredFloat64FromPointer(v, "int")
-	case *int16:
-		return requiredFloat64FromPointer(v, "int16")
-	case *int32:
-		return requiredFloat64FromPointer(v, "int32")
-	case *int64:
-		return requiredFloat64FromPointer(v, "int64")
-	case string:
-		return parseTrimmedFloat64(v)
-	case *string:
-		str, err := derefPointer(v, "string")
-		if err != nil {
-			return 0, err
-		}
-		return parseTrimmedFloat64(str)
-	default:
-		return numutil.Float64(value)
-	}
-}
+//
+// The numeric coercion helpers (toFloat64ForEAV, parseTrimmedFloat64) live in
+// numeric_conversion.go alongside the finiteForEAV guard they feed.
 
 func toTimeForEAV(value any) (time.Time, error) {
 	switch v := value.(type) {
@@ -427,18 +406,6 @@ func boolFromNonZero[T ~int32 | ~int64](value T) bool {
 
 func isTrueStringForEAV(value string) bool {
 	return strings.ToLower(value) == "true" || value == "1"
-}
-
-func parseTrimmedFloat64(value string) (float64, error) {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return 0, fmt.Errorf("empty string")
-	}
-	parsed, err := strconv.ParseFloat(trimmed, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse float: %w", err)
-	}
-	return parsed, nil
 }
 
 func toTime(value any) (time.Time, error) {

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -52,8 +52,9 @@ func (c *AttributeConverter) relationRootsFor(schemaID int16) (RelationRoots, er
 
 // ToEAVRecord converts an model.EntityAttribute to an model.EAVRecord.
 //
-// Its conversion failures are plain errors and name the attribute by AttrID,
-// which is the EAV key and the only identity this layer holds — the attribute
+// Its conversion failures are plain errors; the numeric and bool cases name the
+// attribute by AttrID, the rest take their identity from ToEAVRecords' wrap.
+// AttrID is the EAV key and the only identity this layer holds — the attribute
 // name would need a metadata cache it does not take. The caller-facing carrier
 // that names the attribute and wraps forma.ErrInvalidInput is raised earlier,
 // at populateTypedValue (typed_value.go); reaching an error here on the write

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -362,30 +362,42 @@ func toBoolForEAV(value any) (bool, error) {
 		}
 		return boolFromPositive(num), nil
 	case float32:
-		return float64ToBool(float64(v)), nil
+		return finiteFloat64ToBool(float64(v))
 	case *float32:
 		num, err := derefPointer(v, "float32")
 		if err != nil {
 			return false, err
 		}
-		return float64ToBool(float64(num)), nil
+		return finiteFloat64ToBool(float64(num))
 	case float64:
-		return float64ToBool(v), nil
+		return finiteFloat64ToBool(v)
 	case *float64:
 		num, err := derefPointer(v, "float64")
 		if err != nil {
 			return false, err
 		}
-		return float64ToBool(num), nil
+		return finiteFloat64ToBool(num)
 	case json.Number:
 		f, err := v.Float64()
 		if err != nil {
 			return false, fmt.Errorf("cannot convert json.Number %q to bool: %w", v.String(), err)
 		}
+		if err := finiteBoolInput(f); err != nil {
+			return false, err
+		}
 		return f != 0, nil
 	default:
 		return false, fmt.Errorf("cannot convert %T to bool", value)
 	}
+}
+
+// finiteFloat64ToBool is toBoolForEAV's float path: reject non-finite, then
+// apply the existing threshold coercion unchanged.
+func finiteFloat64ToBool(value float64) (bool, error) {
+	if err := finiteBoolInput(value); err != nil {
+		return false, err
+	}
+	return float64ToBool(value), nil
 }
 
 func derefPointer[T any](value *T, typeName string) (T, error) {
@@ -446,11 +458,17 @@ func toBool(value any) (bool, error) {
 	case int64:
 		return v != 0, nil
 	case float64:
+		if err := finiteBoolInput(v); err != nil {
+			return false, err
+		}
 		return v != 0, nil
 	case json.Number:
 		f, err := v.Float64()
 		if err != nil {
 			return false, fmt.Errorf("cannot convert json.Number %q to bool: %w", v.String(), err)
+		}
+		if err := finiteBoolInput(f); err != nil {
+			return false, err
 		}
 		return f != 0, nil
 	default:

--- a/internal/transform/attribute_converter_test.go
+++ b/internal/transform/attribute_converter_test.go
@@ -474,6 +474,8 @@ func TestToEAVRecordRejectsNonFiniteNumbers(t *testing.T) {
 			}, uuid.New())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "non-finite")
+			require.Contains(t, err.Error(), "attrID 2",
+				"this layer holds no attribute name, so the EAV key is the identity the error owes")
 			require.Nil(t, record.ValueNumeric)
 		})
 	}

--- a/internal/transform/attribute_converter_test.go
+++ b/internal/transform/attribute_converter_test.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToFloat64ForEAV(t *testing.T) {
@@ -452,5 +454,27 @@ func TestAttributeConverterFromEAVRecords_SkippedUnknownDoesNotSatisfyRequired(t
 	}
 	if !strings.Contains(err.Error(), "missing required attribute 'id'") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestToEAVRecordRejectsNonFiniteNumbers pins the second numeric funnel
+// (#322): ToEAVRecord must refuse to build a ValueNumeric holding NaN/Inf.
+// Plain error on purpose — this converter's errors are all plain, and on the
+// main write path populateTypedValue has already answered the caller-facing
+// carrier before values get here.
+func TestToEAVRecordRejectsNonFiniteNumbers(t *testing.T) {
+	c := NewAttributeConverter(nil)
+	for name, value := range map[string]any{
+		"float64 NaN": math.NaN(),
+		"string Inf":  "Inf",
+	} {
+		t.Run(name, func(t *testing.T) {
+			record, err := c.ToEAVRecord(model.EntityAttribute{
+				SchemaID: 1, AttrID: 2, ValueType: forma.ValueTypeNumeric, Value: value,
+			}, uuid.New())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "non-finite")
+			require.Nil(t, record.ValueNumeric)
+		})
 	}
 }

--- a/internal/transform/nonfinite_bool_test.go
+++ b/internal/transform/nonfinite_bool_test.go
@@ -1,0 +1,68 @@
+package transform
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPopulateTypedValueRejectsNonFiniteBool pins the bool half of #322's
+// transform guard. A bool attribute stores boolToFloat64 in ValueNumeric, so a
+// non-finite handed in for a bool used to be coerced silently — toBool answers
+// `NaN != 0` == true — and the row was written as if the caller had said so.
+// Rejecting is the only honest answer: no non-finite has a truth value.
+//
+// toBool has no float32 or pointer cases, so only the shapes it accepts are
+// exercised here; toBoolForEAV's wider set is covered by the sibling test.
+func TestPopulateTypedValueRejectsNonFiniteBool(t *testing.T) {
+	meta := forma.AttributeMetadata{AttributeID: 3, ValueType: forma.ValueTypeBool}
+	for name, value := range map[string]any{
+		"float64 NaN":      math.NaN(),
+		"float64 +Inf":     math.Inf(1),
+		"json.Number NaN":  json.Number("NaN"),
+		"json.Number -Inf": json.Number("-Inf"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var attr model.EAVRecord
+			_, err := populateTypedValue(&attr, "active", value, meta)
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			require.Contains(t, err.Error(), "active",
+				"the rejection must name the attribute — that is what makes it actionable")
+			require.Contains(t, err.Error(), "non-finite")
+			require.Nil(t, attr.ValueNumeric, "nothing may be staged for storage")
+		})
+	}
+}
+
+// TestToEAVRecordRejectsNonFiniteBool pins the second bool funnel. It matters
+// beyond symmetry: toBoolForEAV coerces through float64ToBool's threshold, so
+// before the guard the two funnels disagreed about the same NaN — toBool
+// persisted true, toBoolForEAV persisted false. Plain error on purpose, like
+// the rest of this converter's errors.
+func TestToEAVRecordRejectsNonFiniteBool(t *testing.T) {
+	c := NewAttributeConverter(nil)
+	negInf32 := float32(math.Inf(-1))
+	nan64 := math.NaN()
+	for name, value := range map[string]any{
+		"float64 NaN":     math.NaN(),
+		"float64 +Inf":    math.Inf(1),
+		"float32 -Inf":    negInf32,
+		"*float32 -Inf":   &negInf32,
+		"*float64 NaN":    &nan64,
+		"json.Number NaN": json.Number("NaN"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			record, err := c.ToEAVRecord(model.EntityAttribute{
+				SchemaID: 1, AttrID: 3, ValueType: forma.ValueTypeBool, Value: value,
+			}, uuid.New())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "non-finite")
+			require.Nil(t, record.ValueNumeric, "nothing may be staged for storage")
+		})
+	}
+}

--- a/internal/transform/nonfinite_bool_test.go
+++ b/internal/transform/nonfinite_bool_test.go
@@ -33,7 +33,8 @@ func TestPopulateTypedValueRejectsNonFiniteBool(t *testing.T) {
 			require.ErrorIs(t, err, forma.ErrInvalidInput)
 			require.Contains(t, err.Error(), "active",
 				"the rejection must name the attribute — that is what makes it actionable")
-			require.Contains(t, err.Error(), "non-finite")
+			require.Contains(t, err.Error(), "has no truth value",
+				"a bool rejection must keep its own prose, not the numeric guard's 'not storable'")
 			require.Nil(t, attr.ValueNumeric, "nothing may be staged for storage")
 		})
 	}
@@ -61,7 +62,8 @@ func TestToEAVRecordRejectsNonFiniteBool(t *testing.T) {
 				SchemaID: 1, AttrID: 3, ValueType: forma.ValueTypeBool, Value: value,
 			}, uuid.New())
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "non-finite")
+			require.Contains(t, err.Error(), "has no truth value",
+				"a bool rejection must keep its own prose, not the numeric guard's 'not storable'")
 			require.Contains(t, err.Error(), "attrID 3",
 				"this layer holds no attribute name, so the EAV key is the identity the error owes")
 			require.Nil(t, record.ValueNumeric, "nothing may be staged for storage")

--- a/internal/transform/nonfinite_bool_test.go
+++ b/internal/transform/nonfinite_bool_test.go
@@ -62,6 +62,8 @@ func TestToEAVRecordRejectsNonFiniteBool(t *testing.T) {
 			}, uuid.New())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "non-finite")
+			require.Contains(t, err.Error(), "attrID 3",
+				"this layer holds no attribute name, so the EAV key is the identity the error owes")
 			require.Nil(t, record.ValueNumeric, "nothing may be staged for storage")
 		})
 	}

--- a/internal/transform/numeric_conversion.go
+++ b/internal/transform/numeric_conversion.go
@@ -67,10 +67,17 @@ func requiredFloat64FromPointer[T numutil.NumericScalar](value *T, typeName stri
 // serves the DuckDB read/query path, and hardening a shared function for one
 // caller's write semantics is the #301 trap.
 func finiteForEAV(value float64) (float64, error) {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
+	if isNonFinite(value) {
 		return 0, fmt.Errorf("non-finite number %v is not storable; a finite value is required", value)
 	}
 	return value, nil
+}
+
+// isNonFinite is the shared predicate behind both guards below. They share the
+// test and deliberately not the prose: the two rejections are about different
+// things, and a caller reading one should not be handed the other's vocabulary.
+func isNonFinite(value float64) bool {
+	return math.IsNaN(value) || math.IsInf(value, 0)
 }
 
 // finiteBoolInput guards the bool funnels, which reach storage through the same
@@ -80,7 +87,15 @@ func finiteForEAV(value float64) (float64, error) {
 // `!= 0` turns NaN into true, toBoolForEAV's float64ToBool threshold turns the
 // same NaN into false. Absorbed under report-only mode that silently persisted
 // a bool the caller never wrote (#322, PR #403 review).
+//
+// The message is its own rather than finiteForEAV's: "is not storable" is
+// numeric prose, and the fault here is not that the value cannot be stored but
+// that it does not denote true or false. That reading also has to hold on the
+// read path — extractValueFromEAVRecord sends a stored ValueNumeric back
+// through toBoolForEAV — where the subject is a persisted value, not input.
 func finiteBoolInput(value float64) error {
-	_, err := finiteForEAV(value)
-	return err
+	if isNonFinite(value) {
+		return fmt.Errorf("non-finite value %v has no truth value; a finite value is required", value)
+	}
+	return nil
 }

--- a/internal/transform/numeric_conversion.go
+++ b/internal/transform/numeric_conversion.go
@@ -1,6 +1,52 @@
 package transform
 
-import "github.com/lychee-technology/forma/internal/numutil"
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/lychee-technology/forma/internal/numutil"
+)
+
+func toFloat64ForEAV(value any) (float64, error) {
+	switch v := value.(type) {
+	case *float64:
+		return requiredFloat64FromPointer(v, "float64")
+	case *float32:
+		return requiredFloat64FromPointer(v, "float32")
+	case *int:
+		return requiredFloat64FromPointer(v, "int")
+	case *int16:
+		return requiredFloat64FromPointer(v, "int16")
+	case *int32:
+		return requiredFloat64FromPointer(v, "int32")
+	case *int64:
+		return requiredFloat64FromPointer(v, "int64")
+	case string:
+		return parseTrimmedFloat64(v)
+	case *string:
+		str, err := derefPointer(v, "string")
+		if err != nil {
+			return 0, err
+		}
+		return parseTrimmedFloat64(str)
+	default:
+		return numutil.Float64(value)
+	}
+}
+
+func parseTrimmedFloat64(value string) (float64, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, fmt.Errorf("empty string")
+	}
+	parsed, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse float: %w", err)
+	}
+	return parsed, nil
+}
 
 func requiredFloat64FromPointer[T numutil.NumericScalar](value *T, typeName string) (float64, error) {
 	scalar, err := derefPointer(value, typeName)
@@ -8,4 +54,21 @@ func requiredFloat64FromPointer[T numutil.NumericScalar](value *T, typeName stri
 		return 0, err
 	}
 	return numutil.Float64(scalar)
+}
+
+// finiteForEAV rejects NaN and ±Inf after any numeric coercion. ValueNumeric
+// feeds JSON read paths that cannot represent them — json.Marshal fails — so a
+// stored non-finite would 500 every subsequent read of the row (#322). The
+// guard sits after coercion because the spellings multiply before it:
+// strconv.ParseFloat accepts "NaN"/"Inf"/"Infinity" strings, and json.Number
+// can carry them too.
+//
+// It deliberately does not live inside numutil.Float64: that helper also
+// serves the DuckDB read/query path, and hardening a shared function for one
+// caller's write semantics is the #301 trap.
+func finiteForEAV(value float64) (float64, error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("non-finite number %v is not storable; a finite value is required", value)
+	}
+	return value, nil
 }

--- a/internal/transform/numeric_conversion.go
+++ b/internal/transform/numeric_conversion.go
@@ -73,9 +73,10 @@ func finiteForEAV(value float64) (float64, error) {
 	return value, nil
 }
 
-// isNonFinite is the shared predicate behind both guards below. They share the
-// test and deliberately not the prose: the two rejections are about different
-// things, and a caller reading one should not be handed the other's vocabulary.
+// isNonFinite is the shared predicate behind both guards in this file. They
+// share the test and deliberately not the prose: the two rejections are about
+// different things, and a caller reading one should not be handed the other's
+// vocabulary.
 func isNonFinite(value float64) bool {
 	return math.IsNaN(value) || math.IsInf(value, 0)
 }

--- a/internal/transform/numeric_conversion.go
+++ b/internal/transform/numeric_conversion.go
@@ -72,3 +72,15 @@ func finiteForEAV(value float64) (float64, error) {
 	}
 	return value, nil
 }
+
+// finiteBoolInput guards the bool funnels, which reach storage through the same
+// ValueNumeric column as the numeric ones (boolToFloat64) and so need the same
+// rejection. Coercion cannot stand in for it: no non-finite has a truth value,
+// and the two funnels do not even agree on the one they invent — toBool's
+// `!= 0` turns NaN into true, toBoolForEAV's float64ToBool threshold turns the
+// same NaN into false. Absorbed under report-only mode that silently persisted
+// a bool the caller never wrote (#322, PR #403 review).
+func finiteBoolInput(value float64) error {
+	_, err := finiteForEAV(value)
+	return err
+}

--- a/internal/transform/typed_value.go
+++ b/internal/transform/typed_value.go
@@ -37,6 +37,9 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 		if err != nil {
 			return handleConversionError(err)
 		}
+		if numVal, err = finiteForEAV(numVal); err != nil {
+			return handleConversionError(err)
+		}
 		attr.ValueNumeric = &numVal
 		if meta.ValueType == forma.ValueTypeBigInt {
 			if exact, ok := numutil.Int64Exact(value); ok {

--- a/internal/transform/typed_value_test.go
+++ b/internal/transform/typed_value_test.go
@@ -1,7 +1,9 @@
 package transform
 
 import (
+	"encoding/json"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/lychee-technology/forma"
@@ -61,4 +63,50 @@ func TestPopulateTypedValue_List(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, forma.ErrInvalidInput), "want ErrInvalidInput, got %v", err)
 	})
+}
+
+// TestPopulateTypedValueRejectsNonFiniteNumbers pins #322's transform-layer
+// guard. ValueNumeric feeds JSON read paths that cannot represent NaN/Inf
+// (json.Marshal fails), so a stored non-finite poisons every subsequent read
+// of the row. The string spellings matter: strconv.ParseFloat accepts them,
+// which made a report-only HTTP update able to store NaN before this guard.
+func TestPopulateTypedValueRejectsNonFiniteNumbers(t *testing.T) {
+	for _, valueType := range []forma.ValueType{
+		forma.ValueTypeNumeric, forma.ValueTypeBigInt, forma.ValueTypeInteger, forma.ValueTypeSmallInt,
+	} {
+		meta := forma.AttributeMetadata{AttributeID: 7, ValueType: valueType}
+		for name, value := range map[string]any{
+			"float64 NaN":     math.NaN(),
+			"float64 +Inf":    math.Inf(1),
+			"float32 -Inf":    float32(math.Inf(-1)),
+			"string NaN":      "NaN",
+			"string Infinity": "-Infinity",
+			"json.Number NaN": json.Number("NaN"),
+		} {
+			t.Run(string(valueType)+"/"+name, func(t *testing.T) {
+				var attr model.EAVRecord
+				_, err := populateTypedValue(&attr, "score", value, meta)
+				require.ErrorIs(t, err, forma.ErrInvalidInput)
+				require.Contains(t, err.Error(), "score",
+					"the rejection must name the attribute — that is what makes it actionable")
+				require.Contains(t, err.Error(), "non-finite")
+				require.Nil(t, attr.ValueNumeric, "nothing may be staged for storage")
+			})
+		}
+	}
+}
+
+// TestPopulateTypedValueRejectsNonFiniteListElement pins the list funnel: array
+// elements recurse into populateTypedValue with the items type, and must hit
+// the same guard.
+func TestPopulateTypedValueRejectsNonFiniteListElement(t *testing.T) {
+	meta := forma.AttributeMetadata{
+		AttributeID: 7,
+		ValueType:   forma.ValueTypeList,
+		ItemsType:   forma.ValueTypeNumeric,
+	}
+	attr := model.EAVRecord{ArrayIndices: "0"}
+	_, err := populateTypedValue(&attr, "scores", math.NaN(), meta)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	require.Contains(t, err.Error(), "non-finite")
 }


### PR DESCRIPTION
Closes #322.

## What this fixes

A write payload carrying `math.NaN()`/`math.Inf()` failed `Validator.Validate` at `json.Marshal` with a **plain** error — surfacing as an operator-visible 5xx, though it is the caller's own input. Worse, the planning investigation found the issue's "not reachable over HTTP" premise is false for the string spelling: `numutil.Float64` coerces strings via `strconv.ParseFloat`, which accepts `"NaN"`/`"Inf"`/`"Infinity"`, so an HTTP update body `{"score": "NaN"}` under the shipped report-only default was warn-absorbed as a schema violation and then **stored a NaN** — a poison row that 500s on every subsequent read (the response `json.Marshal` cannot represent it).

## The original branch (7 commits, ordered so every intermediate commit is safe)

1. **`406a48f` — transform-layer guard (the load-bearing half).** `finiteForEAV` rejects NaN/±Inf after numeric coercion at both write-side `ValueNumeric` funnels: `populateTypedValue` (publishes `invalid value for attribute '<name>' (attrID=<id>): non-finite number <v> is not storable; a finite value is required`) and `ToEAVRecord`'s numeric case (plain, per that converter's existing class). Deliberately **not** inside `numutil.Float64`, which also serves the DuckDB query path. Landing this first is what makes step 2 safe. Includes a pure move of `toFloat64ForEAV`/`parseTrimmedFloat64` into `numeric_conversion.go` to keep `attribute_converter.go` under the 500-line standard.
2. **`903ddc9` — validator reclassification (the issue's headline).** A `json.Marshal` refusal of the caller's payload now returns a published `forma.InvalidInputf` — 4xx for embedders, absorbable by report-only mode like any carrier, and safe to absorb only because of (1). Missing resolved schema and post-marshal failures stay plain.
3. **`6d2a441` + `f21a705` — manager-level pins.** New `entity_write_nonfinite_test.go`: embedder `math.NaN()` on Create → `ErrInvalidInput`; report-only update rejects **both** the float64 and the HTTP-reachable `"NaN"` string spelling naming the attribute, and the stored finite value survives.
4. **`d4fbddb` + `9c14bed` + `571254b` — prose sync.** Every site claiming "marshal failures stay plain" corrected; the class split is stated everywhere on **sentinel evidence**, matching the code.

## Review waves (7 further commits, each responding to review findings on this PR)

- **`f17a54f` — bool funnels closed (review P1).** `toBool`/`toBoolForEAV` silently coerced non-finite floats — and disagreed (NaN → true vs false). Finite check now guards every float/`json.Number` branch of both; `TestReportOnlyUpdateRejectsNonFiniteBool` pins the report-only path. Side effect, blessed as intended: a stored bool `value_numeric` holding NaN (corrupt storage — every writer produces only 0/1) now reads as a loud plain error instead of silently `false`.
- **`cbd5f47` + `ad74370` — attrID context (review P2).** `ToEAVRecord`'s conversion errors name `attrID` (that layer holds no attribute cache; the name-bearing carrier is `populateTypedValue`'s, which runs first).
- **`e9f1377` — published marshal message names the attribute (review P2).** `encoding/json` carries no path, so after a refusal the validator walks the payload (`nonFinitePaths`) and publishes e.g. `payload cannot be encoded as JSON: attribute "profile.score" holds non-finite number +Inf; a finite number is required`.
- **`077e252` + `d81e3ac` — walk hardened (round-2 P1).** Depth cap 1000; cycles and >1000-deep payloads **abandon** the walk (nil, never a truncated list) and publish the library text. Abandon-over-truncate is mutation-pinned.
- **`f1848ec` — walk taught the remaining refusing shapes (round-2 P2).** `*float64`/`*float32` and `json.Number` non-finite spellings; `json.Number("1e400")` is deliberately NOT flagged (valid JSON grammar, marshals fine — ParseFloat's ErrRange is the probe-verified tell).
- **`1b36ecc` — bool wording (round-3):** bool rejections publish `non-finite value <v> has no truth value; a finite value is required` instead of the numeric-flavored prose.

**Known boundary (deliberate):** the diagnostic walk is shape-bound to the payload shapes JSON decoding produces (`map[string]any`, `[]any`, floats, their pointers, `json.Number`). An embedder handing concrete Go containers (`[]float64{NaN}`, `map[string]float64`) still gets the 4xx carrier, but with the library's text and no attribute named — documented in `nonfinite_paths.go` rather than type-switching every numeric container.

## Found along the way

- **#402** — `{"score": 1e400}` (numeric literal fitting neither `int64` nor `float64`) answers a redacted 500 for pure caller input; documented honestly at every touched site, out of scope here.
- **#404** — the two bool funnels embody different truth tables for finite values they both accept (0.3/negatives/strings).
- **#405** — read-path consistency errors name attrID but never the row.
- **#406** — cyclic embedder payloads crash at transform normalization, before any guard can reject them (pre-existing; the round-2 depth cap is precedent for the fix shape).

## Verification

- TDD throughout; red-first and mutation evidence per wave (disabling any guard reddens exactly its pins; `-overlay` runs re-executed with `-count=1` after one `ok (cached)` non-result).
- `make fmt-check`, `make lint` (pinned golangci v1.64.8), full unit suite — clean at every wave head. The only local failure is `internal/e2e_harness`'s Docker-dependent smoke (daemon down locally — environmental); CI runs it green.
- Full review artifacts and per-finding responses are in the PR comments; execution record on #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
