### PR TITLE
test: close two guards that cannot fail for the regressions they name (#321)

### DIFF
--- a/cmd/lambda/main_test.go
+++ b/cmd/lambda/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -20,42 +22,102 @@ func TestBootstrapLambda_CanceledContext(t *testing.T) {
 	}
 }
 
+// knownManagerBuilders are the cmd/ directories that build an EntityManager
+// today. The walk below discovers directories rather than reading this list, so
+// this is a floor and never a ceiling: it exists only so a walk that finds
+// nothing — wrong root, renamed directory, a scan that matches no files — fails
+// loudly instead of passing vacuously.
+var knownManagerBuilders = []string{"lambda", "server", "sample"}
+
 // TestEntityConfigFromEnvWiredInEveryWriteEntryPoint guards that every entry point
-// serving the write API overlays the entity config from the environment, so the
-// #314 staged rollout (VALIDATE_UPDATES_STRICT) is available on all deployment
-// targets rather than only the ones someone remembered to wire.
+// building an EntityManager overlays the entity config from the environment, so
+// the #314 staged rollout (VALIDATE_UPDATES_STRICT) is available on all
+// deployment targets rather than only the ones someone remembered to wire.
+//
+// It walks every directory under cmd/ and matches the "factory.NewEntityManager"
+// prefix, so an entry point added later is read without anyone updating this
+// test, and the WithConfig / WithConfigContext wrappers — and any future one —
+// all count. Before #321 the directories were a hardcoded pair and the match was
+// the exact WithConfigContext spelling, so the regression this comment names
+// could not fail it: a scratch cmd/apiworker went unread, and the already
+// existing cmd/sample used the unmatched WithConfig wrapper.
+//
+// Classification is per directory, not per file, so an entry point that builds
+// its manager outside main.go is still covered.
 //
 // This is a source-level guard rather than a wiring test on purpose.
 // bootstrapLambda takes no injection seams and connects to a real database before
 // reaching the config assignment, so exercising the wiring would need a live
-// Postgres/DSQL — a heavyweight harness for a one-line assignment. Scanning the
-// source costs nothing and catches the regression that actually matters: a third
-// entry point added later that builds an EntityManager and forgets the overlay.
+// Postgres/DSQL — a heavyweight harness for a one-line assignment. What a source
+// scan cannot see remains: replacing the call with a comment naming the symbol
+// still passes.
 //
-// It lives in this package because cmd/ has no shared test package; it
-// deliberately covers cmd/server too rather than being duplicated in both.
+// It lives in this package because cmd/ has no shared test package.
 func TestEntityConfigFromEnvWiredInEveryWriteEntryPoint(t *testing.T) {
 	// Relative to this package directory, which is the cwd for `go test`.
-	entryPoints := map[string]string{
-		"cmd/lambda": "main.go",
-		"cmd/server": "../server/main.go",
+	const cmdDir = ".."
+
+	entries, err := os.ReadDir(cmdDir)
+	if err != nil {
+		t.Fatalf("failed to read cmd directory %s: %v", cmdDir, err)
 	}
 
-	for name, path := range entryPoints {
-		source, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("failed to read %s entry point %s: %v", name, path, err)
-		}
-		text := string(source)
-
-		// Only entry points that actually build an EntityManager need the overlay.
-		if !strings.Contains(text, "NewEntityManagerWithConfigContext") {
+	buildsManager := map[string]bool{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
 			continue
 		}
-		if !strings.Contains(text, "bootstrap.EntityConfigFromEnv") {
-			t.Errorf("%s builds an EntityManager but never calls "+
+		builds, overlays, err := scanEntryPointDir(filepath.Join(cmdDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("failed to scan cmd/%s: %v", entry.Name(), err)
+		}
+		if !builds {
+			continue
+		}
+		buildsManager[entry.Name()] = true
+		if !overlays {
+			t.Errorf("cmd/%s builds an EntityManager but never calls "+
 				"bootstrap.EntityConfigFromEnv, so VALIDATE_UPDATES_STRICT is silently "+
-				"ignored on that deployment target (#314)", name)
+				"ignored on that deployment target (#314)", entry.Name())
 		}
 	}
+
+	for _, name := range knownManagerBuilders {
+		if !buildsManager[name] {
+			t.Errorf("the walk did not classify cmd/%s as building an EntityManager; "+
+				"it is reading the wrong tree or matching nothing, so its green would be "+
+				"meaningless (#321)", name)
+		}
+	}
+}
+
+// scanEntryPointDir reports whether any non-test Go file directly in dir builds
+// an EntityManager, and whether any of them applies the environment overlay.
+func scanEntryPointDir(dir string) (builds, overlays bool, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, false, fmt.Errorf("failed to read %s: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return false, false, fmt.Errorf("failed to read %s: %w", path, err)
+		}
+		text := string(source)
+		// The prefix, not one exact wrapper: WithConfig and WithConfigContext both
+		// build a manager, and so will the next wrapper.
+		if strings.Contains(text, "factory.NewEntityManager") {
+			builds = true
+		}
+		if strings.Contains(text, "bootstrap.EntityConfigFromEnv") {
+			overlays = true
+		}
+	}
+	return builds, overlays, nil
 }

--- a/cmd/lambda/main_test.go
+++ b/cmd/lambda/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,8 +26,12 @@ func TestBootstrapLambda_CanceledContext(t *testing.T) {
 // knownManagerBuilders are the cmd/ directories that build an EntityManager
 // today. The walk below discovers directories rather than reading this list, so
 // this is a floor and never a ceiling: it exists only so a walk that finds
-// nothing — wrong root, renamed directory, a scan that matches no files — fails
-// loudly instead of passing vacuously.
+// nothing — wrong root, a scan that matches no files — fails loudly instead of
+// passing vacuously.
+//
+// Because it is indexed by directory name, renaming an entry point turns this
+// red until the name here is updated. That is deliberate: a rename is exactly
+// when the walk silently reading the wrong tree is most likely.
 var knownManagerBuilders = []string{"lambda", "server", "sample"}
 
 // TestEntityConfigFromEnvWiredInEveryWriteEntryPoint guards that every entry point
@@ -34,23 +39,33 @@ var knownManagerBuilders = []string{"lambda", "server", "sample"}
 // the #314 staged rollout (VALIDATE_UPDATES_STRICT) is available on all
 // deployment targets rather than only the ones someone remembered to wire.
 //
-// It walks every directory under cmd/ and matches the "factory.NewEntityManager"
-// prefix, so an entry point added later is read without anyone updating this
-// test, and the WithConfig / WithConfigContext wrappers — and any future one —
-// all count. Before #321 the directories were a hardcoded pair and the match was
-// the exact WithConfigContext spelling, so the regression this comment names
-// could not fail it: a scratch cmd/apiworker went unread, and the already
-// existing cmd/sample used the unmatched WithConfig wrapper.
+// For each child directory of cmd/ it reads every non-test Go file in that
+// child's whole subtree and matches the "factory.NewEntityManager" prefix, so an
+// entry point added later is read without anyone updating this test, and the
+// WithConfig / WithConfigContext wrappers — and any future one — all count.
+// Before #321 the directories were a hardcoded pair and the match was the exact
+// WithConfigContext spelling, so the regression this comment names could not fail
+// it: a scratch cmd/apiworker went unread, and the already existing cmd/sample
+// used the unmatched WithConfig wrapper.
 //
-// Classification is per directory, not per file, so an entry point that builds
-// its manager outside main.go is still covered.
+// The unit of judgement is that whole subtree, not a single file. One cmd/<name>
+// tree is one binary, so an entry point that builds its manager outside main.go,
+// or applies the overlay from a sibling file or a helper subpackage, is wired and
+// must pass. The cost is the converse: a tree where the overlay call sits in a
+// file that is not on the path to the manager also passes. Attributing the
+// overlay to the file that builds the manager would trade that for false
+// failures on the ordinary split-across-files wiring, which is the more common
+// shape — and a substring scan cannot tell a reachable call from a dead one
+// either way.
 //
 // This is a source-level guard rather than a wiring test on purpose.
 // bootstrapLambda takes no injection seams and connects to a real database before
 // reaching the config assignment, so exercising the wiring would need a live
 // Postgres/DSQL — a heavyweight harness for a one-line assignment. What a source
-// scan cannot see remains: replacing the call with a comment naming the symbol
-// still passes.
+// scan cannot see remains, for the call and the overlay alike: writing either
+// symbol in a comment satisfies the scan without wiring anything. Observed, not
+// assumed — the first #321 probe passed on its own doc comment. Closing that
+// needs an AST parse (#429).
 //
 // It lives in this package because cmd/ has no shared test package.
 func TestEntityConfigFromEnvWiredInEveryWriteEntryPoint(t *testing.T) {
@@ -91,23 +106,25 @@ func TestEntityConfigFromEnvWiredInEveryWriteEntryPoint(t *testing.T) {
 	}
 }
 
-// scanEntryPointDir reports whether any non-test Go file directly in dir builds
-// an EntityManager, and whether any of them applies the environment overlay.
+// scanEntryPointDir reports whether any non-test Go file anywhere in dir's
+// subtree builds an EntityManager, and whether any of them applies the
+// environment overlay.
+//
+// The whole subtree, not just dir itself: a nested package under cmd/<name> is
+// part of that binary, and an entry point that grew a subdirectory would
+// otherwise go unread — the same "never looked" hole #321 is about.
 func scanEntryPointDir(dir string) (builds, overlays bool, err error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false, false, fmt.Errorf("failed to read %s: %w", dir, err)
-	}
-
-	for _, entry := range entries {
+	err = filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
+			return nil
 		}
-		path := filepath.Join(dir, name)
 		source, err := os.ReadFile(path)
 		if err != nil {
-			return false, false, fmt.Errorf("failed to read %s: %w", path, err)
+			return fmt.Errorf("failed to read %s: %w", path, err)
 		}
 		text := string(source)
 		// The prefix, not one exact wrapper: WithConfig and WithConfigContext both
@@ -118,6 +135,10 @@ func scanEntryPointDir(dir string) (builds, overlays bool, err error) {
 		if strings.Contains(text, "bootstrap.EntityConfigFromEnv") {
 			overlays = true
 		}
+		return nil
+	})
+	if err != nil {
+		return false, false, fmt.Errorf("failed to walk %s: %w", dir, err)
 	}
 	return builds, overlays, nil
 }

--- a/cmd/sample/main.go
+++ b/cmd/sample/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/lychee-technology/forma/internal/bootstrap"
 	"github.com/lychee-technology/forma/internal/schemameta"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -121,6 +122,11 @@ func main() {
 	config.Database.TableNames.ChangeLog = "change_log_sample"
 
 	config.Entity.SchemaDirectory = *schemaDir
+
+	// The importer is a write path, so it honours the #314 staged rollout
+	// (VALIDATE_UPDATES_STRICT) like the other entry points that build an
+	// EntityManager. Pinned by cmd/lambda's entry-point walk (#321).
+	config.Entity = bootstrap.EntityConfigFromEnv(config.Entity)
 
 	// Clear sample tables before import
 	sugar.Infof("Clearing sample tables...")

--- a/internal/transform/relation_root_required_policy_test.go
+++ b/internal/transform/relation_root_required_policy_test.go
@@ -36,6 +36,16 @@ func relationRootPolicyRegistry() *stubSchemaRegistry {
 			// Outside every relation root: still enforced.
 			"propertySnapshot.price":  {AttributeID: 5, ValueType: forma.ValueTypeNumeric},
 			"propertySnapshot.status": {AttributeID: 6, ValueType: forma.ValueTypeText, RequiredPolicy: forma.RequiredPolicyIfParentPresent},
+
+			// Shares the relation root's characters but not its dot boundary, so
+			// it is an ordinary attribute and stays enforced (#321). The policy is
+			// required_if_parent_present rather than required_always so these two
+			// stay inert in the other tests here, which share this registry and
+			// supply only "id".
+			// IDs skip 7, which the relation-root-itself test below claims for
+			// "contactSnapshot"; missingRequired is keyed by attribute ID.
+			"contactSnapshotExtra.note":   {AttributeID: 10, ValueType: forma.ValueTypeText},
+			"contactSnapshotExtra.status": {AttributeID: 11, ValueType: forma.ValueTypeText, RequiredPolicy: forma.RequiredPolicyIfParentPresent},
 		},
 	}
 }
@@ -122,6 +132,35 @@ func TestFromEAVRecordsEnforcesRequiredPolicyOnRelationRootItself(t *testing.T) 
 		t.Fatal("a required policy on the relation root name itself is not covered by the carve-out")
 	}
 	if !strings.Contains(err.Error(), "missing required attribute 'contactSnapshot'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestFromEAVRecordsEnforcesRequiredPolicyOnSamePrefixSibling pins the other
+// half of Covers' boundary: the separator, not the characters.
+//
+// contactSnapshotExtra merely starts with the relation root's name. It is an
+// ordinary attribute, so its required policy stays enforced — and the sibling
+// supplied here is what makes its parent "present". Covers scans dot positions
+// precisely so this name does not match; a naive
+// strings.HasPrefix(name, root) && name != root would swallow it, and before
+// #321 nothing in the suite failed under that mutation.
+//
+// This is the twin of TestStripKeepsSamePrefixSibling, which pins the same
+// boundary on the strip predicate (RelationIndex.coversRelationSubtree).
+func TestFromEAVRecordsEnforcesRequiredPolicyOnSamePrefixSibling(t *testing.T) {
+	converter, rowID := relationRootPolicyConverter(t)
+
+	id := "visit-1"
+	note := "ordinary attribute"
+	_, err := converter.FromEAVRecords([]model.EAVRecord{
+		{SchemaID: 500, RowID: rowID, AttrID: 1, ValueText: &id},
+		{SchemaID: 500, RowID: rowID, AttrID: 10, ValueText: &note},
+	})
+	if err == nil {
+		t.Fatal("contactSnapshotExtra shares the root's characters but not its dot boundary, so its required policy must still be enforced")
+	}
+	if !strings.Contains(err.Error(), "missing required attribute 'contactSnapshotExtra.status'") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/transform/relation_root_required_policy_test.go
+++ b/internal/transform/relation_root_required_policy_test.go
@@ -146,8 +146,12 @@ func TestFromEAVRecordsEnforcesRequiredPolicyOnRelationRootItself(t *testing.T) 
 // strings.HasPrefix(name, root) && name != root would swallow it, and before
 // #321 nothing in the suite failed under that mutation.
 //
-// This is the twin of TestStripKeepsSamePrefixSibling, which pins the same
-// boundary on the strip predicate (RelationIndex.coversRelationSubtree).
+// It pins the validation half only, deliberately: Covers governs nothing else.
+// The payload strip does not consult this set (relation_roots.go), so whether
+// the sibling still expands is the strip predicate's question, pinned by the
+// twin TestStripKeepsSamePrefixSibling (internal/relation_index_strip_test.go)
+// on RelationIndex.coversRelationSubtree. Between the two, the boundary is held
+// on both halves.
 func TestFromEAVRecordsEnforcesRequiredPolicyOnSamePrefixSibling(t *testing.T) {
 	converter, rowID := relationRootPolicyConverter(t)
 


### PR DESCRIPTION
Closes #321.

Two guards whose comments named a regression they could not fail, plus the
one-line wiring gap the second guard's widening exposed.

## What changed

**`internal/transform/relation_root_required_policy_test.go`** — pins
`RelationRoots.Covers` on the separator rather than the characters. The fixture
gains `contactSnapshotExtra.note` / `contactSnapshotExtra.status` alongside the
`contactSnapshot` root, and the new test asserts the sibling's required policy is
still enforced. The two attributes carry `required_if_parent_present` rather than
`required_always` so they stay inert in the four tests that share this registry
and supply only `id`. This is the twin of `TestStripKeepsSamePrefixSibling`,
which already pins the same boundary on `RelationIndex.coversRelationSubtree`.

**`cmd/sample/main.go`** — applies `bootstrap.EntityConfigFromEnv`. The CSV bulk
importer is a real write path but built its manager from `DefaultConfig` alone,
so `VALIDATE_UPDATES_STRICT` was silently ignored there. `EntityConfigFromEnv`
copies its input and touches only `ValidateUpdatesStrict`, so the
`SchemaDirectory` assigned just above survives.

**`cmd/lambda/main_test.go`** — the entry-point guard now walks every directory
under `cmd/` and matches the `factory.NewEntityManager` prefix, per directory
rather than per file. Both wrappers count, and a directory added later is read
without anyone updating the test. Comment rewritten to what the walk actually
does.

An **anti-vacuity floor** was added beyond the issue's ask: after the walk,
assert `lambda`, `server` and `sample` were all classified as manager builders.
It is a floor, not a ceiling — new entry points are still discovered, never
enumerated. Without it, a wrong root, a renamed directory, or a scan that matches
nothing passes while reading zero files, which is this issue's failure shape
relocated rather than fixed.

## Verification — every guard was watched failing

Both issue premises were re-checked against `main` at `eb1302c` first, not
inherited from #314.

| Mutation | Expected | Result |
|---|---|---|
| `Covers` → naive `strings.HasPrefix(name, root) && name != root`, whole unit tier | red | **before this PR: green** (28 packages, zero failures) |
| same mutant, after the new pin | red | red — `TestFromEAVRecordsEnforcesRequiredPolicyOnSamePrefixSibling`, and only it |
| scratch `cmd/scratchworker` calling `NewEntityManagerWithConfigContext` | red | red |
| same probe using the `NewEntityManagerWithConfig` wrapper | red | red (the spelling the old gate substring missed) |
| walk root pointed at a tree with no `cmd` directories | red | red — all three anti-vacuity assertions fire |
| `cmd/sample` overlay line deleted | red | red |

The `Covers` mutations ran under `go test -overlay=` so the working tree was
never modified; the `cmd/` probes need real files, and the tree was verified
clean after each.

**One incidental finding, worth recording.** The first `cmd/scratchworker` probe
passed. The cause was the probe's own doc comment, which contained the words
`bootstrap.EntityConfigFromEnv` — so the source scan counted the entry point as
wired. That is the scan's known, documented blind spot (a comment naming the
symbol satisfies it), and this is the first time it has actually been observed
rather than assumed. It stays acknowledged in the test comment rather than fixed;
closing it means parsing the AST for a call expression, which is more machinery
than a two-substring gate deserves. Filed as nothing — noting it here so the next
reader of that comment knows it is measured, not theoretical.

## Not covered

- No e2e tier. None of the three changes touches the federated, CDC or compaction
  paths.
- `make fmt-check`, `make lint` (v1.64.8) and `make test` all clean.
