### PR TITLE
feat(httpapi): withheld-detail disclosed 4xx carries error_id (#361)

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1454,8 +1454,9 @@ it should key on is unchanged and sits beside it in `OperationError.Code`
 unknown schema, a schema violation, a missing required attribute — are
 unaffected and still carry their authored message.
 
-The single-operation path is untouched: bodies written by
-`respondErrorWithStatus` are byte-identical to before.
+By design, #318 left the single-operation path untouched: bodies written by
+`respondErrorWithStatus` were byte-identical before and after that change (#361
+later added `error_id` to withheld-detail disclosed bodies).
 
 `publicErrorMessage`'s other wording, `internal read error`, is deliberately not
 reproduced in the batch path. It is reserved for the three federated read-path

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -505,8 +505,9 @@ Two costs come with that, and both are deliberate:
   (`forma.HasOperatorDetail`), so *every* disclosed `4xx` on a relation-declaring
   schema now logs at `Warn` — not only the ones the strip caused. That is intended
   where the note is the real explanation, since it has to clear the production
-  `Info` threshold to be read at all. Today `visit` is the only shipped schema
-  with a relation root, so that is the only entity affected.
+  `Info` threshold to be read at all. Since #361 each of those bodies also
+  carries an `error_id` matching its `Warnw` line. Today `visit` is the only
+  shipped schema with a relation root, so that is the only entity affected.
 
 **A `required_always` attribute policy beneath a relation root breaks the entity
 the same way, and this one is *not* caught at startup.** The attribute-metadata
@@ -953,8 +954,10 @@ Status and disclosure are separately decided in a way that a client must not
 read as coupled: an error that carries a client sentinel but publishes nothing
 — a bare sentinel wrap, or a carrier-less mixed chain — classifies `4xx` on
 that sentinel and **still redacts**, producing a `400` body with `error_class`
-and `error_id`. Clients must key on `error_class`/`error_id` being present,
-never on the status, to know whether a body is redacted.
+and `error_id`. Clients must key on `error_class` being present, never on the
+status, to know whether a body is redacted. `error_id` is not a redaction
+signal: since #361 it also appears on a *disclosed* 4xx that withholds
+operator detail (see "Log levels are contract" below).
 
 **Redacted bodies (#301)** carry a fixed message, a stable `error_class` token,
 an `error_id`, and — when the chain holds a typed read-path carrier — a
@@ -1006,10 +1009,12 @@ message, so operator log queries filter on `schema_id` instead of parsing prose.
 It is omitted from the log line too when zero, so a log entry never asserts a
 schema the error did not name.
 
-Published 4xx bodies are unaffected: population happens on the redacted branch
-only, so a disclosed body carries message text and nothing else — even when the
-chain holds a resolvable carrier as operator detail. Pinned by
-`TestPublished4xxBodyCarriesNoSchemaID`.
+Published 4xx bodies are unaffected: `schema_id` population happens on the
+redacted branch only, so a disclosed body never carries `schema_id` or
+`error_class` — even when the chain holds a resolvable carrier as operator
+detail. (Since #361 such a withheld-detail disclosed body does carry an
+`error_id`; the carrier's schema id still stays out.) Pinned by
+`TestPublished4xxBodyCarriesNoSchemaID`, whose fixture is exactly that shape.
 
 ### Credentials are scrubbed before anything is written
 
@@ -1396,14 +1401,28 @@ Three levels, decided by what the body withheld (`respondErrorWithStatus`):
 | --- | --- | --- |
 | redacted (any status) | `Errorw` | the body carries no text; the log line is the operator's only copy, and production runs at Info (`cmd/server/main.go`) |
 | disclosed 4xx, no withheld detail | `Debugw` | the caller already has everything; client mistakes must not page anyone |
-| disclosed 4xx with withheld detail (`forma.HasOperatorDetail`) | `Warnw` | the boundary just withheld text whose only remaining copy is this line — it must clear the Info threshold, but `Errorw` would hand callers an alert trigger they can pull at will |
+| disclosed 4xx with withheld detail (`forma.HasOperatorDetail`) | `Warnw` | the boundary just withheld text whose only remaining copy is this line — it must clear the Info threshold, but `Errorw` would hand callers an alert trigger they can pull at will — and since #361 that line and the body share an `error_id` the caller can quote |
 
-The standing hazard this creates: a disclosed 4xx that withholds detail carries
-**no `error_id`** for the caller to quote back (correlation fields are a
-redacted-branch shape, pinned by six assertions). If withheld-detail 4xxs turn
-out to need operator correlation in practice, adding `error_id` to disclosed
-bodies is a separate contract change — recorded as a follow-up candidate, not
-done here.
+Since #361 the withheld-detail branch is also the one disclosed branch that
+emits a correlation field: the body carries an `error_id` matching the Warnw
+line. The detail-less branch stays id-free on purpose — its Debugw line does
+not survive the production Info threshold, so an id there would correlate to
+nothing. Correlation fields are therefore no longer a redacted-branch shape:
+`error_class` is, and it is the discriminator clients must key on.
+
+The withheld-detail shape — `error_id` present and matching the Warnw line, no
+`error_class`, no `schema_id` — is pinned by
+`TestRespondError4xxPublishesOnlyTheCarriersMessage`,
+`TestPublished4xxBodyCarriesNoSchemaID`, and
+`TestMixedChainPublishesClientTextOnly`. The detail-less id-free shape is
+pinned by six assertions of the form
+`resp.ErrorClass != "" || resp.ErrorID != ""`:
+`TestParseFailuresPublishThroughTheGate`,
+`TestCreateUnknownSchemaIs404AndVerbatim`,
+`TestUnknownSortAttributeIs400AndPublished`,
+`TestClientErrorPublishesItsMessage`,
+`TestCreateMissingRequiredAttributeIs400AndVerbatim`, and
+`TestAdvancedQueryOperatorWhitelistIs400AndVerbatim`.
 
 ### The best-effort batch result is a second publication surface (#318)
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1412,9 +1412,12 @@ nothing. Correlation fields are therefore no longer a redacted-branch shape:
 
 The withheld-detail shape — `error_id` present and matching the Warnw line, no
 `error_class`, no `schema_id` — is pinned by
-`TestRespondError4xxPublishesOnlyTheCarriersMessage`,
-`TestPublished4xxBodyCarriesNoSchemaID`, and
-`TestMixedChainPublishesClientTextOnly`. The detail-less id-free shape is
+`TestRespondError4xxPublishesOnlyTheCarriersMessage` (the only one that
+asserts the body↔Warnw-line match, and the wiring's fail-closed guard),
+`TestPublished4xxBodyCarriesNoSchemaID` (the only one that asserts `schema_id`
+absence), and `TestMixedChainPublishesClientTextOnly` (id presence and
+`error_class` absence on a mixed chain); the shape holds collectively, not
+per-test. The detail-less id-free shape is
 pinned by six assertions of the form
 `resp.ErrorClass != "" || resp.ErrorID != ""`:
 `TestParseFailuresPublishThroughTheGate`,

--- a/internal/httpapi/credential_redaction_test.go
+++ b/internal/httpapi/credential_redaction_test.go
@@ -122,9 +122,10 @@ func TestRedactCredentialsKnownGaps(t *testing.T) {
 
 // TestRedactCredentialsKeepsOperatorDetail is the other half of the contract and
 // the reason the pattern is narrow rather than a blanket scrub. A redacted
-// response leaves the operator with an error_id and a log line; if that line lost
-// the object key, the schema id, the endpoint, or the driver's own diagnosis,
-// there would be nothing to correlate the id against.
+// response — or, since #361, a withheld-detail disclosed 4xx — leaves the
+// operator with an error_id and a log line; if that line lost the object key,
+// the schema id, the endpoint, or the driver's own diagnosis, there would be
+// nothing to correlate the id against.
 func TestRedactCredentialsKeepsOperatorDetail(t *testing.T) {
 	in := `execute duckdb query: parquet set inconsistent for schema 22: manifest lists ` +
 		`base/schema_22/CANARY-KEY.parquet: HTTP Error: Unable to connect to URL ` +

--- a/internal/httpapi/error_leak_test.go
+++ b/internal/httpapi/error_leak_test.go
@@ -295,12 +295,14 @@ var writeErrorAllowed4xx = map[string]bool{
 // so the next author trusts the guard for exactly what it checks.
 //
 // NOTE: the message axis is checked by TestWriteErrorMessageIsAlwaysALiteral
-// below (#360): direct sites carry string literals only; anything dynamic must
-// arrive as a published carrier through respondError. This guard itself still
-// reads only the *status* expression and cannot tell whether the third argument
-// is safe to disclose. For the one site that builds its message at runtime,
-// respondErrorWithStatus, that judgement belongs to resolvePublicMessage. Every
-// other site is safe because its message is a fixed literal written into the
+// below (#360): every site carries a string literal only; anything dynamic
+// must arrive as a published carrier through respondError. This guard itself
+// still reads only the *status* expression and cannot tell whether the third
+// argument is safe to disclose. Since the #361 review folded the boundary's
+// disclosed write into writeJSON, no writeError site builds its message at
+// runtime — the runtime judgement (resolvePublicMessage) lives entirely inside
+// respondErrorWithStatus, which this guard no longer sees. Every remaining
+// site is safe because its message is a fixed literal written into the
 // source — request text no longer reaches these calls at all, having moved to
 // published carriers under the gate (#360), so no direct message can carry the
 // manager, the engine, S3, or PG_CONN.
@@ -387,8 +389,10 @@ func TestWriteErrorAlwaysCarriesALiteral4xxStatus(t *testing.T) {
 // (respondErrorWithStatus, whose message is built under the disclosure gate,
 // #313) stopped calling writeError when the #361 review folded the disclosed
 // write into writeJSON. Together the two guards make the disclosure rule
-// total for this write path (#360): a handler that needs dynamic text has
-// exactly one road, a published carrier through respondError.
+// total for writeError call sites (#360) — the boundary itself
+// (respondErrorWithStatus, writing through writeJSON) is trusted, not
+// scanned: a handler that needs dynamic text has exactly one road, a
+// published carrier through respondError.
 //
 // go/ast rather than the regex above: an argument expression can contain
 // commas and nested calls a regex cannot parse, and go/parser fails loudly on

--- a/internal/httpapi/error_leak_test.go
+++ b/internal/httpapi/error_leak_test.go
@@ -273,17 +273,17 @@ var writeErrorAllowed4xx = map[string]bool{
 // the build when a new handler reintroduces the #301 leak.
 //
 // The invariant: every writeError call in a non-test file passes a literal 4xx
-// http.Status* constant from writeErrorAllowed4xx, with exactly one sanctioned
-// exception — respondErrorWithStatus in error_response.go, which passes the
-// variable `status` under a runtime gate (isClientError + resolvePublicMessage,
-// #313) that is what actually constrains it. That exception is exempted by
-// asserting it is unique, so if it moves, multiplies, or reappears in another
-// file the guard fails.
+// http.Status* constant from writeErrorAllowed4xx, with no exceptions. Until
+// #361 there was exactly one — respondErrorWithStatus passed the variable
+// `status` under the disclosure gate (isClientError + resolvePublicMessage,
+// #313) — but the #361 review folded the disclosed write into writeJSON, so
+// writeError is handler-literal territory only, and any non-literal status
+// anywhere is a regression.
 //
 // It is an allowlist rather than a blocklist of bad statuses because a blocklist
 // can be spelled around, and the most likely regression shape spells around it
-// for free: copying error_response.go's own `writeError(w, status, ...)` line
-// into a handler yields a 500 body full of S3 keys that no pattern for
+// for free: hand-writing a `writeError(w, status, ...)` call with a
+// runtime-classified status in a handler yields a 500 body full of S3 keys that no pattern for
 // `http.StatusInternalServerError` would ever see. Deny-by-default also covers
 // non-500 5xx constants (503 on the degraded-mode path), bare numerics, and any
 // receiver name. Grep-gate precedent: #260.
@@ -371,27 +371,22 @@ func TestWriteErrorAlwaysCarriesALiteral4xxStatus(t *testing.T) {
 		return
 	}
 
-	if len(unlisted) != 1 {
-		t.Errorf("expected exactly 1 writeError site with a non-literal status "+
-			"(respondErrorWithStatus in error_response.go), found %d: %v\n"+
-			"every other site must pass a literal 4xx constant from writeErrorAllowed4xx; "+
+	if len(unlisted) != 0 {
+		t.Errorf("expected no writeError site with a non-literal status "+
+			"(the boundary writes through writeJSON since #361), found %d: %v\n"+
+			"every site must pass a literal 4xx constant from writeErrorAllowed4xx; "+
 			"anything classified at runtime must go through respondError instead (#301)",
 			len(unlisted), unlisted)
-		return
-	}
-	if !strings.HasPrefix(unlisted[0], "error_response.go:") {
-		t.Errorf("the sanctioned non-literal writeError status moved out of error_response.go to %s; "+
-			"only respondErrorWithStatus may pass a runtime-classified status (#301)", unlisted[0])
 	}
 }
 
 // TestWriteErrorMessageIsAlwaysALiteral closes the axis the status guard above
 // documents as unchecked: the message. Every direct writeError call site must
 // pass an untyped string literal — never fmt.Sprintf, err.Error(), or any
-// other expression — with the same single sanctioned exception as the status
-// guard: respondErrorWithStatus in error_response.go, whose message is built
-// under the disclosure gate (isClientError + resolvePublicMessage +
-// redactCredentials, #313). Together the two guards make the disclosure rule
+// other expression — with no exceptions: the one sanctioned site
+// (respondErrorWithStatus, whose message is built under the disclosure gate,
+// #313) stopped calling writeError when the #361 review folded the disclosed
+// write into writeJSON. Together the two guards make the disclosure rule
 // total for this write path (#360): a handler that needs dynamic text has
 // exactly one road, a published carrier through respondError.
 //
@@ -459,17 +454,11 @@ func TestWriteErrorMessageIsAlwaysALiteral(t *testing.T) {
 			"be introduced without extending this guard (#360)", unchecked)
 		return
 	}
-	if len(dynamic) != 1 {
-		t.Errorf("expected exactly 1 writeError site with a non-literal message "+
-			"(respondErrorWithStatus in error_response.go), found %d: %v\n"+
+	if len(dynamic) != 0 {
+		t.Errorf("expected no writeError site with a non-literal message "+
+			"(the boundary writes through writeJSON since #361), found %d: %v\n"+
 			"a handler must not build its own body text — publish it through a "+
 			"forma.InvalidInputf carrier and respondError instead (#360)",
 			len(dynamic), dynamic)
-		return
-	}
-	if !strings.HasPrefix(dynamic[0], "error_response.go:") {
-		t.Errorf("the sanctioned non-literal writeError message moved out of "+
-			"error_response.go to %s; only respondErrorWithStatus may write a "+
-			"runtime-built message (#360)", dynamic[0])
 	}
 }

--- a/internal/httpapi/error_response.go
+++ b/internal/httpapi/error_response.go
@@ -307,25 +307,24 @@ func respondErrorWithStatus(w http.ResponseWriter, status int, op string, err er
 	safe := redactCredentials(err.Error())
 
 	if msg, ok := resolvePublicMessage(err); ok && status < http.StatusInternalServerError && isClientError(err) {
+		resp := APIResponse{
+			Success: false,
+			Error:   fmt.Sprintf("%s: %s", op, redactCredentials(msg)),
+		}
 		if forma.HasOperatorDetail(err) {
 			// #361: this Warnw line is the only remaining copy of the withheld
 			// detail, so the body carries an error_id the caller can quote back.
-			// The detail-less branch below stays id-free: its Debugw line does
-			// not survive the production Info threshold, and an error_id that
+			// The detail-less branch stays id-free: its Debugw line does not
+			// survive the production Info threshold, and an error_id that
 			// correlates to nothing is worse than none.
-			errorID := uuid.NewString()
-			fields = append(fields, "error_id", errorID, "error", safe)
+			resp.ErrorID = uuid.NewString()
+			fields = append(fields, "error_id", resp.ErrorID, "error", safe)
 			zap.S().Warnw(op, fields...)
-			_ = writeJSON(w, status, APIResponse{
-				Success: false,
-				Error:   fmt.Sprintf("%s: %s", op, redactCredentials(msg)),
-				ErrorID: errorID,
-			})
-			return
+		} else {
+			fields = append(fields, "error", safe)
+			zap.S().Debugw(op, fields...)
 		}
-		fields = append(fields, "error", safe)
-		zap.S().Debugw(op, fields...)
-		_ = writeError(w, status, fmt.Sprintf("%s: %s", op, redactCredentials(msg)))
+		_ = writeJSON(w, status, resp)
 		return
 	}
 

--- a/internal/httpapi/error_response.go
+++ b/internal/httpapi/error_response.go
@@ -291,7 +291,7 @@ func resolvePublicMessage(err error) (string, bool) {
 // operator detail was withheld (forma.HasOperatorDetail): that line is the
 // only copy of the detail, so it must clear the Info threshold, without
 // inheriting Errorw's alerting weight for something a caller can trigger at
-// will.
+// will. The Warnw branch also mints an error_id shared by line and body (#361).
 func respondErrorWithStatus(w http.ResponseWriter, status int, op string, err error, logFields ...any) {
 	fields := make([]any, 0, len(logFields)+8)
 	fields = append(fields, logFields...)
@@ -307,12 +307,24 @@ func respondErrorWithStatus(w http.ResponseWriter, status int, op string, err er
 	safe := redactCredentials(err.Error())
 
 	if msg, ok := resolvePublicMessage(err); ok && status < http.StatusInternalServerError && isClientError(err) {
-		fields = append(fields, "error", safe)
 		if forma.HasOperatorDetail(err) {
+			// #361: this Warnw line is the only remaining copy of the withheld
+			// detail, so the body carries an error_id the caller can quote back.
+			// The detail-less branch below stays id-free: its Debugw line does
+			// not survive the production Info threshold, and an error_id that
+			// correlates to nothing is worse than none.
+			errorID := uuid.NewString()
+			fields = append(fields, "error_id", errorID, "error", safe)
 			zap.S().Warnw(op, fields...)
-		} else {
-			zap.S().Debugw(op, fields...)
+			_ = writeJSON(w, status, APIResponse{
+				Success: false,
+				Error:   fmt.Sprintf("%s: %s", op, redactCredentials(msg)),
+				ErrorID: errorID,
+			})
+			return
 		}
+		fields = append(fields, "error", safe)
+		zap.S().Debugw(op, fields...)
 		_ = writeError(w, status, fmt.Sprintf("%s: %s", op, redactCredentials(msg)))
 		return
 	}

--- a/internal/httpapi/error_response_test.go
+++ b/internal/httpapi/error_response_test.go
@@ -197,15 +197,24 @@ func TestRespondError4xxPublishesOnlyTheCarriersMessage(t *testing.T) {
 	if strings.Contains(rec.Body.String(), canaryKey) {
 		t.Fatalf("operator detail leaked into the 400 body: %s", rec.Body.String())
 	}
-	if resp.ErrorClass != "" || resp.ErrorID != "" {
-		t.Fatalf("4xx must not emit correlation fields, got class=%q id=%q", resp.ErrorClass, resp.ErrorID)
+	if resp.ErrorClass != "" {
+		t.Fatalf("disclosed 4xx must not carry error_class, got %q", resp.ErrorClass)
+	}
+	// #361: the boundary just withheld detail whose only copy is the Warnw line,
+	// so the body carries an error_id the caller can quote back.
+	if _, perr := uuid.Parse(resp.ErrorID); perr != nil {
+		t.Fatalf("withheld-detail 4xx error_id %q is not a UUID: %v", resp.ErrorID, perr)
 	}
 
 	entries := logs.All()
 	if len(entries) != 1 || entries[0].Level != zap.WarnLevel {
 		t.Fatalf("withheld operator detail must log at WARN, got %d entries %v", len(entries), entries)
 	}
-	logged, _ := entries[0].ContextMap()["error"].(string)
+	fields := entries[0].ContextMap()
+	if fields["error_id"] != resp.ErrorID {
+		t.Fatalf("Warnw error_id %v does not match body %q", fields["error_id"], resp.ErrorID)
+	}
+	logged, _ := fields["error"].(string)
 	if !strings.Contains(logged, canaryKey) {
 		t.Fatalf("operator log lost the withheld detail; logged: %s", logged)
 	}

--- a/internal/httpapi/error_response_test.go
+++ b/internal/httpapi/error_response_test.go
@@ -335,7 +335,7 @@ func TestUnknownSortAttributeIs400AndPublished(t *testing.T) {
 		t.Fatalf("the sentinel suffix must stay out of the body (#313), got %q", resp.Error)
 	}
 	if resp.ErrorClass != "" || resp.ErrorID != "" {
-		t.Fatalf("a published 400 must not emit correlation fields, got class=%q id=%q",
+		t.Fatalf("a detail-less published 400 must not emit correlation fields, got class=%q id=%q",
 			resp.ErrorClass, resp.ErrorID)
 	}
 }

--- a/internal/httpapi/error_schema_id_test.go
+++ b/internal/httpapi/error_schema_id_test.go
@@ -218,12 +218,13 @@ func TestRedactedBodyOmitsSchemaIDWithoutACarrier(t *testing.T) {
 
 // TestPublished4xxBodyCarriesNoSchemaID pins that the schema-id reversal is
 // confined to the redacted branch. A published client error keeps a body of
-// message only: no correlation fields, no schema id — even when the chain
-// deliberately carries a ParquetSetInconsistentError that errorSchemaID
-// *would* resolve, attached as operator detail. The test fails if the field
-// is populated before the disclosure gate instead of after it, and the
+// message only: no correlation fields (except error_id when detail is withheld),
+// no schema id — even when the chain deliberately carries a ParquetSetInconsistentError
+// that errorSchemaID *would* resolve, attached as operator detail. The test fails if
+// the field is populated before the disclosure gate instead of after it, and the
 // object-key assertion makes it strictly stronger than its pre-#313 version:
-// the detail's text must not surface either.
+// the detail's text must not surface either. #361: withheld detail generates an
+// error_id for the Warnw line.
 func TestPublished4xxBodyCarriesNoSchemaID(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
 	defer restore()
@@ -239,10 +240,20 @@ func TestPublished4xxBodyCarriesNoSchemaID(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	for _, forbidden := range []string{"schema_id", "error_class", "error_id", canaryKey} {
+	for _, forbidden := range []string{"schema_id", "error_class", canaryKey} {
 		if strings.Contains(body, forbidden) {
 			t.Fatalf("published 4xx body carried %q; body: %s", forbidden, body)
 		}
+	}
+	var resp APIResponse
+	if uerr := json.Unmarshal(rec.Body.Bytes(), &resp); uerr != nil {
+		t.Fatalf("body is not valid JSON: %v", uerr)
+	}
+	// #361: the chain withholds operator detail, so the body carries an
+	// error_id for the Warnw line — and still none of the redacted-branch
+	// fields above.
+	if _, perr := uuid.Parse(resp.ErrorID); perr != nil {
+		t.Fatalf("withheld-detail 4xx error_id %q is not a UUID: %v", resp.ErrorID, perr)
 	}
 	if !strings.Contains(body, "bad filter") {
 		t.Fatalf("expected the published message, got %s", body)

--- a/internal/httpapi/multi_cause_chain_test.go
+++ b/internal/httpapi/multi_cause_chain_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
 	"go.uber.org/zap"
 )
@@ -149,7 +150,8 @@ func TestClientErrorPublishesItsMessage(t *testing.T) {
 // unrenderable caller-supplied path template: a carrier with the render error
 // attached as operator detail. Pre-#313 this chain collapsed to an opaque
 // redacted 400; now the caller learns what to fix while the operator cause
-// stays out of the body.
+// stays out of the body. #361: withheld detail generates an error_id for the
+// Warnw line.
 func TestMixedChainPublishesClientTextOnly(t *testing.T) {
 	restore := zap.ReplaceGlobals(zap.NewNop())
 	defer restore()
@@ -179,9 +181,12 @@ func TestMixedChainPublishesClientTextOnly(t *testing.T) {
 	if strings.Contains(resp.Error, "unclosed action") {
 		t.Fatalf("text/template internals leaked into the 400 body: %q", resp.Error)
 	}
-	if resp.ErrorClass != "" || resp.ErrorID != "" {
-		t.Fatalf("a published 400 must not emit correlation fields, got class=%q id=%q",
-			resp.ErrorClass, resp.ErrorID)
+	if resp.ErrorClass != "" {
+		t.Fatalf("a published 400 must not emit error_class, got %q", resp.ErrorClass)
+	}
+	// #361: operator detail (the render error) was withheld, so an error_id rides along.
+	if _, perr := uuid.Parse(resp.ErrorID); perr != nil {
+		t.Fatalf("withheld-detail 400 error_id %q is not a UUID: %v", resp.ErrorID, perr)
 	}
 }
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -140,13 +140,16 @@ type APIResponse struct {
 	Success bool   `json:"success"`
 	Data    any    `json:"data,omitempty"`
 	Error   string `json:"error,omitempty"`
-	// ErrorClass and ErrorID are populated on every redacted response (#301):
-	// a stable machine token for client discrimination, and a correlation id
-	// echoed on the operator log line that holds the error chain. Since #313 a
-	// redacted response can be a 4xx as well as a 5xx: an error that carries a
-	// client sentinel but publishes no message (a bare sentinel wrap, or a
-	// carrier-less mixed chain) keeps its status and loses its body. Both are
-	// omitempty, so success bodies and published 4xx bodies are unchanged.
+	// ErrorClass is populated on every redacted response and only there (#301) —
+	// the stable machine token clients discriminate on. ErrorID, a correlation
+	// id echoed on the operator log line that holds the error chain, appears on
+	// every redacted response and, since #361, on a disclosed 4xx that withholds
+	// operator detail (forma.HasOperatorDetail), where it matches the Warnw line
+	// keeping the only copy of that detail. Since #313 a redacted response can
+	// be a 4xx as well as a 5xx: an error that carries a client sentinel but
+	// publishes no message (a bare sentinel wrap, or a carrier-less mixed chain)
+	// keeps its status and loses its body. Both fields are omitempty, so success
+	// bodies and detail-less published 4xx bodies are unchanged.
 	ErrorClass string `json:"error_class,omitempty"`
 	ErrorID    string `json:"error_id,omitempty"`
 	// SchemaID names the schema a redacted read failure was addressed to (#301,


### PR DESCRIPTION
Closes #361.

## Contract change (deliberate)

A disclosed 4xx that withholds operator detail (`forma.WithOperatorDetail`)
now carries an `error_id` in the body, matching the `error_id` field on its
Warnw log line. Detail-less disclosed 4xxs are unchanged (no id — their
Debugw line does not survive the production Info threshold). Redacted
responses are unchanged.

**Migration note:** "`error_id` present ⇒ redacted" is no longer a valid
client inference. The redacted-body discriminator is `error_class`.

Ruling: Option A (targeted; id only where a log line exists to correlate),
chosen by the issue owner 2026-08-18 — see the plan comment on #361.

## Commits

- `1182f90` boundary change + fail-closed test (body `error_id` ⇔ Warnw line, UUID-parse + body↔log match assertions)
- `c2d8fac` the two withheld-detail pins flipped to expect `error_id` (negative guards on `error_class`/`schema_id`/canary preserved)
- `ee24c6e` docs/error-handling.md contract record + code-comment sweep (discriminator guidance now keys on `error_class` alone; grep-verified pin set named)
- `92fe403` final-review fix: scope the #318 "byte-identical" sentence to its own change

## Verification

- `make fmt-check`, `make lint` (pinned v1.64.8), `make test` all green at head; full unit suite 35 packages.
- All six remaining detail-less pins verified empirically (parse failures ×15, unknown-schema 404, write-validation 400, condition-DSL 400, unknown-sort 400, publication-message 400): no `error_id` leaks onto detail-less disclosed bodies.
- `tests/e2e/` greps clean for `error_id` — no black-box assertions affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
