### PR TITLE
fix: demote and memoize the dropped-attr EAV skip log (#343)

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -597,11 +597,13 @@ deployment, and should be treated as operator-visible consistency failures.
 EAV records whose attribute id is no longer present in the schema metadata are
 not an error: they are skipped on read and preserved on update (#294
 tolerate-and-preserve), so removing an attribute from a schema is
-non-destructive and re-adding it restores the stored values. An attributeID
-freed by removing an attribute must never be reused for a different attribute:
-preserved EAV rows would silently bind to the new attribute's name (same value
-type) or make the row unreadable with a storage type mismatch (different value
-type).
+non-destructive and re-adding it restores the stored values. The read-path skip
+is logged at Info, once per process per (schema, skipped attributeID set),
+naming the first row observed as `exampleRowID` — a supported state's audit
+trail, not an incident signal (#343). An attributeID freed by removing an
+attribute must never be reused for a different attribute: preserved EAV rows
+would silently bind to the new attribute's name (same value type) or make the
+row unreadable with a storage type mismatch (different value type).
 
 Since #342 that rule is enforced. `generate-attributes` keeps the removed
 attribute's entry in `<schema>_attributes.json` marked `"retired": true` and

--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -215,8 +215,7 @@ func (c *AttributeConverter) FromEAVRecords(records []model.EAVRecord) ([]model.
 			ids = append(ids, id)
 		}
 		slices.Sort(ids)
-		zap.S().Warnw("skipped EAV records for attribute ids not in metadata cache (removed by schema evolution; rows preserved, #294)",
-			"schemaID", schemaID, "rowID", records[0].RowID, "attrIDs", ids)
+		logSkippedAttrIDs(schemaID, records[0].RowID, ids)
 	}
 
 	if err := c.checkRequiredAttributes(schemaID, cache, presentAttrIndices); err != nil {

--- a/internal/transform/skipped_attr_log.go
+++ b/internal/transform/skipped_attr_log.go
@@ -1,0 +1,55 @@
+package transform
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// skippedAttrLogMessage is a const so the tests pinning the once-per-shape
+// contract filter on the exact string production emits.
+const skippedAttrLogMessage = "skipped EAV records for attribute ids not in metadata cache (removed by schema evolution or retired; rows preserved, #294)"
+
+// skippedAttrLogSeen dedupes the tolerated-skip log across the process (#343).
+// FromEAVRecords runs once per row on the read path, and the skipped condition
+// is a property of the schema shape, not of the row, so per-call logging turned
+// a #294-supported state into per-row noise. Package-level deliberately:
+// production builds a fresh AttributeConverter per row
+// (persistentRecordTransformer.newConverter), so converter-scoped state would
+// dedupe nothing. Keys are schemaID plus the sorted skipped attrID set; the
+// population is bounded by registered schemas times the few dropped/retired
+// sets each can accumulate, so the map needs no eviction.
+var skippedAttrLogSeen = struct {
+	mu   sync.Mutex
+	keys map[string]struct{}
+}{keys: make(map[string]struct{})}
+
+// logSkippedAttrIDs emits the skip log at Info once per process per (schemaID,
+// skipped attrID set). Info, not Warn: #294 defines the state as supported, and
+// Warn reads as an incident to an on-call operator. ids must already be sorted
+// so equal sets build equal keys; exampleRowID is the first row observed with
+// this shape, recorded as a lookup pointer, not as the condition's scope.
+func logSkippedAttrIDs(schemaID int16, exampleRowID uuid.UUID, ids []int16) {
+	var key strings.Builder
+	key.WriteString(strconv.Itoa(int(schemaID)))
+	for _, id := range ids {
+		key.WriteByte(':')
+		key.WriteString(strconv.Itoa(int(id)))
+	}
+
+	skippedAttrLogSeen.mu.Lock()
+	_, dup := skippedAttrLogSeen.keys[key.String()]
+	if !dup {
+		skippedAttrLogSeen.keys[key.String()] = struct{}{}
+	}
+	skippedAttrLogSeen.mu.Unlock()
+	if dup {
+		return
+	}
+
+	zap.S().Infow(skippedAttrLogMessage,
+		"schemaID", schemaID, "exampleRowID", exampleRowID, "attrIDs", ids)
+}

--- a/internal/transform/skipped_attr_log_test.go
+++ b/internal/transform/skipped_attr_log_test.go
@@ -1,0 +1,117 @@
+package transform
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// resetSkippedAttrLogMemo clears the process-wide memo so each test observes
+// first-emission behavior regardless of what earlier tests in the package
+// (e.g. TestAttributeConverterFromEAVRecords_SkipsUnknownAttributeIDs) fed it.
+func resetSkippedAttrLogMemo() {
+	skippedAttrLogSeen.mu.Lock()
+	defer skippedAttrLogSeen.mu.Unlock()
+	skippedAttrLogSeen.keys = make(map[string]struct{})
+}
+
+func skipLogRegistry(schemaID int16) *stubSchemaRegistry {
+	return &stubSchemaRegistry{
+		schemaID:   schemaID,
+		schemaName: fmt.Sprintf("skip_log_schema_%d", schemaID),
+		cache: forma.SchemaAttributeCache{
+			"name": {AttributeID: 1, ValueType: forma.ValueTypeText},
+		},
+	}
+}
+
+func skipLogRecords(schemaID int16, staleAttrID int16) []model.EAVRecord {
+	rowID := uuid.Must(uuid.NewV7())
+	known := "alive"
+	stale := "mystery"
+	return []model.EAVRecord{
+		{SchemaID: schemaID, RowID: rowID, AttrID: 1, ValueText: &known},
+		{SchemaID: schemaID, RowID: rowID, AttrID: staleAttrID, ValueText: &stale},
+	}
+}
+
+// TestSkippedAttrLogInfoOncePerShape pins #343: the #294 tolerated-skip log is
+// Info (not Warn — the state is supported, not an incident) and fires once per
+// process per (schemaID, skipped-attrID-set), surviving converter churn — the
+// read path builds a fresh converter per row (persistentRecordTransformer's
+// newConverter), which is exactly why the memo must be package-level.
+func TestSkippedAttrLogInfoOncePerShape(t *testing.T) {
+	resetSkippedAttrLogMemo()
+	registry := skipLogRegistry(441)
+
+	core, logs := observer.New(zap.InfoLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	records := skipLogRecords(441, 999)
+	// Fresh converter per call mirrors the per-row production pattern.
+	for i := 0; i < 3; i++ {
+		if _, err := NewAttributeConverter(registry).FromEAVRecords(records); err != nil {
+			t.Fatalf("FromEAVRecords call %d: %v", i, err)
+		}
+	}
+
+	entries := logs.FilterMessage(skippedAttrLogMessage).All()
+	if len(entries) != 1 {
+		t.Fatalf("got %d skip-log entries after 3 identical calls, want exactly 1 (memoized per shape)", len(entries))
+	}
+	if entries[0].Level != zapcore.InfoLevel {
+		t.Fatalf("skip log level = %s, want Info: #294 defines the state as supported, Warn reads as an incident", entries[0].Level)
+	}
+	fields := entries[0].ContextMap()
+	if fmt.Sprint(fields["attrIDs"]) != "[999]" {
+		t.Fatalf("attrIDs field = %v, want [999]", fields["attrIDs"])
+	}
+	if fmt.Sprint(fields["schemaID"]) != "441" {
+		t.Fatalf("schemaID field = %v, want 441", fields["schemaID"])
+	}
+
+	// A different skipped set on the same schema is a new shape: logged again.
+	if _, err := NewAttributeConverter(registry).FromEAVRecords(skipLogRecords(441, 998)); err != nil {
+		t.Fatalf("FromEAVRecords with second shape: %v", err)
+	}
+	if got := len(logs.FilterMessage(skippedAttrLogMessage).All()); got != 2 {
+		t.Fatalf("got %d entries after a distinct skipped set, want 2 (memo keys on the set, not the schema)", got)
+	}
+}
+
+// TestSkippedAttrLogConcurrentCallsEmitOnce pins the once-per-process contract
+// under concurrency: parallel readers hitting the same shape must not race two
+// emissions past the memo. CI's -race run exercises the lock discipline.
+func TestSkippedAttrLogConcurrentCallsEmitOnce(t *testing.T) {
+	resetSkippedAttrLogMemo()
+	registry := skipLogRegistry(442)
+
+	core, logs := observer.New(zap.InfoLevel)
+	restore := zap.ReplaceGlobals(zap.New(core))
+	t.Cleanup(restore)
+
+	records := skipLogRecords(442, 999)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := NewAttributeConverter(registry).FromEAVRecords(records); err != nil {
+				t.Errorf("FromEAVRecords: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := len(logs.FilterMessage(skippedAttrLogMessage).All()); got != 1 {
+		t.Fatalf("got %d skip-log entries from 8 concurrent calls, want exactly 1", got)
+	}
+}


### PR DESCRIPTION
Closes #343.

`transform.FromEAVRecords` logged a Warn once per call — i.e. once per row on the read path — whenever it skipped attrIDs removed by schema evolution, a condition #294 defines as supported. A 1000-row page over such a schema attempted 1000 Warn emissions, and Warn reads as an incident to on-call.

Changes:
- The skip log is demoted to **Info** and **memoized per (schemaID, sorted skipped-attrID set)**: one emission per process per schema shape. The memo is package-level because the read path builds a fresh `AttributeConverter` per row (`persistentRecordTransformer.newConverter`), so instance state would dedupe nothing.
- Message text now covers the #342 nuance ("removed by schema evolution **or retired**") — shipped ledgers retiring e.g. `visit_full.logs` (29) route those ids through this same skip path.
- Field rename `rowID` → `exampleRowID`: under memoization the logged row is only the first one observed with that shape. Grep found no doc/test/alerting reference to the old message text or field.
- The previously untested emission behavior is pinned: level, once-per-shape across fresh converters, re-log on a distinct skipped set, and exactly-once under 8-way concurrency (runs under CI's `-race`). A mutation check (memo disconnected → both tests red) was performed during development.
- `docs/error-handling.md` records the log contract next to the #294 tolerate-and-preserve paragraph.

Operator note: any log-based alerting keyed on the old Warn text/level must move to the new Info message (`skipped_attr_log.go`'s `skippedAttrLogMessage` const; stable fields `schemaID`, `attrIDs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)