### PR TITLE
feat(federated): correlate #256 scan-guard failures back to the offending parquet object

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -503,7 +503,9 @@ Note that #251 verification drains `SELECT *` without the guard, so a
 schema-wrong (as opposed to byte-corrupt) object is never confirmed corrupt and
 never excluded — correct: exclusion is for unreadable bytes, while an
 export-schema violation is an operator-visible consistency fault, not something
-to route around.
+to route around. The guarded per-file identification pass (#351) is the
+deliberate counterpart: it uses the guard precisely to *name* such an object,
+while still never excluding it.
 
 **Trust boundary.** A stamp is trusted without reading bytes only because every
 object behind one was written by a Forma writer under manifest transactionality:
@@ -524,16 +526,35 @@ in the tool; and (c) the `deleted_at` presence channel, which stays gated at
 the read path until pre-#274 legacy delta objects are retired (#365) and is
 therefore reachable *only* through (b) until then.
 
-**Triage: the guard names the invariant, not the object.** When the guard fires,
-the operator gets the violated invariant and the offending column, but no path.
-Three things compound to that: the guard runs inside a single `union_by_name`
-scan over the whole resolved set, so DuckDB raises one error for the set rather
-than per file; the object *exists*, so nothing in the missing-key classification
-path speaks up; and the #251 drain above is unguarded, so its verify pass reads
-the file clean and excludes nothing. Until #351 adds guarded per-file
-identification, the triage path is manual bisection: list the schema's manifest
-paths, then run the guarded scan against one path at a time until the failing
-object is isolated.
+**Triage: the guard failure names its objects.** The set-scan error itself
+cannot name a path — the guard runs inside a single `union_by_name` scan over
+the whole resolved set, so DuckDB raises one error for the set — but on a
+guard-classified failure the engine now runs a guarded per-file drain over the
+manifest-listed set (#351): each object is re-read alone through the same
+guarded scan source, and an object whose guarded drain fails twice while its
+bare `SELECT *` drain reads clean is attributed as a schema-invariant violator.
+The differential is what separates the three failure families — byte
+corruption fails both drains (#251 territory), a missing object never gets
+here (#187 classification wins first), and only a schema-wrong object splits
+them. Attribution surfaces in two places: the returned
+`ParquetGuardViolationError` names the schema and the offending storage keys,
+and the engine logs an Error with the same paths — the log matters because
+under `AllowPartialDegradedMode` the error is absorbed by the postgres-only
+fallback. Identification never excludes: unlike byte corruption, a
+schema-wrong object may legitimately own rows that exclusion would silently
+drop once the object is repaired, so the retry-after-exclusion machinery
+stays #251-only. Note the deliberate breadth: a single-file guarded scan is
+strictly stricter than the set scan (a file missing only `deleted_at` fails
+alone but is tolerated in a set where a sibling carries the column), so the
+error's wording is an invariant statement — "fails the guarded single-file
+scan" — not a causation claim. Hint-authored path sets are not identified
+(no manifest vouches for them); for those the manual path remains: list the
+schema's manifest paths, then run the guarded scan against one path at a time.
+The cost envelope stays on the failure path: identification runs only when a
+read has already failed, adds at most ~3 drains per manifest-listed object
+(the guarded pair plus the bare confirmation) on top of #251's verification
+drains, runs the paths sequentially on the engine's DuckDB pool (one open
+connection by default, #285), and bails on context cancellation.
 
 **Cache invalidation.** The validator caches each path it validates, keyed by
 path **and by the stamp it was validated under** (nil for probe-validated). Path

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -528,15 +528,22 @@ therefore reachable *only* through (b) until then.
 
 **Triage: the guard failure names its objects.** The set-scan error itself
 cannot name a path — the guard runs inside a single `union_by_name` scan over
-the whole resolved set, so DuckDB raises one error for the set — but on a
-guard-classified failure the engine now runs a guarded per-file drain over the
-manifest-listed set (#351): each object is re-read alone through the same
-guarded scan source, and an object whose guarded drain fails twice while its
-bare `SELECT *` drain reads clean is attributed as a schema-invariant violator.
-The differential is what separates the three failure families — byte
-corruption fails both drains (#251 territory), a missing object never gets
-here (#187 classification wins first), and only a schema-wrong object splits
-them. Attribution surfaces in two places: the returned
+the whole resolved set, so DuckDB raises one error for the set — but on a read
+failure that neither the missing-object classification (#187) nor the
+corruption confirmation (#251) claims, the engine now runs a guarded per-file
+drain over the manifest-listed set (#351): each object is re-read alone through
+the same guarded scan source, and an object whose guarded drain fails twice
+while its bare `SELECT *` drain reads clean is attributed as a schema-invariant
+violator. Note that the trigger is deliberately *not* a guard-specific
+classification — no such classification exists. Recognizing a fired guard would
+mean matching driver error text, which would miss the BIGINT `CAST` channel
+entirely, whose wording is DuckDB's own rather than one of the authored guard
+messages. Identification therefore runs on any unclaimed read failure and lets
+the differential decide; that same differential separates the three failure
+families — byte corruption fails both drains (#251 territory), a missing object
+never gets here (#187 classification wins first), and only a schema-wrong
+object splits them. On a failure no object owns, every guarded drain passes and
+nothing is attributed. Attribution surfaces in two places: the returned
 `ParquetGuardViolationError` names the schema and the offending storage keys,
 and the engine logs an Error with the same paths — the log matters because
 under `AllowPartialDegradedMode` the error is absorbed by the postgres-only
@@ -634,7 +641,7 @@ One unreadable parquet object no longer fails a whole manifest-authored scan. Th
 
 **Why a drain, not a footer probe.** DuckDB answers `DESCRIBE` and `COUNT(*)` from the Thrift footer and row-group metadata without touching data pages, so a footer probe passes cleanly on a page-corrupt object — the pre-read schema validator already footer-probes, and scenario 7 still failed. Only a drain reads the pages. A **solo drain reads a superset of the columns the scan projects**, so whatever per-file failure made the set scan fail is deterministically reproduced by the per-file pass; there is no failure that the set scan can detect and the verification pass cannot. That superset property is what makes attribution sound: an object is excluded because it was proven unreadable on its own, not because it was in the set when something went wrong.
 
-**Operator note — failure-path cost.** Verification drains every object of the failed set sequentially on the engine's single pooled connection (#285), and the retry then re-scans the remainder: for a tier of N listed objects, the first query after a corruption pays roughly N solo drains (one extra re-drain per failing object, for the two-failure confirmation) plus a second scan — and because cache entries expire, the same bill recurs on the first query of each retention window for as long as the corrupt object stays listed. This is the deliberate trade (cost bounded by failures, not by queries), but on large tiers it surfaces as a periodic latency blip, once per corrupt object per TTL window, until compaction or a manifest reconcile retires the object. A footer-probe pre-filter would not reduce it: footer-dead objects already fail the drain at open time (the drain's bind IS a footer read), and the dominant term — draining the healthy objects — cannot be certified by any metadata-only probe.
+**Operator note — failure-path cost.** Verification drains every object of the failed set sequentially on the engine's pooled connection (one open connection by default, #285), and the retry then re-scans the remainder: for a tier of N listed objects, the first query after a corruption pays roughly N solo drains (one extra re-drain per failing object, for the two-failure confirmation) plus a second scan — and because cache entries expire, the same bill recurs on the first query of each retention window for as long as the corrupt object stays listed. This is the deliberate trade (cost bounded by failures, not by queries), but on large tiers it surfaces as a periodic latency blip, once per corrupt object per TTL window, until compaction or a manifest reconcile retires the object. A footer-probe pre-filter would not reduce it: footer-dead objects already fail the drain at open time (the drain's bind IS a footer read), and the dominant term — draining the healthy objects — cannot be certified by any metadata-only probe.
 
 **Why not `ignore_errors`.** It does not exist. On the pinned engine (DuckDB **v1.4.5** via `github.com/duckdb/duckdb-go/v2`) `read_parquet(..., ignore_errors := true)` fails at bind time with `Binder Error: Invalid named parameter "ignore_errors" for function read_parquet`, and DuckDB enumerates the complete accepted parameter list — it contains no error-tolerance knob of any kind (`ignore_errors` is a `read_csv` parameter). The option therefore cannot be adopted today, and it would be rejected even if a later version added it: a reader-level skip is **silent** — no execution-plan marker, no classification, no per-object attribution — which recreates exactly the scenario-2 silent-loss class this subsystem exists to prevent. Depending on a flag whose appearance in a future upgrade would silently change read semantics is the wrong shape of dependency. See `docs/superpowers/plans/2026-08-02-issue-251-spike-findings.md` for the raw evidence.
 

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -305,9 +305,13 @@ func newRepositoryAndEngine(
 	planCache := queryplan.NewCache(4096)
 	repository := internal.NewDBPersistentRecordRepository(pool, metadataCache, internal.WithPlanCache(planCache))
 	// zap.L() is the same global the rest of this package logs through. It
-	// carries the federated validator's #256 stamp/footer cross-check, whose
-	// only surface is a log line: the read it observes succeeds, so no caller
-	// error and no execution plan would ever mention it.
+	// carries two log-only signals. The federated validator's #256
+	// stamp/footer cross-check, whose only surface is a log line: the read it
+	// observes succeeds, so no caller error and no execution plan would ever
+	// mention it. And the #351 guard-violation attribution: under
+	// AllowPartialDegradedMode the error naming the offending objects is
+	// absorbed into a Postgres-only answer and toExecutionPlan drops plan
+	// Notes, so the log line is the only surface that survives.
 	engineOpts := []federated.EngineOption{
 		federated.WithPlanCache(planCache),
 		federated.WithLogger(zap.L()),

--- a/internal/federated/circuit_breaker_integration_test.go
+++ b/internal/federated/circuit_breaker_integration_test.go
@@ -32,14 +32,18 @@ func (f *failingScanRows) Scan(dest ...any) error { return fmt.Errorf("forced sc
 func (f *failingScanRows) Err() error             { return nil }
 func (f *failingScanRows) Close() error           { return nil }
 
-// scriptedDuckDBExecutor plays one prepared outcome per Query call and
-// repeats the last one when the script runs out.
+// scriptedDuckDBExecutor plays one prepared outcome per MAIN-scan Query call
+// and repeats the last one when the script runs out. Per-file drains are
+// answered clean off-script (see answerParquetDrainSQL).
 type scriptedDuckDBExecutor struct {
 	calls  int
 	script []func() (duckDBRowsIterator, error)
 }
 
 func (s *scriptedDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
+	if drained, ok := answerParquetDrainSQL(sql); ok {
+		return drained, nil
+	}
 	idx := s.calls
 	s.calls++
 	if idx >= len(s.script) {

--- a/internal/federated/corrupt_retry_seam_test.go
+++ b/internal/federated/corrupt_retry_seam_test.go
@@ -71,6 +71,14 @@ func (d *retryFakeDuck) Query(ctx context.Context, sql string, args ...any) (duc
 	if strings.HasPrefix(sql, "DESCRIBE ") || strings.HasPrefix(sql, "SELECT file FROM glob(") {
 		return d.fakeDuckDBExecutor.Query(ctx, sql, args...)
 	}
+	if isGuardedParquetDrainSQL(sql) {
+		// #351 guarded drains stay off both odometers: this fake scripts main
+		// scans and the bare #251 verification drains (drainsAtClose is the
+		// #285 ordering proof and counts exactly those). Without this branch a
+		// guarded drain would fall through to the main-scan arm and silently
+		// advance the pass index.
+		return &verifyFakeRows{rowsLeft: 1}, nil
+	}
 	if strings.HasPrefix(sql, "SELECT * FROM read_parquet(") {
 		d.drains++
 		for _, token := range d.pass().drainFails {

--- a/internal/federated/duckdb_query_execute.go
+++ b/internal/federated/duckdb_query_execute.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/redact"
+	"go.uber.org/zap"
 )
 
 // Execute-and-stream half of the DuckDB federated read path: running the
@@ -99,6 +100,11 @@ func (e *DBFederatedQueryEngine) executeAndStreamDuckDB(
 // verification pass just read every other object through the same engine and
 // session, so it hands back the probe slot instead of recording a failure —
 // a permanently corrupt object must not hold the breaker open forever.
+// Last, a failure neither branch claimed runs the #351 guard identification:
+// the bare drains just read every object clean, so if a guarded single-file
+// drain fails deterministically the failure is a schema-invariant violation
+// and the error names the object(s). Identification decorates — it never
+// excludes, never retries, and never changes the classification chain.
 func (e *DBFederatedQueryEngine) failDuckDBScan(ctx context.Context, q *model.FederatedAttributeQuery, sc scan, cause error, op string) error {
 	classified := e.classifyDuckDBReadError(ctx, q, sc.parquetPaths, sc.pathsFromSource)
 	var inconsistent *ParquetSetInconsistentError
@@ -118,7 +124,34 @@ func (e *DBFederatedQueryEngine) failDuckDBScan(ctx context.Context, q *model.Fe
 	if e.breaker != nil {
 		e.breaker.RecordFailure()
 	}
-	return fmt.Errorf("%s: %w: %w", op, classified, cause)
+	wrapped := fmt.Errorf("%s: %w: %w", op, classified, cause)
+	violating := e.identifyGuardViolationPaths(ctx, sc)
+	if len(violating) == 0 {
+		return wrapped
+	}
+	var schemaID int16
+	if q != nil {
+		schemaID = q.SchemaID
+	}
+	// Degraded mode absorbs this error and toExecutionPlan drops plan Notes,
+	// so the log is the only outlet that survives the fallback.
+	e.log().Error("parquet scan-guard failure attributed to objects",
+		zap.Int16("schema_id", schemaID),
+		zap.Strings("paths", violating))
+	return &ParquetGuardViolationError{SchemaID: schemaID, Paths: violating, cause: wrapped}
+}
+
+// identifyGuardViolationPaths gates the #351 identification the way
+// confirmCorruptPaths gates #251 verification: source-authored sets only —
+// hint-authored paths name objects no manifest vouches for, and the caller
+// pinned them deliberately. Unlike #251 it runs for single-path sets too:
+// verification needs a readable remainder to be worth confirming, whereas
+// naming the one object in the set is exactly what an operator needs.
+func (e *DBFederatedQueryEngine) identifyGuardViolationPaths(ctx context.Context, sc scan) []string {
+	if e == nil || e.duck == nil || !sc.pathsFromSource || len(sc.parquetPaths) == 0 {
+		return nil
+	}
+	return identifyGuardViolations(ctx, e.duck, sc.parquetPaths)
 }
 
 // confirmCorruptPaths runs per-file verification when the failed scan ran

--- a/internal/federated/duckdb_query_execute.go
+++ b/internal/federated/duckdb_query_execute.go
@@ -129,16 +129,12 @@ func (e *DBFederatedQueryEngine) failDuckDBScan(ctx context.Context, q *model.Fe
 	if len(violating) == 0 {
 		return wrapped
 	}
-	var schemaID int16
-	if q != nil {
-		schemaID = q.SchemaID
-	}
 	// Degraded mode absorbs this error and toExecutionPlan drops plan Notes,
 	// so the log is the only outlet that survives the fallback.
 	e.log().Error("parquet scan-guard failure attributed to objects",
-		zap.Int16("schema_id", schemaID),
+		zap.Int16("schema_id", q.SchemaID),
 		zap.Strings("paths", violating))
-	return &ParquetGuardViolationError{SchemaID: schemaID, Paths: violating, cause: wrapped}
+	return &ParquetGuardViolationError{SchemaID: q.SchemaID, Paths: violating, cause: wrapped}
 }
 
 // identifyGuardViolationPaths gates the #351 identification the way

--- a/internal/federated/duckdb_query_execute_test.go
+++ b/internal/federated/duckdb_query_execute_test.go
@@ -133,6 +133,14 @@ func TestFailDuckDBScanAllPathsUnreadableIsEngineSickness(t *testing.T) {
 	if errors.As(err, &retry) {
 		t.Fatal("every-object-unreadable is store/engine sickness, not per-file corruption")
 	}
+	// The #351 firewall: a sick store fails the guarded drain of every object,
+	// so identification must decline it too. It can only do so because it
+	// confirms the BARE drain succeeds before naming a path — delete that leg
+	// and every object in a sick store is misattributed as schema-wrong.
+	var viol *ParquetGuardViolationError
+	if errors.As(err, &viol) {
+		t.Fatalf("store/engine sickness must not be attributed to objects, got: %v", viol.Paths)
+	}
 	if !breaker.IsOpen() {
 		t.Fatal("store-wide failure must feed the breaker")
 	}

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lychee-technology/forma/internal/schemameta"
 	"github.com/lychee-technology/forma/internal/sqlgen"
 	"github.com/lychee-technology/forma/internal/sqlutil"
+	"go.uber.org/zap"
 )
 
 // PostgresFederatedSource is the Postgres-side seam the federated engine
@@ -80,6 +81,14 @@ type DBFederatedQueryEngine struct {
 	// (#251) so resolveParquetPaths can exclude them. TTL-bounded — see
 	// corruptParquetCache. Only source-authored path sets consult it.
 	corruptPaths *corruptParquetCache
+	// logger is the engine's own operator outlet; zap.NewNop() when unset
+	// (see log(), in engine_options.go beside the option that sets this).
+	// Two writers use it: the pre-read validator's stamp cross-check (#256,
+	// via schemaValidator.logger, set together in WithLogger) and the
+	// guard-violation identification (#351), which needs a log precisely
+	// because in degraded mode its error is absorbed by the postgres-only
+	// fallback and plan Notes never reach API callers.
+	logger *zap.Logger
 }
 
 // flushGraceCutoffMs computes the per-request dirty-barrier cutoff from the

--- a/internal/federated/engine_empty_page_test.go
+++ b/internal/federated/engine_empty_page_test.go
@@ -24,6 +24,12 @@ type sequencedDuckDBExecutor struct {
 }
 
 func (f *sequencedDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
+	// Per-file drains are answered clean off-sequence: the sequence scripts
+	// main scans, and duck.calls is asserted as a main-scan odometer
+	// (see answerParquetDrainSQL).
+	if drained, ok := answerParquetDrainSQL(sql); ok {
+		return drained, nil
+	}
 	idx := f.calls
 	f.calls++
 	if idx < len(f.errs) && f.errs[idx] != nil {

--- a/internal/federated/engine_fakes_test.go
+++ b/internal/federated/engine_fakes_test.go
@@ -65,12 +65,6 @@ type fakeDuckDBExecutor struct {
 	// test relies on: fixed system columns, unlistable globs.
 	globFiles    []string
 	describeCols map[string][][2]string
-
-	// drainCalls counts the per-file drains the failure path issues (#251
-	// verification and #351 guard identification). Counted separately from
-	// calls for the same reason describeCalls is: `calls`/`rows`/`err` model
-	// the MAIN scan, and every test that asserts on them means main scans.
-	drainCalls int
 }
 
 // isBareParquetDrainSQL / isGuardedParquetDrainSQL recognize the two per-file
@@ -136,7 +130,9 @@ func (f *fakeDuckDBExecutor) Query(ctx context.Context, sql string, args ...any)
 		return nil, fmt.Errorf("glob listing not faked")
 	}
 	if drained, ok := answerParquetDrainSQL(sql); ok {
-		f.drainCalls++
+		// Per-file drains (#251 verification, #351 identification) never touch
+		// calls/lastSQL/rows: those model the MAIN scan, and every test that
+		// asserts on them means main scans.
 		return drained, nil
 	}
 	f.calls++

--- a/internal/federated/engine_fakes_test.go
+++ b/internal/federated/engine_fakes_test.go
@@ -65,6 +65,44 @@ type fakeDuckDBExecutor struct {
 	// test relies on: fixed system columns, unlistable globs.
 	globFiles    []string
 	describeCols map[string][][2]string
+
+	// drainCalls counts the per-file drains the failure path issues (#251
+	// verification and #351 guard identification). Counted separately from
+	// calls for the same reason describeCalls is: `calls`/`rows`/`err` model
+	// the MAIN scan, and every test that asserts on them means main scans.
+	drainCalls int
+}
+
+// isBareParquetDrainSQL / isGuardedParquetDrainSQL recognize the two per-file
+// drain renderings by their SQL shape, never by driver text: verifyParquetPaths
+// (#251) drains `SELECT * FROM read_parquet('p')`, while identifyGuardViolations
+// (#351) drains through sqlgen.BuildParquetScanSource, which wraps the read in
+// the guarded `(SELECT * REPLACE (...) FROM ...) AS cold_scan` sub-select. A
+// rendered main scan is the advanced template (`WITH dirty_ids AS (...`) and
+// matches neither.
+func isBareParquetDrainSQL(sqlStr string) bool {
+	return strings.HasPrefix(sqlStr, "SELECT * FROM read_parquet(")
+}
+
+func isGuardedParquetDrainSQL(sqlStr string) bool {
+	return strings.HasPrefix(sqlStr, "SELECT * FROM (SELECT ") &&
+		strings.HasSuffix(sqlStr, ") AS cold_scan")
+}
+
+// answerParquetDrainSQL answers a per-file drain with a clean, BOUNDED
+// iterator and reports false for anything else. Every sequencing fake in this
+// package scripts MAIN scans; letting a drain consume the next scripted
+// outcome would both spend a slot the test never budgeted and risk spinning
+// forever, because a main-scan iterator may legitimately be unbounded
+// (failingScanRows.Next never returns false) while a drain iterates to
+// exhaustion. Clean is also the neutral answer: no test that merely fails a
+// main scan then acquires a corruption (#251) or guard-violation (#351)
+// verdict it never asked for.
+func answerParquetDrainSQL(sqlStr string) (duckDBRowsIterator, bool) {
+	if isBareParquetDrainSQL(sqlStr) || isGuardedParquetDrainSQL(sqlStr) {
+		return &verifyFakeRows{rowsLeft: 1}, true
+	}
+	return nil, false
 }
 
 func (f *fakeDuckDBExecutor) Query(ctx context.Context, sql string, args ...any) (duckDBRowsIterator, error) {
@@ -96,6 +134,10 @@ func (f *fakeDuckDBExecutor) Query(ctx context.Context, sql string, args ...any)
 			return &fakeStringRows{vals: f.globFiles}, nil
 		}
 		return nil, fmt.Errorf("glob listing not faked")
+	}
+	if drained, ok := answerParquetDrainSQL(sql); ok {
+		f.drainCalls++
+		return drained, nil
 	}
 	f.calls++
 	f.lastSQL = sql

--- a/internal/federated/engine_options.go
+++ b/internal/federated/engine_options.go
@@ -21,18 +21,33 @@ func WithPlanCache(c *queryplan.Cache) EngineOption {
 
 // WithLogger gives the engine a logger; the default is zap.NewNop(). The
 // engine reports itself through returned errors and the execution plan, so
-// this is deliberately narrow: it carries the pre-read validator's
-// stamp-versus-footer cross-check (#256), which has no other outlet because
-// the read it observes SUCCEEDS. A manifest entry whose column stamp
-// contradicts the object's real footer is an operator's problem — no caller's
-// result would ever mention it.
+// this stays narrow — two outlets whose observations have nowhere else to go:
+// the pre-read validator's stamp-versus-footer cross-check (#256), invisible
+// because the read it observes SUCCEEDS (a manifest entry whose column stamp
+// contradicts the object's real footer is an operator's problem no caller's
+// result would ever mention), and the scan-guard violation identification
+// (#351), invisible under AllowPartialDegradedMode because the degraded
+// fallback absorbs the error and toExecutionPlan drops plan Notes.
 func WithLogger(l *zap.Logger) EngineOption {
 	return func(e *DBFederatedQueryEngine) {
-		if l == nil || e.schemaValidator == nil {
+		if l == nil {
 			return
 		}
-		e.schemaValidator.logger = l
+		e.logger = l
+		if e.schemaValidator != nil {
+			e.schemaValidator.logger = l
+		}
 	}
+}
+
+// log is the nil-safe accessor for the engine's optional logger, mirroring
+// parquetSchemaValidator.log. It lives here, beside WithLogger, to keep
+// engine.go within the 500-line file limit.
+func (e *DBFederatedQueryEngine) log() *zap.Logger {
+	if e == nil || e.logger == nil {
+		return zap.NewNop()
+	}
+	return e.logger
 }
 
 // defaultCorruptPathRetention bounds how long a confirmed-corrupt parquet

--- a/internal/federated/guard_identify_seam_test.go
+++ b/internal/federated/guard_identify_seam_test.go
@@ -92,7 +92,7 @@ func TestGuardFailureIdentifiesOffendingObject(t *testing.T) {
 
 	require.Error(t, err)
 	var viol *ParquetGuardViolationError
-	require.ErrorAs(t, err, &viol, "a guard-classified failure must carry per-file identification (#351)")
+	require.ErrorAs(t, err, &viol, "an unclaimed read failure must carry per-file identification (#351)")
 	require.Equal(t, []string{guardRoguePath}, viol.Paths)
 	require.Equal(t, int16(7), viol.SchemaID)
 	require.ErrorIs(t, err, ErrFederatedReadFailed, "classification chain unchanged")

--- a/internal/federated/guard_identify_seam_test.go
+++ b/internal/federated/guard_identify_seam_test.go
@@ -1,0 +1,214 @@
+package federated
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// The #351 seam needs a two-object set: one healthy object and one whose
+// EXPORT SCHEMA is wrong. The set scan fails as a whole, the #251 bare drains
+// read BOTH objects clean (that is precisely the triage gap #351 closes), and
+// only the guarded single-file drain separates them.
+const (
+	guardHealthyPath = "s3://bucket/7/base/healthy.parquet"
+	guardRoguePath   = "s3://bucket/7/base/rogue.parquet"
+)
+
+// guardSeamFakeDuck reproduces the #351 failure shape end to end: every main
+// set scan fails carrying the guard's authored message (as the real engine
+// surfaces it through DuckDB), every BARE drain reads clean — including the
+// rogue object's, which is what makes #251 verification decline — and the
+// GUARDED single-file drain fails only for the rogue path. Schema probes are
+// delegated to the standard engine fake, as in retryFakeDuck.
+type guardSeamFakeDuck struct {
+	fakeDuckDBExecutor
+	rogue string
+
+	mainSQL  []string // one entry per main-scan attempt
+	drainSQL []string // every per-file drain, bare and guarded alike
+}
+
+func (d *guardSeamFakeDuck) Query(ctx context.Context, sqlStr string, args ...any) (duckDBRowsIterator, error) {
+	if strings.HasPrefix(sqlStr, "DESCRIBE ") || strings.HasPrefix(sqlStr, "SELECT file FROM glob(") {
+		return d.fakeDuckDBExecutor.Query(ctx, sqlStr, args...)
+	}
+	if isBareParquetDrainSQL(sqlStr) || isGuardedParquetDrainSQL(sqlStr) {
+		d.drainSQL = append(d.drainSQL, sqlStr)
+		if isGuardedParquetDrainSQL(sqlStr) && d.rogue != "" && strings.Contains(sqlStr, d.rogue) {
+			return nil, fmt.Errorf("Invalid Error: %s", sqlgen.ParquetNullRowIDMessage)
+		}
+		return &verifyFakeRows{rowsLeft: 1}, nil
+	}
+	d.mainSQL = append(d.mainSQL, sqlStr)
+	return nil, fmt.Errorf("Invalid Error: %s", sqlgen.ParquetNullRowIDMessage)
+}
+
+func (d *guardSeamFakeDuck) guardedDrains() []string {
+	var out []string
+	for _, q := range d.drainSQL {
+		if isGuardedParquetDrainSQL(q) {
+			out = append(out, q)
+		}
+	}
+	return out
+}
+
+// newGuardSeamEngine mirrors newParquetSourceTestEngine but forwards extra
+// engine options, which the degraded-mode log test needs (WithLogger is the
+// only logger setter).
+func newGuardSeamEngine(t *testing.T, duck DuckDBQueryExecutor, src ParquetSource, opts ...EngineOption) *DBFederatedQueryEngine {
+	t.Helper()
+	all := append([]EngineOption{WithParquetSource(src)}, opts...)
+	return NewDBFederatedQueryEngine(&fakePostgresFederatedSource{}, &fakeDirtyIDFetcher{}, duck, nil,
+		hybridDuckConfig(), testMetadataCacheSchema7(t), "host=x", all...)
+}
+
+func guardSeamTables() model.StorageTables {
+	return model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"}
+}
+
+// TestGuardFailureIdentifiesOffendingObject is the payload: a set-scan failure
+// that neither the missing-object classifier nor the #251 verification pass
+// claims must come back naming the object(s) that fail the guarded single-file
+// scan — and it must do so without retrying or altering the classification.
+func TestGuardFailureIdentifiesOffendingObject(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &guardSeamFakeDuck{rogue: guardRoguePath}
+	e := newGuardSeamEngine(t, duck, &fakeParquetSource{paths: []string{guardHealthyPath, guardRoguePath}})
+
+	_, err := e.Query(context.Background(), guardSeamTables(), coldTierQuery(), nil)
+
+	require.Error(t, err)
+	var viol *ParquetGuardViolationError
+	require.ErrorAs(t, err, &viol, "a guard-classified failure must carry per-file identification (#351)")
+	require.Equal(t, []string{guardRoguePath}, viol.Paths)
+	require.Equal(t, int16(7), viol.SchemaID)
+	require.ErrorIs(t, err, ErrFederatedReadFailed, "classification chain unchanged")
+	require.Len(t, duck.mainSQL, 1, "identification only: no retry pass — exclusion is #251's, not #351's")
+}
+
+// TestGuardViolationIsNeverExcluded is the load-bearing negative: the violator
+// is identified, NOT cached for exclusion. A schema-wrong object may
+// legitimately own rows, so dropping it would silently shorten every answer
+// for the retention window. This test goes red the moment someone wires
+// identification into corruptPaths.Add.
+func TestGuardViolationIsNeverExcluded(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &guardSeamFakeDuck{rogue: guardRoguePath}
+	e := newGuardSeamEngine(t, duck, &fakeParquetSource{paths: []string{guardHealthyPath, guardRoguePath}})
+
+	_, _ = e.Query(context.Background(), guardSeamTables(), coldTierQuery(), nil)
+	_, _ = e.Query(context.Background(), guardSeamTables(), coldTierQuery(), nil)
+
+	require.Len(t, duck.mainSQL, 2)
+	require.Contains(t, duck.mainSQL[1], guardRoguePath,
+		"identification must not shrink the second query's scan set")
+
+	kept, excluded := e.corruptPaths.Split([]string{guardHealthyPath, guardRoguePath})
+	require.Empty(t, excluded, "an identified guard violator must never be cached for exclusion")
+	require.Len(t, kept, 2)
+}
+
+// TestGuardIdentificationLogsUnderDegradedMode pins the loud outlet: degraded
+// mode absorbs the error into a Postgres-only answer and toExecutionPlan drops
+// plan Notes, so the log line is the only place the attribution survives.
+func TestGuardIdentificationLogsUnderDegradedMode(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	core, logs := observer.New(zap.ErrorLevel)
+	duck := &guardSeamFakeDuck{rogue: guardRoguePath}
+	e := newGuardSeamEngine(t, duck,
+		&fakeParquetSource{paths: []string{guardHealthyPath, guardRoguePath}},
+		WithLogger(zap.New(core)))
+
+	opts := &model.FederatedQueryOptions{AllowPartialDegradedMode: true}
+	page, err := e.Query(context.Background(), guardSeamTables(), coldTierQuery(), opts)
+
+	require.NoError(t, err, "degradable classification must be unchanged by identification")
+	require.NotNil(t, page)
+
+	entries := logs.FilterMessage("parquet scan-guard failure attributed to objects").All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	require.Equal(t, []any{guardRoguePath}, fields["paths"])
+	require.Equal(t, int16(7), fields["schema_id"])
+}
+
+// TestMissingObjectClassificationWinsOverIdentification pins the ordering: a
+// manifest-listed object missing from storage is #187 scenario 2 —
+// non-degradable inconsistency. It must win, and identification must not run
+// at all: its drains would spend failing round trips on a store already known
+// inconsistent, and a missing object fails the guarded drain too, so it would
+// be misattributed as a schema violation.
+func TestMissingObjectClassificationWinsOverIdentification(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &guardSeamFakeDuck{rogue: guardRoguePath}
+	src := &fakeParquetSource{
+		paths:   []string{guardHealthyPath, guardRoguePath},
+		missing: []string{"7/base/healthy.parquet"},
+	}
+	e := newGuardSeamEngine(t, duck, src)
+
+	_, err := e.Query(context.Background(), guardSeamTables(), coldTierQuery(), nil)
+
+	require.ErrorIs(t, err, ErrParquetSetInconsistent)
+	var viol *ParquetGuardViolationError
+	require.False(t, errors.As(err, &viol),
+		"an inconsistency classification must not be decorated with guard identification")
+	require.Empty(t, duck.guardedDrains(),
+		"no guarded identification drains after an inconsistency classification")
+}
+
+// TestGuardIdentificationSkippedForHintAuthoredSet pins the gating that
+// mirrors confirmCorruptPaths: a caller-pinned hint set names objects no
+// manifest vouches for, so identification never probes them.
+func TestGuardIdentificationSkippedForHintAuthoredSet(t *testing.T) {
+	duck := &guardSeamFakeDuck{rogue: guardRoguePath}
+	e := NewDBFederatedQueryEngine(nil, nil, duck, nil, hybridDuckConfig(), nil, "",
+		WithParquetSource(&fakeParquetSource{}))
+
+	sc := scan{parquetPaths: []string{guardHealthyPath, guardRoguePath}, pathsFromSource: false}
+	err := e.failDuckDBScan(context.Background(),
+		&model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7}}, sc,
+		fmt.Errorf("scan: %w: guard fired", ErrFederatedReadFailed), "execute duckdb query")
+
+	var viol *ParquetGuardViolationError
+	require.False(t, errors.As(err, &viol))
+	require.Empty(t, duck.drainSQL, "hint-authored sets must not be probed at all")
+}
+
+// TestGuardIdentificationRunsForSinglePathSet is the one place #351 is
+// deliberately WIDER than #251: verification needs a readable remainder and so
+// declines below two paths, but naming the single object in the set is exactly
+// what an operator needs.
+func TestGuardIdentificationRunsForSinglePathSet(t *testing.T) {
+	duck := &guardSeamFakeDuck{rogue: guardRoguePath}
+	e := NewDBFederatedQueryEngine(nil, nil, duck, nil, hybridDuckConfig(), nil, "",
+		WithParquetSource(&fakeParquetSource{}))
+
+	sc := scan{parquetPaths: []string{guardRoguePath}, pathsFromSource: true}
+	err := e.failDuckDBScan(context.Background(),
+		&model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7}}, sc,
+		fmt.Errorf("scan: %w: guard fired", ErrFederatedReadFailed), "execute duckdb query")
+
+	var viol *ParquetGuardViolationError
+	require.ErrorAs(t, err, &viol, "a one-object set must still name its object")
+	require.Equal(t, []string{guardRoguePath}, viol.Paths)
+	require.ErrorIs(t, err, ErrFederatedReadFailed)
+}

--- a/internal/federated/guard_identify_seam_test.go
+++ b/internal/federated/guard_identify_seam_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/sqlgen"
@@ -191,6 +192,36 @@ func TestGuardIdentificationSkippedForHintAuthoredSet(t *testing.T) {
 	var viol *ParquetGuardViolationError
 	require.False(t, errors.As(err, &viol))
 	require.Empty(t, duck.drainSQL, "hint-authored sets must not be probed at all")
+}
+
+// TestGuardViolationStillFeedsTheBreaker pins the half of the classification
+// contract identification must NOT change. The pressure here is real, not
+// hypothetical: #351's own framing — a schema-wrong object is a file problem,
+// not engine sickness — is verbatim the argument #251 used two branches above
+// to justify handing back the probe slot INSTEAD of recording a failure. So
+// this branch ships with a standing invitation to make the same edit, and the
+// invitation must be declined: unlike a confirmed-corrupt object, a guard
+// violation is not contained by the objects it names — the set scan failed
+// outright, no rows were served, and nothing here proves the engine or store
+// is healthy. Move the violation return above RecordFailure, or swap
+// RecordFailure for ReleaseProbe, and this test goes red.
+func TestGuardViolationStillFeedsTheBreaker(t *testing.T) {
+	duck := &guardSeamFakeDuck{rogue: guardRoguePath}
+	breaker := NewCircuitBreaker(1, time.Minute, time.Minute) // threshold 1: one RecordFailure opens it
+	e := NewDBFederatedQueryEngine(nil, nil, duck, breaker, hybridDuckConfig(), nil, "",
+		WithParquetSource(&fakeParquetSource{}))
+
+	sc := scan{parquetPaths: []string{guardHealthyPath, guardRoguePath}, pathsFromSource: true}
+	err := e.failDuckDBScan(context.Background(),
+		&model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7}}, sc,
+		fmt.Errorf("scan: %w: guard fired", ErrFederatedReadFailed), "execute duckdb query")
+
+	var viol *ParquetGuardViolationError
+	require.ErrorAs(t, err, &viol,
+		"precondition: this must be the guard-violation branch, not one of the earlier ones")
+	require.Equal(t, []string{guardRoguePath}, viol.Paths)
+	require.True(t, breaker.IsOpen(),
+		"an identified guard violation is still a failed scan: the breaker must record it (#351 decorates, it does not reclassify)")
 }
 
 // TestGuardIdentificationRunsForSinglePathSet is the one place #351 is

--- a/internal/federated/parquet_guard_identify.go
+++ b/internal/federated/parquet_guard_identify.go
@@ -87,20 +87,22 @@ func drainGuardedParquet(ctx context.Context, duck DuckDBQueryExecutor, path str
 // ParquetGuardViolationError decorates a read failure that neither the
 // missing-object classification (#187) nor the corruption confirmation (#251)
 // claimed, with the objects identified by the guarded per-file drain (#351).
-// Deliberate
-// wording: the paths FAIL the guarded single-file scan — an invariant
-// statement, not a causation claim, because a single-file scan is strictly
-// stricter than the set scan (a file missing only deleted_at fails alone but
-// is tolerated in a set where a sibling carries the column). Unwrap keeps the
-// original classification chain (ErrFederatedReadFailed): identification must
-// not change degradability, retry, or breaker behavior. Paths are full
-// storage URIs — operator detail; safe internally because httpapi redacts
-// non-published error text and toExecutionPlan drops Notes (#301/#306), the
-// same boundary contract corruptParquetRetryError relies on.
+// Deliberate wording: the paths FAIL the guarded single-file scan — an
+// invariant statement, not a causation claim, because a single-file scan is
+// strictly stricter than the set scan (a file missing only deleted_at fails
+// alone but is tolerated in a set where a sibling carries the column). Unwrap
+// keeps the original classification chain (ErrFederatedReadFailed):
+// identification must not change degradability, retry, or breaker behavior.
 type ParquetGuardViolationError struct {
+	// SchemaID is the schema the failed federated read was addressed to.
 	SchemaID int16
-	Paths    []string
-	cause    error
+	// Paths are the full storage URIs of the objects whose guarded
+	// single-file drain failed deterministically while their bare drain read
+	// clean. Operator detail; safe internally because httpapi redacts
+	// non-published error text and toExecutionPlan drops Notes (#301/#306),
+	// the same boundary contract corruptParquetRetryError relies on.
+	Paths []string
+	cause error
 }
 
 func (e *ParquetGuardViolationError) Error() string {

--- a/internal/federated/parquet_guard_identify.go
+++ b/internal/federated/parquet_guard_identify.go
@@ -1,0 +1,111 @@
+package federated
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lychee-technology/forma/internal/sqlgen"
+)
+
+// identifyGuardViolations attributes a #256 scan-guard failure to the parquet
+// object(s) that violate the export schema invariant (#351). The set scan is a
+// multi-file union, so DuckDB raises one error for the whole set; the #251
+// verify pass drains bare SELECT * and reads a schema-wrong object clean; and
+// the missing-key classifier only speaks for objects that are absent. This
+// pass closes that triage gap by re-reading each concrete path through the
+// GUARDED single-file scan (sqlgen.BuildParquetScanSource) and attributing by
+// differential: a path is a violator iff its guarded drain fails
+// deterministically — two consecutive failures, mirroring #251 R2-1 — while
+// its bare drain succeeds. Byte corruption and a sick store fail BOTH drains,
+// so they can never be misattributed as schema violations; the differential is
+// also what keeps this free of driver-message matching (errors.go), which the
+// CAST channel would otherwise force.
+//
+// Guarded-first ordering is the cost choice: a healthy path costs exactly one
+// guarded drain, so the common one-rogue-in-N failure costs ~N+3 drains; the
+// bare confirmation leg runs only for paths already failing the guard twice.
+// Glob and quote-bearing entries are skipped — unverifiable per-file, exactly
+// as in verifyParquetPaths. A cancelled context attributes nothing.
+//
+// Identification only (#351): callers must never exclude the returned paths —
+// unlike byte corruption, a schema-wrong object may legitimately own rows that
+// exclusion would silently drop once the object is repaired. Runs only on the
+// read-failure path, so cost is bounded by failures, not by queries.
+func identifyGuardViolations(ctx context.Context, duck DuckDBQueryExecutor, paths []string) []string {
+	if duck == nil {
+		return nil
+	}
+	var violating []string
+	for _, path := range paths {
+		if strings.ContainsAny(path, `'";`) || strings.ContainsAny(path, "*?[") {
+			continue
+		}
+		if err := drainGuardedParquet(ctx, duck, path); err == nil {
+			continue
+		}
+		if ctx.Err() != nil {
+			return nil
+		}
+		if err := drainGuardedParquet(ctx, duck, path); err == nil {
+			continue // transient blip, not a deterministic violation
+		}
+		if ctx.Err() != nil {
+			return nil
+		}
+		if err := drainParquet(ctx, duck, path); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			continue // bare drain fails too: bytes or store, not schema — #251 territory
+		}
+		violating = append(violating, path)
+	}
+	return violating
+}
+
+// drainGuardedParquet opens one parquet object through the guarded scan
+// source and iterates it to exhaustion, so it reproduces whatever guard
+// failure the object contributes to a set scan: the error() presence guards,
+// the BIGINT CAST type guard, and the binder failure when a guarded column is
+// absent from the single-file set (proved against the pinned DuckDB in
+// sqlgen/duckdb_cold_scan_identify_test.go).
+func drainGuardedParquet(ctx context.Context, duck DuckDBQueryExecutor, path string) error {
+	src := sqlgen.BuildParquetScanSource(fmt.Sprintf("'%s'", path), nil)
+	rows, err := duck.Query(ctx, "SELECT * FROM "+src)
+	if err != nil {
+		return fmt.Errorf("open guarded parquet %s: %w", path, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read guarded parquet %s: %w", path, err)
+	}
+	return nil
+}
+
+// ParquetGuardViolationError decorates a guard-classified read failure with
+// the objects identified by the guarded per-file drain (#351). Deliberate
+// wording: the paths FAIL the guarded single-file scan — an invariant
+// statement, not a causation claim, because a single-file scan is strictly
+// stricter than the set scan (a file missing only deleted_at fails alone but
+// is tolerated in a set where a sibling carries the column). Unwrap keeps the
+// original classification chain (ErrFederatedReadFailed): identification must
+// not change degradability, retry, or breaker behavior. Paths are full
+// storage URIs — operator detail; safe internally because httpapi redacts
+// non-published error text and toExecutionPlan drops Notes (#301/#306), the
+// same boundary contract corruptParquetRetryError relies on.
+type ParquetGuardViolationError struct {
+	SchemaID int16
+	Paths    []string
+	cause    error
+}
+
+func (e *ParquetGuardViolationError) Error() string {
+	return fmt.Sprintf(
+		"schema %d: %d parquet object(s) fail the guarded single-file scan (export schema invariant #189/#256) %v: %v",
+		e.SchemaID, len(e.Paths), e.Paths, e.cause)
+}
+
+func (e *ParquetGuardViolationError) Unwrap() error { return e.cause }

--- a/internal/federated/parquet_guard_identify.go
+++ b/internal/federated/parquet_guard_identify.go
@@ -3,7 +3,6 @@ package federated
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/lychee-technology/forma/internal/sqlgen"
 )
@@ -38,7 +37,7 @@ func identifyGuardViolations(ctx context.Context, duck DuckDBQueryExecutor, path
 	}
 	var violating []string
 	for _, path := range paths {
-		if strings.ContainsAny(path, `'";`) || strings.ContainsAny(path, "*?[") {
+		if unverifiablePath(path) {
 			continue
 		}
 		if err := drainGuardedParquet(ctx, duck, path); err == nil {
@@ -85,8 +84,10 @@ func drainGuardedParquet(ctx context.Context, duck DuckDBQueryExecutor, path str
 	return nil
 }
 
-// ParquetGuardViolationError decorates a guard-classified read failure with
-// the objects identified by the guarded per-file drain (#351). Deliberate
+// ParquetGuardViolationError decorates a read failure that neither the
+// missing-object classification (#187) nor the corruption confirmation (#251)
+// claimed, with the objects identified by the guarded per-file drain (#351).
+// Deliberate
 // wording: the paths FAIL the guarded single-file scan — an invariant
 // statement, not a causation claim, because a single-file scan is strictly
 // stricter than the set scan (a file missing only deleted_at fails alone but

--- a/internal/federated/parquet_guard_identify_test.go
+++ b/internal/federated/parquet_guard_identify_test.go
@@ -1,0 +1,114 @@
+package federated
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/sqlgen"
+	"github.com/stretchr/testify/require"
+)
+
+// identifyFakeDuck routes drains by SQL shape: a guarded drain contains the
+// REPLACE guard (we assert via the authored message constant, which is ours,
+// not the driver's), a bare drain does not. Per-path failure counts model
+// deterministic vs transient failures.
+type identifyFakeDuck struct {
+	guardFailN map[string]int // path → number of guarded drains that fail (-1 = always)
+	bareFailN  map[string]int // path → number of bare drains that fail (-1 = always)
+	queries    []string
+}
+
+func isGuardedSQL(sqlStr string) bool {
+	return strings.Contains(sqlStr, sqlgen.ParquetNullRowIDMessage)
+}
+
+func (d *identifyFakeDuck) Query(ctx context.Context, sqlStr string, args ...any) (duckDBRowsIterator, error) {
+	d.queries = append(d.queries, sqlStr)
+	failN := d.bareFailN
+	if isGuardedSQL(sqlStr) {
+		failN = d.guardFailN
+	}
+	for p, n := range failN {
+		if !strings.Contains(sqlStr, p) {
+			continue
+		}
+		if n != 0 {
+			if n > 0 {
+				failN[p] = n - 1
+			}
+			return nil, fmt.Errorf("drain failed for %s", p)
+		}
+	}
+	return &verifyFakeRows{rowsLeft: 1}, nil
+}
+
+func TestIdentifyGuardViolationsAttributesSchemaWrongObject(t *testing.T) {
+	duck := &identifyFakeDuck{guardFailN: map[string]int{"s3://b/rogue.parquet": -1}}
+	got := identifyGuardViolations(context.Background(), duck,
+		[]string{"s3://b/healthy.parquet", "s3://b/rogue.parquet"})
+	require.Equal(t, []string{"s3://b/rogue.parquet"}, got)
+
+	// Contract: attribution requires guarded-fail ×2 AND bare-pass. The
+	// healthy path must cost exactly one guarded drain and zero bare drains.
+	var healthyDrains, rogueGuarded, rogueBare int
+	for _, q := range duck.queries {
+		switch {
+		case strings.Contains(q, "healthy.parquet"):
+			healthyDrains++
+			require.True(t, isGuardedSQL(q), "a healthy path must only ever see the guarded drain")
+		case strings.Contains(q, "rogue.parquet") && isGuardedSQL(q):
+			rogueGuarded++
+		case strings.Contains(q, "rogue.parquet"):
+			rogueBare++
+		}
+	}
+	require.Equal(t, 1, healthyDrains)
+	require.Equal(t, 2, rogueGuarded, "deterministic confirmation is two consecutive guarded failures (#251 R2-1 mirror)")
+	require.Equal(t, 1, rogueBare)
+}
+
+func TestIdentifyGuardViolationsRejectsByteCorruptAndSickStore(t *testing.T) {
+	// Byte-corrupt / sick store: bare drain fails too → differential does not
+	// split → NOT attributed. This is the misattribution firewall.
+	duck := &identifyFakeDuck{
+		guardFailN: map[string]int{"s3://b/corrupt.parquet": -1},
+		bareFailN:  map[string]int{"s3://b/corrupt.parquet": -1},
+	}
+	got := identifyGuardViolations(context.Background(), duck, []string{"s3://b/corrupt.parquet"})
+	require.Empty(t, got)
+}
+
+func TestIdentifyGuardViolationsTransientGuardedFailureNotAttributed(t *testing.T) {
+	// One guarded failure then clean re-drain = transient blip, not a
+	// deterministic invariant violation.
+	duck := &identifyFakeDuck{guardFailN: map[string]int{"s3://b/blip.parquet": 1}}
+	got := identifyGuardViolations(context.Background(), duck, []string{"s3://b/blip.parquet"})
+	require.Empty(t, got)
+}
+
+func TestIdentifyGuardViolationsSkipsUnverifiableEntries(t *testing.T) {
+	duck := &identifyFakeDuck{}
+	got := identifyGuardViolations(context.Background(), duck,
+		[]string{"s3://b/glob-*.parquet", "s3://b/it's.parquet"})
+	require.Empty(t, got)
+	require.Empty(t, duck.queries, "glob and quote-bearing entries are unverifiable per-file — no drains at all")
+}
+
+func TestIdentifyGuardViolationsCancelledContextIdentifiesNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	duck := &identifyFakeDuck{guardFailN: map[string]int{"s3://b/rogue.parquet": -1}}
+	got := identifyGuardViolations(ctx, duck, []string{"s3://b/rogue.parquet"})
+	require.Empty(t, got, "cancellation is indistinguishable from failure — attribute nothing")
+}
+
+func TestParquetGuardViolationErrorChain(t *testing.T) {
+	cause := fmt.Errorf("execute duckdb query: %w: boom", ErrFederatedReadFailed)
+	err := &ParquetGuardViolationError{SchemaID: 7, Paths: []string{"s3://b/rogue.parquet"}, cause: cause}
+	require.ErrorIs(t, err, ErrFederatedReadFailed,
+		"identification must not change classification: still a degradable read failure")
+	require.Contains(t, err.Error(), "s3://b/rogue.parquet")
+	require.Contains(t, err.Error(), "schema 7")
+}

--- a/internal/federated/parquet_guard_identify_test.go
+++ b/internal/federated/parquet_guard_identify_test.go
@@ -6,8 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/sqlgen"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // identifyFakeDuck routes drains by SQL shape: a guarded drain contains the
@@ -111,4 +114,16 @@ func TestParquetGuardViolationErrorChain(t *testing.T) {
 		"identification must not change classification: still a degradable read failure")
 	require.Contains(t, err.Error(), "s3://b/rogue.parquet")
 	require.Contains(t, err.Error(), "schema 7")
+}
+
+func TestWithLoggerFeedsEngineAndValidator(t *testing.T) {
+	core, _ := observer.New(zap.WarnLevel)
+	l := zap.New(core)
+	e := NewDBFederatedQueryEngine(nil, nil, nil, nil, forma.DuckDBConfig{}, nil, "", WithLogger(l))
+	require.Same(t, l, e.logger, "WithLogger must feed the engine's own outlet (#351)")
+	require.Same(t, l, e.schemaValidator.logger, "…without dropping the validator outlet (#256)")
+
+	var nilEngine *DBFederatedQueryEngine
+	require.NotNil(t, nilEngine.log(), "log() must be nil-safe like the validator's")
+	require.NotNil(t, (&DBFederatedQueryEngine{}).log())
 }

--- a/internal/federated/parquet_verify.go
+++ b/internal/federated/parquet_verify.go
@@ -39,7 +39,7 @@ func verifyParquetPaths(ctx context.Context, duck DuckDBQueryExecutor, paths []s
 	}
 	var corrupt []string
 	for _, path := range paths {
-		if strings.ContainsAny(path, `'";`) || strings.ContainsAny(path, "*?[") {
+		if unverifiablePath(path) {
 			continue
 		}
 		if err := drainParquet(ctx, duck, path); err != nil {
@@ -55,6 +55,15 @@ func verifyParquetPaths(ctx context.Context, duck DuckDBQueryExecutor, paths []s
 		}
 	}
 	return corrupt
+}
+
+// unverifiablePath reports whether a path cannot be probed on its own: both
+// per-file drains interpolate it straight into SQL, so a quote-bearing entry
+// is unquotable and a glob names a set rather than one object. These are
+// exactly the entries the main scan keeps all-or-nothing behavior for —
+// unverifiable means neither excludable (#251) nor nameable (#351).
+func unverifiablePath(path string) bool {
+	return strings.ContainsAny(path, `'";`) || strings.ContainsAny(path, "*?[")
 }
 
 // drainParquet opens one parquet object and iterates it to exhaustion.

--- a/internal/federated/parquet_verify.go
+++ b/internal/federated/parquet_verify.go
@@ -16,6 +16,12 @@ import (
 // that pre-existing integrity gap is documented in the #251 spike findings
 // and tracked in #347.
 //
+// The guarded sibling — identifyGuardViolations in parquet_guard_identify.go —
+// deliberately inverts this drain's blindness: it reads through the #256 scan
+// guard to NAME a schema-wrong object (#351), where this pass reads bare to
+// EXCLUDE a byte-corrupt one. Keep the two drains distinct: guarding this one
+// would auto-exclude schema-wrong objects, which #351 forbids.
+//
 // Confirmation requires TWO consecutive failed drains (#349 review R2-1):
 // deterministic corruption fails every drain — same bytes, same decode —
 // while a transient object-level fault (an S3 timeout, a reset connection)

--- a/internal/sqlgen/duckdb_cold_scan.go
+++ b/internal/sqlgen/duckdb_cold_scan.go
@@ -30,9 +30,12 @@ type NullScanColumn struct {
 // (#306). The manifest entry and the pre-read validator identify the offending
 // object.
 //
-// Correlating a fired guard back to a specific object is therefore manual
-// bisection today (see the triage note in docs/federated-query/design.md §5);
-// #351 tracks giving the guard per-file identification.
+// Correlating a fired guard back to a specific object is the read path's job:
+// on a guard-classified failure, federated.identifyGuardViolations re-reads
+// each manifest-listed object through this same guarded source one file at a
+// time and names the violator(s) in the returned ParquetGuardViolationError
+// and the engine log (#351). Manual bisection (design.md §5) remains the
+// fallback for hint-authored path sets, which identification does not cover.
 const (
 	ParquetNullRowIDMessage     = "parquet scan produced NULL row_id: a scanned object violates the export schema invariant (#189/#256)"
 	ParquetNullChangedAtMessage = "parquet scan produced NULL changed_at: a scanned object violates the export schema invariant (#189/#256)"

--- a/internal/sqlgen/duckdb_cold_scan.go
+++ b/internal/sqlgen/duckdb_cold_scan.go
@@ -31,10 +31,15 @@ type NullScanColumn struct {
 // object.
 //
 // Correlating a fired guard back to a specific object is the read path's job:
-// on a guard-classified failure, federated.identifyGuardViolations re-reads
-// each manifest-listed object through this same guarded source one file at a
-// time and names the violator(s) in the returned ParquetGuardViolationError
-// and the engine log (#351). Manual bisection (design.md §5) remains the
+// on a read failure that neither the missing-object classification (#187) nor
+// the corruption confirmation (#251) claims, federated.identifyGuardViolations
+// re-reads each manifest-listed object through this same guarded source one
+// file at a time and names the violator(s) in the returned
+// ParquetGuardViolationError and the engine log (#351). The trigger is
+// deliberately not a guard-specific classification: recognizing a fired guard
+// would mean matching error text, which misses the BIGINT CAST channel
+// entirely — its wording is DuckDB's own — so identification decides by
+// differential drain instead. Manual bisection (design.md §5) remains the
 // fallback for hint-authored path sets, which identification does not cover.
 const (
 	ParquetNullRowIDMessage     = "parquet scan produced NULL row_id: a scanned object violates the export schema invariant (#189/#256)"

--- a/internal/sqlgen/duckdb_cold_scan_identify_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_identify_test.go
@@ -47,12 +47,15 @@ func singleFileScanSource(path string) string {
 func drainQuery(db *sql.DB, query string) error {
 	rows, err := db.Query(query)
 	if err != nil {
-		return err
+		return fmt.Errorf("query differential-drain SQL: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 	}
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate differential-drain rows: %w", err)
+	}
+	return nil
 }
 
 // bareDrain is the differential's bare leg (parquet_verify.go, #251);

--- a/internal/sqlgen/duckdb_cold_scan_identify_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_identify_test.go
@@ -1,6 +1,7 @@
 package sqlgen
 
 import (
+	"database/sql"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -40,26 +41,33 @@ func singleFileScanSource(path string) string {
 	return BuildParquetScanSource(fmt.Sprintf("'%s'", path), nil)
 }
 
+// drainQuery runs one query and iterates it to exhaustion, returning whichever
+// leg raised first: a guard can fire at open or mid-read, and the
+// identification pass treats both alike.
+func drainQuery(db *sql.DB, query string) error {
+	rows, err := db.Query(query)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+	}
+	return rows.Err()
+}
+
+// bareDrain is the differential's bare leg (parquet_verify.go, #251);
+// guardedDrain is its guarded leg (parquet_guard_identify.go, #351).
+func bareDrain(db *sql.DB, path string) error {
+	return drainQuery(db, fmt.Sprintf("SELECT * FROM read_parquet('%s')", path))
+}
+
+func guardedDrain(db *sql.DB, path string) error {
+	return drainQuery(db, "SELECT * FROM "+singleFileScanSource(path))
+}
+
 func TestSingleFileDifferentialDrainSplitsSchemaWrongFromHealthy(t *testing.T) {
 	db := guardDuckDB(t)
 	fx := guardFixtures(t, db)
-
-	drain := func(query string) error {
-		rows, err := db.Query(query)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = rows.Close() }()
-		for rows.Next() {
-		}
-		return rows.Err()
-	}
-	bare := func(path string) error {
-		return drain(fmt.Sprintf("SELECT * FROM read_parquet('%s')", path))
-	}
-	guarded := func(path string) error {
-		return drain("SELECT * FROM " + singleFileScanSource(path))
-	}
 
 	cases := []struct {
 		name, path string
@@ -74,9 +82,9 @@ func TestSingleFileDifferentialDrainSplitsSchemaWrongFromHealthy(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.NoError(t, bare(tc.path),
+			require.NoError(t, bareDrain(db, tc.path),
 				"bare SELECT * must read the object clean — that is why #251 verify cannot attribute it")
-			gerr := guarded(tc.path)
+			gerr := guardedDrain(db, tc.path)
 			if tc.violates {
 				require.Error(t, gerr, "guarded single-file scan must fail a schema-wrong object")
 			} else {
@@ -86,29 +94,46 @@ func TestSingleFileDifferentialDrainSplitsSchemaWrongFromHealthy(t *testing.T) {
 	}
 }
 
-// TestSingleFileGuardedDrainRaisesNullPresenceMessage covers the error()
-// channel rather than the binder channel: a file that HAS the column but with
-// NULL values in it. Written inline because rows with row_id present-but-NULL
-// cannot come from guardFixtures (its rogue shapes drop columns outright). The
-// NULL literal must be typed so parquet keeps the column.
-func TestSingleFileGuardedDrainRaisesNullPresenceMessage(t *testing.T) {
+// TestSingleFileGuardedDrainRaisesNullPresenceMessages covers BOTH error()
+// presence channels rather than the binder channel: a file that HAS the column
+// but with NULL values in it. Written inline because rows with a
+// present-but-NULL row_id or changed_at cannot come from guardFixtures (its
+// rogue shapes drop columns outright). The NULL literal must be typed so
+// parquet keeps the column. Each case also asserts the bare leg reads clean,
+// so the differential identification relies on is characterized per channel,
+// not just the guarded half.
+func TestSingleFileGuardedDrainRaisesNullPresenceMessages(t *testing.T) {
 	db := guardDuckDB(t)
-	path := filepath.Join(t.TempDir(), "null_row_id.parquet")
-	_, err := db.Exec(fmt.Sprintf(
-		`COPY (SELECT CAST(NULL AS UUID) AS row_id, CAST(1 AS BIGINT) AS changed_at, `+
-			`CAST(0 AS BIGINT) AS deleted_at) TO '%s' (FORMAT PARQUET)`, path))
-	require.NoError(t, err)
+	dir := t.TempDir()
+	const liveRowID = `CAST('018f05c0-0000-7000-8000-00000000000a' AS UUID) AS row_id`
 
-	rows, qerr := db.Query("SELECT * FROM " + singleFileScanSource(path))
-	gerr := qerr
-	if qerr == nil {
-		defer func() { _ = rows.Close() }()
-		for rows.Next() {
-		}
-		gerr = rows.Err()
+	cases := []struct{ name, sel, message string }{
+		{
+			name: "null_row_id",
+			sel: `CAST(NULL AS UUID) AS row_id, CAST(1 AS BIGINT) AS changed_at, ` +
+				`CAST(0 AS BIGINT) AS deleted_at`,
+			message: ParquetNullRowIDMessage,
+		},
+		{
+			name: "null_changed_at",
+			sel: liveRowID + `, CAST(NULL AS BIGINT) AS changed_at, ` +
+				`CAST(0 AS BIGINT) AS deleted_at`,
+			message: ParquetNullChangedAtMessage,
+		},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name+".parquet")
+			_, err := db.Exec(fmt.Sprintf(
+				"COPY (SELECT %s) TO '%s' (FORMAT PARQUET)", tc.sel, path))
+			require.NoError(t, err)
 
-	require.Error(t, gerr)
-	require.Contains(t, gerr.Error(), ParquetNullRowIDMessage,
-		"the presence channel must raise our authored message — the one text callers may quote in triage")
+			require.NoError(t, bareDrain(db, path),
+				"bare SELECT * must read the object clean — that is why #251 verify cannot attribute it")
+			gerr := guardedDrain(db, path)
+			require.Error(t, gerr)
+			require.Contains(t, gerr.Error(), tc.message,
+				"the presence channel must raise our authored message — the one text callers may quote in triage")
+		})
+	}
 }

--- a/internal/sqlgen/duckdb_cold_scan_identify_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_identify_test.go
@@ -1,0 +1,114 @@
+package sqlgen
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Single-file differential-drain proof for #351: a schema-wrong object reads
+// clean under a bare SELECT * (which is why the #251 verify pass can never
+// attribute it) but fails the guarded single-file scan — for every guard
+// channel: the two error() presence guards, the changed_at/deleted_at CAST
+// type guard, and the binder failure when a guarded column is absent from the
+// single-file scan set. federated.identifyGuardViolations relies on exactly
+// this split; if one of these tests goes red on a DuckDB upgrade, the
+// identification pass loses that channel.
+//
+// The SQL shapes below are the ones the identification pass renders: the bare
+// leg mirrors parquet_verify.go's `SELECT * FROM read_parquet('<path>')`, and
+// the guarded leg feeds BuildParquetScanSource the single-path rendering
+// formatDuckDBPathList produces for a one-element set (a bare quoted string,
+// not a list literal).
+//
+// Deliberate breadth note: deleted_at is part of the parquetcheck invariant,
+// so a file missing it fails the guarded SINGLE-file scan (binder: REPLACE
+// target absent) even though a MULTI-file set scan tolerates it when a
+// sibling carries the column (characterized in
+// TestParquetScanGuardTolerateNullDeletedAt). Identification may therefore
+// name an object whose only deviation is a missing deleted_at — a real
+// invariant violation (the footer probe would reject it too), just not
+// necessarily the one that fired this particular query's guard. The error
+// wording in ParquetGuardViolationError says "fails the guarded single-file
+// scan", not "caused this failure", for exactly this reason.
+
+// singleFileScanSource renders the guarded scan over exactly one path, in the
+// shape formatDuckDBPathList yields for a single-element set.
+func singleFileScanSource(path string) string {
+	return BuildParquetScanSource(fmt.Sprintf("'%s'", path), nil)
+}
+
+func TestSingleFileDifferentialDrainSplitsSchemaWrongFromHealthy(t *testing.T) {
+	db := guardDuckDB(t)
+	fx := guardFixtures(t, db)
+
+	drain := func(query string) error {
+		rows, err := db.Query(query)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+		}
+		return rows.Err()
+	}
+	bare := func(path string) error {
+		return drain(fmt.Sprintf("SELECT * FROM read_parquet('%s')", path))
+	}
+	guarded := func(path string) error {
+		return drain("SELECT * FROM " + singleFileScanSource(path))
+	}
+
+	cases := []struct {
+		name, path string
+		violates   bool
+	}{
+		{"healthy", fx.healthy, false},
+		{"varchar_row_id_benchmark_shape", fx.varcharRowID, false}, // untyped COALESCE adopts VARCHAR (#147)
+		{"no_row_id", fx.noRowID, true},                            // binder: REPLACE target absent
+		{"no_changed_at", fx.noChangedAt, true},                    // binder: REPLACE target absent
+		{"no_deleted_at", fx.noDeletedAt, true},                    // binder — see breadth note above
+		{"garbage_changed_at", fx.garbageChangedAt, true},          // CAST conversion failure
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, bare(tc.path),
+				"bare SELECT * must read the object clean — that is why #251 verify cannot attribute it")
+			gerr := guarded(tc.path)
+			if tc.violates {
+				require.Error(t, gerr, "guarded single-file scan must fail a schema-wrong object")
+			} else {
+				require.NoError(t, gerr, "guarded single-file scan must pass a healthy object")
+			}
+		})
+	}
+}
+
+// TestSingleFileGuardedDrainRaisesNullPresenceMessage covers the error()
+// channel rather than the binder channel: a file that HAS the column but with
+// NULL values in it. Written inline because rows with row_id present-but-NULL
+// cannot come from guardFixtures (its rogue shapes drop columns outright). The
+// NULL literal must be typed so parquet keeps the column.
+func TestSingleFileGuardedDrainRaisesNullPresenceMessage(t *testing.T) {
+	db := guardDuckDB(t)
+	path := filepath.Join(t.TempDir(), "null_row_id.parquet")
+	_, err := db.Exec(fmt.Sprintf(
+		`COPY (SELECT CAST(NULL AS UUID) AS row_id, CAST(1 AS BIGINT) AS changed_at, `+
+			`CAST(0 AS BIGINT) AS deleted_at) TO '%s' (FORMAT PARQUET)`, path))
+	require.NoError(t, err)
+
+	rows, qerr := db.Query("SELECT * FROM " + singleFileScanSource(path))
+	gerr := qerr
+	if qerr == nil {
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+		}
+		gerr = rows.Err()
+	}
+
+	require.Error(t, gerr)
+	require.Contains(t, gerr.Error(), ParquetNullRowIDMessage,
+		"the presence channel must raise our authored message — the one text callers may quote in triage")
+}


### PR DESCRIPTION
Closes #351.

On a federated read failure that neither the #187 missing-object classification nor the #251 corruption confirmation claims, the engine now runs a guarded per-file drain over the manifest-listed set and names the violating object(s) in a new `ParquetGuardViolationError` and an engine Error log — **identification only, never exclusion** (schema-wrong ≠ byte-corrupt: exclusion would silently drop rows the object legitimately owns once repaired).

Attribution is by **differential drain** — the guarded single-file scan (`sqlgen.BuildParquetScanSource` over one path) fails twice consecutively AND the bare `SELECT *` drain reads clean — so it needs no driver-message matching and covers the CAST channel, whose error text is DuckDB's own. Byte corruption and a sick store fail both drains and can never be misattributed. Classification chain (`ErrFederatedReadFailed`), degradability, breaker, retry, and the #348 partial marker are all unchanged; the log line is the outlet that survives `AllowPartialDegradedMode` (where the error is absorbed and `toExecutionPlan` drops Notes).

## Changes

- **sqlgen**: real-DuckDB characterization of the single-file differential (`duckdb_cold_scan_identify_test.go`) — all guard channels including both `error()` presence guards, plus the deliberate-breadth caveat (a file missing only `deleted_at` fails alone but is tolerated in a set; wording everywhere is invariant-shaped, not causal).
- **federated**: `identifyGuardViolations` + `ParquetGuardViolationError` (`parquet_guard_identify.go`); wired as the last branch of `failDuckDBScan`; source-authored sets only, single-path sets included; shared `unverifiablePath()` skip predicate with #251 verification.
- **federated**: engine-level logger outlet — `WithLogger` now feeds the engine (`e.log()`, accessor in `engine_options.go` due to the 500-line cap on `engine.go`) alongside the #256 validator.
- **docs**: `design.md` §5 triage rewritten (guard failures now name their objects; manual bisection remains the fallback for hint-authored sets), cost envelope documented (failure-path only, ≤~3 drains per listed object on top of #251's verification, cancellation bail); stale "until #351" comments retired.

## Review notes

- Trigger is deliberately NOT guard-specific: recognizing the CAST channel by message would require matching DuckDB driver text, which `errors.go` forbids. On a non-guard unclaimed failure the extra cost is one passing guarded drain per healthy path (mid-execution ruling recorded on #351).
- Test-fake adaptations for the new drains (no assertion changed): `engine_fakes_test.go` (`fakeDuckDBExecutor` + shared drain answering), `circuit_breaker_integration_test.go` (`scriptedDuckDBExecutor`), `engine_empty_page_test.go` (`sequencedDuckDBExecutor`), `corrupt_retry_seam_test.go` (`retryFakeDuck`, defensive).
- Key pins are mutation-verified (via `go test -overlay`): reverting identification, hoisting the violation return above `RecordFailure`, adding `corruptPaths.Add(violating)`, and deleting the bare-drain misattribution firewall each turn a specific test red.
- Follow-up material (not in this PR): early-bail cost cap when bare drains fail store-wide; `engine.go` at 495/500 lines; §5 triage paragraph density.

Gates: `make fmt-check`, `make lint` (v1.64.8), `make test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)