### PR TITLE
refactor(httpapi): #368 delete dead handleGet, pin row-id GET through dispatch

### DIFF
--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -83,38 +83,9 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	_ = writeSuccess(w, http.StatusCreated, result)
 }
 
-// handleGet handles GET /api/v1/{schema_name}/{row_id}
-func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		_ = writeError(w, http.StatusMethodNotAllowed, "method not allowed")
-		return
-	}
-
-	schemaName, rowIDStr, err := parsePath(r.URL.Path)
-	if err != nil {
-		respondError(w, "invalid path", err)
-		return
-	}
-
-	if rowIDStr == "" {
-		_ = writeError(w, http.StatusBadRequest, "row_id is required")
-		return
-	}
-	zap.S().Infow("get request received", "schema", schemaName, "rowID", rowIDStr)
-
-	rowID, err := parseUUID(rowIDStr)
-	if err != nil {
-		respondError(w, "invalid row_id", forma.InvalidInputf("%v", err))
-		return
-	}
-
-	attrs := parseAttrs(r.URL.Query())
-	s.executeGet(w, r, schemaName, rowID, attrs)
-}
-
 // executeGet performs the actual Get manager call and writes the response.
-// Extracted so that handleQuery can invoke the same logic without re-entering
-// handleGet through the http.Handler interface (re-entry pattern).
+// It is handleQuery's row-id branch: GET /api/v1/{schema}/{row_id} reaches it
+// through apiHandler, which is the only dispatch path into a single record.
 func (s *Server) executeGet(w http.ResponseWriter, r *http.Request, schemaName string, rowID uuid.UUID, attrs []string) {
 	queryReq := &forma.QueryRequest{
 		SchemaName: schemaName,

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -252,7 +252,12 @@ func TestClassifyManagerError(t *testing.T) {
 	}
 }
 
-func TestHandleGetErrorMapping(t *testing.T) {
+// TestGetByRowIDMapsManagerErrors drives the request through the registered mux
+// so the assertion covers the chain production actually uses: apiHandler's GET
+// branch -> handleQuery's row-id branch -> executeGet. Invoking a handler method
+// directly would leave that routing unpinned, which is how #368's dead handler
+// kept a test to itself after the live path had moved on.
+func TestGetByRowIDMapsManagerErrors(t *testing.T) {
 	rowID := uuid.New()
 
 	// Since #301 only a sentinel earns the 404; "entity not found" as bare prose
@@ -269,13 +274,11 @@ func TestHandleGetErrorMapping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := &Server{
-				manager: &mockEntityManager{getErr: tt.err},
-			}
+			server := NewServer(&mockEntityManager{getErr: tt.err}, Options{})
 
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/lead/"+rowID.String(), nil)
 			rec := httptest.NewRecorder()
-			server.handleGet(rec, req)
+			server.Handler().ServeHTTP(rec, req)
 
 			if rec.Code != tt.wantStatus {
 				t.Fatalf("expected status %d, got %d", tt.wantStatus, rec.Code)


### PR DESCRIPTION
Closes #368. Refs #220, #367.

`handleGet` had no production caller. `registerRoutes` wires `handleHealth` /
`handleAdvancedQuery` / `handleSearch` / `apiHandler`; `apiHandler`'s GET branch goes to
`handleQuery`, which handles the row-id case itself via `executeGet`. The only reference
left in the repo was the direct-invocation test at `server_test.go:278`.

### What changed

1. **Coverage migrated first.** `TestHandleGetErrorMapping` → `TestGetByRowIDMapsManagerErrors`,
   now driving the request through `NewServer(...).Handler().ServeHTTP` instead of calling a
   handler method. The three error-mapping cases (sentinel → 404, bare-prose "not found" → 500,
   internal → 500) are unchanged; what changed is that they now assert the chain production
   uses: mux → `apiHandler` → `handleQuery`'s row-id branch → `executeGet`. This follows the
   existing pattern in `error_leak_test.go` / `sentinel_status_test.go` / `handlers_parse_error_test.go`.
2. **`handleGet` deleted**, and `executeGet`'s doc comment rewritten — it described itself in
   terms of "not re-entering `handleGet`", i.e. in terms of a function that no longer exists.
   `executeGet` itself stays; it is `handleQuery`'s row-id implementation.

### Behaviour delta: none

`handleGet`'s only branch `handleQuery` does not have is `rowIDStr == ""` → 400
`"row_id is required"`. That branch is unreachable under the real router: a request with an
empty row-id is `/api/v1/{schema}`, which is a list query, and `handleQuery` answers it with the
paginated path. Deleting it loses no observable behaviour. Every other branch of `handleGet`
(path parse error, UUID parse error, `attrs` parsing, the `executeGet` call) has a
one-for-one counterpart in `handleQuery`.

### Red verification

The migrated test was proven to fail before anything was deleted, using `go test -overlay` so
the working tree was never mutated:

| Mutation | Result |
| --- | --- |
| `handleQuery`'s `if rowIDStr != ""` forced false (row-id request falls into the list path) | `sentinel not found` fails: `expected status 404, got 500` |
| `apiHandler`'s `case http.MethodGet: s.handleQuery(w, r)` replaced with a 418 writer | all three cases fail: `got 418` |

The first mutation only reddens the sentinel case, because both the row-id path and the list
path answer 500 for the other two errors — the sentinel case is the one that discriminates
between them. The second pins the mux + dispatch leg.

### Gates

`make fmt-check`, `make lint`, `make test` — all exit 0 (`no FAIL lines` across the suite).

### Out of scope

No other direct-invocation tests were touched (`server_advanced_query_test.go` and the
create/update/search cases in `server_test.go` keep their current shape), `handleQuery` was not
refactored, and no handler-reachability guard was added — that was considered and declined:
this dead code is a leftover of the #220 slicing, not a recurring class, and an AST-scanning
meta-test would be a new maintenance burden needing its own red verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCSCNgQmz3EWokjH4G3C7h
