### PR TITLE
feat: aggregate signal for report-only schema validation (#317)

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,6 +65,12 @@ type EntityConfig struct {
 	// their schema, and rejecting on update would make them un-updatable — a
 	// caller touching one unrelated field would be refused for a pre-existing
 	// violation elsewhere. Creates are always enforced; they have no legacy data.
+	//
+	// Whether it is safe to flip this yet is answered by the #317 aggregate:
+	// the "report-only schema validation violations reached a milestone" Warn
+	// line (per schema, at the 1st and every 100th accepted violation) and the
+	// entity_report_only_validation_violation_total telemetry counter. When a
+	// schema's milestones stop advancing, its rows are repaired.
 	ValidateUpdatesStrict bool `json:"validateUpdatesStrict"`
 }
 

--- a/config.go
+++ b/config.go
@@ -69,8 +69,13 @@ type EntityConfig struct {
 	// Whether it is safe to flip this yet is answered by the #317 aggregate:
 	// the "report-only schema validation violations reached a milestone" Warn
 	// line (per schema, at the 1st and every 100th accepted violation) and the
-	// entity_report_only_validation_violation_total telemetry counter. When a
-	// schema's milestones stop advancing, its rows are repaired.
+	// entity_report_only_validation_violation_total telemetry counter. While
+	// those lines keep appearing for a schema, its rows are not yet repaired.
+	// Their absence is not proof of the converse: the signal fires only when a
+	// violating row is written, and only every 100th time thereafter within one
+	// process, so a schema whose bad rows are never updated stays silent.
+	// Confirm with an e2e pass over real data before flipping
+	// (docs/error-handling.md).
 	ValidateUpdatesStrict bool `json:"validateUpdatesStrict"`
 }
 

--- a/config.go
+++ b/config.go
@@ -73,7 +73,8 @@ type EntityConfig struct {
 	// those lines keep appearing for a schema, its rows are not yet repaired.
 	// Their absence is not proof of the converse: the signal fires only when a
 	// violating row is written, and only every 100th time thereafter within one
-	// process, so a schema whose bad rows are never updated stays silent.
+	// process (strictly, per EntityManager — the shipped wiring builds exactly
+	// one), so a schema whose bad rows are never updated stays silent.
 	// Confirm with an e2e pass over real data before flipping
 	// (docs/error-handling.md).
 	ValidateUpdatesStrict bool `json:"validateUpdatesStrict"`

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -130,7 +130,9 @@ payload-free. Every accepted violation increments the counter
 `entity_report_only_validation_violation_total`, labelled `schema_id`,
 `schema_name` and `kind`, where `kind` is `required` (a property is absent, so
 the repair is to backfill data) or `constraint` (a present value is illegal, so
-the repair is to fix the value). Because a deployment need not register a
+the repair is to fix the value); `kind` is read off the validator's message — a
+metric label is the one sanctioned prose key, carved out under "There is no
+substring heuristic" below. Because a deployment need not register a
 telemetry emitter, the same accounting also reaches the log: at a schema's 1st
 accepted violation and every 100th after, a `Warn` line — "report-only schema
 validation violations reached a milestone..." — carries the cumulative total and
@@ -803,6 +805,15 @@ errors that wrapped no sentinel. It was removed for two reasons:
   4xx.
 - **It was the last site classifying an error by string comparison**, which
   `AGENTS.md` forbids.
+
+One later arrival is deliberately outside that rule's blast radius, and it is
+the only one: `classifyViolation` (#317) reads the validator's message to pick
+the `required`-versus-`constraint` label on the report-only aggregate. It
+decides a metric label and nothing else — never a status, a body, or whether a
+write proceeds — so a wrong match cannot reproduce either failure above, and
+the prose it keys on is pinned against the real validator by
+`TestClassifyViolationPinsLibraryProse`. A prose key that feeds any *decision*
+remains forbidden.
 
 The consequence is that a genuine client error earns its 4xx only by carrying a
 sentinel. Removing the heuristic therefore required a sweep of the sites that

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -143,7 +143,8 @@ Read it in one direction only. While those milestones keep appearing for a
 schema, its rows are not yet repaired. Silence does not establish the converse:
 the signal fires only when a violating row is written, so rows nobody updates
 never announce themselves, the stride means a schema is quiet between
-milestones, and the counts are per process and reset on restart. The signal
+milestones, and the counts live on the `EntityManager` — one per process in
+the shipped wiring — and reset on restart. The signal
 narrows where to look; the e2e pass above is still what licenses the flip.
 
 ### Which errors are which class
@@ -812,8 +813,13 @@ the `required`-versus-`constraint` label on the report-only aggregate. It
 decides a metric label and nothing else — never a status, a body, or whether a
 write proceeds — so a wrong match cannot reproduce either failure above, and
 the prose it keys on is pinned against the real validator by
-`TestClassifyViolationPinsLibraryProse`. A prose key that feeds any *decision*
-remains forbidden.
+`TestClassifyViolationPinsLibraryProse`. A prose key that feeds any decision
+*on this path* — a status, a disclosed body, a write outcome — remains
+forbidden. (Two older string keys sit outside this paragraph's rule and
+predate the carve-out: `manifest.IsNotFound` reads S3 driver prose to recognise
+an absent object on the read path, and the e2e harness's
+`isFederatedTierFileError` is test-only. Neither classifies an error toward a
+caller.)
 
 The consequence is that a genuine client error earns its 4xx only by carrying a
 sentinel. Removing the heuristic therefore required a sweep of the sites that

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -810,8 +810,9 @@ errors that wrapped no sentinel. It was removed for two reasons:
 One later arrival is deliberately outside that rule's blast radius, and it is
 the only one: `classifyViolation` (#317) reads the validator's message to pick
 the `required`-versus-`constraint` label on the report-only aggregate. It
-decides a metric label and nothing else — never a status, a body, or whether a
-write proceeds — so a wrong match cannot reproduce either failure above, and
+decides a metric label — and the matching `kind` field on the per-write Warn
+line — and nothing else: never a status, a body, or whether a write proceeds.
+So a wrong match cannot reproduce either failure above, and
 the prose it keys on is pinned against the real validator by
 `TestClassifyViolationPinsLibraryProse`. A prose key that feeds any decision
 *on this path* — a status, a disclosed body, a write outcome — remains

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -125,6 +125,25 @@ bites, so any reconstruction that is lossy for such a field turns a legitimate
 partial update into a rejection the caller cannot diagnose from their own
 payload.
 
+Report-only mode carries its own rollout signal (#317), aggregate and
+payload-free. Every accepted violation increments the counter
+`entity_report_only_validation_violation_total`, labelled `schema_id`,
+`schema_name` and `kind`, where `kind` is `required` (a property is absent, so
+the repair is to backfill data) or `constraint` (a present value is illegal, so
+the repair is to fix the value). Because a deployment need not register a
+telemetry emitter, the same accounting also reaches the log: at a schema's 1st
+accepted violation and every 100th after, a `Warn` line — "report-only schema
+validation violations reached a milestone..." — carries the cumulative total and
+the per-kind split for that schema, and nothing else. No violation text, no row
+id, no payload.
+
+Read it in one direction only. While those milestones keep appearing for a
+schema, its rows are not yet repaired. Silence does not establish the converse:
+the signal fires only when a violating row is written, so rows nobody updates
+never announce themselves, the stride means a schema is quiet between
+milestones, and the counts are per process and reset on restart. The signal
+narrows where to look; the e2e pass above is still what licenses the flip.
+
 ### Which errors are which class
 
 `validateWritePayload` splits on sentinel evidence, not on the enforce flag:

--- a/internal/entity_batch_service.go
+++ b/internal/entity_batch_service.go
@@ -28,6 +28,7 @@ type entityBatchService struct {
 	// error, not a no-op.
 	validator             *schemavalidate.Validator
 	validateUpdatesStrict bool
+	reportOnlyStats       *reportOnlyStats
 }
 
 // newEntityBatchService takes the CRUD service as an explicit parameter so the
@@ -57,6 +58,7 @@ func newEntityBatchService(em *entityManager, crud *entityCRUDService) *entityBa
 
 		validator:             em.validator,
 		validateUpdatesStrict: em.validateUpdatesStrict,
+		reportOnlyStats:       em.reportOnlyStats,
 	}
 }
 
@@ -219,7 +221,7 @@ func (s *entityBatchService) batchCreateAtomic(ctx context.Context, req *forma.B
 
 		// Creates always enforce, and this batch is atomic: one violation fails
 		// the whole request before anything is written.
-		if err := validateWritePayload(writeValidation{
+		if err := validateWritePayload(ctx, writeValidation{
 			validator:     s.validator,
 			schemaID:      schemaID,
 			schemaName:    op.SchemaName,
@@ -228,6 +230,7 @@ func (s *entityBatchService) batchCreateAtomic(ctx context.Context, req *forma.B
 			data:          inputData,
 			enforce:       true,
 			relationRoots: relationRoots.resolve(op.SchemaName),
+			stats:         s.reportOnlyStats,
 		}); err != nil {
 			return nil, forma.WrapPublicf(err, "operation[%d]", i)
 		}
@@ -307,7 +310,7 @@ func (s *entityBatchService) batchUpdateAtomic(ctx context.Context, req *forma.B
 
 		// The *merged* document is what gets validated, so a partial update that
 		// does not mention a required attribute still succeeds.
-		if err := validateWritePayload(writeValidation{
+		if err := validateWritePayload(ctx, writeValidation{
 			validator:     s.validator,
 			schemaID:      schemaID,
 			schemaName:    op.SchemaName,
@@ -316,6 +319,7 @@ func (s *entityBatchService) batchUpdateAtomic(ctx context.Context, req *forma.B
 			data:          mergedData,
 			enforce:       s.validateUpdatesStrict,
 			relationRoots: relationRoots.resolve(op.SchemaName),
+			stats:         s.reportOnlyStats,
 		}); err != nil {
 			return nil, forma.WrapPublicf(err, "operation[%d]", i)
 		}

--- a/internal/entity_crud_service.go
+++ b/internal/entity_crud_service.go
@@ -26,6 +26,7 @@ type entityCRUDService struct {
 	// error, not a no-op.
 	validator             *schemavalidate.Validator
 	validateUpdatesStrict bool
+	reportOnlyStats       *reportOnlyStats
 }
 
 func newEntityCRUDService(em *entityManager) *entityCRUDService {
@@ -43,6 +44,7 @@ func newEntityCRUDService(em *entityManager) *entityCRUDService {
 
 		validator:             em.validator,
 		validateUpdatesStrict: em.validateUpdatesStrict,
+		reportOnlyStats:       em.reportOnlyStats,
 	}
 }
 
@@ -101,7 +103,7 @@ func (s *entityCRUDService) Create(ctx context.Context, req *forma.EntityOperati
 	// why the 4xx cannot be answered rather than inferring it. Do not resolve the
 	// hazard by validating before stripping: that defeats the guard and judges a
 	// document no row will hold.
-	if err := validateWritePayload(writeValidation{
+	if err := validateWritePayload(ctx, writeValidation{
 		validator:     s.validator,
 		schemaID:      schemaID,
 		schemaName:    req.SchemaName,
@@ -110,6 +112,7 @@ func (s *entityCRUDService) Create(ctx context.Context, req *forma.EntityOperati
 		data:          inputData,
 		enforce:       true,
 		relationRoots: s.relations.RelationRootNames(req.SchemaName),
+		stats:         s.reportOnlyStats,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to validate create payload: %w", err)
 	}
@@ -227,7 +230,7 @@ func (s *entityCRUDService) Update(ctx context.Context, req *forma.EntityOperati
 	// The *merged* document is what gets validated: a partial update that does
 	// not mention a required attribute must still succeed. The relation-root
 	// hazard noted in Create applies here too.
-	if err := validateWritePayload(writeValidation{
+	if err := validateWritePayload(ctx, writeValidation{
 		validator:     s.validator,
 		schemaID:      schemaID,
 		schemaName:    req.SchemaName,
@@ -236,6 +239,7 @@ func (s *entityCRUDService) Update(ctx context.Context, req *forma.EntityOperati
 		data:          mergedData,
 		enforce:       s.validateUpdatesStrict,
 		relationRoots: s.relations.RelationRootNames(req.SchemaName),
+		stats:         s.reportOnlyStats,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to validate update payload: %w", err)
 	}

--- a/internal/entity_manager.go
+++ b/internal/entity_manager.go
@@ -29,6 +29,9 @@ type entityManager struct {
 	// 500 on every write rather than being ignored.
 	validator             *schemavalidate.Validator
 	validateUpdatesStrict bool
+	// reportOnlyStats feeds the #317 milestone log line. Owned here so the CRUD
+	// and batch services aggregate into one set of per-schema counts.
+	reportOnlyStats *reportOnlyStats
 
 	crud     *entityCRUDService
 	query    *entityQueryService
@@ -164,6 +167,7 @@ func NewEntityManager(
 
 		validator:             validator,
 		validateUpdatesStrict: config.Entity.ValidateUpdatesStrict,
+		reportOnlyStats:       newReportOnlyStats(),
 	}
 	// Options run before the relation index is resolved, because one of them
 	// supplies it: WithRelationIndex is how the composition root hands over the

--- a/internal/entity_write_relation_diagnosis_test.go
+++ b/internal/entity_write_relation_diagnosis_test.go
@@ -182,7 +182,7 @@ func TestWriteDiagnosisIsSilentOnOperatorClassErrors(t *testing.T) {
 
 	// schemaID 9999 is registered nowhere, so Validate answers "no resolved JSON
 	// schema", which is a plain error and not a violation.
-	err = validateWritePayload(writeValidation{
+	err = validateWritePayload(context.Background(), writeValidation{
 		validator:     validator,
 		schemaID:      9999,
 		schemaName:    "child",
@@ -217,7 +217,7 @@ func TestWriteDiagnosisDoesNotChangeWhichWritesPass(t *testing.T) {
 	t.Run("a passing payload stays passing", func(t *testing.T) {
 		validator, schemaID := resolveFixtureValidator(t, "relation_ok_not")
 
-		require.NoError(t, validateWritePayload(writeValidation{
+		require.NoError(t, validateWritePayload(context.Background(), writeValidation{
 			validator:     validator,
 			schemaID:      schemaID,
 			schemaName:    "child",
@@ -230,7 +230,7 @@ func TestWriteDiagnosisDoesNotChangeWhichWritesPass(t *testing.T) {
 	t.Run("report-only still absorbs the violation", func(t *testing.T) {
 		validator, schemaID := resolveFixtureValidator(t, "relation_required_double_not")
 
-		require.NoError(t, validateWritePayload(writeValidation{
+		require.NoError(t, validateWritePayload(context.Background(), writeValidation{
 			validator:     validator,
 			schemaID:      schemaID,
 			schemaName:    "child",
@@ -297,7 +297,7 @@ func TestWriteValidationAttachesNoDiagnosisWithoutRelationRoots(t *testing.T) {
 		transform.NormalizeDottedKeys(payload, nil, validator.ArrayPaths(schemaID)))
 	require.Error(t, bare, "the fixture must fail validation for this to say anything")
 
-	err := validateWritePayload(writeValidation{
+	err := validateWritePayload(context.Background(), writeValidation{
 		validator:  validator,
 		schemaID:   schemaID,
 		schemaName: "child",

--- a/internal/entity_write_validation.go
+++ b/internal/entity_write_validation.go
@@ -108,6 +108,15 @@ func validateWritePayload(ctx context.Context, v writeValidation) error {
 	if err == nil {
 		return nil
 	}
+	// kind is a property of the schema violation itself, so it is classified
+	// here — before explainStrippedRelationRoots decorates the error below.
+	// classifyViolation sniffs a substring of err.Error(), and the diagnosis
+	// prose is repo-owned text that interpolates the schema's relation root
+	// names; classifying after the wrap would let that text, rather than the
+	// validator's verdict, decide the label. The enforce path computes it and
+	// never reads it, which is a string comparison's worth of waste in exchange
+	// for the classifier having exactly one possible input.
+	kind := classifyViolation(err)
 	// The gate lives here rather than inside the decorator: a schema declaring no
 	// relation root strips nothing, so there is nothing to explain, and asking
 	// explainStrippedRelationRoots to decide that would make it a function that
@@ -131,12 +140,16 @@ func validateWritePayload(ctx context.Context, v writeValidation) error {
 	// counts only — no violation text, no payload — so they widen nothing.
 	//
 	// Volume is bounded by zap's production sampling, not by this code:
-	// cmd/server installs zap.NewProduction(), whose sampler passes the first
-	// 100 entries per second for an identical message and every 100th after.
-	// This message is constant, so a violation-heavy corpus is capped at that
-	// rate, and the milestone line carries cumulative counts so sampled-away
-	// per-write lines lose no aggregate information (#317).
-	kind := classifyViolation(err)
+	// cmd/server and cmd/lambda install zap.NewProduction(), whose sampler
+	// passes the first 100 entries per second for an identical message and every
+	// 100th after. This message is constant, so a violation-heavy corpus is
+	// capped at that rate, and the milestone line carries cumulative counts so
+	// sampled-away per-write lines lose no aggregate information, short of rates
+	// where the milestone line itself is sampled (~10k violations/sec for one
+	// schema, since it fires once per 100) (#317).
+	//
+	// kind was classified above, off the validator's own error, before the
+	// relation-root decoration could join the string.
 	telemetry.EmitReportOnlyValidationViolation(ctx, v.schemaID, v.schemaName, kind)
 	zap.S().Warnw("write payload violates the entity JSON schema; accepted because strict update validation is off",
 		"schemaName", v.schemaName, "schemaID", v.schemaID, "rowID", v.rowID, "kind", kind, "error", err.Error())

--- a/internal/entity_write_validation.go
+++ b/internal/entity_write_validation.go
@@ -1,10 +1,12 @@
 package internal
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/lychee-technology/forma/internal/schemavalidate"
+	"github.com/lychee-technology/forma/internal/telemetry"
 	"github.com/lychee-technology/forma/internal/transform"
 
 	"github.com/google/uuid"
@@ -50,6 +52,12 @@ type writeValidation struct {
 	// validator any more, so there is nothing left to carve out; do not
 	// reintroduce that use through this field.
 	relationRoots []string
+	// stats aggregates accepted violations for the #317 milestone log line. It
+	// is nil-tolerant — embedders and tests constructing services directly get
+	// per-write telemetry and logging but no milestones — and the production
+	// wiring from NewEntityManager down is pinned by
+	// TestReportOnlyUpdateLogsMilestoneOnFirstViolation, so deleting it goes red.
+	stats *reportOnlyStats
 }
 
 // validateWritePayload validates a write payload against the JSON Schema
@@ -90,7 +98,7 @@ type writeValidation struct {
 //
 // It is a package-level function rather than a method so the CRUD and batch
 // services cannot drift apart on any of the above.
-func validateWritePayload(v writeValidation) error {
+func validateWritePayload(ctx context.Context, v writeValidation) error {
 	if v.validator == nil {
 		return nil
 	}
@@ -114,9 +122,29 @@ func validateWritePayload(v writeValidation) error {
 	// Report-only mode exists so an operator can find and repair violating rows
 	// before flipping VALIDATE_UPDATES_STRICT, which is impossible without the
 	// schema name and the row id. The payload itself is deliberately not logged:
-	// entity data is caller content and may be sensitive.
+	// entity data is caller content and may be sensitive. The violation text
+	// does embed the offending value ("enum: banana does not equal any of ..."),
+	// which for shipped schemas can mean an email or phone value reaches the
+	// log. That is the same deliberate disclosure #313 ruled for the published
+	// 400 body, confirmed for this log line in #317: the operator repairing the
+	// row needs to see what is wrong with it. The aggregate signals below carry
+	// counts only — no violation text, no payload — so they widen nothing.
+	//
+	// Volume is bounded by zap's production sampling, not by this code:
+	// cmd/server installs zap.NewProduction(), whose sampler passes the first
+	// 100 entries per second for an identical message and every 100th after.
+	// This message is constant, so a violation-heavy corpus is capped at that
+	// rate, and the milestone line carries cumulative counts so sampled-away
+	// per-write lines lose no aggregate information (#317).
+	kind := classifyViolation(err)
+	telemetry.EmitReportOnlyValidationViolation(ctx, v.schemaID, v.schemaName, kind)
 	zap.S().Warnw("write payload violates the entity JSON schema; accepted because strict update validation is off",
-		"schemaName", v.schemaName, "schemaID", v.schemaID, "rowID", v.rowID, "error", err.Error())
+		"schemaName", v.schemaName, "schemaID", v.schemaID, "rowID", v.rowID, "kind", kind, "error", err.Error())
+	if milestone, total, required, constraint := v.stats.record(v.schemaID, kind); milestone {
+		zap.S().Warnw(reportOnlyMilestoneMessage,
+			"schemaName", v.schemaName, "schemaID", v.schemaID,
+			"total", total, "required", required, "constraint", constraint)
+	}
 	return nil
 }
 

--- a/internal/entity_write_validation_stats.go
+++ b/internal/entity_write_validation_stats.go
@@ -29,10 +29,12 @@ const (
 //
 // It classifies one error, and the validator hands it the first failure only —
 // so a document that both omits a required property and carries an illegal
-// value is counted once, as "required". The split is therefore a triage hint
-// and not a census: "required: N, constraint: 0" means no violation has yet
-// surfaced as a constraint, not that the constraint work is done. Expect
-// constraint counts to appear as the required backfill lands.
+// value is counted once, as "constraint": jsonschema-go reports the
+// properties-level failure before the root "required" one, so the constraint
+// masks the required. The split is therefore a triage hint and not a census:
+// "constraint: N, required: 0" means no violation has yet surfaced as
+// required, not that the backfill work is done. Expect required counts to
+// appear as the constraint repairs land.
 //
 // Its input must be the validator's own error, undecorated: see the classify
 // site in validateWritePayload for why.

--- a/internal/entity_write_validation_stats.go
+++ b/internal/entity_write_validation_stats.go
@@ -26,6 +26,16 @@ const (
 // "missing properties" mislabels its increment — accepted at the same cost.
 // TestClassifyViolationPinsLibraryProse pins both halves against the real
 // validator, so a library upgrade re-opens this deliberately.
+//
+// It classifies one error, and the validator hands it the first failure only —
+// so a document that both omits a required property and carries an illegal
+// value is counted once, as "required". The split is therefore a triage hint
+// and not a census: "required: N, constraint: 0" means no violation has yet
+// surfaced as a constraint, not that the constraint work is done. Expect
+// constraint counts to appear as the required backfill lands.
+//
+// Its input must be the validator's own error, undecorated: see the classify
+// site in validateWritePayload for why.
 func classifyViolation(err error) string {
 	if err != nil && strings.Contains(err.Error(), "missing properties") {
 		return violationKindRequired
@@ -42,8 +52,10 @@ const reportOnlyMilestoneMessage = "report-only schema validation violations rea
 	"rows still violate their schema and VALIDATE_UPDATES_STRICT is not yet safe to flip"
 
 // reportOnlyMilestoneEvery is the milestone stride after the first violation.
-// 100 matches zap.NewProduction's sampling stride, so on the busiest corpus
-// roughly one milestone line survives per sampled bucket of per-write lines.
+// 100 is a round stride, chosen to echo zap.NewProduction's Thereafter value so
+// the two numbers read alike; the mechanisms are unrelated and the match buys
+// nothing. The sampler buckets per second over identical messages, this counts
+// per accepted violation over the process lifetime.
 const reportOnlyMilestoneEvery = 100
 
 // reportOnlyStats aggregates accepted violations per schema for the lifetime
@@ -55,12 +67,19 @@ type reportOnlyStats struct {
 	schemas map[int16]*reportOnlySchemaCounts
 }
 
+// reportOnlySchemaCounts is one schema's running tally. required and constraint
+// partition total: record classifies every violation into exactly one of them,
+// so required+constraint == total is an invariant of the type and is asserted
+// under -race by TestReportOnlyStatsRecordIsConcurrencySafe.
 type reportOnlySchemaCounts struct {
 	total      uint64
 	required   uint64
 	constraint uint64
 }
 
+// newReportOnlyStats builds the empty per-manager aggregate. The schema map is
+// allocated here rather than lazily in record, so record's nil check is about
+// the receiver — the optional-wiring case — and never about the map.
 func newReportOnlyStats() *reportOnlyStats {
 	return &reportOnlyStats{schemas: map[int16]*reportOnlySchemaCounts{}}
 }

--- a/internal/entity_write_validation_stats.go
+++ b/internal/entity_write_validation_stats.go
@@ -61,9 +61,15 @@ const reportOnlyMilestoneMessage = "report-only schema validation violations rea
 const reportOnlyMilestoneEvery = 100
 
 // reportOnlyStats aggregates accepted violations per schema for the lifetime
-// of one EntityManager (#317). Counts reset with the process; the milestone
-// log line carries them, so the trend survives in the log stream rather than
-// in memory.
+// of one EntityManager (#317) — the shipped wiring (NewEntityManager, one call
+// per process in cmd/server and cmd/lambda) makes that the process lifetime,
+// but an embedder holding several managers gets one tally per manager. Counts
+// reset on restart; the milestone log line carries them, so the trend survives
+// in the log stream rather than in memory.
+//
+// A count means "validated and accepted at that instant", not "persisted": an
+// atomic batch whose later operation fails has already counted its earlier
+// ones, exactly as the per-write Warn has always fired at validation time.
 type reportOnlyStats struct {
 	mu      sync.Mutex
 	schemas map[int16]*reportOnlySchemaCounts

--- a/internal/entity_write_validation_stats.go
+++ b/internal/entity_write_validation_stats.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"strings"
+)
+
+// Violation kinds for the #317 aggregate. "required" means the document lacks
+// a property, so the repair is to backfill data; "constraint" means a present
+// value is illegal, so the repair is to fix the value. The rollout actions
+// differ, which is why the label exists.
+const (
+	violationKindRequired   = "required"
+	violationKindConstraint = "constraint"
+)
+
+// classifyViolation sorts a schema violation into required-versus-constraint
+// for the #317 kind label.
+//
+// jsonschema-go returns unstructured errors, so this keys on library prose:
+// the "required" and "dependentRequired" keywords render as "... missing
+// properties ..." and no other keyword does. Keying behavior on library prose
+// was rejected for explainStrippedRelationRoots' gate; it is accepted here
+// because the blast radius is one metric label, never a write outcome. The
+// enum prose embeds the caller's own value, so a value that itself contains
+// "missing properties" mislabels its increment — accepted at the same cost.
+// TestClassifyViolationPinsLibraryProse pins both halves against the real
+// validator, so a library upgrade re-opens this deliberately.
+func classifyViolation(err error) string {
+	if err != nil && strings.Contains(err.Error(), "missing properties") {
+		return violationKindRequired
+	}
+	return violationKindConstraint
+}

--- a/internal/entity_write_validation_stats.go
+++ b/internal/entity_write_validation_stats.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"strings"
+	"sync"
 )
 
 // Violation kinds for the #317 aggregate. "required" means the document lacks
@@ -30,4 +31,61 @@ func classifyViolation(err error) string {
 		return violationKindRequired
 	}
 	return violationKindConstraint
+}
+
+// reportOnlyMilestoneMessage is the aggregate answer to "is it safe to flip
+// VALIDATE_UPDATES_STRICT yet" (#317): as long as these lines keep appearing
+// for a schema, rows still violate it. The line is payload-free on purpose —
+// counts only, no violation text, no row id — so it adds no disclosure however
+// often it fires.
+const reportOnlyMilestoneMessage = "report-only schema validation violations reached a milestone; " +
+	"rows still violate their schema and VALIDATE_UPDATES_STRICT is not yet safe to flip"
+
+// reportOnlyMilestoneEvery is the milestone stride after the first violation.
+// 100 matches zap.NewProduction's sampling stride, so on the busiest corpus
+// roughly one milestone line survives per sampled bucket of per-write lines.
+const reportOnlyMilestoneEvery = 100
+
+// reportOnlyStats aggregates accepted violations per schema for the lifetime
+// of one EntityManager (#317). Counts reset with the process; the milestone
+// log line carries them, so the trend survives in the log stream rather than
+// in memory.
+type reportOnlyStats struct {
+	mu      sync.Mutex
+	schemas map[int16]*reportOnlySchemaCounts
+}
+
+type reportOnlySchemaCounts struct {
+	total      uint64
+	required   uint64
+	constraint uint64
+}
+
+func newReportOnlyStats() *reportOnlyStats {
+	return &reportOnlyStats{schemas: map[int16]*reportOnlySchemaCounts{}}
+}
+
+// record adds one accepted violation and reports whether the new total is a
+// milestone — the 1st, then every reportOnlyMilestoneEvery-th — together with
+// the counts to log when it is. A nil receiver records nothing and never
+// reaches a milestone: stats are optional wiring, validation is not.
+func (s *reportOnlyStats) record(schemaID int16, kind string) (milestone bool, total, required, constraint uint64) {
+	if s == nil {
+		return false, 0, 0, 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	counts := s.schemas[schemaID]
+	if counts == nil {
+		counts = &reportOnlySchemaCounts{}
+		s.schemas[schemaID] = counts
+	}
+	counts.total++
+	if kind == violationKindRequired {
+		counts.required++
+	} else {
+		counts.constraint++
+	}
+	milestone = counts.total == 1 || counts.total%reportOnlyMilestoneEvery == 0
+	return milestone, counts.total, counts.required, counts.constraint
 }

--- a/internal/entity_write_validation_stats_test.go
+++ b/internal/entity_write_validation_stats_test.go
@@ -60,3 +60,55 @@ func TestClassifyViolationPinsLibraryProse(t *testing.T) {
 		})
 	}
 }
+
+// TestReportOnlyStatsMilestones pins the milestone rule: the 1st accepted
+// violation fires (the operator learns the schema has violations at all), then
+// every 100th (the operator sees the trend without one line per write).
+func TestReportOnlyStatsMilestones(t *testing.T) {
+	stats := newReportOnlyStats()
+
+	milestone, total, required, constraint := stats.record(7, violationKindConstraint)
+	require.True(t, milestone, "the 1st violation must be a milestone")
+	require.EqualValues(t, 1, total)
+	require.EqualValues(t, 0, required)
+	require.EqualValues(t, 1, constraint)
+
+	for i := 2; i <= 99; i++ {
+		milestone, _, _, _ = stats.record(7, violationKindRequired)
+		require.False(t, milestone, "violation %d must not be a milestone", i)
+	}
+
+	milestone, total, required, constraint = stats.record(7, violationKindRequired)
+	require.True(t, milestone, "the 100th violation must be a milestone")
+	require.EqualValues(t, 100, total)
+	require.EqualValues(t, 99, required)
+	require.EqualValues(t, 1, constraint)
+}
+
+// TestReportOnlyStatsCountsPerSchema pins that milestones are per schema: the
+// flip decision is per deployment but the repair work is per schema, and one
+// noisy schema must not swallow another's first violation.
+func TestReportOnlyStatsCountsPerSchema(t *testing.T) {
+	stats := newReportOnlyStats()
+	stats.record(1, violationKindConstraint)
+
+	milestone, total, _, _ := stats.record(2, violationKindConstraint)
+
+	require.True(t, milestone, "schema 2's first violation is its own milestone")
+	require.EqualValues(t, 1, total)
+}
+
+// TestReportOnlyStatsNilReceiver pins that a manager constructed without stats
+// (embedders and tests building services directly) skips milestones instead of
+// panicking. Production wiring is pinned separately by
+// TestReportOnlyUpdateLogsMilestoneOnFirstViolation.
+func TestReportOnlyStatsNilReceiver(t *testing.T) {
+	var stats *reportOnlyStats
+
+	milestone, total, required, constraint := stats.record(1, violationKindConstraint)
+
+	require.False(t, milestone)
+	require.Zero(t, total)
+	require.Zero(t, required)
+	require.Zero(t, constraint)
+}

--- a/internal/entity_write_validation_stats_test.go
+++ b/internal/entity_write_validation_stats_test.go
@@ -50,7 +50,7 @@ func TestClassifyViolationPinsLibraryProse(t *testing.T) {
 		{"missing required property", map[string]any{}, violationKindRequired},
 		{"dependentRequired counts as required", map[string]any{"name": "open", "email": "a@b.c"}, violationKindRequired},
 		{"enum violation is a constraint", map[string]any{"name": "banana"}, violationKindConstraint},
-		{"type violation is a constraint", map[string]any{"name": "open", "email": 7}, violationKindConstraint},
+		{"type violation is a constraint", map[string]any{"name": "open", "email": 7, "phone": "x"}, violationKindConstraint},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/entity_write_validation_stats_test.go
+++ b/internal/entity_write_validation_stats_test.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/schemavalidate"
+	"github.com/stretchr/testify/require"
+)
+
+// classifyProseRegistry extends the package's shared validation stub with a
+// dependentRequired clause, so one schema exercises every prose shape the
+// classifier keys on.
+type classifyProseRegistry struct{ validationRegistry }
+
+const classifyProseSchemaJSON = `{
+  "type": "object",
+  "properties": {
+    "name":  {"type": "string", "enum": ["open", "won"]},
+    "email": {"type": "string"},
+    "phone": {"type": "string"}
+  },
+  "required": ["name"],
+  "dependentRequired": {"email": ["phone"]}
+}`
+
+func (classifyProseRegistry) GetSchemaByName(string) (int16, forma.JSONSchema, error) {
+	return 100, forma.JSONSchema{ID: 100, Name: "test", Schema: classifyProseSchemaJSON}, nil
+}
+
+func (classifyProseRegistry) GetSchemaByID(int16) (string, forma.JSONSchema, error) {
+	return "test", forma.JSONSchema{ID: 100, Name: "test", Schema: classifyProseSchemaJSON}, nil
+}
+
+// TestClassifyViolationPinsLibraryProse pins both halves of the prose contract
+// classifyViolation keys on: jsonschema-go renders required and
+// dependentRequired failures — and only those — with "missing properties".
+// A library upgrade that changes either half turns this red and re-opens the
+// classification (same pinning precedent as
+// TestValidatorNamesTheMissingRootUnderOnlySomeApplicators).
+func TestClassifyViolationPinsLibraryProse(t *testing.T) {
+	validator, err := schemavalidate.New(classifyProseRegistry{}, t.TempDir())
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		doc  map[string]any
+		kind string
+	}{
+		{"missing required property", map[string]any{}, violationKindRequired},
+		{"dependentRequired counts as required", map[string]any{"name": "open", "email": "a@b.c"}, violationKindRequired},
+		{"enum violation is a constraint", map[string]any{"name": "banana"}, violationKindConstraint},
+		{"type violation is a constraint", map[string]any{"name": "open", "email": 7}, violationKindConstraint},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			verr := validator.Validate(100, tc.doc)
+			require.ErrorIs(t, verr, forma.ErrInvalidInput)
+			require.Equal(t, tc.kind, classifyViolation(verr))
+		})
+	}
+}

--- a/internal/entity_write_validation_stats_test.go
+++ b/internal/entity_write_validation_stats_test.go
@@ -1,11 +1,16 @@
 package internal
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/schemavalidate"
+	"github.com/lychee-technology/forma/internal/telemetry"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // classifyProseRegistry extends the package's shared validation stub with a
@@ -58,6 +63,108 @@ func TestClassifyViolationPinsLibraryProse(t *testing.T) {
 			require.ErrorIs(t, verr, forma.ErrInvalidInput)
 			require.Equal(t, tc.kind, classifyViolation(verr))
 		})
+	}
+}
+
+// TestReportOnlyKindIsClassifiedBeforeDecoration pins what the classifier is
+// allowed to see: the validator's own error, and never the error after
+// explainStrippedRelationRoots has decorated it.
+//
+// The hazard is not hypothetical. The diagnosis interpolates the schema's
+// relation root names verbatim (%q), so a root named "missing properties" is by
+// itself enough to make the decorated string satisfy the substring test
+// classifyViolation keys on — the local demonstration below shows the same enum
+// violation classifying both ways depending on which error is handed over. The
+// root name is contrived, and that is the point: it turns "a future edit to this
+// repo-owned prose would silently relabel every violation on every
+// relation-declaring schema" into something a test holds today.
+//
+// It asserts at validateWritePayload rather than through a manager because that
+// is the seam all four write paths share and the only place the ordering exists
+// to get wrong. Classifying after the wrap turns this red: the emitted kind
+// becomes "required".
+func TestReportOnlyKindIsClassifiedBeforeDecoration(t *testing.T) {
+	validator, err := schemavalidate.New(classifyProseRegistry{}, t.TempDir())
+	require.NoError(t, err)
+	payload := map[string]any{"name": "banana"}
+
+	// The decoration really can flip the label; production is immune only
+	// because it classifies first.
+	verr := validator.Validate(100, payload)
+	require.Error(t, verr)
+	require.Equal(t, violationKindConstraint, classifyViolation(verr))
+	require.Equal(t, violationKindRequired,
+		classifyViolation(explainStrippedRelationRoots(verr, "test", []string{"missing properties"})),
+		"the decorated error genuinely misclassifies, which is what the ordering protects against")
+
+	var kinds []string
+	telemetry.RegisterTelemetryEmitter(func(_ context.Context, _ string, labels map[string]string, _ any) {
+		kinds = append(kinds, labels["kind"])
+	})
+	t.Cleanup(func() { telemetry.RegisterTelemetryEmitter(nil) })
+	core, logs := observer.New(zap.WarnLevel)
+	t.Cleanup(zap.ReplaceGlobals(zap.New(core)))
+
+	require.NoError(t, validateWritePayload(context.Background(), writeValidation{
+		validator:     validator,
+		schemaID:      100,
+		schemaName:    "test",
+		data:          payload,
+		relationRoots: []string{"missing properties"},
+		enforce:       false,
+	}))
+
+	require.Equal(t, []string{violationKindConstraint}, kinds,
+		"an enum violation is a constraint however the diagnosis is worded")
+	perWrite := logs.FilterMessageSnippet("violates the entity JSON schema").All()
+	require.Len(t, perWrite, 1)
+	fields := perWrite[0].ContextMap()
+	require.Equal(t, violationKindConstraint, fields["kind"])
+	// Vacuity guard: the assertion above says something only if the decoration
+	// really joined the logged error and really does satisfy the classifier's
+	// substring test.
+	require.Contains(t, fields["error"], "missing properties")
+}
+
+// TestReportOnlyStatsRecordIsConcurrencySafe pins record against the way it is
+// actually called: four write paths, one shared aggregate, no coordination
+// above it. Two schemas are recorded from disjoint goroutine groups, so the
+// lazy map insert races too and not only the counters.
+//
+// Removing the mutex fails this under -race (CI runs -race), and usually
+// without it as well: the map insert becomes a "concurrent map writes" fatal
+// and the increments lose updates, so the exact totals below stop holding.
+func TestReportOnlyStatsRecordIsConcurrencySafe(t *testing.T) {
+	const groupsPerSchema, recordsPerGoroutine = 4, 250
+	stats := newReportOnlyStats()
+
+	var wg sync.WaitGroup
+	for _, schemaID := range []int16{1, 2} {
+		for g := 0; g < groupsPerSchema; g++ {
+			wg.Add(1)
+			go func(schemaID int16) {
+				defer wg.Done()
+				for i := 0; i < recordsPerGoroutine; i++ {
+					kind := violationKindConstraint
+					if i%2 == 0 {
+						kind = violationKindRequired
+					}
+					stats.record(schemaID, kind)
+				}
+			}(schemaID)
+		}
+	}
+	wg.Wait()
+
+	for _, schemaID := range []int16{1, 2} {
+		counts := stats.schemas[schemaID]
+		require.NotNil(t, counts, "schema %d must have been recorded", schemaID)
+		require.EqualValues(t, groupsPerSchema*recordsPerGoroutine, counts.total,
+			"schema %d lost or double-counted a violation", schemaID)
+		require.EqualValues(t, groupsPerSchema*recordsPerGoroutine/2, counts.required)
+		require.EqualValues(t, groupsPerSchema*recordsPerGoroutine/2, counts.constraint)
+		require.EqualValues(t, counts.total, counts.required+counts.constraint,
+			"the kinds must partition the total")
 	}
 }
 

--- a/internal/entity_write_validation_test.go
+++ b/internal/entity_write_validation_test.go
@@ -289,6 +289,34 @@ func TestBatchUpdateAtomicStrictRejectsViolation(t *testing.T) {
 	require.ErrorIs(t, err, forma.ErrInvalidInput)
 }
 
+// TestBatchUpdateReportOnlyLogsMilestoneOnFirstViolation pins the batch update
+// seam's stats wiring the way TestReportOnlyUpdateLogsMilestoneOnFirstViolation
+// pins the CRUD one: batchUpdateAtomic runs report-only in the shipped default
+// configuration, and before this test, deleting `stats: s.reportOnlyStats` from
+// that one call site left the whole suite green (PR #422 round-4 review).
+func TestBatchUpdateReportOnlyLogsMilestoneOnFirstViolation(t *testing.T) {
+	manager, _ := newValidatingManager(t, false)
+	created, err := manager.Create(context.Background(), createOp(map[string]any{"name": "open"}))
+	require.NoError(t, err)
+
+	core, logs := observer.New(zap.WarnLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	_, err = manager.BatchUpdate(context.Background(), &forma.BatchOperation{
+		Atomic:     true,
+		Operations: []forma.EntityOperation{*updateOp(created.RowID, map[string]any{"name": "banana"})},
+	})
+	require.NoError(t, err)
+
+	entries := logs.FilterMessage(reportOnlyMilestoneMessage).All()
+	require.Len(t, entries, 1, "the batch update seam must feed the same aggregate as CRUD update")
+	fields := entries[0].ContextMap()
+	require.Equal(t, "test", fields["schemaName"])
+	require.EqualValues(t, 1, fields["total"])
+	require.EqualValues(t, 1, fields["constraint"])
+}
+
 // TestReportOnlyUpdateRefusesToAbsorbConfigurationFault pins the boundary of
 // report-only mode: it forgives *violations*, not everything Validate can return.
 //

--- a/internal/entity_write_validation_test.go
+++ b/internal/entity_write_validation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemavalidate"
+	"github.com/lychee-technology/forma/internal/telemetry"
 	"github.com/lychee-technology/forma/internal/transform"
 
 	"github.com/google/uuid"
@@ -339,4 +340,91 @@ func TestUpdateOfUnrelatedFieldKeepsRequiredSatisfied(t *testing.T) {
 	}))
 
 	require.NoError(t, err)
+}
+
+// TestReportOnlyUpdateEmitsAggregateCounter pins #317's telemetry half: every
+// accepted violation increments entity_report_only_validation_violation_total
+// with the schema and kind the flip decision is made over. The default
+// deployment registers no emitter, so this is behavior-neutral there; the
+// milestone log line below is its default-visible counterpart.
+func TestReportOnlyUpdateEmitsAggregateCounter(t *testing.T) {
+	manager, _ := newValidatingManager(t, false)
+	created, err := manager.Create(context.Background(), createOp(map[string]any{"name": "open"}))
+	require.NoError(t, err)
+
+	type emitted struct {
+		name   string
+		labels map[string]string
+		value  any
+	}
+	var got []emitted
+	telemetry.RegisterTelemetryEmitter(func(_ context.Context, name string, labels map[string]string, value any) {
+		got = append(got, emitted{name: name, labels: labels, value: value})
+	})
+	t.Cleanup(func() { telemetry.RegisterTelemetryEmitter(nil) })
+
+	_, err = manager.Update(context.Background(), updateOp(created.RowID, map[string]any{"name": "banana"}))
+	require.NoError(t, err)
+
+	require.Len(t, got, 1, "one accepted violation must emit exactly one increment")
+	require.Equal(t, "entity_report_only_validation_violation_total", got[0].name)
+	require.Equal(t, map[string]string{
+		"schema_id":   "100",
+		"schema_name": "test",
+		"kind":        "constraint",
+	}, got[0].labels)
+	require.Equal(t, int64(1), got[0].value)
+}
+
+// TestReportOnlyUpdateLogsMilestoneOnFirstViolation is the wiring test (#318's
+// lesson: fail-closed wiring needs a test that goes red when the wiring is
+// deleted). It exercises the full production path — NewEntityManager builds
+// the stats, the services carry them, validateWritePayload records — and
+// pins that the milestone line is aggregate-only: counts, no violation text,
+// no row id, no payload.
+func TestReportOnlyUpdateLogsMilestoneOnFirstViolation(t *testing.T) {
+	manager, _ := newValidatingManager(t, false)
+	created, err := manager.Create(context.Background(), createOp(map[string]any{"name": "open"}))
+	require.NoError(t, err)
+
+	core, logs := observer.New(zap.WarnLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	_, err = manager.Update(context.Background(), updateOp(created.RowID, map[string]any{"name": "banana"}))
+	require.NoError(t, err)
+
+	entries := logs.FilterMessage(reportOnlyMilestoneMessage).All()
+	require.Len(t, entries, 1, "the first accepted violation must log a milestone")
+
+	fields := entries[0].ContextMap()
+	require.Equal(t, "test", fields["schemaName"])
+	require.EqualValues(t, 100, fields["schemaID"])
+	require.EqualValues(t, 1, fields["total"])
+	require.EqualValues(t, 0, fields["required"])
+	require.EqualValues(t, 1, fields["constraint"])
+	require.NotContains(t, fields, "error", "the milestone line must not carry violation text")
+	require.NotContains(t, fields, "rowID", "the milestone line aggregates; the per-write line names rows")
+}
+
+// TestStrictRejectionEmitsNoAggregate pins the counter's scope: #317 counts
+// violations *accepted* in report-only mode, because the question it answers
+// is whether report-only can end. A strict rejection already surfaces as a 4xx
+// and must not inflate the aggregate.
+func TestStrictRejectionEmitsNoAggregate(t *testing.T) {
+	manager, _ := newValidatingManager(t, true)
+	created, err := manager.Create(context.Background(), createOp(map[string]any{"name": "open"}))
+	require.NoError(t, err)
+
+	var emits int
+	telemetry.RegisterTelemetryEmitter(func(context.Context, string, map[string]string, any) { emits++ })
+	t.Cleanup(func() { telemetry.RegisterTelemetryEmitter(nil) })
+
+	_, err = manager.Update(context.Background(), updateOp(created.RowID, map[string]any{"name": "banana"}))
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+
+	_, err = manager.Create(context.Background(), createOp(map[string]any{"name": "banana"}))
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+
+	require.Zero(t, emits, "rejected writes must not increment the report-only aggregate")
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -93,3 +93,18 @@ func EmitCompactionRewriteApplied(ctx context.Context, schemaID int16) {
 	labels := map[string]string{"schema_id": fmt.Sprintf("%d", schemaID)}
 	currentEmitter()(ctx, "compaction_rewrite_applied_total", labels, int64(1))
 }
+
+// EmitReportOnlyValidationViolation records a write that violated its entity
+// JSON schema and was accepted because strict update validation is off (#317).
+// kind is "required" (the document lacks a property) or "constraint" (a
+// present value is illegal); package internal classifies it.
+// name: "entity_report_only_validation_violation_total" with labels
+// {"schema_id": "<id>", "schema_name": "<name>", "kind": "required"|"constraint"}
+func EmitReportOnlyValidationViolation(ctx context.Context, schemaID int16, schemaName, kind string) {
+	labels := map[string]string{
+		"schema_id":   fmt.Sprintf("%d", schemaID),
+		"schema_name": schemaName,
+		"kind":        kind,
+	}
+	currentEmitter()(ctx, "entity_report_only_validation_violation_total", labels, int64(1))
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,32 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmitReportOnlyValidationViolation pins the #317 counter's wire shape:
+// the name a scraping deployment keys its dashboard on, and the three labels
+// the rollout question ("is it safe to flip VALIDATE_UPDATES_STRICT for this
+// schema yet") is asked over.
+func TestEmitReportOnlyValidationViolation(t *testing.T) {
+	var gotName string
+	var gotLabels map[string]string
+	var gotValue any
+	RegisterTelemetryEmitter(func(_ context.Context, name string, labels map[string]string, value any) {
+		gotName, gotLabels, gotValue = name, labels, value
+	})
+	t.Cleanup(func() { RegisterTelemetryEmitter(nil) })
+
+	EmitReportOnlyValidationViolation(context.Background(), 100, "lead", "required")
+
+	require.Equal(t, "entity_report_only_validation_violation_total", gotName)
+	require.Equal(t, map[string]string{
+		"schema_id":   "100",
+		"schema_name": "lead",
+		"kind":        "required",
+	}, gotLabels)
+	require.Equal(t, int64(1), gotValue)
+}


### PR DESCRIPTION
Closes #317.

Report-only update validation (the shipped default) had no aggregate signal: one `Warn` per accepted violation, nothing to answer "is it safe to flip `VALIDATE_UPDATES_STRICT` yet". This adds, at the single throat point (`validateWritePayload`'s report-only branch):

- `entity_report_only_validation_violation_total` telemetry counter, labels `schema_id`/`schema_name`/`kind` — for deployments that register an emitter;
- a per-schema **milestone summary Warn** (1st, then every 100th accepted violation) carrying cumulative `total`/`required`/`constraint` counts — visible on the default deployment, no background goroutine, payload-free;
- a `kind` label (`required` vs `constraint`) classified from jsonschema-go's prose (`"missing properties"`), pinned by `TestClassifyViolationPinsLibraryProse`; misclassification cost is one label, never behavior.

Rulings from #317, adjudicated with the user and written into code comments:
- per-write `Warn` volume relies on `zap.NewProduction()` sampling (100/sec then 1-in-100 for the constant message) — documented, not re-implemented; milestones make sampled-away lines lossless in aggregate;
- the violation text embedding the offending value in the per-write `Warn` is confirmed deliberate, mirroring #313's 400-body ruling; the new aggregate signals carry no violation text.

Behavior-neutral: no write is accepted or rejected differently. Wiring is pinned by `TestReportOnlyUpdateLogsMilestoneOnFirstViolation` (deleting the stats plumbing goes red — #318's lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)