### PR TITLE
test: close false-negative paths in TestInitSchemaScopedIsolation (#248)

### DIFF
--- a/internal/e2e_harness/production/cdc_fault_helpers_e2e_test.go
+++ b/internal/e2e_harness/production/cdc_fault_helpers_e2e_test.go
@@ -196,22 +196,22 @@ func assertSameRowIDs(t *testing.T, label string, got, want map[string]bool) {
 	}
 }
 
-// schemaKeyPrefix returns the Env-scoped S3 key prefix of one schema's
+// buildSchemaKeyPrefix returns the Env-scoped S3 key prefix of one schema's
 // parquet partition (e.g. "e2e/<run>/env3/22/"). Matching on the full prefix
 // rather than a bare "/22/" substring keeps the filter unambiguous no matter
 // what the run ID or env sequence look like.
-func schemaKeyPrefix(env *Env, schema SchemaRef) string {
+func buildSchemaKeyPrefix(env *Env, schema SchemaRef) string {
 	return fmt.Sprintf("%s/%d/", env.S3Prefix, schema.ID)
 }
 
-// finalsForSchema filters keys down to one schema's final parquet objects
+// filterFinalsForSchema filters keys down to one schema's final parquet objects
 // (multi-schema passes legitimately mix partitions in one report, so the
 // global splitKeys alone cannot attribute objects to a schema).
-func finalsForSchema(env *Env, keys []string, schema SchemaRef) []string {
+func filterFinalsForSchema(env *Env, keys []string, schema SchemaRef) []string {
 	finals, _ := splitKeys(keys)
 	var got []string
 	for _, k := range finals {
-		if strings.HasPrefix(k, schemaKeyPrefix(env, schema)) {
+		if strings.HasPrefix(k, buildSchemaKeyPrefix(env, schema)) {
 			got = append(got, k)
 		}
 	}
@@ -225,12 +225,12 @@ func finalsForSchema(env *Env, keys []string, schema SchemaRef) []string {
 // legitimately create objects in the same report.
 func assertSchemaUntouchedByFault(ctx context.Context, t *testing.T, env *Env, report *FlushReport, schema SchemaRef, wantDirty int) {
 	t.Helper()
-	if finals := finalsForSchema(env, report.NewObjects, schema); len(finals) != 0 {
+	if finals := filterFinalsForSchema(env, report.NewObjects, schema); len(finals) != 0 {
 		t.Errorf("schema %d must promote no final parquet after its fault, got %v", schema.ID, finals)
 	}
 	_, tmps := splitKeys(report.NewObjects)
 	for _, k := range tmps {
-		if strings.HasPrefix(k, schemaKeyPrefix(env, schema)) {
+		if strings.HasPrefix(k, buildSchemaKeyPrefix(env, schema)) {
 			t.Errorf("schema %d must leave no tmp residue after its copy fault (#226), got %s", schema.ID, k)
 		}
 	}
@@ -256,7 +256,7 @@ func assertSchemaFullyFlushed(ctx context.Context, t *testing.T, env *Env, newKe
 		t.Fatalf("schema %d must be fully flushed: flushed=%v dirty=%v, want %d flushed",
 			schema.ID, flushed, dirty, wantRows)
 	}
-	finals := finalsForSchema(env, newKeys, schema)
+	finals := filterFinalsForSchema(env, newKeys, schema)
 	if len(finals) != 1 {
 		t.Fatalf("schema %d must promote exactly one final delta, got %v", schema.ID, finals)
 	}

--- a/internal/e2e_harness/production/compaction_e2e_test.go
+++ b/internal/e2e_harness/production/compaction_e2e_test.go
@@ -153,7 +153,7 @@ func TestCompactionPromotionEquivalence(t *testing.T) {
 	mBefore := loadSchemaManifest(ctx, t, env, wide)
 	assertDeltaSizesPopulated(t, mBefore)
 	baseBefore, deltaBefore := countTier(mBefore, "base"), countTier(mBefore, "delta")
-	invBefore := snapshotS3Inventory(t, ctx, env)
+	invBefore := snapshotS3Inventory(t, ctx, env, env.S3Prefix+"/")
 
 	result := assertCompactionEquivalence(ctx, t, env, wide,
 		compactionEquivalenceQueries(wide), CompactionOverrides{TargetBaseSizeBytes: 1}, "promotion")
@@ -180,7 +180,7 @@ func TestCompactionPromotionEquivalence(t *testing.T) {
 
 	// Promotion is a manifest-only relabel: zero parquet objects created,
 	// deleted, or modified.
-	assertParquetInventoryUnchanged(t, "promotion", invBefore, snapshotS3Inventory(t, ctx, env))
+	assertParquetInventoryUnchanged(t, "promotion", invBefore, snapshotS3Inventory(t, ctx, env, env.S3Prefix+"/"))
 
 	// The relabeled entries still serve reads: the post-compaction query must
 	// route through DuckDB over the manifest-listed objects.

--- a/internal/e2e_harness/production/concurrent_flush_multi_schema_e2e_test.go
+++ b/internal/e2e_harness/production/concurrent_flush_multi_schema_e2e_test.go
@@ -85,7 +85,7 @@ func TestConcurrentFlushDifferentSchemas(t *testing.T) {
 		t.Fatalf("runner2 must not touch the locked schema %d: flushed=%v dirty=%v",
 			simple.ID, flushedA, dirtyA)
 	}
-	if finals := finalsForSchema(env, r2.NewObjects, simple); len(finals) != 0 {
+	if finals := filterFinalsForSchema(env, r2.NewObjects, simple); len(finals) != 0 {
 		t.Errorf("runner2 must not promote finals for the locked schema %d, got %v", simple.ID, finals)
 	}
 

--- a/internal/e2e_harness/production/dryrun_immutability_e2e_test.go
+++ b/internal/e2e_harness/production/dryrun_immutability_e2e_test.go
@@ -9,10 +9,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/lychee-technology/forma/internal/manifest"
 )
@@ -85,12 +81,6 @@ type changeLogRow struct {
 	DeletedAt int64 // 0 when NULL
 }
 
-type s3ObjectStat struct {
-	Size         int64
-	ETag         string
-	LastModified time.Time
-}
-
 // stateSnapshot captures the three mutation surfaces #180 guards.
 type stateSnapshot struct {
 	changeLog    map[string]changeLogRow
@@ -104,7 +94,7 @@ func captureState(t *testing.T, ctx context.Context, env *Env, schema SchemaRef)
 	raw, etag := snapshotManifest(t, ctx, env, schema)
 	return stateSnapshot{
 		changeLog:    snapshotChangeLog(t, ctx, env),
-		s3:           snapshotS3Inventory(t, ctx, env),
+		s3:           snapshotS3Inventory(t, ctx, env, env.S3Prefix+"/"),
 		manifestRaw:  raw,
 		manifestETag: etag,
 	}
@@ -134,51 +124,6 @@ func snapshotChangeLog(t *testing.T, ctx context.Context, env *Env) map[string]c
 		t.Fatalf("iterate change_log rows: %v", err)
 	}
 	return snap
-}
-
-func snapshotS3Inventory(t *testing.T, ctx context.Context, env *Env) map[string]s3ObjectStat {
-	t.Helper()
-	inv := make(map[string]s3ObjectStat)
-	var token *string
-	for {
-		out, err := env.Cluster.S3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(env.Cluster.Bucket),
-			Prefix:            aws.String(env.S3Prefix + "/"),
-			ContinuationToken: token,
-		})
-		if err != nil {
-			t.Fatalf("snapshot s3 inventory: %v", err)
-		}
-		for _, obj := range out.Contents {
-			stat := s3ObjectStat{Size: aws.ToInt64(obj.Size), ETag: aws.ToString(obj.ETag)}
-			if obj.LastModified != nil {
-				stat.LastModified = obj.LastModified.UTC()
-			}
-			inv[aws.ToString(obj.Key)] = stat
-		}
-		if out.NextContinuationToken == nil {
-			return inv
-		}
-		token = out.NextContinuationToken
-	}
-}
-
-// snapshotManifest returns the manifest's raw bytes and ETag. The seed phase
-// runs a real flush + init first, so the manifest must exist by the time any
-// snapshot is taken — a load failure here is a test bug, not a skip.
-func snapshotManifest(t *testing.T, ctx context.Context, env *Env, schema SchemaRef) ([]byte, string) {
-	t.Helper()
-	store := &manifest.S3Store{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket}
-	resolver := manifest.PathResolver{Prefix: env.CDC.ManifestPrefix, PathTemplate: env.CDC.ManifestTemplate}
-	path, err := resolver.Resolve(schema.ID)
-	if err != nil {
-		t.Fatalf("resolve manifest path for schema %d: %v", schema.ID, err)
-	}
-	raw, etag, err := store.Load(ctx, path)
-	if err != nil {
-		t.Fatalf("load manifest %s (seed must have created it): %v", path, err)
-	}
-	return raw, etag
 }
 
 func assertStateUnchanged(t *testing.T, label string, before, after stateSnapshot) {

--- a/internal/e2e_harness/production/init_rerun_e2e_test.go
+++ b/internal/e2e_harness/production/init_rerun_e2e_test.go
@@ -65,10 +65,8 @@ func TestInitRerunIdempotency(t *testing.T) {
 
 	// Same federated results after the rerun (base-only source).
 	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", wide.ID)
-	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
-	if result != nil && len(result.Records) != 20 {
-		t.Fatalf("federated result has %d rows after rerun, want 20", len(result.Records))
-	}
+	assertFederatedRowCount(ctx, t, env, "post-rerun base tier",
+		Query{Schema: wide, Limit: 100}, 20)
 }
 
 func buildBasePaths(m *manifest.Manifest) map[string]bool {
@@ -152,8 +150,6 @@ func TestInitRerunAfterChangesReconcilesManifest(t *testing.T) {
 	if flush.UnflushedAfter != 0 {
 		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
 	}
-	result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})
-	if result != nil && len(result.Records) != 23 {
-		t.Fatalf("federated result has %d rows after changed rerun, want 23", len(result.Records))
-	}
+	assertFederatedRowCount(ctx, t, env, "post-rerun parity",
+		Query{Schema: wide, Limit: 100}, 23)
 }

--- a/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+++ b/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
@@ -303,14 +303,14 @@ func TestInitSchemaScopedIsolation(t *testing.T) {
 	}
 
 	// Onboarding contract: init does not clear change_log; clear it so the
-	// base tier alone must answer, then oracle-check both schemas.
+	// base tier alone must answer, then oracle-check both schemas. The count
+	// is only cold-tier evidence if the query actually routed to DuckDB —
+	// a PG-only routing regression would still count 5 entity_main rows (#248).
 	for _, ref := range []SchemaRef{simple, second} {
 		env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", ref.ID)
 	}
 	for _, ref := range []SchemaRef{simple, second} {
-		result := env.AssertQueryMatches(ctx, Query{Schema: ref, Limit: 100})
-		if result != nil && len(result.Records) != 5 {
-			t.Errorf("schema %d federated result has %d rows, want 5", ref.ID, len(result.Records))
-		}
+		assertFederatedRowCount(ctx, t, env,
+			fmt.Sprintf("schema %d base tier", ref.ID), Query{Schema: ref, Limit: 100}, 5)
 	}
 }

--- a/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+++ b/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
@@ -272,6 +272,12 @@ func TestInitSchemaScopedIsolation(t *testing.T) {
 		t.Fatal("schema 22 init must produce base entries (positive control)")
 	}
 
+	// #248: the NewObjects key diff is blind to overwrites that reuse the
+	// deterministic min_max keys, and the base-path comparison below is blind
+	// to a manifest rewritten with the same paths. Require exact stat/byte
+	// identity of the sibling's whole S3 surface across the rerun.
+	siblingBefore := captureSchemaS3State(t, ctx, env, second)
+
 	// Rerun schema 20's init: the sibling's manifest and objects must be
 	// byte-for-byte uninvolved (deterministic keys make the rerun itself a
 	// pure overwrite, so any sibling-partition key here is a leak).
@@ -280,6 +286,8 @@ func TestInitSchemaScopedIsolation(t *testing.T) {
 		t.Fatalf("rerun init schema %d: %v", simple.ID, err)
 	}
 	assertInitTouchesOnly(rerun, simple, second)
+	assertSchemaS3StateUnchanged(t, "schema 20 rerun vs sibling 22",
+		siblingBefore, captureSchemaS3State(t, ctx, env, second))
 	manifests, err = env.loadManifests(ctx)
 	if err != nil {
 		t.Fatalf("reload manifests: %v", err)

--- a/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+++ b/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
@@ -262,11 +262,18 @@ func TestInitSchemaScopedIsolation(t *testing.T) {
 		t.Fatalf("schema %d must have no manifest before its own init, got %+v", second.ID, manifests[second.ID])
 	}
 
+	// #248: schema 20's surface already exists here, so schema 22's init is
+	// held to the same overwrite-proof contract as the rerun below — the key
+	// diff alone would miss an in-place re-export of the sibling.
+	simpleBefore := captureSchemaS3State(t, ctx, env, simple)
+
 	secondInit, err := env.RunInit(ctx, second)
 	if err != nil {
 		t.Fatalf("init schema %d: %v", second.ID, err)
 	}
 	assertInitTouchesOnly(secondInit, second, simple)
+	assertSchemaS3StateUnchanged(t, "schema 22 init vs sibling 20",
+		simpleBefore, captureSchemaS3State(t, ctx, env, simple))
 	siblingPaths := buildBasePaths(secondInit.Manifest)
 	if len(siblingPaths) == 0 {
 		t.Fatal("schema 22 init must produce base entries (positive control)")

--- a/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+++ b/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
@@ -81,7 +81,7 @@ func testMultiSchemaCopyFault(ctx context.Context, t *testing.T) {
 	simple, second := seedTwoSchemas(ctx, t, env)
 
 	faulty := &FaultInjectingS3{Inner: env.Cluster.S3,
-		Fault: S3Fault{Op: S3OpCopy, KeyContains: schemaKeyPrefix(env, second)}}
+		Fault: S3Fault{Op: S3OpCopy, KeyContains: buildSchemaKeyPrefix(env, second)}}
 	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty})
 	if err == nil {
 		t.Fatal("flush with one schema's CopyObject failing must fail")
@@ -141,7 +141,7 @@ func testMultiSchemaManifestSaveFault(ctx context.Context, t *testing.T) {
 		t.Fatalf("schema %d rows must stay dirty when its manifest append fails: flushed=%v dirty=%v",
 			second.ID, flushed, dirty)
 	}
-	finals := finalsForSchema(env, report.NewObjects, second)
+	finals := filterFinalsForSchema(env, report.NewObjects, second)
 	if len(finals) != 1 {
 		t.Fatalf("schema %d final must exist when its manifest save fails, got %v", second.ID, finals)
 	}
@@ -161,11 +161,11 @@ func testMultiSchemaManifestSaveFault(ctx context.Context, t *testing.T) {
 		t.Errorf("retry must drain only the faulted schema: unflushed before/after = %d/%d, want 3/0",
 			retry.UnflushedBefore, retry.UnflushedAfter)
 	}
-	retryFinals := finalsForSchema(env, retry.NewObjects, second)
+	retryFinals := filterFinalsForSchema(env, retry.NewObjects, second)
 	if len(retryFinals) != 1 {
 		t.Fatalf("retry must promote exactly one new final for the faulted schema, got %v", retry.NewObjects)
 	}
-	if healthy := finalsForSchema(env, retry.NewObjects, simple); len(healthy) != 0 {
+	if healthy := filterFinalsForSchema(env, retry.NewObjects, simple); len(healthy) != 0 {
 		t.Errorf("healthy schema must gain no new objects on retry, got %v", healthy)
 	}
 	assertManifestDeltaPaths(t, retry.Manifests, second, retryFinals)
@@ -187,7 +187,7 @@ func TestMultiSchemaRetryRepairsOnlyFailed(t *testing.T) {
 	simple, second := seedTwoSchemas(ctx, t, env)
 
 	faulty := &FaultInjectingS3{Inner: env.Cluster.S3,
-		Fault: S3Fault{Op: S3OpCopy, KeyContains: schemaKeyPrefix(env, second)}}
+		Fault: S3Fault{Op: S3OpCopy, KeyContains: buildSchemaKeyPrefix(env, second)}}
 	report, err := env.RunFlushWith(ctx, FlushOverrides{S3: faulty})
 	if err == nil {
 		t.Fatal("flush with one schema's CopyObject failing must fail")
@@ -207,7 +207,7 @@ func TestMultiSchemaRetryRepairsOnlyFailed(t *testing.T) {
 	if retry.UnflushedBefore != 3 || retry.UnflushedAfter != 0 {
 		t.Errorf("retry unflushed %d -> %d, want 3 -> 0", retry.UnflushedBefore, retry.UnflushedAfter)
 	}
-	if healthyNew := finalsForSchema(env, retry.NewObjects, simple); len(healthyNew) != 0 {
+	if healthyNew := filterFinalsForSchema(env, retry.NewObjects, simple); len(healthyNew) != 0 {
 		t.Errorf("retry must not re-export the healthy schema, got new finals %v", healthyNew)
 	}
 	assertSchemaFullyFlushed(ctx, t, env, retry.NewObjects, retry.Manifests, second, 3)
@@ -243,7 +243,7 @@ func TestInitSchemaScopedIsolation(t *testing.T) {
 		t.Helper()
 		siblingManifestKey := fmt.Sprintf("%s/manifest/%d.json", env.S3Prefix, sibling.ID)
 		for _, k := range report.NewObjects {
-			if strings.HasPrefix(k, schemaKeyPrefix(env, sibling)) || k == siblingManifestKey {
+			if strings.HasPrefix(k, buildSchemaKeyPrefix(env, sibling)) || k == siblingManifestKey {
 				t.Errorf("init of schema %d touched sibling schema %d: %s", target.ID, sibling.ID, k)
 			}
 		}

--- a/internal/e2e_harness/production/parquet_corruption_e2e_test.go
+++ b/internal/e2e_harness/production/parquet_corruption_e2e_test.go
@@ -102,7 +102,7 @@ func TestParquetCorruption_WrongSchemaFile(t *testing.T) {
 		t.Fatalf("precondition: healthy query did not route to duckdb: %+v", healthy.Plan.Routing)
 	}
 
-	wrongKey := schemaKeyPrefix(env, wide) + "wrong_schema_zzz.parquet"
+	wrongKey := buildSchemaKeyPrefix(env, wide) + "wrong_schema_zzz.parquet"
 	writeParquetViaDuck(ctx, t, env, "SELECT 1 AS wrong_col, 'x' AS other_col", wrongKey)
 	if err := env.RegisterParquetInManifest(ctx, wide, wrongKey, "delta"); err != nil {
 		t.Fatalf("register wrong-schema parquet: %v", err)
@@ -151,7 +151,7 @@ func TestParquetCorruption_WrongTypeFile(t *testing.T) {
 
 	// Same column names as the real export, poisoned types for the two
 	// columns every projection touches.
-	wrongTypeKey := schemaKeyPrefix(env, wide) + "wrong_type_zzz.parquet"
+	wrongTypeKey := buildSchemaKeyPrefix(env, wide) + "wrong_type_zzz.parquet"
 	writeParquetViaDuck(ctx, t, env, fmt.Sprintf(
 		"SELECT 'not-a-uuid' AS row_id, 'not-an-epoch' AS changed_at, * EXCLUDE (row_id, changed_at) FROM read_parquet('s3://%s/%s') LIMIT 1",
 		env.Cluster.Bucket, keys[0]), wrongTypeKey)
@@ -194,7 +194,7 @@ func TestParquetCorruption_EmptyParquetFile(t *testing.T) {
 		t.Fatalf("expected exactly one parquet after seedTwoTiers, got %v", keys)
 	}
 
-	emptyKey := schemaKeyPrefix(env, wide) + "empty_zzz.parquet"
+	emptyKey := buildSchemaKeyPrefix(env, wide) + "empty_zzz.parquet"
 	writeParquetViaDuck(ctx, t, env,
 		fmt.Sprintf("SELECT * FROM read_parquet('s3://%s/%s') WHERE 1=0", env.Cluster.Bucket, keys[0]),
 		emptyKey)
@@ -232,7 +232,7 @@ func TestParquetCorruption_WrongSchemaFile_GlobHint(t *testing.T) {
 
 	// The rogue file is NOT manifest-registered: only the hinted glob can
 	// reach it, which is exactly the bypass under test.
-	wrongKey := schemaKeyPrefix(env, wide) + "wrong_schema_glob_zzz.parquet"
+	wrongKey := buildSchemaKeyPrefix(env, wide) + "wrong_schema_glob_zzz.parquet"
 	writeParquetViaDuck(ctx, t, env, "SELECT 1 AS wrong_col, 'x' AS other_col", wrongKey)
 
 	failCtx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/internal/e2e_harness/production/parquet_fault_helpers_e2e_test.go
+++ b/internal/e2e_harness/production/parquet_fault_helpers_e2e_test.go
@@ -25,7 +25,7 @@ func schemaParquetKeys(ctx context.Context, t *testing.T, env *Env, schema Schem
 	}
 	var got []string
 	for _, k := range keys {
-		if strings.HasPrefix(k, schemaKeyPrefix(env, schema)) &&
+		if strings.HasPrefix(k, buildSchemaKeyPrefix(env, schema)) &&
 			strings.HasSuffix(k, ".parquet") && !strings.Contains(k, "/_tmp/") {
 			got = append(got, k)
 		}

--- a/internal/e2e_harness/production/state_snapshot_helpers_e2e_test.go
+++ b/internal/e2e_harness/production/state_snapshot_helpers_e2e_test.go
@@ -1,0 +1,118 @@
+//go:build e2e
+
+package production
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// s3ObjectStat is one object's mutation-detection fingerprint. An in-place
+// overwrite that reuses a deterministic key can be byte-identical: the init
+// re-export was measured reproducing the same parquet bytes, leaving Size and
+// ETag unchanged, so for data objects this leg can rest on LastModified
+// alone — which S3 reports at one-second granularity. Treat it as
+// best-effort; schemaS3State's manifest leg is the unconditional detector.
+type s3ObjectStat struct {
+	Size         int64
+	ETag         string
+	LastModified time.Time
+}
+
+// snapshotS3Inventory stats every object under prefix (hoisted from the
+// dry-run test when #248 gave it a second consumer; the prefix parameter
+// lets callers scope to one schema's partition or a single key).
+func snapshotS3Inventory(t *testing.T, ctx context.Context, env *Env, prefix string) map[string]s3ObjectStat {
+	t.Helper()
+	inv := make(map[string]s3ObjectStat)
+	var token *string
+	for {
+		out, err := env.Cluster.S3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(env.Cluster.Bucket),
+			Prefix:            aws.String(prefix),
+			ContinuationToken: token,
+		})
+		if err != nil {
+			t.Fatalf("snapshot s3 inventory: %v", err)
+		}
+		for _, obj := range out.Contents {
+			stat := s3ObjectStat{Size: aws.ToInt64(obj.Size), ETag: aws.ToString(obj.ETag)}
+			if obj.LastModified != nil {
+				stat.LastModified = obj.LastModified.UTC()
+			}
+			inv[aws.ToString(obj.Key)] = stat
+		}
+		if out.NextContinuationToken == nil {
+			return inv
+		}
+		token = out.NextContinuationToken
+	}
+}
+
+// snapshotManifest returns the manifest's raw bytes and ETag. Callers snapshot
+// only after the schema's manifest exists — a load failure here is a test
+// bug, not a skip.
+func snapshotManifest(t *testing.T, ctx context.Context, env *Env, schema SchemaRef) ([]byte, string) {
+	t.Helper()
+	store := &manifest.S3Store{Client: env.Cluster.S3, Bucket: env.Cluster.Bucket}
+	resolver := manifest.PathResolver{Prefix: env.CDC.ManifestPrefix, PathTemplate: env.CDC.ManifestTemplate}
+	path, err := resolver.Resolve(schema.ID)
+	if err != nil {
+		t.Fatalf("resolve manifest path for schema %d: %v", schema.ID, err)
+	}
+	raw, etag, err := store.Load(ctx, path)
+	if err != nil {
+		t.Fatalf("load manifest %s (seed must have created it): %v", path, err)
+	}
+	return raw, etag
+}
+
+// schemaS3State is one schema's full observable S3 surface: every object
+// under its partition plus its manifest object, with the manifest's raw
+// bytes. The key diff in InitReport.NewObjects cannot see an overwrite that
+// reuses a deterministic key, and a base-path set comparison cannot see a
+// manifest rewritten with the same paths; stat + byte identity can (#248).
+//
+// The manifest is the leg that always fires: any rewrite increments its
+// version field, so its bytes and ETag necessarily move even when the data
+// objects beside it are reproduced byte-for-byte (see s3ObjectStat).
+type schemaS3State struct {
+	objects      map[string]s3ObjectStat
+	manifestRaw  []byte
+	manifestETag string
+}
+
+func captureSchemaS3State(t *testing.T, ctx context.Context, env *Env, schema SchemaRef) schemaS3State {
+	t.Helper()
+	objects := snapshotS3Inventory(t, ctx, env, buildSchemaKeyPrefix(env, schema))
+	manifestKey := fmt.Sprintf("%s/manifest/%d.json", env.S3Prefix, schema.ID)
+	for k, stat := range snapshotS3Inventory(t, ctx, env, manifestKey) {
+		objects[k] = stat
+	}
+	raw, etag := snapshotManifest(t, ctx, env, schema)
+	return schemaS3State{objects: objects, manifestRaw: raw, manifestETag: etag}
+}
+
+// assertSchemaS3StateUnchanged requires exact identity — same key set, same
+// per-object size/ETag/LastModified, byte-identical manifest — so both
+// creations/deletions and in-place mutations fail the no-write contract.
+func assertSchemaS3StateUnchanged(t *testing.T, label string, before, after schemaS3State) {
+	t.Helper()
+	if !reflect.DeepEqual(before.objects, after.objects) {
+		t.Errorf("%s: schema objects mutated:\n before: %+v\n after:  %+v",
+			label, before.objects, after.objects)
+	}
+	if before.manifestETag != after.manifestETag || !bytes.Equal(before.manifestRaw, after.manifestRaw) {
+		t.Errorf("%s: schema manifest rewritten in place: etag %s -> %s\n before: %s\n after:  %s",
+			label, before.manifestETag, after.manifestETag, before.manifestRaw, after.manifestRaw)
+	}
+}

--- a/internal/e2e_harness/production/state_snapshot_helpers_e2e_test.go
+++ b/internal/e2e_harness/production/state_snapshot_helpers_e2e_test.go
@@ -28,8 +28,8 @@ type s3ObjectStat struct {
 	LastModified time.Time
 }
 
-// snapshotS3Inventory stats every object under prefix (hoisted from the
-// dry-run test when #248 gave it a second consumer; the prefix parameter
+// snapshotS3Inventory stats every object under prefix (hoisted when #248
+// added a consumer needing a schema-scoped prefix; the prefix parameter
 // lets callers scope to one schema's partition or a single key).
 func snapshotS3Inventory(t *testing.T, ctx context.Context, env *Env, prefix string) map[string]s3ObjectStat {
 	t.Helper()
@@ -82,9 +82,9 @@ func snapshotManifest(t *testing.T, ctx context.Context, env *Env, schema Schema
 // reuses a deterministic key, and a base-path set comparison cannot see a
 // manifest rewritten with the same paths; stat + byte identity can (#248).
 //
-// The manifest is the leg that always fires: any rewrite increments its
-// version field, so its bytes and ETag necessarily move even when the data
-// objects beside it are reproduced byte-for-byte (see s3ObjectStat).
+// The manifest is the leg that always fires: any save through the manifest
+// store increments its version field, so its bytes and ETag necessarily move
+// even when the data objects beside it are reproduced byte-for-byte (see s3ObjectStat).
 type schemaS3State struct {
 	objects      map[string]s3ObjectStat
 	manifestRaw  []byte


### PR DESCRIPTION
Closes #248

Test-only hardening of the production e2e harness, per the plan on the issue ([plan](https://github.com/Lychee-Technology/forma/issues/248#issuecomment-5347935727), [execution evidence](https://github.com/Lychee-Technology/forma/issues/248#issuecomment-5348124521)).

## What changed

1. **Sibling snapshot closes the overwrite blind spot (issue item 1).** `TestInitSchemaScopedIsolation` proved "scoped init never touches the sibling" only via the `InitReport.NewObjects` key diff and a `buildBasePaths` set comparison — both blind to in-place overwrites (deterministic `min_max` keys) and to a manifest rewritten with the same paths. The test now captures the sibling's full observable S3 surface (every partition object + the manifest object, each with size/ETag/LastModified, plus manifest raw bytes + ETag) before the target-scoped rerun and requires exact identity after. `snapshotS3Inventory`/`snapshotManifest`/`s3ObjectStat` are hoisted from the dry-run test into `state_snapshot_helpers_e2e_test.go`, with `snapshotS3Inventory` gaining a prefix parameter (both pre-existing consumers — `captureState`, `compaction_e2e_test.go` — pass the old hardcoded prefix verbatim).
2. **Routing assertion guards the base-tier oracle (issue item 2).** The final clear-and-count check now goes through `assertFederatedRowCount`, which additionally asserts `result.Plan.Routing.UseDuckDB` — a PostgreSQL-only routing regression would still count 5 `entity_main` rows. The issue's optional note is included: the two #176 rerun tests (`TestInitRerunIdempotency`, `TestInitRerunAfterChangesReconcilesManifest`) got the same strengthening.
3. **Verb-first renames (issue item 3).** `schemaKeyPrefix` → `buildSchemaKeyPrefix`, `finalsForSchema` → `filterFinalsForSchema`, swept across the whole package (call sites now include the #347-era consumers, not just the two #186 files).

## Mutation verification (acceptance criteria)

- **Sibling overwrite turns the test red.** The plan's original probe (garbage-bytes PutObject) was replaced by ruling — it would corrupt the base tier and fail the final oracle for the wrong reason. The shipped probe was the exact regression class: `sleep 1.1s` + `env.RunInit(ctx, second)` (in-place sibling re-export, valid data, same keys). Old test with probe: **PASS** (false negative proven). New assertions with probe: **FAIL**, both legs firing — `schema manifest rewritten in place` (ETag + raw bytes, version 1→2) and `schema objects mutated` (parquet caught by LastModified only). Probe removed: green.
- **Empirical finding en route:** the init re-export is **byte-deterministic** (same size, same ETag) — the plan's comment rationale claiming a re-export "also changes bytes" was falsified by measurement and the committed comments state the observed behavior instead: the object leg may rest on LastModified (1s granularity) alone; the manifest leg (version increments on every save through the manifest store) is the unconditional detector.
- **Non-DuckDB routing turns the parity check red.** Temporary `PreferHot: true` (forces the PostgreSQL-only path per `EvaluateRoutingPolicy`) → **FAIL** with `did not route to duckdb`; reverted → green.

## Verification

- `make fmt-check`, `make lint`, `make test`, `make test-e2e-production` all green at the review head (5381131; 529fb38 on top is a comment-only polish, fmt+lint re-verified) (no flakes, no re-runs needed).
- Whole-branch review (0 critical/important findings): deferred follow-ups — manifest-key derivation is duplicated in 4 places (two pre-existing) and could route through `manifest.PathResolver`; `assertFederatedRowCount` (pre-existing) lacks a nil-`Plan` guard; `snapshotManifest`'s "seed must have created it" hint misattributes a hypothetical deletion regression. Follow-up: #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
