### PR TITLE
fix(httpapi): #360 publish request-parsing failures through the disclosure gate

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -790,9 +790,10 @@ had been relying on it — every one of them now builds a `forma.InvalidInputf`
 carrier publishing the same human-authored text it always rendered. The table
 below is the maintained list of the carrier sites that answer a caller mistake,
 and it is no longer only that sweep: the `internal/httpapi` row was added by
-#360 and never depended on the heuristic (see below the table). `respondError`'s
-own comment in `internal/httpapi/error_response.go` enumerates the sweep, and
-counts only it.
+#360 and never depended on the heuristic (see below the table).
+`classifyManagerError`'s doc comment
+(`internal/httpapi/error_response.go:148-192`) enumerates the sweep, and counts
+only it.
 
 | site | caller mistake |
 | --- | --- |
@@ -822,23 +823,43 @@ no schema name lost its doubled prefix (`invalid path: invalid path: empty
 schema name` → `invalid path: empty schema name`). This is one more reason for
 the standing advice below: key on the status code, never on full body text.
 
-Two of these sites publish third-party prose rather than human-authored text —
-`encoding/json`'s decode error and `google/uuid`'s parse error — on the same
-footing as `schemavalidate`'s `jsonschema-go` prose below, and the reason is the
-same: what those libraries render is derived from the caller's own request and
-from compile-time type names, never from server state. `uuid.Parse` reports the
-offending literal's length or that its format is wrong (`invalid UUID length:
-3`), without echoing it. `encoding/json` reports the JSON kind the caller sent
-plus **the Go type it was decoding into** — either a bare type (`json: cannot
-unmarshal array into Go value of type map[string]interface {}` for a `PUT` body
-that is not an object) or a struct field keyed by the caller's own JSON name
-(`json: cannot unmarshal number into Go struct field Alias.schema_name of type
-string` for `POST /api/v1/advanced_query` with `{"schema_name": 5}`). That Go
-type name is an internal detail leaking as noise — `Alias` is the local alias
-`forma.QueryRequest.UnmarshalJSON` decodes through — but it is a static
-identifier, not caller data or environment: no paths, keys, or credentials. If
-that ever stops holding for a decode target, the fix is `forma.WithOperatorDetail`
-at the wrap site, exactly as recorded for the `jsonschema-go` prose.
+Several of these sites publish prose that was not written at the wrap site —
+`encoding/json`'s decode error, `google/uuid`'s parse error, and (on `POST
+/api/v1/advanced_query`, whose body decodes through
+`forma.QueryRequest.UnmarshalJSON`) `forma`'s own condition-decoding errors from
+`types.go`: `composite condition missing logic`, `unknown logic: <the caller's
+value>`, `invalid condition payload: expected 'logic' or 'attr'`. All of them
+are flattened into the published message by the same
+`forma.InvalidInputf("%v", err)` wrap, and all stand on the same footing as
+`schemavalidate`'s `jsonschema-go` prose below, for the same reason: what is
+rendered comes from the caller's own request and from compile-time identifiers,
+never from server state.
+
+`encoding/json` reports the JSON kind the caller sent plus **the Go type it was
+decoding into** — either a bare type (`json: cannot unmarshal array into Go
+value of type map[string]interface {}` for a `PUT` body that is not an object)
+or a struct field keyed by the caller's own JSON name (`json: cannot unmarshal
+number into Go struct field Alias.schema_name of type string` for
+`{"schema_name": 5}`). That Go type name is an internal detail leaking as noise
+— `Alias` is the local alias `forma.QueryRequest.UnmarshalJSON` decodes through
+— but it is a static identifier, not caller data or environment.
+
+`uuid.Parse` usually reports only the offending literal's length or that its
+format is wrong (`invalid UUID length: 3`), without echoing it — but not
+always: a 45-character `row_id` is read as the `urn:uuid:…` form, and if its
+first nine characters are not that prefix, `google/uuid` v1.6.0 answers
+`invalid urn prefix: "<those nine characters>"` — quoting the caller's own input
+back. That is caller data rather than server state, and `redactCredentials` runs
+on it like every other published message, so it stays within the rule.
+
+No paths, keys, or credentials are reachable through any of these. If that ever
+stops holding for a decode target, the fix is not a wrapper around the same text
+— today's `forma.InvalidInputf("%v", err)` has already flattened the library
+prose into the published message. The site must be restructured so the
+publication and the detail are separate errors:
+`forma.WithOperatorDetail(forma.InvalidInputf("<generic message>"), err)`, which
+publishes the generic message and keeps the library's text in `Error()` and the
+log — exactly as recorded for the `jsonschema-go` prose.
 
 **The sentinel suffix no longer reaches bodies — #309's clause is overturned by
 #313.** `Error()` still renders `<message>: invalid input` (likewise

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -717,18 +717,42 @@ being read. It is raised before any path reaches a scan.
 split follows the two error classes above, and is enforced by
 `respondErrorWithStatus` in `internal/httpapi/error_response.go`. That is the
 only gate **for manager-layer errors**: `respondError` merely classifies and
-delegates to it, and `executeGet` (`internal/httpapi/server.go:175`) calls
+delegates to it, and `executeGet` (`internal/httpapi/handlers.go`) calls
 `respondErrorWithStatus` directly so it can choose its own 404 wording.
 
-Handlers also call `writeError` directly — 33 sites in `server.go` — and those
-bodies are verbatim without passing the gate. They are safe because every one of
-them reports a request-parsing failure (`parsePath`, `readJSONBody`,
-`parseUUID`, `parseCreateObjects`, `parseSortParams`); none touches the manager,
-the engine, S3, or `PG_CONN`. What holds that line is the source-level guard
-`TestWriteErrorAlwaysCarriesALiteral4xxStatus`
-(`internal/httpapi/error_leak_test.go`), which fails the build unless every
-direct site passes a literal 4xx constant from an allowlist — so a new handler
-cannot echo a runtime-classified status without going through `respondError`.
+Handlers also call `writeError` directly — 16 sites in `handlers.go`, each
+passing a fixed string literal (`"method not allowed"`, `"row_id is required"`,
+`"condition is required"`, …) — and those bodies are verbatim without passing
+the gate. Since #360 they are safe *structurally*, not by convention: a
+request-parsing failure, whose message embeds parser prose about what the caller
+sent, is built as a `forma.InvalidInputf` carrier and routed through
+`respondError`, so its text crosses as a published message — scrubbed and logged
+like every other disclosed 4xx. `parsePath`, `parseSortParams` and
+`parseCreateObjects` (`internal/httpapi/server.go`) author that carrier
+themselves; `readJSONBody` and `parseUUID` return `encoding/json`'s and
+`google/uuid`'s own prose, which each call site publishes deliberately as
+`forma.InvalidInputf("%v", err)`. No direct `writeError` message is derived from
+a request or a runtime error at all, so none can carry the manager, the engine,
+S3, or `PG_CONN`.
+
+Two source-level guards in `internal/httpapi/error_leak_test.go` hold that line
+over the package's non-test sources, each with the same single sanctioned
+exception — `respondErrorWithStatus`, whose status and message are both
+constrained at runtime by the gate itself:
+
+- `TestWriteErrorAlwaysCarriesALiteral4xxStatus` fails the build unless every
+  direct site passes a literal 4xx constant from an allowlist
+  (`http.StatusBadRequest`, `http.StatusMethodNotAllowed`) — so a new handler
+  cannot echo a runtime-classified status without going through `respondError`;
+- `TestWriteErrorMessageIsAlwaysALiteral` closes the axis the status guard
+  leaves unchecked, failing the build unless every direct site's message is a
+  string literal — so a handler that needs dynamic text has exactly one road, a
+  published carrier through `respondError`.
+
+Neither guard is allowed to go quiet: a call site the status guard's receiver
+pattern cannot parse, and a `writeError` arity the message guard does not
+expect, are each reported as a failure rather than skipped, so reshaping the
+call or the signature cannot silently drop sites out of the scan.
 
 **The status is decided by sentinel evidence and by nothing else.**
 `classifyManagerError` matches `errors.Is` against `forma.ErrNotFound` (404),
@@ -772,11 +796,22 @@ always rendered:
 | `internal/sqlgen/predicate_normalizer.go` | filtering on an unknown attribute; unparseable numeric/bool filter value; unsupported operator; an operator the attribute's type does not accept (`starts_with`/`contains` on a non-text column, an inequality on a boolean) |
 | `internal/sqlgen/dualpath_sql_helpers.go` | unparseable numeric/date/bool literal in a main-column or federated predicate |
 | `internal/conditionexpr/parser.go` | malformed `"op:value"`; unknown operator; unparseable date |
+| `internal/httpapi` (`server.go` parse helpers, `handlers.go` wrap sites) | malformed request path; undecodable JSON body; invalid `row_id`; invalid sort parameters; malformed create-payload shape (#360) |
 
 The write-path entry matters most: without it, a `POST` omitting a required
 attribute would answer `500` with an opaque body instead of naming the attribute.
 The `sqlgen`/`conditionexpr` group is reachable through `POST
 /api/v1/advanced_query`, whose `condition` payload is entirely caller-supplied.
+
+The `httpapi` entry joined later and for a different reason. Those sites never
+relied on the heuristic — they always named a literal `400` — but their bodies
+reached the client through `writeError`, outside the gate. #360 republished them
+as carriers so the same text now passes `resolvePublicMessage` and
+`redactCredentials` like everything else in this table. Two of them publish
+third-party prose rather than human-authored text — `encoding/json`'s decode
+error and `google/uuid`'s parse error, both of which describe only the literal
+the caller sent — on the same footing as `schemavalidate`'s `jsonschema-go`
+prose below.
 
 **The sentinel suffix no longer reaches bodies — #309's clause is overturned by
 #313.** `Error()` still renders `<message>: invalid input` (likewise

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -720,20 +720,21 @@ only gate **for manager-layer errors**: `respondError` merely classifies and
 delegates to it, and `executeGet` (`internal/httpapi/handlers.go`) calls
 `respondErrorWithStatus` directly so it can choose its own 404 wording.
 
-Handlers also call `writeError` directly — 16 sites in `handlers.go`, each
-passing a fixed string literal (`"method not allowed"`, `"row_id is required"`,
-`"condition is required"`, …) — and those bodies are verbatim without passing
-the gate. Since #360 they are safe *structurally*, not by convention: a
-request-parsing failure, whose message embeds parser prose about what the caller
-sent, is built as a `forma.InvalidInputf` carrier and routed through
-`respondError`, so its text crosses as a published message — scrubbed and logged
-like every other disclosed 4xx. `parsePath`, `parseSortParams` and
-`parseCreateObjects` (`internal/httpapi/server.go`) author that carrier
-themselves; `readJSONBody` and `parseUUID` return `encoding/json`'s and
-`google/uuid`'s own prose, which each call site publishes deliberately as
-`forma.InvalidInputf("%v", err)`. No direct `writeError` message is derived from
-a request or a runtime error at all, so none can carry the manager, the engine,
-S3, or `PG_CONN`.
+Handlers also call `writeError` directly — the fixed-literal sites in
+`handlers.go` (`"method not allowed"`, `"row_id is required"`, `"condition is
+required"`, …) — and those bodies are verbatim without passing the gate. Since
+#360 they are safe *structurally*, not by convention: a request-parsing failure,
+whose message embeds parser prose about what the caller sent, is built as a
+`forma.InvalidInputf` carrier and routed through `respondError`, so its text
+crosses as a published message — scrubbed and logged like every other disclosed
+4xx. `parsePath`, `parseSortParams` and `parseCreateObjects`
+(`internal/httpapi/server.go`) author that carrier themselves; `readJSONBody` and
+`parseUUID` return `encoding/json`'s and `google/uuid`'s own prose, which each
+call site publishes deliberately as `forma.InvalidInputf("%v", err)` — batch
+delete adds the offending element's position, `forma.InvalidInputf("index %d:
+%v", i, err)`. No direct `writeError` message is derived from a request or a
+runtime error at all, so none can carry the manager, the engine, S3, or
+`PG_CONN`.
 
 Two source-level guards in `internal/httpapi/error_leak_test.go` hold that line
 over the package's non-test sources, each with the same single sanctioned
@@ -786,8 +787,12 @@ errors that wrapped no sentinel. It was removed for two reasons:
 The consequence is that a genuine client error earns its 4xx only by carrying a
 sentinel. Removing the heuristic therefore required a sweep of the sites that
 had been relying on it — every one of them now builds a `forma.InvalidInputf`
-carrier, and the message each publishes is the same human-authored text it
-always rendered:
+carrier publishing the same human-authored text it always rendered. The table
+below is the maintained list of the carrier sites that answer a caller mistake,
+and it is no longer only that sweep: the `internal/httpapi` row was added by
+#360 and never depended on the heuristic (see below the table). `respondError`'s
+own comment in `internal/httpapi/error_response.go` enumerates the sweep, and
+counts only it.
 
 | site | caller mistake |
 | --- | --- |
@@ -806,12 +811,34 @@ The `sqlgen`/`conditionexpr` group is reachable through `POST
 The `httpapi` entry joined later and for a different reason. Those sites never
 relied on the heuristic — they always named a literal `400` — but their bodies
 reached the client through `writeError`, outside the gate. #360 republished them
-as carriers so the same text now passes `resolvePublicMessage` and
-`redactCredentials` like everything else in this table. Two of them publish
-third-party prose rather than human-authored text — `encoding/json`'s decode
-error and `google/uuid`'s parse error, both of which describe only the literal
-the caller sent — on the same footing as `schemavalidate`'s `jsonschema-go`
-prose below.
+as carriers, so the same prose now passes `resolvePublicMessage` and
+`redactCredentials` like everything else in this table. The prose is the same;
+the exact body is not always byte-identical to what #360 replaced, because the
+operation name is now prefixed uniformly by the gate: a malformed create payload
+answers `invalid json body: body must be an object or array` where it used to
+answer the bare message, a bad `row_id` in a batch delete answers `invalid
+row_id: index 0: …` rather than `invalid row_id at index 0: …`, and a path with
+no schema name lost its doubled prefix (`invalid path: invalid path: empty
+schema name` → `invalid path: empty schema name`). This is one more reason for
+the standing advice below: key on the status code, never on full body text.
+
+Two of these sites publish third-party prose rather than human-authored text —
+`encoding/json`'s decode error and `google/uuid`'s parse error — on the same
+footing as `schemavalidate`'s `jsonschema-go` prose below, and the reason is the
+same: what those libraries render is derived from the caller's own request and
+from compile-time type names, never from server state. `uuid.Parse` reports the
+offending literal's length or that its format is wrong (`invalid UUID length:
+3`), without echoing it. `encoding/json` reports the JSON kind the caller sent
+plus **the Go type it was decoding into** — either a bare type (`json: cannot
+unmarshal array into Go value of type map[string]interface {}` for a `PUT` body
+that is not an object) or a struct field keyed by the caller's own JSON name
+(`json: cannot unmarshal number into Go struct field Alias.schema_name of type
+string` for `POST /api/v1/advanced_query` with `{"schema_name": 5}`). That Go
+type name is an internal detail leaking as noise — `Alias` is the local alias
+`forma.QueryRequest.UnmarshalJSON` decodes through — but it is a static
+identifier, not caller data or environment: no paths, keys, or credentials. If
+that ever stops holding for a decode target, the fix is `forma.WithOperatorDetail`
+at the wrap site, exactly as recorded for the `jsonschema-go` prose.
 
 **The sentinel suffix no longer reaches bodies — #309's clause is overturned by
 #313.** `Error()` still renders `<message>: invalid input` (likewise

--- a/internal/httpapi/error_leak_test.go
+++ b/internal/httpapi/error_leak_test.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -290,13 +294,16 @@ var writeErrorAllowed4xx = map[string]bool{
 // body-writing path was judged out of scope for #301; the boundary is recorded
 // so the next author trusts the guard for exactly what it checks.
 //
-// NOTE: the other unchecked axis is the message. This guard reads only the
-// *status* expression; it cannot tell whether the third argument is safe to
-// disclose. That judgement belongs to resolvePublicMessage inside
-// respondErrorWithStatus, and the direct call sites stay safe only because their
-// messages come from request parsing (parsePath, readJSONBody, parseUUID,
-// parseCreateObjects, parseSortParams), never from the manager, the engine, S3,
-// or PG_CONN.
+// NOTE: the message axis is checked by TestWriteErrorMessageIsAlwaysALiteral
+// below (#360): direct sites carry string literals only; anything dynamic must
+// arrive as a published carrier through respondError. This guard itself still
+// reads only the *status* expression and cannot tell whether the third argument
+// is safe to disclose. For the one site that builds its message at runtime,
+// respondErrorWithStatus, that judgement belongs to resolvePublicMessage. Every
+// other site is safe because its message is a fixed literal written into the
+// source — request text no longer reaches these calls at all, having moved to
+// published carriers under the gate (#360), so no direct message can carry the
+// manager, the engine, S3, or PG_CONN.
 func TestWriteErrorAlwaysCarriesALiteral4xxStatus(t *testing.T) {
 	// Captures the status expression of each call. The receiver pattern is
 	// deliberately narrow, so it does NOT match every legal Go expression —
@@ -375,5 +382,74 @@ func TestWriteErrorAlwaysCarriesALiteral4xxStatus(t *testing.T) {
 	if !strings.HasPrefix(unlisted[0], "error_response.go:") {
 		t.Errorf("the sanctioned non-literal writeError status moved out of error_response.go to %s; "+
 			"only respondErrorWithStatus may pass a runtime-classified status (#301)", unlisted[0])
+	}
+}
+
+// TestWriteErrorMessageIsAlwaysALiteral closes the axis the status guard above
+// documents as unchecked: the message. Every direct writeError call site must
+// pass an untyped string literal — never fmt.Sprintf, err.Error(), or any
+// other expression — with the same single sanctioned exception as the status
+// guard: respondErrorWithStatus in error_response.go, whose message is built
+// under the disclosure gate (isClientError + resolvePublicMessage +
+// redactCredentials, #313). Together the two guards make the disclosure rule
+// total for this write path (#360): a handler that needs dynamic text has
+// exactly one road, a published carrier through respondError.
+//
+// go/ast rather than the regex above: an argument expression can contain
+// commas and nested calls a regex cannot parse, and go/parser fails loudly on
+// what it cannot read instead of skipping it.
+func TestWriteErrorMessageIsAlwaysALiteral(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	calls := 0
+	var dynamic []string
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				var name string
+				switch fun := call.Fun.(type) {
+				case *ast.Ident:
+					name = fun.Name
+				case *ast.SelectorExpr:
+					name = fun.Sel.Name
+				}
+				if name != "writeError" || len(call.Args) != 3 {
+					return true
+				}
+				calls++
+				if lit, ok := call.Args[2].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					return true
+				}
+				dynamic = append(dynamic, fset.Position(call.Args[2].Pos()).String())
+				return true
+			})
+		}
+	}
+
+	if calls == 0 {
+		t.Fatalf("guard matched no writeError call sites — it would pass vacuously")
+	}
+	if len(dynamic) != 1 {
+		t.Errorf("expected exactly 1 writeError site with a non-literal message "+
+			"(respondErrorWithStatus in error_response.go), found %d: %v\n"+
+			"a handler must not build its own body text — publish it through a "+
+			"forma.InvalidInputf carrier and respondError instead (#360)",
+			len(dynamic), dynamic)
+		return
+	}
+	if !strings.HasPrefix(dynamic[0], "error_response.go:") {
+		t.Errorf("the sanctioned non-literal writeError message moved out of "+
+			"error_response.go to %s; only respondErrorWithStatus may write a "+
+			"runtime-built message (#360)", dynamic[0])
 	}
 }

--- a/internal/httpapi/error_leak_test.go
+++ b/internal/httpapi/error_leak_test.go
@@ -398,6 +398,15 @@ func TestWriteErrorAlwaysCarriesALiteral4xxStatus(t *testing.T) {
 // go/ast rather than the regex above: an argument expression can contain
 // commas and nested calls a regex cannot parse, and go/parser fails loudly on
 // what it cannot read instead of skipping it.
+//
+// A call is counted the moment its name matches, before its shape is examined,
+// and any arity other than (w, status, message) is reported rather than
+// skipped. Skipping would be the same silent-vacuity hole the status guard
+// reconciles against: if writeError ever became variadic
+// (format string, args ...any), 4-argument calls would drop out of the scan
+// while the surviving 3-argument ones kept calls > 0, so the vacuity Fatal
+// would not fire and the guard would report green for precisely the dynamic
+// message it exists to forbid.
 func TestWriteErrorMessageIsAlwaysALiteral(t *testing.T) {
 	fset := token.NewFileSet()
 	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
@@ -409,6 +418,7 @@ func TestWriteErrorMessageIsAlwaysALiteral(t *testing.T) {
 
 	calls := 0
 	var dynamic []string
+	var unchecked []string
 	for _, pkg := range pkgs {
 		for _, file := range pkg.Files {
 			ast.Inspect(file, func(n ast.Node) bool {
@@ -423,10 +433,14 @@ func TestWriteErrorMessageIsAlwaysALiteral(t *testing.T) {
 				case *ast.SelectorExpr:
 					name = fun.Sel.Name
 				}
-				if name != "writeError" || len(call.Args) != 3 {
+				if name != "writeError" {
 					return true
 				}
 				calls++
+				if len(call.Args) != 3 {
+					unchecked = append(unchecked, fset.Position(call.Pos()).String())
+					return true
+				}
 				if lit, ok := call.Args[2].(*ast.BasicLit); ok && lit.Kind == token.STRING {
 					return true
 				}
@@ -438,6 +452,12 @@ func TestWriteErrorMessageIsAlwaysALiteral(t *testing.T) {
 
 	if calls == 0 {
 		t.Fatalf("guard matched no writeError call sites — it would pass vacuously")
+	}
+	if len(unchecked) > 0 {
+		t.Errorf("writeError call sites with unexpected arity, so their message went unchecked: %v\n"+
+			"writeError takes exactly (w, status, message); a variadic or reshaped signature must not "+
+			"be introduced without extending this guard (#360)", unchecked)
+		return
 	}
 	if len(dynamic) != 1 {
 		t.Errorf("expected exactly 1 writeError site with a non-literal message "+

--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -1,7 +1,6 @@
 package httpapi
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -30,20 +29,20 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	schemaName, _, err := parsePath(r.URL.Path)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid path: %v", err))
+		respondError(w, "invalid path", err)
 		return
 	}
 	zap.S().Infow("create request received", "schema", schemaName)
 
 	var rawBody any
 	if err := readJSONBody(r, &rawBody); err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid json body: %v", err))
+		respondError(w, "invalid json body", forma.InvalidInputf("%v", err))
 		return
 	}
 
 	jsonObjects, isSingleObject, err := parseCreateObjects(rawBody)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, err.Error())
+		respondError(w, "invalid json body", err)
 		return
 	}
 	zap.S().Debugw("create payload parsed", "schema", schemaName, "records", len(jsonObjects))
@@ -93,7 +92,7 @@ func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
 
 	schemaName, rowIDStr, err := parsePath(r.URL.Path)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid path: %v", err))
+		respondError(w, "invalid path", err)
 		return
 	}
 
@@ -105,7 +104,7 @@ func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
 
 	rowID, err := parseUUID(rowIDStr)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid row_id: %v", err))
+		respondError(w, "invalid row_id", forma.InvalidInputf("%v", err))
 		return
 	}
 
@@ -149,14 +148,14 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	schemaName, rowIDStr, err := parsePath(r.URL.Path)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid path: %v", err))
+		respondError(w, "invalid path", err)
 		return
 	}
 
 	if rowIDStr != "" {
 		rowID, err := parseUUID(rowIDStr)
 		if err != nil {
-			_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid row_id: %v", err))
+			respondError(w, "invalid row_id", forma.InvalidInputf("%v", err))
 			return
 		}
 		zap.S().Infow("get request received", "schema", schemaName, "rowID", rowIDStr)
@@ -169,7 +168,7 @@ func (s *Server) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	sortFields, sortOrder, err := parseSortParams(queryParams)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid sort parameters: %v", err))
+		respondError(w, "invalid sort parameters", err)
 		return
 	}
 
@@ -207,7 +206,7 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 	schemaName, rowIDStr, err := parsePath(r.URL.Path)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid path: %v", err))
+		respondError(w, "invalid path", err)
 		return
 	}
 
@@ -219,13 +218,13 @@ func (s *Server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 	rowID, err := parseUUID(rowIDStr)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid row_id: %v", err))
+		respondError(w, "invalid row_id", forma.InvalidInputf("%v", err))
 		return
 	}
 
 	var body map[string]any
 	if err := readJSONBody(r, &body); err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid json body: %v", err))
+		respondError(w, "invalid json body", forma.InvalidInputf("%v", err))
 		return
 	}
 
@@ -283,13 +282,13 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 
 	schemaName, _, err := parsePath(r.URL.Path)
 	if err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid path: %v", err))
+		respondError(w, "invalid path", err)
 		return
 	}
 
 	var rowIDStrs []string
 	if err := readJSONBody(r, &rowIDStrs); err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid json body: %v", err))
+		respondError(w, "invalid json body", forma.InvalidInputf("%v", err))
 		return
 	}
 
@@ -303,7 +302,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 	for i, idStr := range rowIDStrs {
 		rowID, err := parseUUID(idStr)
 		if err != nil {
-			_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid row_id at index %d: %v", i, err))
+			respondError(w, "invalid row_id", forma.InvalidInputf("index %d: %v", i, err))
 			return
 		}
 
@@ -383,7 +382,7 @@ func (s *Server) handleAdvancedQuery(w http.ResponseWriter, r *http.Request) {
 
 	var payload forma.QueryRequest
 	if err := readJSONBody(r, &payload); err != nil {
-		_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid json body: %v", err))
+		respondError(w, "invalid json body", forma.InvalidInputf("%v", err))
 		return
 	}
 
@@ -424,14 +423,14 @@ func (s *Server) apiHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodDelete {
 		schemaName, rowIDStr, err := parsePath(path)
 		if err != nil {
-			_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid path: %v", err))
+			respondError(w, "invalid path", err)
 			return
 		}
 
 		if rowIDStr != "" {
 			rowID, err := parseUUID(rowIDStr)
 			if err != nil {
-				_ = writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid row_id: %v", err))
+				respondError(w, "invalid row_id", forma.InvalidInputf("%v", err))
 				return
 			}
 			s.handleSingleDelete(w, r, schemaName, rowID)

--- a/internal/httpapi/handlers_parse_error_test.go
+++ b/internal/httpapi/handlers_parse_error_test.go
@@ -68,6 +68,8 @@ func TestParseFailuresPublishThroughTheGate(t *testing.T) {
 			"invalid row_id: index 0: invalid UUID length: 1"},
 		{"advanced query bad json", http.MethodPost, "/api/v1/advanced_query", `{`,
 			"invalid json body: unexpected EOF"},
+		{"delete bad path", http.MethodDelete, "/api/v1/a/b/c", "",
+			"invalid path: invalid path format"},
 	}
 
 	for _, tc := range cases {

--- a/internal/httpapi/handlers_parse_error_test.go
+++ b/internal/httpapi/handlers_parse_error_test.go
@@ -1,0 +1,121 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/redact"
+	"go.uber.org/zap"
+)
+
+// newParseProbeManager returns a manager whose every entry point fails with an
+// operator error. A parse failure must reject the request before the manager
+// is touched, so each case below proving a 400 with our exact published body
+// (not a redacted 500) is also proof the manager was never reached.
+func newParseProbeManager() *mockEntityManager {
+	probe := errors.New("manager must not be reached by a parse failure")
+	return &mockEntityManager{
+		batchCreateErr: probe, getErr: probe, advancedErr: probe,
+		updateErr: probe, batchDeleteErr: probe, crossSchemaErr: probe,
+	}
+}
+
+// TestParseFailuresPublishThroughTheGate pins #360: every request-parsing
+// rejection is a disclosed 400 built from a published message — same status
+// and (mostly) same text as the pre-#360 direct writeError bodies, but now on
+// the gated branch: no error_class, no error_id, scrub applied.
+func TestParseFailuresPublishThroughTheGate(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	cases := []struct {
+		name     string
+		method   string
+		target   string
+		body     string
+		wantBody string
+	}{
+		{"create bad path", http.MethodPost, "/api/v1/a/b/c", `{}`,
+			"invalid path: invalid path format"},
+		{"query empty schema", http.MethodGet, "/api/v1/", "",
+			"invalid path: empty schema name"},
+		{"create bad json", http.MethodPost, "/api/v1/lead", `{`,
+			"invalid json body: unexpected EOF"},
+		{"create empty array", http.MethodPost, "/api/v1/lead", `[]`,
+			"invalid json body: empty array not allowed"},
+		{"create non-object element", http.MethodPost, "/api/v1/lead", `[{"a":1},42]`,
+			"invalid json body: body[1] must be an object"},
+		{"create scalar body", http.MethodPost, "/api/v1/lead", `"x"`,
+			"invalid json body: body must be an object or array"},
+		{"get bad row_id", http.MethodGet, "/api/v1/lead/nope", "",
+			"invalid row_id: invalid UUID length: 4"},
+		{"query bad sort", http.MethodGet, "/api/v1/lead?sort_by=age&sort_order=up", "",
+			"invalid sort parameters: invalid sort_order: up"},
+		{"update bad row_id", http.MethodPut, "/api/v1/lead/nope", `{}`,
+			"invalid row_id: invalid UUID length: 4"},
+		{"update bad json", http.MethodPut, "/api/v1/lead/0190b7b8-0000-7000-8000-000000000000", `{`,
+			"invalid json body: unexpected EOF"},
+		{"single delete bad row_id", http.MethodDelete, "/api/v1/lead/nope", "",
+			"invalid row_id: invalid UUID length: 4"},
+		{"batch delete bad json", http.MethodDelete, "/api/v1/lead", `{`,
+			"invalid json body: unexpected EOF"},
+		{"batch delete bad element", http.MethodDelete, "/api/v1/lead", `["a"]`,
+			"invalid row_id: index 0: invalid UUID length: 1"},
+		{"advanced query bad json", http.MethodPost, "/api/v1/advanced_query", `{`,
+			"invalid json body: unexpected EOF"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewServer(newParseProbeManager(), Options{})
+			req := httptest.NewRequest(tc.method, tc.target, bytes.NewReader([]byte(tc.body)))
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+			}
+			var resp APIResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("body is not valid JSON: %v", err)
+			}
+			if resp.Error != tc.wantBody {
+				t.Fatalf("body %q, want %q", resp.Error, tc.wantBody)
+			}
+			if resp.ErrorClass != "" || resp.ErrorID != "" {
+				t.Fatalf("a parse failure took the redacted branch: error_class=%q error_id=%q",
+					resp.ErrorClass, resp.ErrorID)
+			}
+		})
+	}
+}
+
+// TestParseFailureScrubsPublishedCredential pins the concrete win of the
+// conversion: sort_order is caller text interpolated into a published message,
+// and before #360 the direct writeError path echoed it with no scrub at all.
+func TestParseFailureScrubsPublishedCredential(t *testing.T) {
+	restore := zap.ReplaceGlobals(zap.NewNop())
+	defer restore()
+
+	srv := NewServer(newParseProbeManager(), Options{})
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/lead?sort_by=age&sort_order=password%3Ds3cr3t", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "s3cr3t") {
+		t.Fatalf("published parse message leaked credential-shaped caller text: %s", body)
+	}
+	if !strings.Contains(body, redact.Placeholder) {
+		t.Fatalf("expected the scrub placeholder in the body, got: %s", body)
+	}
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -2,7 +2,6 @@ package httpapi
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -57,7 +56,7 @@ func parsePath(path string) (schemaName string, rowID string, err error) {
 	path = strings.Trim(path, "/")
 
 	if path == "" {
-		return "", "", fmt.Errorf("invalid path: empty schema name")
+		return "", "", forma.InvalidInputf("empty schema name")
 	}
 
 	parts := strings.Split(path, "/")
@@ -68,7 +67,7 @@ func parsePath(path string) (schemaName string, rowID string, err error) {
 	case 2:
 		return parts[0], parts[1], nil
 	default:
-		return "", "", fmt.Errorf("invalid path format")
+		return "", "", forma.InvalidInputf("invalid path format")
 	}
 }
 
@@ -103,7 +102,7 @@ func parseSortParams(queryParams url.Values) ([]string, forma.SortOrder, error) 
 
 	if !hasSort || len(rawSortBy) == 0 {
 		if sortOrderParam != "" {
-			return nil, "", fmt.Errorf("sort_order requires sort_by to be specified")
+			return nil, "", forma.InvalidInputf("sort_order requires sort_by to be specified")
 		}
 		return nil, "", nil
 	}
@@ -119,7 +118,7 @@ func parseSortParams(queryParams url.Values) ([]string, forma.SortOrder, error) 
 	}
 
 	if len(sortFields) == 0 {
-		return nil, "", fmt.Errorf("sort_by provided but contained no valid fields")
+		return nil, "", forma.InvalidInputf("sort_by provided but contained no valid fields")
 	}
 
 	if sortOrderParam == "" {
@@ -132,7 +131,7 @@ func parseSortParams(queryParams url.Values) ([]string, forma.SortOrder, error) 
 	case "desc":
 		return sortFields, forma.SortOrderDesc, nil
 	default:
-		return nil, "", fmt.Errorf("invalid sort_order: %s", sortOrderParam)
+		return nil, "", forma.InvalidInputf("invalid sort_order: %s", sortOrderParam)
 	}
 }
 
@@ -193,20 +192,20 @@ func parseCreateObjects(rawBody any) ([]map[string]any, bool, error) {
 		return []map[string]any{v}, true, nil
 	case []any:
 		if len(v) == 0 {
-			return nil, false, fmt.Errorf("empty array not allowed")
+			return nil, false, forma.InvalidInputf("empty array not allowed")
 		}
 
 		objects := make([]map[string]any, len(v))
 		for i, item := range v {
 			obj, ok := item.(map[string]any)
 			if !ok {
-				return nil, false, fmt.Errorf("body[%d] must be an object", i)
+				return nil, false, forma.InvalidInputf("body[%d] must be an object", i)
 			}
 			objects[i] = obj
 		}
 		return objects, false, nil
 	default:
-		return nil, false, fmt.Errorf("body must be an object or array")
+		return nil, false, forma.InvalidInputf("body must be an object or array")
 	}
 }
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -169,7 +169,11 @@ func writeSuccess(w http.ResponseWriter, statusCode int, data any) error {
 	return writeJSON(w, statusCode, data)
 }
 
-// parseUUID parses a UUID string.
+// parseUUID parses a UUID string. Its error is google/uuid's own prose about
+// the malformed literal the caller sent — caller-addressed parse feedback
+// carrying no operator data — so call sites publish it deliberately via
+// forma.InvalidInputf("%v", err) and route it through respondError (#360); the
+// gate's scrub still applies to it.
 func parseUUID(s string) (uuid.UUID, error) {
 	return uuid.Parse(s)
 }
@@ -178,6 +182,11 @@ func parseUUID(s string) (uuid.UUID, error) {
 // decode as json.Number so integer attribute values above 2^53 reach any-typed
 // sinks (entity data maps) undamaged (#205, #282); decoding into typed struct
 // fields is unaffected by UseNumber.
+//
+// Its error is encoding/json's own prose — caller-addressed parse feedback
+// carrying no operator data — so call sites publish it deliberately via
+// forma.InvalidInputf("%v", err) and route it through respondError (#360); the
+// gate's scrub still applies to it.
 func readJSONBody(r *http.Request, v any) error {
 	defer r.Body.Close()
 	dec := json.NewDecoder(r.Body)

--- a/internal/httpapi/utils_test.go
+++ b/internal/httpapi/utils_test.go
@@ -186,10 +186,14 @@ func TestReadJSONBodyDecodesNumbersExactly(t *testing.T) {
 	}
 }
 
-// TestParseHelpersPublishInvalidInput pins #360: every error a parse helper
-// returns must carry forma.ErrInvalidInput and publish its whole message,
-// because handlers route it through the disclosure gate — an unpublished
-// error would keep its 400 but answer a redacted body.
+// TestParseHelpersPublishInvalidInput pins #360: every error a
+// carrier-authoring parse helper (parsePath, parseSortParams,
+// parseCreateObjects) returns must carry forma.ErrInvalidInput and publish
+// its whole message, because handlers route it through the disclosure gate —
+// an unpublished error would keep its 400 but answer a redacted body. The
+// other two parse helpers, readJSONBody and parseUUID, return the library's
+// raw error with no sentinel; their call sites author the carrier instead
+// (forma.InvalidInputf("%v", err)), covered by the handler-level tests.
 func TestParseHelpersPublishInvalidInput(t *testing.T) {
 	_, _, pathEmptyErr := parsePath("/api/v1/")
 	_, _, pathFormatErr := parsePath("/api/v1/a/b/c")

--- a/internal/httpapi/utils_test.go
+++ b/internal/httpapi/utils_test.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -182,5 +183,48 @@ func TestReadJSONBodyDecodesNumbersExactly(t *testing.T) {
 	got := decoded["n"]
 	if want := json.Number("9007199254740993"); got != want {
 		t.Fatalf("decoded[n] = %#v (%T), want %#v", got, got, want)
+	}
+}
+
+// TestParseHelpersPublishInvalidInput pins #360: every error a parse helper
+// returns must carry forma.ErrInvalidInput and publish its whole message,
+// because handlers route it through the disclosure gate — an unpublished
+// error would keep its 400 but answer a redacted body.
+func TestParseHelpersPublishInvalidInput(t *testing.T) {
+	_, _, pathEmptyErr := parsePath("/api/v1/")
+	_, _, pathFormatErr := parsePath("/api/v1/a/b/c")
+	_, _, orderErr := parseSortParams(url.Values{"sort_by": {"age"}, "sort_order": {"up"}})
+	_, _, danglingErr := parseSortParams(url.Values{"sort_order": {"desc"}})
+	_, _, noFieldsErr := parseSortParams(url.Values{"sort_by": {" , "}})
+	_, _, emptyArrErr := parseCreateObjects([]any{})
+	_, _, nonObjErr := parseCreateObjects([]any{42})
+	_, _, scalarErr := parseCreateObjects("bad")
+
+	cases := map[string]struct {
+		err  error
+		want string
+	}{
+		"path empty schema":      {pathEmptyErr, "empty schema name"},
+		"path format":            {pathFormatErr, "invalid path format"},
+		"sort order":             {orderErr, "invalid sort_order: up"},
+		"sort order without by":  {danglingErr, "sort_order requires sort_by to be specified"},
+		"sort by without fields": {noFieldsErr, "sort_by provided but contained no valid fields"},
+		"create empty array":     {emptyArrErr, "empty array not allowed"},
+		"create non-object":      {nonObjErr, "body[0] must be an object"},
+		"create scalar":          {scalarErr, "body must be an object or array"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if !errors.Is(tc.err, forma.ErrInvalidInput) {
+				t.Fatalf("error does not carry ErrInvalidInput: %v", tc.err)
+			}
+			msg, ok := forma.ResolvePublicMessage(tc.err)
+			if !ok {
+				t.Fatalf("error publishes nothing: %v", tc.err)
+			}
+			if msg != tc.want {
+				t.Fatalf("published %q, want %q", msg, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The 17 request-parsing failure sites in `internal/httpapi` interpolated `err` straight into `writeError`, publishing their prose outside the #313 disclosure gate — the last hole in a rule that was supposed to be total. They now author `forma.InvalidInputf` carriers and answer through `respondError`, so the same text passes `resolvePublicMessage` and `redactCredentials` like every other client error. The one behavioral win: credential-shaped caller text on this path is now scrubbed — pre-branch, `?sort_order=password%3Ds3cr3t` came back echoed verbatim in the 400 body.

Closes #360

## Site inventory (the 17 interpolating sites, all in `internal/httpapi/handlers.go` @ main)

| # | Line | Handler | Source | Message before |
|---|------|---------|--------|-----------------|
| 1 | 33 | handleCreate | parsePath | `invalid path: %v` |
| 2 | 40 | handleCreate | readJSONBody | `invalid json body: %v` |
| 3 | 46 | handleCreate | parseCreateObjects | bare `err.Error()` |
| 4 | 96 | handleGet | parsePath | `invalid path: %v` |
| 5 | 108 | handleGet | parseUUID | `invalid row_id: %v` |
| 6 | 152 | handleQuery | parsePath | `invalid path: %v` |
| 7 | 159 | handleQuery | parseUUID | `invalid row_id: %v` |
| 8 | 172 | handleQuery | parseSortParams | `invalid sort parameters: %v` |
| 9 | 210 | handleUpdate | parsePath | `invalid path: %v` |
| 10 | 222 | handleUpdate | parseUUID | `invalid row_id: %v` |
| 11 | 228 | handleUpdate | readJSONBody | `invalid json body: %v` |
| 12 | 286 | handleDelete | parsePath | `invalid path: %v` |
| 13 | 292 | handleDelete | readJSONBody | `invalid json body: %v` |
| 14 | 306 | handleDelete | parseUUID (loop) | `invalid row_id at index %d: %v` |
| 15 | 386 | handleAdvancedQuery | readJSONBody | `invalid json body: %v` |
| 16 | 427 | apiHandler | parsePath | `invalid path: %v` |
| 17 | 434 | apiHandler | parseUUID | `invalid row_id: %v` |

The fixed-literal `writeError` sites (9× `method not allowed` 405, `row_id is required` ×2, `empty row_id array not allowed`, `schemas query parameter is required`, `q query parameter is required`, `schema_name is required`, `condition is required` — 16 sites in all) **stay direct** — they are curated literals, and the new message guard is what makes leaving them direct structurally safe.

## Body-text delta

No Go test and no bun e2e test asserts these texts today — only statuses are pinned — so this is an external-consumer contract change with zero test churn.

| Case | Before | After |
|------|-------|-------|
| malformed path (`/a/b/c`) | `invalid path: invalid path format` | unchanged |
| empty schema (`/api/v1/`) | `invalid path: invalid path: empty schema name` | `invalid path: empty schema name` (double prefix collapses) |
| bad JSON body | `invalid json body: unexpected EOF` | unchanged |
| create payload: empty array | `empty array not allowed` | `invalid json body: empty array not allowed` |
| create payload: non-object element | `body[1] must be an object` | `invalid json body: body[1] must be an object` |
| create payload: scalar | `body must be an object or array` | `invalid json body: body must be an object or array` |
| bad row_id | `invalid row_id: invalid UUID length: 4` | unchanged |
| bad row_id in delete array | `invalid row_id at index 1: <uuid prose>` | `invalid row_id: index 1: <uuid prose>` |
| bad sort_order | `invalid sort parameters: invalid sort_order: up` | unchanged |
| `advanced_query` type mismatch (`{"schema_name": 5}`) | `json: cannot unmarshal number into Go struct field Alias.schema_name of type string` | unchanged in kind — the json decoder's Go type name was already echoed pre-#360, but now travels under the gate; `docs/error-handling.md` records why the static identifier is acceptable noise and what to do if that stops holding |
| **credential-shaped caller text** | echoed verbatim (no scrub on this path) | scrubbed by `redactCredentials` |

## Guards

Two AST guards over `internal/httpapi`, on independent axes, pin every remaining **direct** `writeError` site:

- `TestWriteErrorAlwaysCarriesALiteral4xxStatus` (status axis, pre-existing) — every direct call names a literal 4xx status. Its two allowlist entries were verified still live; no mechanical change needed.
- `TestWriteErrorMessageIsAlwaysALiteral` (message axis, **new**) — every direct call's message argument is a string literal, so no interpolated caller data can reach a client body outside the gate again. Arity reconciliation **fails loudly**: if the guard cannot match a call's shape it errors rather than silently skipping, so a future signature change cannot quietly blind it. Mutation-verified — reverting a converted site to interpolation reddens the guard.

`TestNoBareSentinelWraps` (root package) stays green: the new sites are `InvalidInputf` carriers, not bare `%w` sentinel wraps.

## Notes

- **Statuses unchanged** — 400 everywhere on these paths; `Success:false` preserved. Responses are now provably on the *disclosed* branch (no `error_class`/`error_id` fields).
- **New `Debugw` log line per parse failure**, invisible at production Info level.
- `docs/error-handling.md` rewritten accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

