### PR TITLE
refactor(e2e): #324 dedupe Postgres-only scan source, split ExecuteFederatedQuery, guard function size

### DIFF
--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -29,13 +29,13 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 	tradeTimeOnlyProjection := usesTradeTimeOnlyBenchmarkProjectionForSelect(opts)
 	if needsBenchmarkDuckDBMacros(opts, benchmarkProjection, tradeTimeOnlyProjection) {
 		if err := prepareBenchmarkDuckDBMacros(ctx, h); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("prepare benchmark duckdb macros: %w", err)
 		}
 	}
 
 	tiers, err := h.probeFederatedTiers(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("probe federated tiers: %w", err)
 	}
 	if tiers.isEmpty() {
 		return h.ExecutePostgresQuery(ctx, opts)
@@ -57,7 +57,8 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 		return nil, fmt.Errorf("count query: %w", err)
 	}
 	if opts.CountOnly {
-		return &QueryResult{TotalRecords: totalRecords, Duration: time.Since(start), Plan: tiers.executionPlan(time.Since(start))}, nil
+		countDuration := time.Since(start)
+		return &QueryResult{TotalRecords: totalRecords, Duration: countDuration, Plan: tiers.executionPlan(countDuration)}, nil
 	}
 	if shouldSkipFederatedSelect(totalRecords, opts.Offset) {
 		return tiers.emptyPageResult(totalRecords, time.Since(start)), nil
@@ -74,7 +75,7 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 
 	records, err := h.scanQueryResults(rows, benchmarkProjection)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("scan query results: %w", err)
 	}
 
 	duration := time.Since(start)

--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -94,7 +94,7 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 func (h *FederatedTestHarness) executePreferHotQuery(ctx context.Context, opts *QueryOptions, start time.Time) (*QueryResult, error) {
 	result, err := h.ExecutePostgresQuery(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("prefer-hot postgres query: %w", err)
 	}
 	if result.Plan == nil {
 		result.Plan = &model.ExecutionPlan{Notes: []string{}, Timings: map[string]int64{}}
@@ -119,6 +119,10 @@ func (s federatedTierState) isEmpty() bool {
 	return !s.hasBaseFiles && !s.hasDeltaFiles && len(s.dirtyIDs) == 0
 }
 
+// executionPlan adapts the probe's three fields to buildExecutionPlan, which is
+// the plan vocabulary shared with buildPostgresOnlyExecutionPlan. It exists to
+// keep the four-argument unpacking out of three call sites in
+// ExecuteFederatedQuery, not to add a layer over the builder.
 func (s federatedTierState) executionPlan(duration time.Duration) *model.ExecutionPlan {
 	return buildExecutionPlan(len(s.dirtyIDs), s.hasBaseFiles, s.hasDeltaFiles, duration)
 }
@@ -142,7 +146,7 @@ func (s federatedTierState) emptyPageResult(totalRecords int64, duration time.Du
 func (h *FederatedTestHarness) probeFederatedTiers(ctx context.Context) (federatedTierState, error) {
 	hasBaseFiles, hasDeltaFiles, err := h.checkTierFiles(ctx)
 	if err != nil {
-		return federatedTierState{}, err
+		return federatedTierState{}, fmt.Errorf("check tier files: %w", err)
 	}
 	dirtyIDs, err := h.getDirtyIDs(ctx)
 	if err != nil {

--- a/internal/e2e_harness/federated/query.go
+++ b/internal/e2e_harness/federated/query.go
@@ -23,17 +23,7 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 	opts = normalizeQueryOptions(opts)
 	start := time.Now()
 	if opts.PreferHot {
-		result, err := h.ExecutePostgresQuery(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
-		if result.Plan == nil {
-			result.Plan = &model.ExecutionPlan{Notes: []string{}, Timings: map[string]int64{}}
-		}
-		result.Plan.Notes = append(result.Plan.Notes, "prefer_hot_override", "postgres_only_execution")
-		result.Plan.Timings["total"] = time.Since(start).Milliseconds()
-		result.Duration = time.Since(start)
-		return result, nil
+		return h.executePreferHotQuery(ctx, opts, start)
 	}
 	benchmarkProjection := usesBenchmarkProjectionForSelect(opts)
 	tradeTimeOnlyProjection := usesTradeTimeOnlyBenchmarkProjectionForSelect(opts)
@@ -43,20 +33,11 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 		}
 	}
 
-	// Check which tiers have parquet files
-	hasBaseFiles, hasDeltaFiles, err := h.checkTierFiles(ctx)
+	tiers, err := h.probeFederatedTiers(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get dirty IDs from change_log
-	dirtyIDs, err := h.getDirtyIDs(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get dirty ids: %w", err)
-	}
-
-	// If no parquet files exist and no hot records, fall back to Postgres-only query
-	if !hasBaseFiles && !hasDeltaFiles && len(dirtyIDs) == 0 {
+	if tiers.isEmpty() {
 		return h.ExecutePostgresQuery(ctx, opts)
 	}
 
@@ -65,8 +46,8 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 	deltaPath := fmt.Sprintf("s3://%s/%s/%d/delta/*.parquet", h.S3Bucket, h.S3Prefix, h.SchemaID)
 
 	// Build and execute the federated query
-	query := h.buildFederatedQuerySQLDynamic(basePath, deltaPath, hasBaseFiles, hasDeltaFiles, dirtyIDs, opts)
-	countQuery := h.buildFederatedQueryCountSQLDynamic(basePath, deltaPath, hasBaseFiles, hasDeltaFiles, dirtyIDs, opts)
+	query := h.buildFederatedQuerySQLDynamic(basePath, deltaPath, tiers.hasBaseFiles, tiers.hasDeltaFiles, tiers.dirtyIDs, opts)
+	countQuery := h.buildFederatedQueryCountSQLDynamic(basePath, deltaPath, tiers.hasBaseFiles, tiers.hasDeltaFiles, tiers.dirtyIDs, opts)
 
 	var totalRecords int64
 	if err := h.Duck.DB.QueryRowContext(ctx, countQuery).Scan(&totalRecords); err != nil {
@@ -76,17 +57,10 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 		return nil, fmt.Errorf("count query: %w", err)
 	}
 	if opts.CountOnly {
-		return &QueryResult{TotalRecords: totalRecords, Duration: time.Since(start), Plan: buildExecutionPlan(len(dirtyIDs), hasBaseFiles, hasDeltaFiles, time.Since(start))}, nil
+		return &QueryResult{TotalRecords: totalRecords, Duration: time.Since(start), Plan: tiers.executionPlan(time.Since(start))}, nil
 	}
 	if shouldSkipFederatedSelect(totalRecords, opts.Offset) {
-		plan := buildExecutionPlan(len(dirtyIDs), hasBaseFiles, hasDeltaFiles, time.Since(start))
-		plan.Notes = append(plan.Notes, "empty_page_short_circuit")
-		return &QueryResult{
-			Records:      nil,
-			TotalRecords: totalRecords,
-			Duration:     time.Since(start),
-			Plan:         plan,
-		}, nil
+		return tiers.emptyPageResult(totalRecords, time.Since(start)), nil
 	}
 
 	rows, err := h.Duck.DB.QueryContext(ctx, query)
@@ -104,7 +78,7 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 	}
 
 	duration := time.Since(start)
-	plan := buildExecutionPlan(len(dirtyIDs), hasBaseFiles, hasDeltaFiles, duration)
+	plan := tiers.executionPlan(duration)
 
 	return &QueryResult{
 		Records:      records,
@@ -112,6 +86,69 @@ func (h *FederatedTestHarness) ExecuteFederatedQuery(ctx context.Context, opts *
 		Duration:     duration,
 		Plan:         plan,
 	}, nil
+}
+
+// executePreferHotQuery serves the PreferHot override, which is a separate
+// execution path rather than a step in the federated one: it answers straight
+// from Postgres and only annotates the plan to say why.
+func (h *FederatedTestHarness) executePreferHotQuery(ctx context.Context, opts *QueryOptions, start time.Time) (*QueryResult, error) {
+	result, err := h.ExecutePostgresQuery(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	if result.Plan == nil {
+		result.Plan = &model.ExecutionPlan{Notes: []string{}, Timings: map[string]int64{}}
+	}
+	result.Plan.Notes = append(result.Plan.Notes, "prefer_hot_override", "postgres_only_execution")
+	result.Plan.Timings["total"] = time.Since(start).Milliseconds()
+	result.Duration = time.Since(start)
+	return result, nil
+}
+
+// federatedTierState is what one probe of the three tiers found: which parquet
+// tiers have files, and which row IDs are still unflushed in Postgres.
+type federatedTierState struct {
+	hasBaseFiles  bool
+	hasDeltaFiles bool
+	dirtyIDs      []uuid.UUID
+}
+
+// isEmpty reports that there is nothing for DuckDB to federate — no parquet in
+// either tier and no hot rows — so the query belongs on Postgres alone.
+func (s federatedTierState) isEmpty() bool {
+	return !s.hasBaseFiles && !s.hasDeltaFiles && len(s.dirtyIDs) == 0
+}
+
+func (s federatedTierState) executionPlan(duration time.Duration) *model.ExecutionPlan {
+	return buildExecutionPlan(len(s.dirtyIDs), s.hasBaseFiles, s.hasDeltaFiles, duration)
+}
+
+// emptyPageResult answers a page that starts past the last row: the count is
+// still real, so it is reported, but no select is worth running.
+func (s federatedTierState) emptyPageResult(totalRecords int64, duration time.Duration) *QueryResult {
+	plan := s.executionPlan(duration)
+	plan.Notes = append(plan.Notes, "empty_page_short_circuit")
+	return &QueryResult{
+		Records:      nil,
+		TotalRecords: totalRecords,
+		Duration:     duration,
+		Plan:         plan,
+	}
+}
+
+// probeFederatedTiers gathers everything the query shape depends on: parquet
+// availability per tier plus the dirty set that decides which S3 rows are
+// discarded in favour of their hot versions.
+func (h *FederatedTestHarness) probeFederatedTiers(ctx context.Context) (federatedTierState, error) {
+	hasBaseFiles, hasDeltaFiles, err := h.checkTierFiles(ctx)
+	if err != nil {
+		return federatedTierState{}, err
+	}
+	dirtyIDs, err := h.getDirtyIDs(ctx)
+	if err != nil {
+		return federatedTierState{}, fmt.Errorf("get dirty ids: %w", err)
+	}
+	return federatedTierState{hasBaseFiles: hasBaseFiles, hasDeltaFiles: hasDeltaFiles, dirtyIDs: dirtyIDs}, nil
 }
 
 // normalizeQueryOptions sets default values for query options.

--- a/internal/e2e_harness/federated/query_file_size_test.go
+++ b/internal/e2e_harness/federated/query_file_size_test.go
@@ -43,9 +43,12 @@ func countSourceLines(source []byte) int {
 	return lines
 }
 
-func listGuardedSourceFiles() ([]string, error) {
+// listNonTestSources collects the non-test files matching the given patterns.
+// The two size guards apply the same rule to different scopes, so the scope is
+// the argument and the rule lives here once.
+func listNonTestSources(patterns ...string) ([]string, error) {
 	var files []string
-	for _, pattern := range []string{"query*.go", "harness*.go"} {
+	for _, pattern := range patterns {
 		candidates, err := filepath.Glob(pattern)
 		if err != nil {
 			return nil, fmt.Errorf("glob guarded source files %q: %w", pattern, err)
@@ -57,9 +60,13 @@ func listGuardedSourceFiles() ([]string, error) {
 		}
 	}
 	if len(files) == 0 {
-		return nil, fmt.Errorf("no guarded source files matched query*.go or harness*.go")
+		return nil, fmt.Errorf("no guarded source files matched %s", strings.Join(patterns, " or "))
 	}
 	return files, nil
+}
+
+func listGuardedSourceFiles() ([]string, error) {
+	return listNonTestSources("query*.go", "harness*.go")
 }
 
 // TestGuardedSourcesStayWithinFileSizeLimit prevents query assembly and harness

--- a/internal/e2e_harness/federated/query_function_size_test.go
+++ b/internal/e2e_harness/federated/query_function_size_test.go
@@ -1,0 +1,143 @@
+package federated
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// maxGuardedFunctionLines is coding-standard.md §7's refactoring trigger, which
+// is deliberately tighter than AGENTS.md's 100-line hard limit: the point is to
+// catch a function on its way past 80, not once it is already unmaintainable.
+const maxGuardedFunctionLines = 80
+
+type guardedFunction struct {
+	name  string
+	lines int
+}
+
+// measureFunctionLines reports the span of every function body in one source
+// file, from its func keyword through its closing brace. A doc comment sits
+// before FuncDecl.Pos() and so is not counted — the guard measures code, not
+// the explanation of it.
+func measureFunctionLines(filename string, source []byte) ([]guardedFunction, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, source, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filename, err)
+	}
+
+	var functions []guardedFunction
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		functions = append(functions, guardedFunction{
+			name:  fn.Name.Name,
+			lines: fset.Position(fn.End()).Line - fset.Position(fn.Pos()).Line + 1,
+		})
+	}
+	return functions, nil
+}
+
+// listFunctionGuardedSourceFiles deliberately does not reuse
+// listGuardedSourceFiles: that one also covers harness*.go, where
+// NewFederatedTestHarness is already past the 100-line hard limit, so pulling it
+// in would make this guard unsatisfiable without a harness.go refactor this
+// change does not own. Widening the scope is the follow-up's job (#324).
+func listFunctionGuardedSourceFiles() ([]string, error) {
+	candidates, err := filepath.Glob("query*.go")
+	if err != nil {
+		return nil, fmt.Errorf("glob function-guarded source files: %w", err)
+	}
+
+	var files []string
+	for _, name := range candidates {
+		if !strings.HasSuffix(name, "_test.go") {
+			files = append(files, name)
+		}
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no function-guarded source files matched query*.go")
+	}
+	return files, nil
+}
+
+func TestMeasureFunctionLinesSpansFuncKeywordToClosingBrace(t *testing.T) {
+	source := []byte(`package fixture
+
+// Doc comments precede the func keyword and must not be counted.
+// This second line would inflate the measurement if they were.
+func measured() int {
+	x := 1
+	return x
+}
+
+func declared()
+`)
+
+	functions, err := measureFunctionLines("fixture.go", source)
+	if err != nil {
+		t.Fatalf("measure function lines: %v", err)
+	}
+	if len(functions) != 1 {
+		t.Fatalf("expected only the function with a body, got %v", functions)
+	}
+	if functions[0].name != "measured" {
+		t.Fatalf("measured the wrong function: %q", functions[0].name)
+	}
+	if functions[0].lines != 4 {
+		t.Fatalf("measured %d lines, want 4 (func keyword through closing brace)", functions[0].lines)
+	}
+}
+
+func TestListFunctionGuardedSourceFilesScopesToQuerySources(t *testing.T) {
+	files, err := listFunctionGuardedSourceFiles()
+	if err != nil {
+		t.Fatalf("list function-guarded source files: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("expected function-guarded source files")
+	}
+	for _, name := range files {
+		if strings.HasSuffix(name, "_test.go") {
+			t.Errorf("test file %s included in function guard", name)
+		}
+		if !strings.HasPrefix(name, "query") {
+			t.Errorf("%s is outside the query*.go scope this guard can hold", name)
+		}
+	}
+}
+
+// TestGuardedFunctionsStayWithinRefactoringTrigger keeps the query assembly
+// entry points from accumulating back into oversized functions. ExecuteFederatedQuery
+// reached 94 lines because nothing was watching; this is what watches (#324).
+func TestGuardedFunctionsStayWithinRefactoringTrigger(t *testing.T) {
+	names, err := listFunctionGuardedSourceFiles()
+	if err != nil {
+		t.Fatalf("list function-guarded source files: %v", err)
+	}
+
+	for _, name := range names {
+		source, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		functions, err := measureFunctionLines(name, source)
+		if err != nil {
+			t.Fatalf("measure %s: %v", name, err)
+		}
+		for _, fn := range functions {
+			if fn.lines > maxGuardedFunctionLines {
+				t.Errorf("%s: %s has %d lines, exceeds the %d-line refactoring trigger",
+					name, fn.name, fn.lines, maxGuardedFunctionLines)
+			}
+		}
+	}
+}

--- a/internal/e2e_harness/federated/query_function_size_test.go
+++ b/internal/e2e_harness/federated/query_function_size_test.go
@@ -6,7 +6,6 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -46,27 +45,13 @@ func measureFunctionLines(filename string, source []byte) ([]guardedFunction, er
 	return functions, nil
 }
 
-// listFunctionGuardedSourceFiles deliberately does not reuse
-// listGuardedSourceFiles: that one also covers harness*.go, where
-// NewFederatedTestHarness is already past the 100-line hard limit, so pulling it
-// in would make this guard unsatisfiable without a harness.go refactor this
-// change does not own. Widening the scope is the follow-up's job (#324).
+// listFunctionGuardedSourceFiles scans a narrower set than the file-size guard,
+// which also covers harness*.go: NewFederatedTestHarness there is already past
+// the 100-line hard limit, so including it would make this guard unsatisfiable
+// without a harness.go refactor this change does not own. Widening the scope to
+// match is #431's job, at which point both guards can share one pattern list.
 func listFunctionGuardedSourceFiles() ([]string, error) {
-	candidates, err := filepath.Glob("query*.go")
-	if err != nil {
-		return nil, fmt.Errorf("glob function-guarded source files: %w", err)
-	}
-
-	var files []string
-	for _, name := range candidates {
-		if !strings.HasSuffix(name, "_test.go") {
-			files = append(files, name)
-		}
-	}
-	if len(files) == 0 {
-		return nil, fmt.Errorf("no function-guarded source files matched query*.go")
-	}
-	return files, nil
+	return listNonTestSources("query*.go")
 }
 
 func TestMeasureFunctionLinesSpansFuncKeywordToClosingBrace(t *testing.T) {

--- a/internal/e2e_harness/federated/query_postgres_build.go
+++ b/internal/e2e_harness/federated/query_postgres_build.go
@@ -33,25 +33,7 @@ func (h *FederatedTestHarness) buildPostgresOnlySelectQuery(opts *QueryOptions) 
 			COALESCE(hot_vals.trade_type, em.smallint_01::BIGINT, 0) as tradeType,
 			COALESCE(hot_vals.trade_time, em.bigint_02, 0) as tradeTime`)
 	}
-	query.WriteString(fmt.Sprintf(`
-		FROM change_log cl
-		LEFT JOIN entity_main em
-			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id = cl.row_id
-		LEFT JOIN (
-			SELECT schema_id, row_id,
-				MAX(CASE WHEN attr_id = %d THEN value_text END) AS symbol,
-				MAX(CASE WHEN attr_id = %d THEN value_text END) AS exchange,
-				MAX(CASE WHEN attr_id = %d THEN value_text END) AS region,
-				MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS trade_type,
-				MAX(CASE WHEN attr_id = %d THEN value_numeric::BIGINT END) AS trade_time,
-				MAX(CASE WHEN attr_id = %d THEN value_text END) AS name
-			FROM eav_data
-			WHERE attr_id IN (%d, %d, %d, %d, %d, %d)
-			GROUP BY schema_id, row_id
-		) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id
-		WHERE cl.schema_id = $1 AND cl.flushed_at = 0 AND (cl.deleted_at IS NULL OR cl.deleted_at = 0)`,
-		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name,
-		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name))
+	query.WriteString(buildPostgresOnlyScanSource(attrIDs))
 	filterSQL, filterArgs := buildPostgresOnlyFilterClauses(opts, 2)
 	query.WriteString(filterSQL)
 	args = append(args, filterArgs...)
@@ -64,8 +46,23 @@ func (h *FederatedTestHarness) buildPostgresOnlyCountQuery(opts *QueryOptions) (
 	args := []any{h.SchemaID}
 	attrIDs := h.benchmarkPostgresAttributeIDs()
 	query := strings.Builder{}
-	query.WriteString(fmt.Sprintf(`
-		SELECT COUNT(*)
+	query.WriteString(`
+		SELECT COUNT(*)`)
+	query.WriteString(buildPostgresOnlyScanSource(attrIDs))
+	filterSQL, filterArgs := buildPostgresOnlyFilterClauses(opts, 2)
+	query.WriteString(filterSQL)
+	args = append(args, filterArgs...)
+	return query.String(), args
+}
+
+// buildPostgresOnlyScanSource renders the FROM/JOIN/WHERE block shared by the
+// Postgres-only select and count builders: the change_log/entity_main joins, the
+// hot_vals EAV pivot, and the unflushed-and-live guard. The count has to scan
+// exactly the row set the select returns, so rendering the block once makes that
+// structural rather than a convention two copies must keep agreeing on (#324).
+// TestPostgresOnlyCountSharesSelectScanSource is the guard against re-divergence.
+func buildPostgresOnlyScanSource(attrIDs postgresBenchmarkAttributeIDs) string {
+	return fmt.Sprintf(`
 		FROM change_log cl
 		LEFT JOIN entity_main em
 			ON em.ltbase_schema_id = cl.schema_id AND em.ltbase_row_id = cl.row_id
@@ -83,11 +80,7 @@ func (h *FederatedTestHarness) buildPostgresOnlyCountQuery(opts *QueryOptions) (
 		) hot_vals ON hot_vals.schema_id = cl.schema_id AND hot_vals.row_id = cl.row_id
 		WHERE cl.schema_id = $1 AND cl.flushed_at = 0 AND (cl.deleted_at IS NULL OR cl.deleted_at = 0)`,
 		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name,
-		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name))
-	filterSQL, filterArgs := buildPostgresOnlyFilterClauses(opts, 2)
-	query.WriteString(filterSQL)
-	args = append(args, filterArgs...)
-	return query.String(), args
+		attrIDs.symbol, attrIDs.exchange, attrIDs.region, attrIDs.tradeType, attrIDs.tradeTime, attrIDs.name)
 }
 
 func buildPostgresOnlyFilterClauses(opts *QueryOptions, placeholderStart int) (string, []any) {

--- a/internal/e2e_harness/federated/query_postgres_build_test.go
+++ b/internal/e2e_harness/federated/query_postgres_build_test.go
@@ -1,0 +1,65 @@
+package federated
+
+import (
+	"strings"
+	"testing"
+)
+
+// Unit tests for query_postgres_build.go, split out of query_unit_test.go when
+// that file reached 496 of the 500-line limit. The file-size guard does not
+// watch it: listNonTestSources excludes _test.go (#324).
+
+func TestBuildPostgresOnlyQueriesSupportBenchmarkFilters(t *testing.T) {
+	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade}
+	selectQuery, _ := h.buildPostgresOnlySelectQuery(&QueryOptions{PreferHot: true, Filter: &Filter{Conditions: map[string]any{"tradeType": 0, "exchange": "NYSE"}}, TradeTimeStart: 1000, TradeTimeEnd: 2000, SortBy: "tradeTime", SortDesc: true, Limit: 20})
+	countQuery, _ := h.buildPostgresOnlyCountQuery(&QueryOptions{PreferHot: true, Filter: &Filter{Conditions: map[string]any{"tradeType": 0, "exchange": "NYSE"}}, TradeTimeStart: 1000, TradeTimeEnd: 2000})
+	for _, query := range []string{selectQuery, countQuery} {
+		for _, expected := range []string{"COALESCE(hot_vals.trade_type, em.smallint_01::BIGINT, 0)", "COALESCE(hot_vals.exchange, '')", "COALESCE(hot_vals.trade_time, em.bigint_02, 0)", "FROM change_log cl"} {
+			if !strings.Contains(query, expected) {
+				t.Fatalf("expected postgres-only query to include %q: %s", expected, query)
+			}
+		}
+	}
+	if strings.Contains(countQuery, "LIMIT") {
+		t.Fatalf("count query should not include pagination: %s", countQuery)
+	}
+}
+
+// TestPostgresOnlyCountSharesSelectScanSource pins the invariant the two
+// Postgres-only builders exist to keep: the count must scan exactly the row set
+// the select returns. The count query ends after its filters and the select
+// continues with ORDER BY/LIMIT, so the count's scan source and predicates are a
+// prefix of the select's. Comparing two independently assembled strings is what
+// makes this catch drift; asserting both contain one shared helper's output
+// would only restate that they call it (#324).
+//
+// The options carry at most one Conditions entry on purpose:
+// buildPostgresOnlyFilterClauses ranges over that map, so Go randomizes clause
+// order per call and two or more entries would make the prefix assertion flaky.
+// Ordering does not matter to the SQL — AND commutes and each builder keeps its
+// own args in step — so the constraint lives here rather than in the builders.
+func TestPostgresOnlyCountSharesSelectScanSource(t *testing.T) {
+	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade}
+	opts := func() *QueryOptions {
+		return &QueryOptions{
+			Filter:         &Filter{Conditions: map[string]any{"exchange": "NYSE"}},
+			TradeTimeStart: 1000,
+			TradeTimeEnd:   2000,
+			SortBy:         "tradeTime",
+			SortDesc:       true,
+			Limit:          20,
+		}
+	}
+	selectQuery, _ := h.buildPostgresOnlySelectQuery(opts())
+	countQuery, _ := h.buildPostgresOnlyCountQuery(opts())
+
+	const scanSourceAnchor = "FROM change_log cl"
+	selectAt := strings.Index(selectQuery, scanSourceAnchor)
+	countAt := strings.Index(countQuery, scanSourceAnchor)
+	if selectAt < 0 || countAt < 0 {
+		t.Fatalf("expected %q in both postgres-only queries:\nselect: %s\ncount: %s", scanSourceAnchor, selectQuery, countQuery)
+	}
+	if !strings.HasPrefix(selectQuery[selectAt:], countQuery[countAt:]) {
+		t.Fatalf("count scan source diverges from select scan source:\nselect: %s\ncount: %s", selectQuery[selectAt:], countQuery[countAt:])
+	}
+}

--- a/internal/e2e_harness/federated/query_unit_test.go
+++ b/internal/e2e_harness/federated/query_unit_test.go
@@ -148,61 +148,6 @@ func TestBuildParquetTierQueryAppliesPushdownSemijoin(t *testing.T) {
 	}
 }
 
-func TestBuildPostgresOnlyQueriesSupportBenchmarkFilters(t *testing.T) {
-	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade}
-	selectQuery, _ := h.buildPostgresOnlySelectQuery(&QueryOptions{PreferHot: true, Filter: &Filter{Conditions: map[string]any{"tradeType": 0, "exchange": "NYSE"}}, TradeTimeStart: 1000, TradeTimeEnd: 2000, SortBy: "tradeTime", SortDesc: true, Limit: 20})
-	countQuery, _ := h.buildPostgresOnlyCountQuery(&QueryOptions{PreferHot: true, Filter: &Filter{Conditions: map[string]any{"tradeType": 0, "exchange": "NYSE"}}, TradeTimeStart: 1000, TradeTimeEnd: 2000})
-	for _, query := range []string{selectQuery, countQuery} {
-		for _, expected := range []string{"COALESCE(hot_vals.trade_type, em.smallint_01::BIGINT, 0)", "COALESCE(hot_vals.exchange, '')", "COALESCE(hot_vals.trade_time, em.bigint_02, 0)", "FROM change_log cl"} {
-			if !strings.Contains(query, expected) {
-				t.Fatalf("expected postgres-only query to include %q: %s", expected, query)
-			}
-		}
-	}
-	if strings.Contains(countQuery, "LIMIT") {
-		t.Fatalf("count query should not include pagination: %s", countQuery)
-	}
-}
-
-// TestPostgresOnlyCountSharesSelectScanSource pins the invariant the two
-// Postgres-only builders exist to keep: the count must scan exactly the row set
-// the select returns. The count query ends after its filters and the select
-// continues with ORDER BY/LIMIT, so the count's scan source and predicates are a
-// prefix of the select's. Comparing two independently assembled strings is what
-// makes this catch drift; asserting both contain one shared helper's output
-// would only restate that they call it (#324).
-//
-// The options carry at most one Conditions entry on purpose:
-// buildPostgresOnlyFilterClauses ranges over that map, so Go randomizes clause
-// order per call and two or more entries would make the prefix assertion flaky.
-// Ordering does not matter to the SQL — AND commutes and each builder keeps its
-// own args in step — so the constraint lives here rather than in the builders.
-func TestPostgresOnlyCountSharesSelectScanSource(t *testing.T) {
-	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade}
-	opts := func() *QueryOptions {
-		return &QueryOptions{
-			Filter:         &Filter{Conditions: map[string]any{"exchange": "NYSE"}},
-			TradeTimeStart: 1000,
-			TradeTimeEnd:   2000,
-			SortBy:         "tradeTime",
-			SortDesc:       true,
-			Limit:          20,
-		}
-	}
-	selectQuery, _ := h.buildPostgresOnlySelectQuery(opts())
-	countQuery, _ := h.buildPostgresOnlyCountQuery(opts())
-
-	const scanSourceAnchor = "FROM change_log cl"
-	selectAt := strings.Index(selectQuery, scanSourceAnchor)
-	countAt := strings.Index(countQuery, scanSourceAnchor)
-	if selectAt < 0 || countAt < 0 {
-		t.Fatalf("expected %q in both postgres-only queries:\nselect: %s\ncount: %s", scanSourceAnchor, selectQuery, countQuery)
-	}
-	if !strings.HasPrefix(selectQuery[selectAt:], countQuery[countAt:]) {
-		t.Fatalf("count scan source diverges from select scan source:\nselect: %s\ncount: %s", selectQuery[selectAt:], countQuery[countAt:])
-	}
-}
-
 func TestBuildParquetTierQueryTradeTimeOnlyProjection(t *testing.T) {
 	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "base", "", "", "", true, true)
 	for _, expected := range []string{"'' as name", "'' as symbol", "'' as exchange", "'' as region", "0 as tradeType, tradeTime,"} {

--- a/internal/e2e_harness/federated/query_unit_test.go
+++ b/internal/e2e_harness/federated/query_unit_test.go
@@ -164,6 +164,45 @@ func TestBuildPostgresOnlyQueriesSupportBenchmarkFilters(t *testing.T) {
 	}
 }
 
+// TestPostgresOnlyCountSharesSelectScanSource pins the invariant the two
+// Postgres-only builders exist to keep: the count must scan exactly the row set
+// the select returns. The count query ends after its filters and the select
+// continues with ORDER BY/LIMIT, so the count's scan source and predicates are a
+// prefix of the select's. Comparing two independently assembled strings is what
+// makes this catch drift; asserting both contain one shared helper's output
+// would only restate that they call it (#324).
+//
+// The options carry at most one Conditions entry on purpose:
+// buildPostgresOnlyFilterClauses ranges over that map, so Go randomizes clause
+// order per call and two or more entries would make the prefix assertion flaky.
+// Ordering does not matter to the SQL — AND commutes and each builder keeps its
+// own args in step — so the constraint lives here rather than in the builders.
+func TestPostgresOnlyCountSharesSelectScanSource(t *testing.T) {
+	h := &FederatedTestHarness{SchemaID: benchmarkSchemaIDTrade}
+	opts := func() *QueryOptions {
+		return &QueryOptions{
+			Filter:         &Filter{Conditions: map[string]any{"exchange": "NYSE"}},
+			TradeTimeStart: 1000,
+			TradeTimeEnd:   2000,
+			SortBy:         "tradeTime",
+			SortDesc:       true,
+			Limit:          20,
+		}
+	}
+	selectQuery, _ := h.buildPostgresOnlySelectQuery(opts())
+	countQuery, _ := h.buildPostgresOnlyCountQuery(opts())
+
+	const scanSourceAnchor = "FROM change_log cl"
+	selectAt := strings.Index(selectQuery, scanSourceAnchor)
+	countAt := strings.Index(countQuery, scanSourceAnchor)
+	if selectAt < 0 || countAt < 0 {
+		t.Fatalf("expected %q in both postgres-only queries:\nselect: %s\ncount: %s", scanSourceAnchor, selectQuery, countQuery)
+	}
+	if !strings.HasPrefix(selectQuery[selectAt:], countQuery[countAt:]) {
+		t.Fatalf("count scan source diverges from select scan source:\nselect: %s\ncount: %s", selectQuery[selectAt:], countQuery[countAt:])
+	}
+}
+
 func TestBuildParquetTierQueryTradeTimeOnlyProjection(t *testing.T) {
 	query := buildParquetTierQuery("trade-path", benchmarkSchemaIDTrade, "base", "", "", "", true, true)
 	for _, expected := range []string{"'' as name", "'' as symbol", "'' as exchange", "'' as region", "0 as tradeType, tradeTime,"} {


### PR DESCRIPTION
Closes #324

The two cleanups PR #323 deferred, plus the guard that keeps the second one from
coming back. Execution plan: https://github.com/Lychee-Technology/forma/issues/324#issuecomment-5358570578

## 1. Dedupe the Postgres-only select/count SQL

`buildPostgresOnlySelectQuery` and `buildPostgresOnlyCountQuery` each carried the
whole FROM/JOIN/WHERE block — the `change_log`/`entity_main` joins, the
`hot_vals` EAV pivot with its twelve attribute-ID format args, and the
unflushed-and-live guard. Sixteen identical SQL lines per copy, over
coding-standard.md §2's duplication gate.

Extracted `buildPostgresOnlyScanSource`; filter/order/limit handling stays
per-builder, as the issue proposed.

**Byte-identical output**, verified by diffing the rendered SQL and args across
the change for both a fully-filtered and a bare `QueryOptions` — the only
difference in the captured output was the `go test` timing line.

## 2. `ExecuteFederatedQuery`: 94 → 68 lines

Split along the seam the #323 review identified. Three extractions, all in
`query.go`:

- `executePreferHotQuery` — the `PreferHot` override is an alternative execution
  path, not a step in the federated one.
- `federatedTierState` + `probeFederatedTiers` — one probe of parquet
  availability plus the dirty set. `isEmpty()` names the Postgres-fallback
  condition that was a three-clause boolean; `executionPlan()` collapses three
  verbose `buildExecutionPlan` call sites. `buildExecutionPlan` itself is
  unchanged.
- `emptyPageResult` — the short-circuit answer for a page past the last row.
  This one is beyond what the plan listed: the first two extractions landed at
  75 lines, and the plan promised headroom rather than five lines of slack.

Same order of operations, same fallbacks, same plan notes.

## 3. A function-length guard, so it cannot regrow

`ExecuteFederatedQuery` reached 94 lines because the package guards file size and
nothing else. New `query_function_size_test.go` walks non-test `query*.go` with
`go/parser` and fails any function past coding-standard.md §7's 80-line trigger.

Scoped to `query*.go` rather than the existing `listGuardedSourceFiles()` set,
which also covers `harness*.go` — where `NewFederatedTestHarness` is 131 lines,
already past AGENTS.md's 100-line hard limit. Including it would have made the
guard unsatisfiable on arrival. Reason is recorded in the source; the function is
now #431.

**Commit 3 is intentionally red** and commit 4 greens it. A guard committed
alongside its own fix is a guard nobody has watched fail (#321).

## Evidence

Every claim below was run, not reasoned about.

| Check | Result |
|---|---|
| `make test` | pass |
| `make fmt-check` | pass |
| `make lint` (golangci-lint v1.64.8) | pass |
| `go test ./internal/e2e_harness/federated/... -tags=e2e -short` | pass |
| `go test ./internal/e2e_harness/federated/ -tags=e2e` (full, no `-short`) | 123 pass, 0 fail, 0 skip, 246s |
| Guard red before the fix | `query.go: ExecuteFederatedQuery has 94 lines, exceeds the 80-line refactoring trigger` |
| Guard green after | pass; `ExecuteFederatedQuery` measures 68 |

**Mutation proofs** (the two new tests can actually fail):

1. Item 1's guard: swapping `attrIDs.symbol`/`attrIDs.exchange` in
   `buildPostgresOnlyCountQuery` alone turns
   `TestPostgresOnlyCountSharesSelectScanSource` red while the pre-existing
   `TestBuildPostgresOnlyQueriesSupportBenchmarkFilters` stays **green** — the
   old test only does `strings.Contains` checks, so it never saw that class of
   drift. That is the coverage the new test adds.
2. Item 3's guard: an 86-line function added to `query_hot.go` is reported by
   name, confirming the guard scans the whole `query*.go` family and not just
   the file this PR shrank.

## Two things worth knowing

**`go test -overlay` cannot mutation-test a guard that reads source from disk.**
My first attempt at proof 2 used `-overlay` (per the #354 practice of mutating
without dirtying the tree) and the guard passed — a false green. The overlay
only affects compilation; `TestGuardedFunctionsStayWithinRefactoringTrigger`
calls `os.ReadFile`, so it read the unmutated file. Redone as a real on-disk edit
restored from a copy. The same trap applies to the existing file-size guard.

**`-tags=e2e -short`, which is what CI runs, skips `data_tier_test.go`,
`merge_on_read_test.go`, `deduplication_test.go`, `soft_delete_test.go` and
`performance_test.go`.** It still exercises `ExecuteFederatedQuery` through
`consistency_test.go` and `failure_modes_test.go`, so CI's coverage of item 2 is
partial rather than absent — but the full suite was run locally for this PR
because a `-short` pass alone would not have been honest evidence. Flagging the
gap as an observation; not filing it, since CI runtime is presumably the reason.

## Follow-ups filed

- **#430** — `ExecutePostgresQuery`'s inline scan loop duplicates
  `scanQueryResults` (~50 lines, larger than what this issue was filed for), and
  neither loop checks `rows.Err()`, so a mid-iteration error silently truncates
  the result set. Kept out of this PR by user ruling: it changes a scan
  destination type and only the docker e2e suite can verify it. It also drops
  `ExecutePostgresQuery` from 78 lines to about 35 — relevant, because 78 against
  the new 80-line guard is two lines of headroom.
- **#431** — `NewFederatedTestHarness` at 131 lines, which is what blocks
  widening the function guard to `harness*.go`.

Out of scope and unchanged, per the issue: `harness.go`'s file size (#220) and
the 500-line file guard's scope.
