### PR TITLE
fix: #331 evict and close superseded Runner cache entries on credential rotation

### DIFF
--- a/cdc/flush.go
+++ b/cdc/flush.go
@@ -17,7 +17,11 @@ type S3ObjectClient = internalcdc.S3ObjectClient
 // S3FullClient extends S3ObjectClient with manifest read/write operations.
 type S3FullClient = internalcdc.S3FullClient
 
-// FlushRunner reuses AWS/S3/DuckDB initialization across multiple flush passes.
+// FlushRunner reuses AWS/S3/DuckDB initialization across multiple flush
+// passes. Safe for long-lived use under credential rotation: superseded
+// cached exporters are evicted and closed once idle (#331), so rotations do
+// not accumulate open DuckDB instances. Call Close at shutdown to release
+// whatever is still cached.
 type FlushRunner struct {
 	runner *internalcdc.Runner
 }

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -30,7 +30,7 @@ type Runner struct {
 	logger        *zap.Logger
 	mu            sync.Mutex
 	s3Runtimes    map[s3RuntimeGroupKey]*cachedS3Runtime
-	duckExporters map[duckExporterKey]*DuckExporter
+	duckExporters map[duckExporterGroupKey]*cachedDuckExporter
 }
 
 type cachedS3Runtime struct {
@@ -64,20 +64,50 @@ type s3RuntimeGroupKey struct {
 	usePath  bool
 }
 
-type duckExporterKey struct {
-	dbPath      string
-	threads     int
-	memLimit    string
-	region      string
-	endpoint    string
-	useSSL      bool
-	usePath     bool
-	accessKeyID string
-	// Same rule as s3RuntimeKey: the exporter bakes the token into
-	// SET s3_session_token at construction, so a key without it returns a
-	// stale-token exporter after a rotation (#329).
+// duckExporterGroupKey identifies a cache slot by everything *except* the
+// credential triple. Credentials live on the cached entry and are compared on
+// lookup, so a rotation replaces the slot's occupant instead of stranding it
+// under a sibling key for process lifetime (#331).
+type duckExporterGroupKey struct {
+	dbPath   string
+	threads  int
+	memLimit string
+	// The raw cfg region, not s3Runtime.region: the exporter is configured
+	// from cfg alone, and an empty cfg.S3Region suppresses SET s3_region
+	// entirely. Keying on the chain-resolved region claims a distinction
+	// the exporter never makes, so two runs producing byte-identical
+	// exporters would miss the cache (#329). It also cut the other way: an
+	// empty-region cfg whose chain resolved to some region could collide
+	// with an explicitly-configured cfg of that same region, two configs
+	// that build *different* exporters, so the second silently reused the
+	// first's — a latent wrong cache hit the raw cfg region rules out.
+	region   string
+	endpoint string
+	useSSL   bool
+	usePath  bool
+}
+
+// cachedDuckExporter is one cache slot's occupant. refs counts in-flight
+// RunOnce frames currently holding the exporter; doomed marks an entry that
+// has been superseded (or hard-closed via Close) and must not be handed out
+// again. A doomed entry's DB closes when refs reaches zero — immediately at
+// supersession if idle, else at the last release (#331).
+type cachedDuckExporter struct {
+	exporter        *DuckExporter
+	accessKeyID     string
 	secretAccessKey string
 	sessionToken    string
+	refs            int
+	doomed          bool
+}
+
+// credsEqual: same rule as cachedS3Runtime.credsEqual — the exporter bakes
+// the token into SET s3_session_token at construction, so an entry built from
+// a different triple is a stale-token artifact, never a cache hit (#329).
+func (c *cachedDuckExporter) credsEqual(accessKeyID, secretAccessKey, sessionToken string) bool {
+	return c.accessKeyID == accessKeyID &&
+		c.secretAccessKey == secretAccessKey &&
+		c.sessionToken == sessionToken
 }
 
 func NewRunner(logger *zap.Logger) *Runner {
@@ -87,7 +117,7 @@ func NewRunner(logger *zap.Logger) *Runner {
 	return &Runner{
 		logger:        logger,
 		s3Runtimes:    make(map[s3RuntimeGroupKey]*cachedS3Runtime),
-		duckExporters: make(map[duckExporterKey]*DuckExporter),
+		duckExporters: make(map[duckExporterGroupKey]*cachedDuckExporter),
 	}
 }
 
@@ -97,20 +127,23 @@ func (r *Runner) Close() error {
 	}
 
 	r.mu.Lock()
-	exporters := make([]*DuckExporter, 0, len(r.duckExporters))
-	for _, exporter := range r.duckExporters {
-		exporters = append(exporters, exporter)
+	entries := make([]*cachedDuckExporter, 0, len(r.duckExporters))
+	for _, entry := range r.duckExporters {
+		// Hard shutdown: doomed here + idempotent sql.DB.Close means a release
+		// arriving after Close is harmless.
+		entry.doomed = true
+		entries = append(entries, entry)
 	}
 	r.s3Runtimes = make(map[s3RuntimeGroupKey]*cachedS3Runtime)
-	r.duckExporters = make(map[duckExporterKey]*DuckExporter)
+	r.duckExporters = make(map[duckExporterGroupKey]*cachedDuckExporter)
 	r.mu.Unlock()
 
 	var errs []error
-	for _, exporter := range exporters {
-		if exporter == nil || exporter.DB == nil {
+	for _, entry := range entries {
+		if entry.exporter == nil || entry.exporter.DB == nil {
 			continue
 		}
-		if err := exporter.DB.Close(); err != nil {
+		if err := entry.exporter.DB.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -144,12 +177,13 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 	}
 	defer db.Close()
 
-	duck, err := r.getOrCreateDuckExporter(ctx, cfg, s3Runtime)
+	duck, releaseDuck, err := r.getOrCreateDuckExporter(ctx, cfg, s3Runtime)
 	if err != nil {
 		// getOrCreateDuckExporter carries the "new duck exporter:" prefix; this
 		// layer adds the run-level step so the two never duplicate.
 		return fmt.Errorf("prepare duck exporter: %w", err)
 	}
+	defer releaseDuck()
 
 	flushCtx := newSchemaFlushContext(flushContextParams{
 		cfg:            cfg,
@@ -231,55 +265,85 @@ func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cach
 	return runtime, nil
 }
 
-func (r *Runner) getOrCreateDuckExporter(ctx context.Context, cfg CDCConfig, s3Runtime *cachedS3Runtime) (*DuckExporter, error) {
-	key := duckExporterKey{
+func (r *Runner) getOrCreateDuckExporter(ctx context.Context, cfg CDCConfig, s3Runtime *cachedS3Runtime) (*DuckExporter, func(), error) {
+	key := duckExporterGroupKey{
 		dbPath:   cfg.DuckDBPath,
 		threads:  cfg.DuckThreads,
 		memLimit: cfg.DuckMemLimit,
-		// The raw cfg region, not s3Runtime.region: the exporter is configured
-		// from cfg alone, and an empty cfg.S3Region suppresses SET s3_region
-		// entirely. Keying on the chain-resolved region claims a distinction
-		// the exporter never makes, so two runs producing byte-identical
-		// exporters would miss the cache (#329). It also cut the other way: an
-		// empty-region cfg whose chain resolved to some region could collide
-		// with an explicitly-configured cfg of that same region, two configs
-		// that build *different* exporters, so the second silently reused the
-		// first's — a latent wrong cache hit the raw cfg region rules out.
-		region:      cfg.S3Region,
-		endpoint:    cfg.S3Endpoint,
-		useSSL:      cfg.S3UseSSL,
-		usePath:     cfg.S3UsePath,
-		accessKeyID: s3Runtime.accessKeyID,
-		// The cached runtime's token, matching the triple handed to
-		// newDuckExporterFn below (#329).
-		secretAccessKey: s3Runtime.secretAccessKey,
-		sessionToken:    s3Runtime.sessionToken,
+		region:   cfg.S3Region,
+		endpoint: cfg.S3Endpoint,
+		useSSL:   cfg.S3UseSSL,
+		usePath:  cfg.S3UsePath,
 	}
 
 	r.mu.Lock()
-	cached := r.duckExporters[key]
-	r.mu.Unlock()
-	if cached != nil {
-		return cached, nil
+	if entry := r.duckExporters[key]; entry != nil && entry.credsEqual(s3Runtime.accessKeyID, s3Runtime.secretAccessKey, s3Runtime.sessionToken) {
+		entry.refs++
+		r.mu.Unlock()
+		return entry.exporter, r.releaseFunc(entry), nil
 	}
+	r.mu.Unlock()
 
 	// The cached triple, not a fresh resolve: one resolution keeps the SDK
 	// provider and the DuckDB SET statements on the same credentials (#329).
 	exporter, err := newDuckExporterFn(ctx, cfg, s3Runtime.accessKeyID, s3Runtime.secretAccessKey, s3Runtime.sessionToken, r.logger)
 	if err != nil {
-		return nil, fmt.Errorf("new duck exporter: %w", err)
+		return nil, nil, fmt.Errorf("new duck exporter: %w", err)
 	}
 
 	r.mu.Lock()
-	if existing := r.duckExporters[key]; existing != nil {
+	if existing := r.duckExporters[key]; existing != nil && existing.credsEqual(s3Runtime.accessKeyID, s3Runtime.secretAccessKey, s3Runtime.sessionToken) {
+		// Lost a same-credentials build race: ours is redundant.
+		existing.refs++
 		r.mu.Unlock()
-		if exporter.DB != nil {
-			_ = exporter.DB.Close()
-		}
-		return existing, nil
+		closeExporterDB(exporter, r.logger)
+		return existing.exporter, r.releaseFunc(existing), nil
 	}
-	r.duckExporters[key] = exporter
+	superseded := r.duckExporters[key]
+	entry := &cachedDuckExporter{
+		exporter:        exporter,
+		accessKeyID:     s3Runtime.accessKeyID,
+		secretAccessKey: s3Runtime.secretAccessKey,
+		sessionToken:    s3Runtime.sessionToken,
+		refs:            1,
+	}
+	r.duckExporters[key] = entry
+	var toClose *DuckExporter
+	if superseded != nil {
+		superseded.doomed = true
+		if superseded.refs == 0 {
+			toClose = superseded.exporter
+		}
+	}
 	r.mu.Unlock()
+	// Outside the lock: DB.Close can block on an open connection.
+	closeExporterDB(toClose, r.logger)
+	return entry.exporter, r.releaseFunc(entry), nil
+}
 
-	return exporter, nil
+// releaseFunc hands a RunOnce frame its release hook: drop the hold, and if
+// this was the last hold on a superseded entry, close its DB. Each hook must
+// be called exactly once (#331).
+func (r *Runner) releaseFunc(entry *cachedDuckExporter) func() {
+	return func() {
+		r.mu.Lock()
+		entry.refs--
+		shouldClose := entry.doomed && entry.refs == 0
+		r.mu.Unlock()
+		if shouldClose {
+			closeExporterDB(entry.exporter, r.logger)
+		}
+	}
+}
+
+// closeExporterDB closes a doomed exporter's DuckDB handle. Failing the *new*
+// run because an old handle failed to close would be wrong, so errors are
+// logged, never returned. Nil-safe on both exporter and DB.
+func closeExporterDB(exporter *DuckExporter, logger *zap.Logger) {
+	if exporter == nil || exporter.DB == nil {
+		return
+	}
+	if err := exporter.DB.Close(); err != nil {
+		logger.Warn("close superseded duck exporter", zap.Error(err))
+	}
 }

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -349,7 +349,7 @@ func (r *Runner) releaseFunc(entry *cachedDuckExporter) func() {
 	}
 }
 
-// closeExporterDB closes a doomed exporter's DuckDB handle. Failing the *new*
+// closeExporterDB closes a discarded exporter's DuckDB handle. Failing the *new*
 // run because an old handle failed to close would be wrong, so errors are
 // logged, never returned. Nil-safe on both exporter and DB.
 func closeExporterDB(exporter *DuckExporter, logger *zap.Logger) {

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -273,6 +273,9 @@ func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cach
 	return runtime, nil
 }
 
+// getOrCreateDuckExporter returns the group's cached exporter (building and
+// caching one as needed) plus a release hook for the caller's hold: call it
+// exactly once, after the run finishes. The hook is nil when err is non-nil.
 func (r *Runner) getOrCreateDuckExporter(ctx context.Context, cfg CDCConfig, s3Runtime *cachedS3Runtime) (*DuckExporter, func(), error) {
 	key := duckExporterGroupKey{
 		dbPath:   cfg.DuckDBPath,
@@ -307,6 +310,8 @@ func (r *Runner) getOrCreateDuckExporter(ctx context.Context, cfg CDCConfig, s3R
 		closeExporterDB(exporter, r.logger)
 		return existing.exporter, r.releaseFunc(existing), nil
 	}
+	// Last writer wins: a slower build can install an older triple over a
+	// fresher one — pure churn, corrected by the next acquire's credsEqual miss.
 	superseded := r.duckExporters[key]
 	entry := &cachedDuckExporter{
 		exporter:        exporter,
@@ -352,6 +357,6 @@ func closeExporterDB(exporter *DuckExporter, logger *zap.Logger) {
 		return
 	}
 	if err := exporter.DB.Close(); err != nil {
-		logger.Warn("close superseded duck exporter", zap.Error(err))
+		logger.Warn("close discarded duck exporter", zap.Error(err))
 	}
 }

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -26,6 +26,14 @@ var newS3ClientFn = func(cfg aws.Config, endpoint string, usePath bool) *s3.Clie
 
 var newDuckExporterFn = NewDuckExporter
 
+// Runner caches per-config S3 runtimes and DuckDB exporters across RunOnce
+// calls. Each cache holds one entry per non-credential config group; a
+// credential rotation (#329) replaces the group's entry, and a superseded
+// DuckDB exporter is closed once no in-flight RunOnce holds it (#331) — so a
+// long-lived Runner under STS rotation keeps exactly one exporter per group,
+// not one per token. Two configs sharing a group but alternating *different*
+// static credential triples therefore rebuild on every alternation: a rebuild
+// cost, accepted in #331, never a correctness issue.
 type Runner struct {
 	logger        *zap.Logger
 	mu            sync.Mutex

--- a/internal/cdc/runner.go
+++ b/internal/cdc/runner.go
@@ -29,7 +29,7 @@ var newDuckExporterFn = NewDuckExporter
 type Runner struct {
 	logger        *zap.Logger
 	mu            sync.Mutex
-	s3Runtimes    map[s3RuntimeKey]*cachedS3Runtime
+	s3Runtimes    map[s3RuntimeGroupKey]*cachedS3Runtime
 	duckExporters map[duckExporterKey]*DuckExporter
 }
 
@@ -42,17 +42,26 @@ type cachedS3Runtime struct {
 	sessionToken    string
 }
 
-type s3RuntimeKey struct {
-	region      string
-	endpoint    string
-	usePath     bool
-	accessKeyID string
-	// The token is part of the signing identity the cached provider bakes in,
-	// so it belongs in the key alongside the pair: omit it and a rotated
-	// AWS_SESSION_TOKEN under an unchanged pair keeps hitting the cached
-	// runtime, handing every caller a stale-token artifact (#329).
-	secretAccessKey string
-	sessionToken    string
+// credsEqual reports whether this entry was built from exactly this resolved
+// static triple. The token is part of the signing identity the cached provider
+// bakes in, so it participates in the match: omit it and a rotated
+// AWS_SESSION_TOKEN under an unchanged pair keeps hitting the cached runtime,
+// handing every caller a stale-token artifact (#329).
+func (c *cachedS3Runtime) credsEqual(accessKeyID, secretAccessKey, sessionToken string) bool {
+	return c.accessKeyID == accessKeyID &&
+		c.secretAccessKey == secretAccessKey &&
+		c.sessionToken == sessionToken
+}
+
+// s3RuntimeGroupKey identifies a cache slot by everything *except* the
+// credential triple. Credentials live on the cached entry and are compared on
+// lookup: a changed triple (e.g. a rotated AWS_SESSION_TOKEN, #329) rebuilds
+// the runtime and replaces the superseded entry instead of minting a sibling
+// key that strands the old entry for process lifetime (#331).
+type s3RuntimeGroupKey struct {
+	region   string
+	endpoint string
+	usePath  bool
 }
 
 type duckExporterKey struct {
@@ -77,7 +86,7 @@ func NewRunner(logger *zap.Logger) *Runner {
 	}
 	return &Runner{
 		logger:        logger,
-		s3Runtimes:    make(map[s3RuntimeKey]*cachedS3Runtime),
+		s3Runtimes:    make(map[s3RuntimeGroupKey]*cachedS3Runtime),
 		duckExporters: make(map[duckExporterKey]*DuckExporter),
 	}
 }
@@ -92,7 +101,7 @@ func (r *Runner) Close() error {
 	for _, exporter := range r.duckExporters {
 		exporters = append(exporters, exporter)
 	}
-	r.s3Runtimes = make(map[s3RuntimeKey]*cachedS3Runtime)
+	r.s3Runtimes = make(map[s3RuntimeGroupKey]*cachedS3Runtime)
 	r.duckExporters = make(map[duckExporterKey]*DuckExporter)
 	r.mu.Unlock()
 
@@ -169,19 +178,16 @@ func (r *Runner) RunOnce(ctx context.Context, cfg CDCConfig, s3Client S3ObjectCl
 func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cachedS3Runtime, error) {
 	accessKeyID, secretAccessKey, sessionToken := ResolveStaticS3Credentials(cfg)
 
-	key := s3RuntimeKey{
-		region:          cfg.S3Region,
-		endpoint:        cfg.S3Endpoint,
-		usePath:         cfg.S3UsePath,
-		accessKeyID:     accessKeyID,
-		secretAccessKey: secretAccessKey,
-		sessionToken:    sessionToken,
+	key := s3RuntimeGroupKey{
+		region:   cfg.S3Region,
+		endpoint: cfg.S3Endpoint,
+		usePath:  cfg.S3UsePath,
 	}
 
 	r.mu.Lock()
 	cached := r.s3Runtimes[key]
 	r.mu.Unlock()
-	if cached != nil {
+	if cached != nil && cached.credsEqual(accessKeyID, secretAccessKey, sessionToken) {
 		return cached, nil
 	}
 
@@ -213,10 +219,12 @@ func (r *Runner) getOrCreateS3Runtime(ctx context.Context, cfg CDCConfig) (*cach
 	}
 
 	r.mu.Lock()
-	if existing := r.s3Runtimes[key]; existing != nil {
+	if existing := r.s3Runtimes[key]; existing != nil && existing.credsEqual(accessKeyID, secretAccessKey, sessionToken) {
 		r.mu.Unlock()
 		return existing, nil
 	}
+	// Replacing a stale-credential entry needs no close: s3.Client holds no
+	// OS resources, so dropping the map reference is the whole eviction (#331).
 	r.s3Runtimes[key] = runtime
 	r.mu.Unlock()
 

--- a/internal/cdc/runner_eviction_test.go
+++ b/internal/cdc/runner_eviction_test.go
@@ -191,3 +191,45 @@ func TestRunnerDuckExporterDistinctGroupsCoexist(t *testing.T) {
 	require.NoError(t, expA.DB.PingContext(ctx))
 	require.NoError(t, expB.DB.PingContext(ctx))
 }
+
+// TestRunnerDuckExporterConcurrentRotationIsSafe hammers acquire→use→release
+// across two alternating credential triples. The refcount contract under test:
+// a held exporter always answers Ping (never closed underneath its holder),
+// and after the storm exactly one cached entry remains, alive. Run with -race
+// (CI does) — the interleaving itself is the assertion surface.
+func TestRunnerDuckExporterConcurrentRotationIsSafe(t *testing.T) {
+	opened := stubDuckExporterWithDB(t)
+	runner := NewRunner(zap.NewNop())
+	cfg, old, rotated := duckEvictionFixture()
+	runtimes := []*cachedS3Runtime{old, rotated}
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 25; i++ {
+				exporter, release, err := runner.getOrCreateDuckExporter(ctx, cfg, runtimes[(g+i)%2])
+				if err != nil {
+					t.Errorf("goroutine %d iter %d: acquire: %v", g, i, err)
+					return
+				}
+				if pingErr := exporter.DB.PingContext(ctx); pingErr != nil {
+					t.Errorf("goroutine %d iter %d: held exporter closed underneath us: %v", g, i, pingErr)
+				}
+				release()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	require.Len(t, runner.duckExporters, 1)
+	live := 0
+	for _, db := range opened() {
+		if db.PingContext(ctx) == nil {
+			live++
+		}
+	}
+	require.Equal(t, 1, live, "storm settled: exactly the cached entry's handle stays open")
+}

--- a/internal/cdc/runner_eviction_test.go
+++ b/internal/cdc/runner_eviction_test.go
@@ -2,6 +2,9 @@ package cdc
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -38,4 +41,153 @@ func TestRunnerS3RuntimeDistinctEndpointsCoexist(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, rtA, rtA2)
 	require.Equal(t, 2, loadCalls)
+}
+
+// stubDuckExporterWithDB routes newDuckExporterFn to real :memory: DuckDB
+// handles and records every DB it opens, so tests can assert which handles
+// are still alive after rotations. The returned accessor snapshots the list
+// under a mutex: exporter builds happen outside the Runner's lock, so
+// concurrent tests (the -race storm) hit this stub concurrently. Open errors
+// are returned, never require'd — the stub runs on non-test goroutines.
+// t.Cleanup twin of the inline stubs in runner_test.go; no t.Parallel
+// (process-global seam).
+func stubDuckExporterWithDB(t *testing.T) func() []*sql.DB {
+	t.Helper()
+	previous := newDuckExporterFn
+	var mu sync.Mutex
+	var opened []*sql.DB
+	newDuckExporterFn = func(ctx context.Context, cfg CDCConfig, s3AccessKey, s3Secret, s3SessionToken string, logger *zap.Logger) (*DuckExporter, error) {
+		db, err := sql.Open("duckdb", ":memory:")
+		if err != nil {
+			return nil, fmt.Errorf("open stub duckdb: %w", err)
+		}
+		mu.Lock()
+		opened = append(opened, db)
+		mu.Unlock()
+		return &DuckExporter{DB: db, Logger: logger}, nil
+	}
+	t.Cleanup(func() { newDuckExporterFn = previous })
+	return func() []*sql.DB {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]*sql.DB(nil), opened...)
+	}
+}
+
+func duckEvictionFixture() (CDCConfig, *cachedS3Runtime, *cachedS3Runtime) {
+	cfg := CDCConfig{
+		DuckDBPath:   ":memory:",
+		DuckThreads:  4,
+		DuckMemLimit: "4GB",
+		S3Region:     "us-east-1",
+		S3UseSSL:     true,
+	}
+	old := &cachedS3Runtime{region: "us-east-1", accessKeyID: "key", secretAccessKey: "secret", sessionToken: "token-1"}
+	rotated := &cachedS3Runtime{region: "us-east-1", accessKeyID: "key", secretAccessKey: "secret", sessionToken: "token-2"}
+	return cfg, old, rotated
+}
+
+// TestRunnerDuckExporterRotationClosesSuperseded is the #331 red anchor: after
+// a credential rotation the superseded exporter's DuckDB handle must be
+// closed and its slot replaced — not stranded open until process exit.
+func TestRunnerDuckExporterRotationClosesSuperseded(t *testing.T) {
+	stubDuckExporterWithDB(t)
+	runner := NewRunner(zap.NewNop())
+	cfg, old, rotated := duckEvictionFixture()
+
+	exp1, release1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, old)
+	require.NoError(t, err)
+	release1()
+
+	exp2, release2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, rotated)
+	require.NoError(t, err)
+	defer release2()
+
+	require.NotSame(t, exp1, exp2)
+	require.Error(t, exp1.DB.PingContext(context.Background()), "superseded idle exporter must be closed")
+	require.NoError(t, exp2.DB.PingContext(context.Background()))
+	require.Len(t, runner.duckExporters, 1)
+}
+
+// TestRunnerDuckExporterInFlightSupersedeDefersClose pins the refcount rule:
+// an exporter superseded while a RunOnce frame still holds it stays open
+// until that frame's release — then closes. The live replacement's own
+// release must NOT close it (it is cached, not doomed).
+func TestRunnerDuckExporterInFlightSupersedeDefersClose(t *testing.T) {
+	stubDuckExporterWithDB(t)
+	runner := NewRunner(zap.NewNop())
+	cfg, old, rotated := duckEvictionFixture()
+	ctx := context.Background()
+
+	exp1, release1, err := runner.getOrCreateDuckExporter(ctx, cfg, old)
+	require.NoError(t, err)
+	// No release yet: exp1 is "in flight" when the rotation lands.
+	exp2, release2, err := runner.getOrCreateDuckExporter(ctx, cfg, rotated)
+	require.NoError(t, err)
+
+	require.NoError(t, exp1.DB.PingContext(ctx), "in-flight exporter must survive supersession")
+	require.Len(t, runner.duckExporters, 1)
+
+	release1()
+	require.Error(t, exp1.DB.PingContext(ctx), "last release of a doomed exporter must close it")
+	require.NoError(t, exp2.DB.PingContext(ctx))
+
+	release2()
+	require.NoError(t, exp2.DB.PingContext(ctx), "release of the live cached exporter must not close it")
+	require.Len(t, runner.duckExporters, 1)
+}
+
+// TestRunnerDuckExporterRotationLeavesSingleLiveHandle is the leak assertion
+// stated by the issue: N rotations leave exactly one live DuckDB handle, not N.
+func TestRunnerDuckExporterRotationLeavesSingleLiveHandle(t *testing.T) {
+	opened := stubDuckExporterWithDB(t)
+	runner := NewRunner(zap.NewNop())
+	cfg, _, _ := duckEvictionFixture()
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		runtime := &cachedS3Runtime{
+			region:          "us-east-1",
+			accessKeyID:     "key",
+			secretAccessKey: "secret",
+			sessionToken:    fmt.Sprintf("token-%d", i),
+		}
+		_, release, err := runner.getOrCreateDuckExporter(ctx, cfg, runtime)
+		require.NoError(t, err)
+		release()
+	}
+
+	require.Len(t, opened(), 5)
+	live := 0
+	for _, db := range opened() {
+		if db.PingContext(ctx) == nil {
+			live++
+		}
+	}
+	require.Equal(t, 1, live, "every superseded handle must be closed")
+	require.Len(t, runner.duckExporters, 1)
+}
+
+// TestRunnerDuckExporterDistinctGroupsCoexist pins the eviction boundary:
+// different non-credential configs are different groups; neither supersedes
+// the other and both stay open.
+func TestRunnerDuckExporterDistinctGroupsCoexist(t *testing.T) {
+	stubDuckExporterWithDB(t)
+	runner := NewRunner(zap.NewNop())
+	cfg, old, _ := duckEvictionFixture()
+	cfgB := cfg
+	cfgB.S3Endpoint = "http://minio-b:9000"
+	ctx := context.Background()
+
+	expA, releaseA, err := runner.getOrCreateDuckExporter(ctx, cfg, old)
+	require.NoError(t, err)
+	releaseA()
+	expB, releaseB, err := runner.getOrCreateDuckExporter(ctx, cfgB, old)
+	require.NoError(t, err)
+	releaseB()
+
+	require.NotSame(t, expA, expB)
+	require.Len(t, runner.duckExporters, 2)
+	require.NoError(t, expA.DB.PingContext(ctx))
+	require.NoError(t, expB.DB.PingContext(ctx))
 }

--- a/internal/cdc/runner_eviction_test.go
+++ b/internal/cdc/runner_eviction_test.go
@@ -1,0 +1,41 @@
+package cdc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestRunnerS3RuntimeDistinctEndpointsCoexist pins the eviction boundary
+// (#331): supersession is per group (region/endpoint/path-style). Two configs
+// with different endpoints are different groups — the second must not evict
+// the first, and the first must still be a cache hit afterwards.
+func TestRunnerS3RuntimeDistinctEndpointsCoexist(t *testing.T) {
+	loadCalls := 0
+	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		loadCalls++
+		return aws.Config{Region: "us-east-1"}, nil
+	})
+	stubNewS3Client(t, func(aws.Config, string, bool) *s3.Client { return &s3.Client{} })
+
+	runner := NewRunner(zap.NewNop())
+	cfgA := CDCConfig{S3Region: "us-east-1", S3Endpoint: "http://minio-a:9000"}
+	cfgB := CDCConfig{S3Region: "us-east-1", S3Endpoint: "http://minio-b:9000"}
+
+	rtA, err := runner.getOrCreateS3Runtime(context.Background(), cfgA)
+	require.NoError(t, err)
+	rtB, err := runner.getOrCreateS3Runtime(context.Background(), cfgB)
+	require.NoError(t, err)
+	require.NotSame(t, rtA, rtB)
+	require.Len(t, runner.s3Runtimes, 2)
+
+	rtA2, err := runner.getOrCreateS3Runtime(context.Background(), cfgA)
+	require.NoError(t, err)
+	require.Same(t, rtA, rtA2)
+	require.Equal(t, 2, loadCalls)
+}

--- a/internal/cdc/runner_test.go
+++ b/internal/cdc/runner_test.go
@@ -106,12 +106,12 @@ func TestRunnerGetOrCreateS3Runtime_EnvTripleCarriesSessionToken(t *testing.T) {
 	require.Equal(t, "env-token", creds.SessionToken)
 }
 
-// TestRunnerS3RuntimeCacheKeyIncludesSessionToken pins that the cached runtime
-// is keyed on the whole credential triple. The provider bakes the token in, so
-// a rotated AWS_SESSION_TOKEN under an unchanged access-key pair describes a
-// different signing identity — key on the pair alone and the Runner keeps
-// serving the expired token until the process restarts (#329).
-func TestRunnerS3RuntimeCacheKeyIncludesSessionToken(t *testing.T) {
+// TestRunnerS3RuntimeRotationReplacesEntry pins both halves of the #329/#331
+// contract: a rotated AWS_SESSION_TOKEN under an unchanged access-key pair is
+// a different signing identity, so the Runner must rebuild the runtime (#329)
+// — and the stale-credential entry must leave the map instead of stranding
+// there for process lifetime (#331).
+func TestRunnerS3RuntimeRotationReplacesEntry(t *testing.T) {
 	loadCalls := 0
 	stubLoadAWSConfig(t, func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
 		loadCalls++
@@ -138,6 +138,8 @@ func TestRunnerS3RuntimeCacheKeyIncludesSessionToken(t *testing.T) {
 	require.Equal(t, "token-2", second.sessionToken)
 	creds := retrieveCreds(t, second.credProvider)
 	require.Equal(t, "token-2", creds.SessionToken)
+	// #331: the superseded entry is replaced, not accumulated.
+	require.Len(t, runner.s3Runtimes, 1)
 }
 
 func TestRunnerCachesDuckExporter(t *testing.T) {
@@ -277,7 +279,7 @@ func TestRunnerClose_ClearsCachesAndClosesExporters(t *testing.T) {
 	require.NoError(t, err)
 
 	runner := NewRunner(zap.NewNop())
-	runner.s3Runtimes[s3RuntimeKey{region: "us-east-1"}] = &cachedS3Runtime{region: "us-east-1"}
+	runner.s3Runtimes[s3RuntimeGroupKey{region: "us-east-1"}] = &cachedS3Runtime{region: "us-east-1"}
 	runner.duckExporters[duckExporterKey{dbPath: ":memory:"}] = &DuckExporter{
 		DB:     db,
 		Logger: zap.NewNop(),

--- a/internal/cdc/runner_test.go
+++ b/internal/cdc/runner_test.go
@@ -168,10 +168,12 @@ func TestRunnerCachesDuckExporter(t *testing.T) {
 		S3UseSSL:     true,
 	}
 
-	exporter1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, s3Runtime)
+	exporter1, release1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, s3Runtime)
 	require.NoError(t, err)
-	exporter2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, s3Runtime)
+	release1()
+	exporter2, release2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, s3Runtime)
 	require.NoError(t, err)
+	release2()
 
 	require.Same(t, exporter1, exporter2)
 	require.Equal(t, 1, createCalls)
@@ -183,7 +185,8 @@ func TestRunnerCachesDuckExporter(t *testing.T) {
 // SET s3_region entirely — so two runs whose only difference is the region the
 // AWS default chain happened to resolve produce byte-identical exporters. Key
 // on the chain region and the cache claims a distinction the exporter never
-// made, building (and leaking) a second identical DuckDB instance (#329).
+// made, building — and pointlessly churning (#331) — a second identical
+// DuckDB instance (#329).
 func TestRunnerDuckExporterCacheKeyIgnoresChainResolvedRegion(t *testing.T) {
 	origNewDuckExporterFn := newDuckExporterFn
 	defer func() {
@@ -216,20 +219,23 @@ func TestRunnerDuckExporterCacheKeyIgnoresChainResolvedRegion(t *testing.T) {
 		secretAccessKey: "secret",
 	}
 
-	exporter1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeEast)
+	exporter1, release1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeEast)
 	require.NoError(t, err)
-	exporter2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeWest)
+	release1()
+	exporter2, release2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeWest)
 	require.NoError(t, err)
+	release2()
 
 	require.Same(t, exporter1, exporter2)
 	require.Equal(t, 1, createCalls)
 }
 
-// TestRunnerDuckExporterCacheKeyIncludesSessionToken pins the other half of the
+// TestRunnerDuckExporterRotationRebuildsExporter pins the other half of the
 // same rule: the exporter bakes the token into SET s3_session_token at
 // construction, so two runtimes differing only in their token configure
-// different exporters and must not share a cache slot (#329).
-func TestRunnerDuckExporterCacheKeyIncludesSessionToken(t *testing.T) {
+// different exporters and must not share a cache slot (#329) — and the
+// superseded entry leaves the map (#331).
+func TestRunnerDuckExporterRotationRebuildsExporter(t *testing.T) {
 	origNewDuckExporterFn := newDuckExporterFn
 	defer func() {
 		newDuckExporterFn = origNewDuckExporterFn
@@ -264,14 +270,17 @@ func TestRunnerDuckExporterCacheKeyIncludesSessionToken(t *testing.T) {
 		sessionToken:    "token-2",
 	}
 
-	exporter1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeOld)
+	exporter1, release1, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeOld)
 	require.NoError(t, err)
-	exporter2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeRotated)
+	release1()
+	exporter2, release2, err := runner.getOrCreateDuckExporter(context.Background(), cfg, runtimeRotated)
 	require.NoError(t, err)
+	release2()
 
 	require.NotSame(t, exporter1, exporter2)
 	require.Equal(t, 2, createCalls)
 	require.Equal(t, []string{"token-1", "token-2"}, seenTokens)
+	require.Len(t, runner.duckExporters, 1)
 }
 
 func TestRunnerClose_ClearsCachesAndClosesExporters(t *testing.T) {
@@ -280,9 +289,9 @@ func TestRunnerClose_ClearsCachesAndClosesExporters(t *testing.T) {
 
 	runner := NewRunner(zap.NewNop())
 	runner.s3Runtimes[s3RuntimeGroupKey{region: "us-east-1"}] = &cachedS3Runtime{region: "us-east-1"}
-	runner.duckExporters[duckExporterKey{dbPath: ":memory:"}] = &DuckExporter{
-		DB:     db,
-		Logger: zap.NewNop(),
+	runner.duckExporters[duckExporterGroupKey{dbPath: ":memory:"}] = &cachedDuckExporter{
+		exporter: &DuckExporter{DB: db, Logger: zap.NewNop()},
+		refs:     1, // Close is hard shutdown: in-flight holds do not defer it
 	}
 
 	require.NoError(t, runner.Close())


### PR DESCRIPTION
Closes #331.

## What

`Runner.s3Runtimes` and `Runner.duckExporters` were append-only: every
credential rotation minted a new cache key and stranded the old entry —
one open DuckDB instance per rotation — until process exit (#329 review
finding O2). Both caches now key on the non-credential config group and
hold exactly one entry per group:

- **s3Runtimes**: rotation replaces the entry; no close needed (s3.Client
  holds no OS resources), GC reclaims it.
- **duckExporters**: rotation replaces the entry and closes the superseded
  DuckDB handle — immediately when idle, else when its last in-flight
  RunOnce frame releases it (refcount). A held exporter is never closed
  underneath its holder.
- **Runner.Close** keeps hard-shutdown semantics: everything closes at
  once; a straggling release after Close is an idempotent sql.DB re-Close.

Adjudication (issue #331 listed three un-adjudicated directions): user
chose evict-on-supersede with refcounting over bounded LRU and
accept-and-document — see the plan comment on #331.

Accepted trade-off (documented on Runner): two configs sharing a group but
alternating different static credential triples rebuild per alternation —
a rebuild cost, never a correctness issue; rotation itself never alternates.

## Tests

- Red anchor: rotation closes the superseded idle exporter and leaves one
  map entry (`TestRunnerDuckExporterRotationClosesSuperseded`).
- Refcount: in-flight supersession defers close to the last release; the
  live entry's release does not close it.
- Leak assertion from the issue: 5 rotations leave exactly 1 live handle.
- Boundary: distinct endpoints/groups coexist, neither evicted.
- `-race` stress: 8 goroutines alternating two triples; held exporters
  always answer Ping; storm settles to one live handle.
- Existing #329 cache-key tests re-purposed to rotation-replacement tests
  (assertions extended, not weakened); #302/#326 provider-resolution tests
  untouched and green.

Gates: `make fmt-check`, `make lint` (pinned v1.64.8), `make test` all
green; full `internal/cdc` package green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
