### PR TITLE
test(e2e): #345 wire the factory-shape plan cache into the production harness engine

### DIFF
--- a/internal/e2e_harness/production/engine.go
+++ b/internal/e2e_harness/production/engine.go
@@ -8,14 +8,16 @@ import (
 	"github.com/lychee-technology/forma/internal"
 	fedengine "github.com/lychee-technology/forma/internal/federated"
 	"github.com/lychee-technology/forma/internal/manifest"
+	"github.com/lychee-technology/forma/internal/queryplan"
 	"github.com/lychee-technology/forma/internal/schemavalidate"
 	"github.com/lychee-technology/forma/internal/transform"
 )
 
 // Engine returns the Env's real federated query engine, assembling it on
 // first use: the production DBPersistentRecordRepository over the per-test
-// pool, the Postgres dirty-ID fetcher, the per-test DuckDB client, an
-// optional circuit breaker (WithBreaker), and the loaded metadata cache.
+// pool, the Postgres dirty-ID fetcher, the per-test DuckDB client, the
+// factory-shape shared plan cache (#345), an optional circuit breaker
+// (WithBreaker), and the loaded metadata cache.
 // This mirrors the production assembly used by the benchmark runner
 // (internal/e2e_harness/federated/benchmark/execute.go).
 func (e *Env) Engine() *fedengine.DBFederatedQueryEngine {
@@ -23,7 +25,13 @@ func (e *Env) Engine() *fedengine.DBFederatedQueryEngine {
 		return e.engine
 	}
 
-	repo := internal.NewDBPersistentRecordRepository(e.Pool, e.Metadata)
+	// One plan cache per engine assembly, shared between the repository and
+	// the engine exactly as factory.newRepositoryAndEngine pairs them
+	// (#142/#345). Building it here rather than on the Env ties its lifetime
+	// to the memoized engine: EvolveSchema and ReopenDuckDB drop e.engine, so
+	// the cache is discarded with it, matching the cold restart both model.
+	planCache := queryplan.NewCache(4096)
+	repo := internal.NewDBPersistentRecordRepository(e.Pool, e.Metadata, internal.WithPlanCache(planCache))
 	if e.breaker == nil && e.opts.breakerFailures > 0 {
 		// Built once per Env, not per engine assembly: breaker state must
 		// survive ReopenDuckDB/RestartPostgres handle rebuilds so #185
@@ -33,7 +41,10 @@ func (e *Env) Engine() *fedengine.DBFederatedQueryEngine {
 
 	// The engine's logger carries the #256 stamp/footer cross-check warning,
 	// which has no other outlet — the read it observes succeeds.
-	opts := []fedengine.EngineOption{fedengine.WithLogger(e.logger)}
+	opts := []fedengine.EngineOption{
+		fedengine.WithLogger(e.logger),
+		fedengine.WithPlanCache(planCache),
+	}
 	if src := e.parquetSource(); src != nil {
 		if e.ParquetSourceWrap != nil {
 			src = e.ParquetSourceWrap(src)

--- a/internal/e2e_harness/production/engine.go
+++ b/internal/e2e_harness/production/engine.go
@@ -29,7 +29,7 @@ func (e *Env) Engine() *fedengine.DBFederatedQueryEngine {
 	// the engine exactly as factory.newRepositoryAndEngine pairs them
 	// (#142/#345). Building it here rather than on the Env ties its lifetime
 	// to the memoized engine: EvolveSchema and ReopenDuckDB drop e.engine, so
-	// the cache is discarded with it, matching the cold restart both model.
+	// the cache is discarded with it, matching the cold restart that both model.
 	planCache := queryplan.NewCache(4096)
 	repo := internal.NewDBPersistentRecordRepository(e.Pool, e.Metadata, internal.WithPlanCache(planCache))
 	if e.breaker == nil && e.opts.breakerFailures > 0 {

--- a/internal/e2e_harness/production/plan_cache_e2e_test.go
+++ b/internal/e2e_harness/production/plan_cache_e2e_test.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// assertPlanCacheNote pins the compiled-plan cache outcome recorded in the
+// execution plan (recordPlanCache, #142). Notes are internal-plan-only, so
+// asserting on them observes the engine, not the public API surface.
+func assertPlanCacheNote(t *testing.T, res *QueryResult, want string) {
+	t.Helper()
+	if res == nil || res.Plan == nil {
+		t.Fatalf("plan-cache note %q: result carries no execution plan", want)
+	}
+	for _, note := range res.Plan.Notes {
+		if note == want {
+			return
+		}
+	}
+	t.Fatalf("plan notes lack %q, got %v", want, res.Plan.Notes)
+}
+
+// TestEnginePlanCacheServesRepeatedShape is the #345 wiring guard: the
+// harness engine must carry the factory's plan cache, so an identical query
+// shape asked twice compiles once and is served from the cache the second
+// time. Delete the WithPlanCache wiring in Engine() and this goes red —
+// without a cache, recordPlanCache never runs and no plan_cache note exists.
+func TestEnginePlanCacheServesRepeatedShape(t *testing.T) {
+	ctx := context.Background()
+	cluster := SharedCluster(t)
+	v1 := writeSimpleSchemaDir(t, coreProps, coreAttrs)
+	env := NewEnv(t, cluster, WithSchemaDir(v1))
+	simple := DefaultSchemaFixtures()[0]
+
+	// 5 rows landed as base parquet; nothing hot remains after init, so the
+	// dirty set is empty for both queries and cannot re-key the scope hash.
+	seedGeneration(ctx, t, env, simple, 5, buildEvolutionProfile(buildLabeledExtras(nil)))
+	runInitBase(ctx, t, env, simple)
+
+	coldOnly := Query{
+		Schema:         simple,
+		PreferredTiers: []model.DataTier{model.DataTierWarm, model.DataTierCold},
+		Limit:          20,
+	}
+	first := queryTierRestricted(ctx, t, env, coldOnly, 5, "first cold-only read compiles")
+	assertUsesDuckDB(t, first)
+	assertPlanCacheNote(t, first, "plan_cache=miss")
+
+	second := queryTierRestricted(ctx, t, env, coldOnly, 5, "second identical read is cache-served")
+	assertUsesDuckDB(t, second)
+	assertPlanCacheNote(t, second, "plan_cache=hit")
+}

--- a/internal/e2e_harness/production/plan_cache_e2e_test.go
+++ b/internal/e2e_harness/production/plan_cache_e2e_test.go
@@ -55,3 +55,83 @@ func TestEnginePlanCacheServesRepeatedShape(t *testing.T) {
 	assertUsesDuckDB(t, second)
 	assertPlanCacheNote(t, second, "plan_cache=hit")
 }
+
+// TestPlanCacheColdMissingRekeyEndToEnd restores #255's e2e poisoning probe,
+// which was structurally vacuous before #345 (no cache in the harness) and
+// stays masked in the manifest-wired evolution test (a flush changes the
+// resolved path list and re-keys the scope hash regardless). Here the Env is
+// glob-read (WithoutManifest): the path component of the scope key is one
+// constant template string across the flush, and both measured queries run
+// with an empty dirty set. Between the cached pre-flush serve and the
+// post-flush read, the ONLY scope-key component that moves is the
+// cold-missing set — which is why the post-flush plan_cache=miss below is
+// this test's load-bearing assertion. The engine-seam twin is
+// federated.TestEngineColdMissingSetRekeysPlanCache.
+//
+// Why the row count is NOT the instrument: the augmented scan renders as
+//
+//	SELECT * REPLACE (...), NULL::INTEGER AS score
+//	FROM read_parquet(<glob>, union_by_name=true)
+//
+// Post-flush the `*` also expands a real `score`, so a stale cold-absent
+// skeleton projects that name twice and the pinned DuckDB binds the first
+// (real) occurrence — the stale NULL is shadowed, not honored. Deleting the
+// cold-missing lines from duckPlanScopeParts and re-running this test was
+// verified to fail on the plan_cache note alone, with the post-flush total
+// still 3. So the scope component exists precisely so that correctness never
+// rests on that duplicate-name binding order, and only the note observes it.
+func TestPlanCacheColdMissingRekeyEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	cluster := SharedCluster(t)
+	v1 := writeSimpleSchemaDir(t, coreProps, coreAttrs)
+	v2 := writeSimpleSchemaDir(t, scoreIntProps, scoreIntAttrs)
+	env := NewEnv(t, cluster, WithSchemaDir(v1), WithoutManifest())
+	simple := DefaultSchemaFixtures()[0]
+
+	// 5 base rows under v1 (score does not exist), landed as base parquet;
+	// evolve to v2, which adds score BEFORE its first flush. No hot rows
+	// exist after init, so the dirty set is empty for every pre-flush query.
+	seedGeneration(ctx, t, env, simple, 5, buildEvolutionProfile(buildLabeledExtras(nil)))
+	runInitBase(ctx, t, env, simple)
+	if err := env.EvolveSchema(ctx, v2); err != nil {
+		t.Fatalf("evolve schema to v2: %v", err)
+	}
+
+	coldTiers := []model.DataTier{model.DataTierWarm, model.DataTierCold}
+
+	// Positive control: the cold set is visible through the glob at all —
+	// this is what makes the zero-row filter assertions below trustworthy.
+	coldAll := queryTierRestricted(ctx, t, env, Query{
+		Schema: simple, PreferredTiers: coldTiers, Limit: 20,
+	}, 5, "base rows visible via glob read")
+	assertUsesDuckDB(t, coldAll)
+
+	coldFilter := Query{
+		Schema: simple, PreferredTiers: coldTiers,
+		Filters: []Filter{{Attr: "score", Op: "gte", Value: "50"}},
+		Limit:   20,
+	}
+
+	// Pre-flush: score is cold-absent, the augmented scan projects typed
+	// NULL, the filter excludes every base row. First serve compiles...
+	pre := queryTierRestricted(ctx, t, env, coldFilter, 0, "pre-flush cold-only score filter")
+	assertUsesDuckDB(t, pre)
+	assertPlanCacheNote(t, pre, "plan_cache=miss")
+	// ...and the identical shape is then served from the cached skeleton:
+	// the poisoning hazard is now armed.
+	pre2 := queryTierRestricted(ctx, t, env, coldFilter, 0, "pre-flush repeat armed from cache")
+	assertPlanCacheNote(t, pre2, "plan_cache=hit")
+
+	// Land score via its first flush (3 rows, ordinals 5-7 -> score
+	// 50/60/70), leaving nothing hot, and re-run the same shape. The
+	// cold-missing set alone must force a recompile: a hit here would mean a
+	// skeleton compiled against a cold shape that no longer holds is still
+	// serving reads (see the header note on why the total stays 3 anyway).
+	seedGeneration(ctx, t, env, simple, 3, buildEvolutionProfile(buildLabeledExtras(func(ordinal int) map[string]any {
+		return map[string]any{"score": float64(ordinal * 10)}
+	})))
+	mustFlush(ctx, t, env)
+	post := queryTierRestricted(ctx, t, env, coldFilter, 3, "post-flush cold-only score filter")
+	assertUsesDuckDB(t, post)
+	assertPlanCacheNote(t, post, "plan_cache=miss")
+}

--- a/internal/e2e_harness/production/plan_cache_e2e_test.go
+++ b/internal/e2e_harness/production/plan_cache_e2e_test.go
@@ -134,4 +134,13 @@ func TestPlanCacheColdMissingRekeyEndToEnd(t *testing.T) {
 	post := queryTierRestricted(ctx, t, env, coldFilter, 3, "post-flush cold-only score filter")
 	assertUsesDuckDB(t, post)
 	assertPlanCacheNote(t, post, "plan_cache=miss")
+
+	// Standing guard on what the miss above means. Re-running the same shape
+	// must now hit: the post-flush miss produced a usable recompiled entry,
+	// and the cache itself survived the flush. Without this line a future
+	// harness change that discarded the engine (and with it the cache) during
+	// flush would make the miss trivially true — an empty cache rather than a
+	// re-key — and this probe would silently stop testing #255's keying.
+	post2 := queryTierRestricted(ctx, t, env, coldFilter, 3, "post-flush repeat is cache-served")
+	assertPlanCacheNote(t, post2, "plan_cache=hit")
 }

--- a/internal/e2e_harness/production/schema_evolution_never_flushed_e2e_test.go
+++ b/internal/e2e_harness/production/schema_evolution_never_flushed_e2e_test.go
@@ -97,14 +97,12 @@ func TestSchemaEvolutionNeverFlushedColumn(t *testing.T) {
 	// Scope note: this pair proves end-to-end pre/post-flush CORRECTNESS —
 	// the missing set is recomputed per query, so the same shape answers from
 	// the augmented scan before the flush and from the real column after it.
-	// It is NOT a plan-cache proof: the harness engine (production/engine.go)
-	// is built without WithPlanCache, unlike factory.NewEntityManager, so
-	// serveFromPlanCache returns ok=false on every query here and no skeleton
-	// is ever reused. (The harness Env is also manifest-wired, so a flush
-	// changes the resolved path list, which would re-key the scope hash via
-	// parquetPaths regardless.) The genuine re-key proof — same shape, same
-	// paths, cache HIT in between, missing set alone forcing a recompile —
-	// lives in federated.TestEngineColdMissingSetRekeysPlanCache.
+	// It is NOT a plan-cache proof: this Env is manifest-wired, so the flush
+	// changes the resolved path list and re-keys the scope hash regardless of
+	// the missing set (and the flush also empties the dirty set, which is a
+	// key component too). The genuine missing-set-alone re-key proof lives in
+	// TestPlanCacheColdMissingRekeyEndToEnd (glob Env, #345) and, at the
+	// engine seam, federated.TestEngineColdMissingSetRekeysPlanCache.
 	coldFilter := Query{
 		Schema: simple, PreferredTiers: coldTiers,
 		Filters: []Filter{{Attr: "score", Op: "gte", Value: "50"}},


### PR DESCRIPTION
Closes #345

The production e2e harness engine (`internal/e2e_harness/production/engine.go`) built the federated engine without `WithPlanCache`, unlike the real composition root — so `serveFromPlanCache` returned `ok=false` on every harness query and the entire production e2e suite never exercised the compiled-plan serve path. This branch wires it, guards it, restores #255's poisoning probe as a genuine end-to-end proof, and retires the stale prose. Harness-only: no production (non-test) code is touched.

## Commits

- `75afb92` — `Engine()` now builds one `queryplan.NewCache(4096)` shared between its repository and the engine options, exactly the `factory.newRepositoryAndEngine` pairing (#142). The cache is a local of the assembly, so `EvolveSchema`/`ReopenDuckDB` (which nil `e.engine`) discard it with the engine, matching the cold restart both model — `evolve.go`'s existing comment claimed this and is now true. Guarded by `TestEnginePlanCacheServesRepeatedShape`: red-first (no `plan_cache=` note of either kind existed before the wiring), and a deletion spot-check confirmed removing the `WithPlanCache` engine option turns it red again.
- `502b13c` — `TestPlanCacheColdMissingRekeyEndToEnd`: glob Env (`WithoutManifest()`, constant path component) with both measured reads on an empty dirty set, so between the cached pre-flush serve and the post-flush read the ONLY scope-key component that moves is the #255 cold-missing set. Asserts miss → hit → (flush) → miss.
- `cb386f5` — retires the now-false "built without WithPlanCache" scope note in `schema_evolution_never_flushed_e2e_test.go`; a tree-wide sweep confirmed it was the only stale claim.
- `9e51371` — final-review fixes: `post2` re-run asserting `plan_cache=hit` after the post-flush miss (pins that the miss produced a usable recompiled entry AND that the cache survived the flush — a standing guard against the probe going silently vacuous again), plus a one-word comment grammar fix.

## Finding: the #255 scope component is defense-in-depth, not a reachable wrong answer

The issue (and the plan) predicted that a stale cold-absent skeleton served post-flush would keep projecting NULL and answer 0. Mutation verification **disproved the "answer 0" half** (full write-up: [#345 execution note](https://github.com/Lychee-Technology/forma/issues/345#issuecomment-5300696457)): with the cold-missing scope lines deleted (via `go test -overlay`, work tree untouched), the stale skeleton IS reused and still renders `NULL::INTEGER AS score` — but `SELECT *` under `union_by_name` also expands the real post-flush `score`, the name appears twice, and the pinned DuckDB binds the first (real) occurrence. Total stayed 3; only the `plan_cache=hit` note betrayed the staleness. The probe's load-bearing assertion is therefore the post-flush `plan_cache=miss` (keying truthfulness), and the shipped test comment states this true mechanism. The mutated run doubles as positive proof that every other scope component is stable across the flush. Follow-up filed: #409 (collision-proof `BuildParquetScanSource` instead of relying on binding order).

## Scope decision

`EntityManager()`'s repository deliberately keeps its repository-local default cache; only the `Engine()` repo/engine pair shares one cache instance. The OLTP path already caches either way — unifying the harness's two repo constructions into factory's single-instance shape would be a fidelity refactor with no observable behavior difference, and is left out.

## Full sweep (the issue's condition for this change; run at `cb386f5`)

| # | Suite | Command | Result | Counts | Wall |
|---|---|---|---|---|---|
| 1 | Format gate | `make fmt-check` | PASS | — | ~1s |
| 1 | Lint gate | `make lint` | PASS | 0 findings | 1.4s (4.7s cold cache) |
| 1 | Lint, `e2e` tag (extra) | `golangci-lint --build-tags=e2e ./internal/e2e_harness/...` | PASS for `production/` | 0 in changed pkg; 6 pre-existing in `federated/` → #410 | 4.9s |
| 2 | Unit | `make test` | PASS | 35 pkg ok, 0 fail | 16.0s |
| 3 | **Production e2e** | `make test-e2e-production` | **PASS** | 129 tests + 104 subtests, 0 fail, 0 skip | 2:18 |
| 4a | Harness smoke | `go test -v ./internal/e2e_harness/... -timeout=5m` | PASS | 162 pass, 0 fail | 8.2s |
| 4b | Federated e2e short | `go test -v ./internal/e2e_harness/federated/... -tags=e2e -short` | PASS | 187 + 41 subtests, 0 fail, 38 explicit `-short` skips | 2:00 |
| extra | Unit `-race` | `go test -race . ./cdc ./cmd/... ./factory ./internal/...` | PASS | 32 pkg ok, 0 races | 36.2s |
| extra | Production e2e `-race` | `go test -race ./internal/e2e_harness/production/ -tags=e2e` | PASS | 0 races, 0 fail | 2:45 |

Every one of the 129 production e2e tests now routes through `serveFromPlanCache` and answers identically with cached skeletons + per-request arg binding; no harness assertion needed loosening. The `-race` runs were added because a newly shared cache under concurrent queries is exactly where a race would hide. Post-sweep commit `9e51371` touches only the two harness test/comment files; both affected e2e tests were re-run green (`TestPlanCacheColdMissingRekeyEndToEnd` 4.64s, `TestEnginePlanCacheServesRepeatedShape` 4.21s) plus `make fmt-check`.

## Deferred (triaged by the final whole-branch review; none block merge)

- Repo-side `WithPlanCache` injection is unguarded — deleting it degrades only to the repo-local default cache (fidelity, not coverage).
- `assertPlanCacheNote` is membership-only — hit+miss coexistence in Notes is unreachable today (`executionPlanMark.rewind` truncates on retry; #348 tracks the Timings variant).

## Follow-ups filed

- #409 — `BuildParquetScanSource` duplicate-column collision-proofing (from the mutation finding above).
- #410 — CI lint gate never loads e2e-tagged files (6 pre-existing findings in `federated/`); also notes the `-race` e2e gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)