### PR TITLE
chore(lint): #319 enforce the 100-line function cap with funlen

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,3 +12,29 @@ issues:
       linters:
         - staticcheck
       text: "SA5011"
+
+# funlen (#319) enforces coding-standard.md 的 100 行函数上限——在此之前它只是
+# 文档，没有任何东西执行它：#314 期间一个函数长到 110 行、两次通过 make lint。
+linters:
+  enable:
+    - funlen
+    - nolintlint
+
+linters-settings:
+  funlen:
+    lines: 100
+    # 反义警告：golangci-lint v1.64.8 的 pkg/golinters/funlen/funlen.go:23 是
+    #   cfg.ignoreComments = !settings.IgnoreComments
+    # 而上游 ultraware/funlen@v0.2.0 的同名参数为 true 时才扣除注释。所以在这个
+    # 钉死的版本下 false == 排除注释，正是 #319 选定的口径。不要"修正"成 true：
+    # 那会立刻多出 4 处违规让 CI 变红，也会开始惩罚写注释——本仓库的注释是承重的
+    # 成因记录（见 engine.go:Query，103 行里 27 行是 #348/#183/#184 的注释）。
+    ignore-comments: false
+    # 必须是 -1。funlen.go:20 把 0 当作"未设置"并回落到默认的 40 条语句上限。
+    statements: -1
+  nolintlint:
+    # #319 要求 nolint 必须逐处带明确理由；这三项把它从人工约定变成机器检查。
+    # allow-unused: false 让将来函数被重构到 100 行以下后忘删的 nolint 自动变红。
+    require-explanation: true
+    require-specific: true
+    allow-unused: false

--- a/cmd/sample/main.go
+++ b/cmd/sample/main.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func main() {
+func main() { //nolint:funlen // #319: split into logger/flag/run phases by this plan's Task 6
 	// Command line flags
 	csvFile := flag.String("csv", "", "Path to CSV file to import (required)")
 	schemaDir := flag.String("schema-dir", "./schemas", "Directory containing schema files")

--- a/cmd/sample/main.go
+++ b/cmd/sample/main.go
@@ -17,17 +17,24 @@ import (
 	"go.uber.org/zap"
 )
 
-func main() { //nolint:funlen // #319: split into logger/flag/run phases by this plan's Task 6
-	// Command line flags
-	csvFile := flag.String("csv", "", "Path to CSV file to import (required)")
-	schemaDir := flag.String("schema-dir", "./schemas", "Directory containing schema files")
-	schemaName := flag.String("schema", "watch", "Target schema name")
-	batchSize := flag.Int("batch-size", 100, "Batch size for import operations")
-	dbURL := flag.String("db", "postgres://postgres:postgres@localhost:5432/ltbase", "PostgreSQL connection URL (or set DATABASE_URL env)")
-	dryRun := flag.Bool("dry-run", false, "Parse CSV and validate mappings without writing to database")
-	verbose := flag.Bool("verbose", false, "Enable verbose logging")
+// sampleRunConfig carries the parsed sample-importer flags into runSampleImport.
+type sampleRunConfig struct {
+	databaseURL string
+	schemaDir   string
+	schemaName  string
+	csvFile     string
+	batchSize   int
+	mapper      CSVToSchemaMapper
+}
 
-	// Setup logging
+// buildSampleLogger installs the global zap logger and returns its sugared
+// handle plus the sync closure the caller must defer.
+//
+// It is deliberately called BEFORE flag.Parse(), exactly as the code it was
+// extracted from did: *verbose is therefore always false here. That is a
+// pre-existing bug (#319 follow-up), not something this refactor may fix —
+// changing the order would change behaviour in a commit that claims not to.
+func buildSampleLogger(verbose *bool) (*zap.SugaredLogger, func()) {
 	cfg := zap.NewProductionConfig()
 	cfg.Encoding = "console"
 	if *verbose {
@@ -39,33 +46,29 @@ func main() { //nolint:funlen // #319: split into logger/flag/run phases by this
 		fmt.Fprintf(os.Stderr, "failed to build logger: %v\n", err)
 		os.Exit(1)
 	}
-	defer func() { _ = logger.Sync() }()
 	zap.ReplaceGlobals(logger)
-	sugar := logger.Sugar()
+	return logger.Sugar(), func() { _ = logger.Sync() }
+}
 
-	flag.Parse()
-
-	// Validate required flags
+// resolveSampleOptions validates the parsed flags and answers the database URL
+// and mapper the run needs. It exits the process on invalid input, exactly as
+// the inline code did.
+func resolveSampleOptions(csvFile, dbURL, schemaName *string, dryRun *bool, sugar *zap.SugaredLogger) (string, CSVToSchemaMapper) {
 	if *csvFile == "" {
 		sugar.Error("Error: -csv flag is required")
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	// Get database URL from flag or environment
 	databaseURL := *dbURL
 	if databaseURL == "" {
 		databaseURL = os.Getenv("DATABASE_URL")
 	}
-
 	if databaseURL == "" && !*dryRun {
 		sugar.Error("Error: Database URL is required. Use -db flag or set DATABASE_URL environment variable.")
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
-
-	// Create mapper based on schema name
 	var mapper CSVToSchemaMapper
 	switch *schemaName {
 	case "watch":
@@ -75,20 +78,13 @@ func main() { //nolint:funlen // #319: split into logger/flag/run phases by this
 		sugar.Fatalf("Unknown schema: %s. Supported schemas: watch", *schemaName)
 	}
 
-	// Dry run mode - just validate the CSV
-	if *dryRun {
-		sugar.Infof("Dry run mode: validating CSV file %s", *csvFile)
-		result, err := dryRunImport(ctx, *csvFile, mapper, sugar)
-		if err != nil {
-			sugar.Fatalf("Dry run failed: %v", err)
-		}
-		printResult(result, sugar)
-		os.Exit(0)
-	}
+	return databaseURL, mapper
+}
 
+func runSampleImport(ctx context.Context, cfg sampleRunConfig, sugar *zap.SugaredLogger) {
 	// Connect to database
 	sugar.Infof("Connecting to database...")
-	pool, err := pgxpool.New(ctx, databaseURL)
+	pool, err := pgxpool.New(ctx, cfg.databaseURL)
 	if err != nil {
 		sugar.Fatalf("Failed to connect to database: %v", err)
 	}
@@ -101,18 +97,18 @@ func main() { //nolint:funlen // #319: split into logger/flag/run phases by this
 	sugar.Infof("Database connected successfully")
 
 	// Create schema registry
-	sugar.Infof("Loading schemas from: %s", *schemaDir)
-	registry, err := schemameta.NewFileSchemaRegistryFromDirectory(*schemaDir)
+	sugar.Infof("Loading schemas from: %s", cfg.schemaDir)
+	registry, err := schemameta.NewFileSchemaRegistryFromDirectory(cfg.schemaDir)
 	if err != nil {
 		sugar.Fatalf("Failed to create schema registry: %v", err)
 	}
 
 	// Verify schema exists
-	schemaID, _, err := registry.GetSchemaAttributeCacheByName(*schemaName)
+	schemaID, _, err := registry.GetSchemaAttributeCacheByName(cfg.schemaName)
 	if err != nil {
-		sugar.Fatalf("Schema '%s' not found: %v", *schemaName, err)
+		sugar.Fatalf("Schema '%s' not found: %v", cfg.schemaName, err)
 	}
-	sugar.Infof("Schema '%s' found with ID: %d", *schemaName, schemaID)
+	sugar.Infof("Schema '%s' found with ID: %d", cfg.schemaName, schemaID)
 
 	// Create configuration
 	config := forma.DefaultConfig(registry)
@@ -121,7 +117,7 @@ func main() { //nolint:funlen // #319: split into logger/flag/run phases by this
 	config.Database.TableNames.SchemaRegistry = "schema_registry_sample"
 	config.Database.TableNames.ChangeLog = "change_log_sample"
 
-	config.Entity.SchemaDirectory = *schemaDir
+	config.Entity.SchemaDirectory = cfg.schemaDir
 
 	// The importer is a write path, so it honours the #314 staged rollout
 	// (VALIDATE_UPDATES_STRICT) like the other entry points that build an
@@ -150,15 +146,15 @@ func main() { //nolint:funlen // #319: split into logger/flag/run phases by this
 	}()
 
 	// Create importer
-	importer := NewCSVImporter(entityManager, mapper, *batchSize)
+	importer := NewCSVImporter(entityManager, cfg.mapper, cfg.batchSize)
 	importer.SetLogger(sugar.Named("Import"))
 
 	// Execute import
-	sugar.Infof("Starting import from: %s", *csvFile)
-	sugar.Infof("Target schema: %s, Batch size: %d", *schemaName, *batchSize)
+	sugar.Infof("Starting import from: %s", cfg.csvFile)
+	sugar.Infof("Target schema: %s, Batch size: %d", cfg.schemaName, cfg.batchSize)
 
 	startTime := time.Now()
-	result, err := importer.ImportFromFile(ctx, *csvFile)
+	result, err := importer.ImportFromFile(ctx, cfg.csvFile)
 	if err != nil {
 		sugar.Fatalf("Import failed: %v", err)
 	}
@@ -167,11 +163,20 @@ func main() { //nolint:funlen // #319: split into logger/flag/run phases by this
 	sugar.Infof("Import completed in %v", time.Since(startTime))
 	printResult(result, sugar)
 
+	printSampleQueryResults(ctx, entityManager, cfg.schemaName, sugar)
+
+	// Exit with error code if there were failures
+	if result.FailedCount > 0 {
+		os.Exit(1)
+	}
+}
+
+func printSampleQueryResults(ctx context.Context, entityManager forma.EntityManager, schemaName string, sugar *zap.SugaredLogger) {
 	// Execute advanced query example
 	sugar.Infof("Executing advanced query example...")
 	sugar.Infof("Query conditions: yearOfProduction.year >= 2020 AND size.width >= 40")
 	queryResult, err := entityManager.Query(ctx, &forma.QueryRequest{
-		SchemaName:   *schemaName,
+		SchemaName:   schemaName,
 		Page:         1,
 		ItemsPerPage: 10,
 		Condition: &forma.CompositeCondition{
@@ -207,11 +212,46 @@ func main() { //nolint:funlen // #319: split into logger/flag/run phases by this
 			sugar.Info(string(jsonBytes))
 		}
 	}
+}
 
-	// Exit with error code if there were failures
-	if result.FailedCount > 0 {
-		os.Exit(1)
+func main() {
+	// Command line flags
+	csvFile := flag.String("csv", "", "Path to CSV file to import (required)")
+	schemaDir := flag.String("schema-dir", "./schemas", "Directory containing schema files")
+	schemaName := flag.String("schema", "watch", "Target schema name")
+	batchSize := flag.Int("batch-size", 100, "Batch size for import operations")
+	dbURL := flag.String("db", "postgres://postgres:postgres@localhost:5432/ltbase", "PostgreSQL connection URL (or set DATABASE_URL env)")
+	dryRun := flag.Bool("dry-run", false, "Parse CSV and validate mappings without writing to database")
+	verbose := flag.Bool("verbose", false, "Enable verbose logging")
+
+	sugar, syncLogger := buildSampleLogger(verbose)
+	defer syncLogger()
+
+	flag.Parse()
+
+	databaseURL, mapper := resolveSampleOptions(csvFile, dbURL, schemaName, dryRun, sugar)
+
+	ctx := context.Background()
+
+	// Dry run mode - just validate the CSV
+	if *dryRun {
+		sugar.Infof("Dry run mode: validating CSV file %s", *csvFile)
+		result, err := dryRunImport(ctx, *csvFile, mapper, sugar)
+		if err != nil {
+			sugar.Fatalf("Dry run failed: %v", err)
+		}
+		printResult(result, sugar)
+		os.Exit(0)
 	}
+
+	runSampleImport(ctx, sampleRunConfig{
+		databaseURL: databaseURL,
+		schemaDir:   *schemaDir,
+		schemaName:  *schemaName,
+		csvFile:     *csvFile,
+		batchSize:   *batchSize,
+		mapper:      mapper,
+	}, sugar)
 }
 
 // dryRunImport performs a dry run of the import process without database operations.

--- a/cmd/tools/cdc_flags_test.go
+++ b/cmd/tools/cdc_flags_test.go
@@ -69,8 +69,19 @@ func TestParseCDCFlushFlagsRejectsMissingBucket(t *testing.T) {
 	}
 }
 
-// TestParseCDCFlushFlagsUsingDefaults ensures flag defaults survive the flag
-// layer and are not silently overwritten by WithDefaults.
+// TestParseCDCFlushFlagsUsingDefaults pins the flag-layer defaults, but only
+// partially: buildCDCConfig ends in cdc.CDCConfig.WithDefaults(), which
+// backfills any field left <= 0 or "" (internal/cdc/config.go).
+//
+// Genuinely pinned here — WithDefaults never touches them, so deleting the
+// flag default turns this test red: S3Prefix, ManifestTemplate, PGHost,
+// PGPort, PGDB.
+//
+// Shadowed by WithDefaults, which supplies the identical value: MinRecords,
+// MaxAgeMs, BatchSize, PGSSLMode. Deleting those flag defaults leaves this
+// test green (measured), so their assertions cannot detect a missing flag
+// default — they only catch a change in the agreed value. Keep them for that,
+// but do not read them as coverage of the flag layer.
 func TestParseCDCFlushFlagsUsingDefaults(t *testing.T) {
 	opts, err := parseCDCFlushFlags([]string{"-s3-bucket=b"})
 	if err != nil {
@@ -195,8 +206,20 @@ func TestParseCDCInitFlagsRequiresSchemaRegistry(t *testing.T) {
 	}
 }
 
-// TestParseCDCInitFlagsUsingDefaults ensures flag defaults survive the flag
-// layer and are not silently overwritten by WithDefaults.
+// TestParseCDCInitFlagsUsingDefaults pins the flag-layer defaults, but only
+// partially, for the same reason as its cdc-flush sibling: buildCDCInitConfig
+// ends in cdc.CDCConfig.WithDefaults(), which backfills any field left <= 0
+// or "" (internal/cdc/config.go).
+//
+// Genuinely pinned here — WithDefaults never touches them, so deleting the
+// flag default turns this test red: TargetFileSizeMB, S3Prefix,
+// ManifestTemplate, PGHost, PGPort, PGDB.
+//
+// Shadowed by WithDefaults, which supplies the identical value: MaxBatchSize,
+// EntityMainTable, EAVDataTable, PGSSLMode. Deleting those flag defaults
+// leaves this test green (measured), so their assertions cannot detect a
+// missing flag default — they only catch a change in the agreed value. Keep
+// them for that, but do not read them as coverage of the flag layer.
 func TestParseCDCInitFlagsUsingDefaults(t *testing.T) {
 	opts, err := parseCDCInitFlags([]string{
 		"-s3-bucket=b",
@@ -239,10 +262,6 @@ func TestParseCDCInitFlagsUsingDefaults(t *testing.T) {
 	if opts.cfg.PGSSLMode != "require" {
 		t.Errorf("PGSSLMode = %q, want %q", opts.cfg.PGSSLMode, "require")
 	}
-	// Note: buildCDCInitConfig ends in .WithDefaults(), which backfills fields
-	// left <= 0 or "". For those fields, this test cannot distinguish "the flag
-	// default supplied this" from "WithDefaults supplied this". Nevertheless we
-	// assert them to catch accidental regressions.
 }
 
 // TestParseCDCInitFlagsHelp ensures -help exits cleanly with nil error

--- a/cmd/tools/cdc_flags_test.go
+++ b/cmd/tools/cdc_flags_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestParseCDCFlushFlagsMapsArgsToConfig pins the cdc-flush flag surface: the
+// 148-line runCDCFlush had zero coverage before #319 split it, so this is the
+// first thing that would notice a flag being renamed or wired to the wrong
+// config field.
+func TestParseCDCFlushFlagsMapsArgsToConfig(t *testing.T) {
+	opts, err := parseCDCFlushFlags([]string{
+		"-s3-bucket=my-bucket",
+		"-s3-prefix=my-delta",
+		"-change-log-table=cl",
+		"-entity-main-table=em",
+		"-eav-table=eav",
+		"-min-records=5",
+		"-max-age-ms=1000",
+		"-batch-size=7",
+		"-dry-run",
+	})
+	if err != nil {
+		t.Fatalf("parse cdc-flush flags: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("expected options, got nil")
+	}
+	if opts.cfg.S3Bucket != "my-bucket" {
+		t.Errorf("S3Bucket = %q, want %q", opts.cfg.S3Bucket, "my-bucket")
+	}
+	if opts.cfg.S3Prefix != "my-delta" {
+		t.Errorf("S3Prefix = %q, want %q", opts.cfg.S3Prefix, "my-delta")
+	}
+	if opts.cfg.ChangeLogTable != "cl" {
+		t.Errorf("ChangeLogTable = %q, want %q", opts.cfg.ChangeLogTable, "cl")
+	}
+	if opts.cfg.EntityMainTable != "em" {
+		t.Errorf("EntityMainTable = %q, want %q", opts.cfg.EntityMainTable, "em")
+	}
+	if opts.cfg.EAVDataTable != "eav" {
+		t.Errorf("EAVDataTable = %q, want %q", opts.cfg.EAVDataTable, "eav")
+	}
+	if opts.cfg.MinRecords != 5 {
+		t.Errorf("MinRecords = %d, want 5", opts.cfg.MinRecords)
+	}
+	if opts.cfg.MaxAgeMs != 1000 {
+		t.Errorf("MaxAgeMs = %d, want 1000", opts.cfg.MaxAgeMs)
+	}
+	if opts.cfg.BatchSize != 7 {
+		t.Errorf("BatchSize = %d, want 7", opts.cfg.BatchSize)
+	}
+	if !opts.dryRun {
+		t.Error("dryRun = false, want true")
+	}
+}
+
+// TestParseCDCFlushFlagsRejectsMissingBucket keeps the s3Flags.validate(true)
+// gate wired: dropping the validate call must not silently produce a config
+// that fails much later inside RunOnce.
+func TestParseCDCFlushFlagsRejectsMissingBucket(t *testing.T) {
+	if _, err := parseCDCFlushFlags(nil); err == nil {
+		t.Fatal("expected an error when -s3-bucket is missing")
+	}
+}

--- a/cmd/tools/cdc_flags_test.go
+++ b/cmd/tools/cdc_flags_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -59,7 +60,71 @@ func TestParseCDCFlushFlagsMapsArgsToConfig(t *testing.T) {
 // gate wired: dropping the validate call must not silently produce a config
 // that fails much later inside RunOnce.
 func TestParseCDCFlushFlagsRejectsMissingBucket(t *testing.T) {
-	if _, err := parseCDCFlushFlags(nil); err == nil {
+	_, err := parseCDCFlushFlags(nil)
+	if err == nil {
 		t.Fatal("expected an error when -s3-bucket is missing")
+	}
+	if !strings.Contains(err.Error(), "--s3-bucket is required") {
+		t.Errorf("error message = %q, want to contain %q", err.Error(), "--s3-bucket is required")
+	}
+}
+
+// TestParseCDCFlushFlagsUsingDefaults ensures flag defaults survive the flag
+// layer and are not silently overwritten by WithDefaults.
+func TestParseCDCFlushFlagsUsingDefaults(t *testing.T) {
+	opts, err := parseCDCFlushFlags([]string{"-s3-bucket=b"})
+	if err != nil {
+		t.Fatalf("parse cdc-flush flags: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("expected options, got nil")
+	}
+	if opts.cfg.MinRecords != 20000 {
+		t.Errorf("MinRecords = %d, want 20000", opts.cfg.MinRecords)
+	}
+	if opts.cfg.MaxAgeMs != 3600000 {
+		t.Errorf("MaxAgeMs = %d, want 3600000", opts.cfg.MaxAgeMs)
+	}
+	if opts.cfg.BatchSize != 10000 {
+		t.Errorf("BatchSize = %d, want 10000", opts.cfg.BatchSize)
+	}
+	if opts.cfg.S3Prefix != "delta" {
+		t.Errorf("S3Prefix = %q, want %q", opts.cfg.S3Prefix, "delta")
+	}
+	if opts.cfg.ManifestTemplate != "manifest/{{.SchemaID}}.json" {
+		t.Errorf("ManifestTemplate = %q, want %q", opts.cfg.ManifestTemplate, "manifest/{{.SchemaID}}.json")
+	}
+	if opts.cfg.PGHost != "localhost" {
+		t.Errorf("PGHost = %q, want %q", opts.cfg.PGHost, "localhost")
+	}
+	if opts.cfg.PGPort != 5432 {
+		t.Errorf("PGPort = %d, want 5432", opts.cfg.PGPort)
+	}
+	if opts.cfg.PGDB != "forma" {
+		t.Errorf("PGDB = %q, want %q", opts.cfg.PGDB, "forma")
+	}
+	if opts.cfg.PGSSLMode != "require" {
+		t.Errorf("PGSSLMode = %q, want %q", opts.cfg.PGSSLMode, "require")
+	}
+}
+
+// TestParseCDCFlushFlagsHelp ensures -help exits cleanly with nil error
+// and nil options, preserving the CLI's quiet exit.
+func TestParseCDCFlushFlagsHelp(t *testing.T) {
+	opts, err := parseCDCFlushFlags([]string{"-help"})
+	if opts != nil {
+		t.Errorf("opts = %v, want nil", opts)
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+// TestParseCDCFlushFlagsRejectsSchemaRegistryTableWithoutDir ensures
+// schemaRegistry.validate(false) is wired and rejects incomplete config.
+func TestParseCDCFlushFlagsRejectsSchemaRegistryTableWithoutDir(t *testing.T) {
+	_, err := parseCDCFlushFlags([]string{"-s3-bucket=b", "-schema-registry-table=t"})
+	if err == nil {
+		t.Fatal("expected an error when -schema-registry-table is given without -schema-registry-dir")
 	}
 }

--- a/cmd/tools/cdc_flags_test.go
+++ b/cmd/tools/cdc_flags_test.go
@@ -170,6 +170,9 @@ func TestParseCDCInitFlagsMapsArgsToConfig(t *testing.T) {
 	if opts.registry.table != "registry" {
 		t.Errorf("registry table = %q, want %q", opts.registry.table, "registry")
 	}
+	if opts.registry.dir != "/tmp/schemas" {
+		t.Errorf("registry dir = %q, want %q", opts.registry.dir, "/tmp/schemas")
+	}
 	if opts.schemaIDFilter != 3 {
 		t.Errorf("schemaIDFilter = %d, want 3", opts.schemaIDFilter)
 	}
@@ -251,5 +254,40 @@ func TestParseCDCInitFlagsHelp(t *testing.T) {
 	}
 	if err != nil {
 		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+// TestParseCDCInitFlagsRejectsMissingBucket keeps the s3Flags.validate(true)
+// gate wired: dropping the validate call must not silently produce a config
+// that fails much later inside RunInit.
+func TestParseCDCInitFlagsRejectsMissingBucket(t *testing.T) {
+	_, err := parseCDCInitFlags([]string{"-schema-registry-table=t", "-schema-dir=/d"})
+	if err == nil {
+		t.Fatal("expected an error when -s3-bucket is missing")
+	}
+}
+
+// TestParseCDCInitFlagsEstimatedRowBytes ensures that when -estimated-row-bytes
+// is passed, both cfg.EstimatedRowBytes is set to that value and autoEstimateRowBytes
+// is false (not true). This guards against mutations that hardcode autoEstimateRowBytes
+// to true or cross-wire EstimatedRowBytes to a different flag.
+func TestParseCDCInitFlagsEstimatedRowBytes(t *testing.T) {
+	opts, err := parseCDCInitFlags([]string{
+		"-s3-bucket=b",
+		"-schema-registry-table=t",
+		"-schema-dir=/d",
+		"-estimated-row-bytes=4096",
+	})
+	if err != nil {
+		t.Fatalf("parse cdc-init flags: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("expected options, got nil")
+	}
+	if opts.cfg.EstimatedRowBytes != 4096 {
+		t.Errorf("EstimatedRowBytes = %d, want 4096", opts.cfg.EstimatedRowBytes)
+	}
+	if opts.autoEstimateRowBytes {
+		t.Error("autoEstimateRowBytes = true, want false when -estimated-row-bytes is passed")
 	}
 }

--- a/cmd/tools/cdc_flags_test.go
+++ b/cmd/tools/cdc_flags_test.go
@@ -128,3 +128,128 @@ func TestParseCDCFlushFlagsRejectsSchemaRegistryTableWithoutDir(t *testing.T) {
 		t.Fatal("expected an error when -schema-registry-table is given without -schema-registry-dir")
 	}
 }
+
+// TestParseCDCInitFlagsMapsArgsToConfig pins the cdc-init flag surface for the
+// same reason as its cdc-flush sibling: runCDCInit was 155 code lines with no
+// test (#319).
+func TestParseCDCInitFlagsMapsArgsToConfig(t *testing.T) {
+	opts, err := parseCDCInitFlags([]string{
+		"-s3-bucket=init-bucket",
+		"-s3-prefix=my-base",
+		"-schema-registry-table=registry",
+		"-schema-dir=/tmp/schemas",
+		"-entity-main-table=em",
+		"-eav-table=eav",
+		"-batch-size=11",
+		"-target-file-size-mb=64",
+		"-max-batch-size=99",
+		"-schema-id=3",
+		"-dry-run",
+	})
+	if err != nil {
+		t.Fatalf("parse cdc-init flags: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("expected options, got nil")
+	}
+	if opts.cfg.S3Bucket != "init-bucket" {
+		t.Errorf("S3Bucket = %q, want %q", opts.cfg.S3Bucket, "init-bucket")
+	}
+	if opts.cfg.S3Prefix != "my-base" {
+		t.Errorf("S3Prefix = %q, want %q", opts.cfg.S3Prefix, "my-base")
+	}
+	if opts.cfg.BatchSize != 11 {
+		t.Errorf("BatchSize = %d, want 11", opts.cfg.BatchSize)
+	}
+	if opts.cfg.TargetFileSizeMB != 64 {
+		t.Errorf("TargetFileSizeMB = %d, want 64", opts.cfg.TargetFileSizeMB)
+	}
+	if opts.cfg.MaxBatchSize != 99 {
+		t.Errorf("MaxBatchSize = %d, want 99", opts.cfg.MaxBatchSize)
+	}
+	if opts.registry.table != "registry" {
+		t.Errorf("registry table = %q, want %q", opts.registry.table, "registry")
+	}
+	if opts.schemaIDFilter != 3 {
+		t.Errorf("schemaIDFilter = %d, want 3", opts.schemaIDFilter)
+	}
+	if !opts.dryRun {
+		t.Error("dryRun = false, want true")
+	}
+	// -estimated-row-bytes was not passed, so the auto-estimate path stays on.
+	// This flag is derived, not read back from cfg, and dropping the derivation
+	// during the split would be invisible without this assertion.
+	if !opts.autoEstimateRowBytes {
+		t.Error("autoEstimateRowBytes = false, want true when -estimated-row-bytes is absent")
+	}
+}
+
+// TestParseCDCInitFlagsRequiresSchemaRegistry keeps schemaRegistry.validate(true)
+// wired — cdc-init requires the registry pair where cdc-flush does not.
+func TestParseCDCInitFlagsRequiresSchemaRegistry(t *testing.T) {
+	if _, err := parseCDCInitFlags([]string{"-s3-bucket=b"}); err == nil {
+		t.Fatal("expected an error when -schema-registry-table/-schema-dir are missing")
+	}
+}
+
+// TestParseCDCInitFlagsUsingDefaults ensures flag defaults survive the flag
+// layer and are not silently overwritten by WithDefaults.
+func TestParseCDCInitFlagsUsingDefaults(t *testing.T) {
+	opts, err := parseCDCInitFlags([]string{
+		"-s3-bucket=b",
+		"-schema-registry-table=t",
+		"-schema-dir=/d",
+	})
+	if err != nil {
+		t.Fatalf("parse cdc-init flags: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("expected options, got nil")
+	}
+	if opts.cfg.TargetFileSizeMB != 256 {
+		t.Errorf("TargetFileSizeMB = %d, want 256", opts.cfg.TargetFileSizeMB)
+	}
+	if opts.cfg.MaxBatchSize != 10000000 {
+		t.Errorf("MaxBatchSize = %d, want 10000000", opts.cfg.MaxBatchSize)
+	}
+	if opts.cfg.S3Prefix != "base" {
+		t.Errorf("S3Prefix = %q, want %q", opts.cfg.S3Prefix, "base")
+	}
+	if opts.cfg.ManifestTemplate != "manifest/{{.SchemaID}}.json" {
+		t.Errorf("ManifestTemplate = %q, want %q", opts.cfg.ManifestTemplate, "manifest/{{.SchemaID}}.json")
+	}
+	if opts.cfg.EntityMainTable != "entity_main" {
+		t.Errorf("EntityMainTable = %q, want %q", opts.cfg.EntityMainTable, "entity_main")
+	}
+	if opts.cfg.EAVDataTable != "eav_data" {
+		t.Errorf("EAVDataTable = %q, want %q", opts.cfg.EAVDataTable, "eav_data")
+	}
+	if opts.cfg.PGHost != "localhost" {
+		t.Errorf("PGHost = %q, want %q", opts.cfg.PGHost, "localhost")
+	}
+	if opts.cfg.PGPort != 5432 {
+		t.Errorf("PGPort = %d, want 5432", opts.cfg.PGPort)
+	}
+	if opts.cfg.PGDB != "forma" {
+		t.Errorf("PGDB = %q, want %q", opts.cfg.PGDB, "forma")
+	}
+	if opts.cfg.PGSSLMode != "require" {
+		t.Errorf("PGSSLMode = %q, want %q", opts.cfg.PGSSLMode, "require")
+	}
+	// Note: buildCDCInitConfig ends in .WithDefaults(), which backfills fields
+	// left <= 0 or "". For those fields, this test cannot distinguish "the flag
+	// default supplied this" from "WithDefaults supplied this". Nevertheless we
+	// assert them to catch accidental regressions.
+}
+
+// TestParseCDCInitFlagsHelp ensures -help exits cleanly with nil error
+// and nil options, preserving the CLI's quiet exit.
+func TestParseCDCInitFlagsHelp(t *testing.T) {
+	opts, err := parseCDCInitFlags([]string{"-help"})
+	if opts != nil {
+		t.Errorf("opts = %v, want nil", opts)
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}

--- a/cmd/tools/cdc_flush.go
+++ b/cmd/tools/cdc_flush.go
@@ -12,7 +12,19 @@ import (
 	"go.uber.org/zap"
 )
 
-func runCDCFlush(ctx context.Context, args []string) error { //nolint:funlen // #319: flag parsing extracted by this plan's Task 2
+// cdcFlushOptions carries everything runCDCFlush needs after the flag set has
+// been parsed and validated.
+type cdcFlushOptions struct {
+	cfg      publiccdc.Config
+	pg       postgresFlags
+	registry schemaRegistryFlags
+	dryRun   bool
+}
+
+// parseCDCFlushFlags registers, parses and validates the cdc-flush flag set.
+// It answers (nil, nil) for -help so the caller exits quietly, mirroring the
+// errors.Is(err, flag.ErrHelp) branch this was extracted from (#319).
+func parseCDCFlushFlags(args []string) (*cdcFlushOptions, error) {
 	fs := flag.NewFlagSet("cdc-flush", flag.ContinueOnError)
 	fs.SetOutput(flag.CommandLine.Output())
 
@@ -41,7 +53,6 @@ func runCDCFlush(ctx context.Context, args []string) error { //nolint:funlen // 
 		useIAMUsage:     "Use IAM authentication for PostgreSQL",
 	})
 
-	// Change log settings
 	changeLogTable := fs.String("change-log-table", "change_log", "Change log table name")
 	entityMainTable := fs.String("entity-main-table", "entity_main", "Entity main table name")
 	eavDataTable := fs.String("eav-table", "eav_data", "EAV data table name")
@@ -67,32 +78,41 @@ func runCDCFlush(ctx context.Context, args []string) error { //nolint:funlen // 
 		bucketRequired: true,
 	})
 
-	// Manifest settings (optional - enables manifest tracking)
 	manifestPrefix := fs.String("manifest-prefix", "", "Manifest prefix in S3 (enables manifest tracking)")
 	manifestTemplate := fs.String("manifest-template", "manifest/{{.SchemaID}}.json", "Manifest path template")
 
 	var schemaRegistry schemaRegistryFlags
 	schemaRegistry.register(fs, false)
 
-	// Control
 	dryRun := fs.Bool("dry-run", false, "Dry run mode (no actual flush)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			return nil
+			return nil, nil
 		}
-		return err
+		return nil, err
 	}
 
 	if err := s3Config.validate(true); err != nil {
-		return err
+		return nil, err
 	}
 	if err := schemaRegistry.validate(false); err != nil {
-		return err
+		return nil, err
 	}
 
 	password := pg.resolvedPassword("PGPASSWORD")
-	cfg := publiccdc.Config{
+	cfg := buildCDCConfig(pg, password, changeLogTable, entityMainTable, eavDataTable,
+		minRecords, maxAgeMs, batchSize, estimatedRowBytes, maxBatchBytes, duck,
+		s3Config, manifestPrefix, manifestTemplate)
+
+	return &cdcFlushOptions{cfg: cfg, pg: pg, registry: schemaRegistry, dryRun: *dryRun}, nil
+}
+
+// buildCDCConfig constructs a CDC config from parsed flag values.
+func buildCDCConfig(pg postgresFlags, password string, changeLogTable, entityMainTable, eavDataTable *string,
+	minRecords *int, maxAgeMs *int64, batchSize, estimatedRowBytes *int, maxBatchBytes *int64, duck duckExportFlags,
+	s3Config s3Flags, manifestPrefix, manifestTemplate *string) publiccdc.Config {
+	return publiccdc.Config{
 		ChangeLogTable:          *changeLogTable,
 		EntityMainTable:         *entityMainTable,
 		EAVDataTable:            *eavDataTable,
@@ -123,6 +143,17 @@ func runCDCFlush(ctx context.Context, args []string) error { //nolint:funlen // 
 		ManifestPrefix:          *manifestPrefix,
 		ManifestTemplate:        *manifestTemplate,
 	}.WithDefaults()
+}
+
+func runCDCFlush(ctx context.Context, args []string) error {
+	opts, err := parseCDCFlushFlags(args)
+	if err != nil {
+		return err
+	}
+	if opts == nil {
+		return nil
+	}
+	cfg := opts.cfg
 
 	logger, err := buildToolLogger(true)
 	if err != nil {
@@ -131,8 +162,8 @@ func runCDCFlush(ctx context.Context, args []string) error { //nolint:funlen // 
 	defer func() { _ = logger.Sync() }()
 
 	var registry forma.SchemaRegistry
-	if schemaRegistry.table != "" {
-		pool, err := buildToolPostgresPool(ctx, pg.databaseConfig("PGPASSWORD", toolPostgresPoolSettings{
+	if opts.registry.table != "" {
+		pool, err := buildToolPostgresPool(ctx, opts.pg.databaseConfig("PGPASSWORD", toolPostgresPoolSettings{
 			maxConnections: 4,
 			timeout:        30 * time.Second,
 		}))
@@ -140,7 +171,7 @@ func runCDCFlush(ctx context.Context, args []string) error { //nolint:funlen // 
 			return fmt.Errorf("create schema registry pool: %w", err)
 		}
 		defer pool.Close()
-		reg, err := buildToolSchemaRegistry(ctx, pool, schemaRegistry.table, schemaRegistry.dir)
+		reg, err := buildToolSchemaRegistry(ctx, pool, opts.registry.table, opts.registry.dir)
 		if err != nil {
 			return fmt.Errorf("create schema registry: %w", err)
 		}
@@ -157,9 +188,9 @@ func runCDCFlush(ctx context.Context, args []string) error { //nolint:funlen // 
 		zap.String("bucket", cfg.S3Bucket),
 		zap.String("prefix", cfg.S3Prefix),
 		zap.String("manifest_template", cfg.ManifestTemplate),
-		zap.Bool("dry_run", *dryRun))
+		zap.Bool("dry_run", opts.dryRun))
 
-	if err := publiccdc.RunOnce(ctx, cfg, s3Client, *dryRun, logger, registry); err != nil {
+	if err := publiccdc.RunOnce(ctx, cfg, s3Client, opts.dryRun, logger, registry); err != nil {
 		return fmt.Errorf("CDC flush failed: %w", err)
 	}
 

--- a/cmd/tools/cdc_flush.go
+++ b/cmd/tools/cdc_flush.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func runCDCFlush(ctx context.Context, args []string) error {
+func runCDCFlush(ctx context.Context, args []string) error { //nolint:funlen // #319: flag parsing extracted by this plan's Task 2
 	fs := flag.NewFlagSet("cdc-flush", flag.ContinueOnError)
 	fs.SetOutput(flag.CommandLine.Output())
 

--- a/cmd/tools/cdc_flush.go
+++ b/cmd/tools/cdc_flush.go
@@ -53,6 +53,7 @@ func parseCDCFlushFlags(args []string) (*cdcFlushOptions, error) {
 		useIAMUsage:     "Use IAM authentication for PostgreSQL",
 	})
 
+	// Change log settings
 	changeLogTable := fs.String("change-log-table", "change_log", "Change log table name")
 	entityMainTable := fs.String("entity-main-table", "entity_main", "Entity main table name")
 	eavDataTable := fs.String("eav-table", "eav_data", "EAV data table name")
@@ -78,12 +79,14 @@ func parseCDCFlushFlags(args []string) (*cdcFlushOptions, error) {
 		bucketRequired: true,
 	})
 
+	// Manifest settings (optional - enables manifest tracking)
 	manifestPrefix := fs.String("manifest-prefix", "", "Manifest prefix in S3 (enables manifest tracking)")
 	manifestTemplate := fs.String("manifest-template", "manifest/{{.SchemaID}}.json", "Manifest path template")
 
 	var schemaRegistry schemaRegistryFlags
 	schemaRegistry.register(fs, false)
 
+	// Control
 	dryRun := fs.Bool("dry-run", false, "Dry run mode (no actual flush)")
 
 	if err := fs.Parse(args); err != nil {

--- a/cmd/tools/cdc_init.go
+++ b/cmd/tools/cdc_init.go
@@ -156,6 +156,8 @@ func buildCDCInitConfig(pg postgresFlags, password string, entityMainTable, eavD
 	}.WithDefaults()
 }
 
+// runCDCInit parses cdc-init CLI flags and delegates the actual base-file
+// export to cdc.RunInit (the driver was extracted into internal/cdc, #173).
 func runCDCInit(ctx context.Context, args []string) error {
 	opts, err := parseCDCInitFlags(args)
 	if err != nil {

--- a/cmd/tools/cdc_init.go
+++ b/cmd/tools/cdc_init.go
@@ -15,9 +15,21 @@ const (
 	defaultInitBatchSize = 50000
 )
 
-// runCDCInit parses cdc-init CLI flags and delegates the actual base-file
-// export to cdc.RunInit (the driver was extracted into internal/cdc, #173).
-func runCDCInit(ctx context.Context, args []string) error { //nolint:funlen // #319: flag parsing extracted by this plan's Task 3
+// cdcInitOptions carries everything runCDCInit needs after the flag set has
+// been parsed and validated.
+type cdcInitOptions struct {
+	cfg                  cdc.CDCConfig
+	pg                   postgresFlags
+	registry             schemaRegistryFlags
+	schemaIDFilter       int
+	dryRun               bool
+	autoEstimateRowBytes bool
+}
+
+// parseCDCInitFlags registers, parses and validates the cdc-init flag set.
+// It answers (nil, nil) for -help so the caller exits quietly, mirroring the
+// errors.Is(err, flag.ErrHelp) branch this was extracted from (#319).
+func parseCDCInitFlags(args []string) (*cdcInitOptions, error) {
 	fs := flag.NewFlagSet("cdc-init", flag.ContinueOnError)
 	fs.SetOutput(flag.CommandLine.Output())
 
@@ -80,23 +92,41 @@ func runCDCInit(ctx context.Context, args []string) error { //nolint:funlen // #
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			return nil
+			return nil, nil
 		}
-		return err
+		return nil, err
 	}
 
 	if err := s3Config.validate(true); err != nil {
-		return err
+		return nil, err
 	}
 	if err := schemaRegistry.validate(true); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Track if user explicitly provided estimated-row-bytes (0 means auto-calculate from schema)
 	autoEstimateRowBytes := *estimatedRowBytes == 0
 	password := pg.resolvedPassword("PGPASSWORD")
 
-	cfg := cdc.CDCConfig{
+	cfg := buildCDCInitConfig(pg, password, entityMainTable, eavDataTable, batchSize,
+		targetFileSizeMB, estimatedRowBytes, maxBatchSize, duck, s3Config,
+		manifestPrefix, manifestTemplate)
+
+	return &cdcInitOptions{
+		cfg:                  cfg,
+		pg:                   pg,
+		registry:             schemaRegistry,
+		schemaIDFilter:       *schemaIDFilter,
+		dryRun:               *dryRun,
+		autoEstimateRowBytes: autoEstimateRowBytes,
+	}, nil
+}
+
+// buildCDCInitConfig constructs a CDC config from parsed flag values.
+func buildCDCInitConfig(pg postgresFlags, password string, entityMainTable, eavDataTable *string,
+	batchSize, targetFileSizeMB, estimatedRowBytes, maxBatchSize *int, duck duckExportFlags,
+	s3Config s3Flags, manifestPrefix, manifestTemplate *string) cdc.CDCConfig {
+	return cdc.CDCConfig{
 		EntityMainTable:         *entityMainTable,
 		EAVDataTable:            *eavDataTable,
 		BatchSize:               *batchSize,
@@ -124,6 +154,17 @@ func runCDCInit(ctx context.Context, args []string) error { //nolint:funlen // #
 		ManifestPrefix:          *manifestPrefix,
 		ManifestTemplate:        *manifestTemplate,
 	}.WithDefaults()
+}
+
+func runCDCInit(ctx context.Context, args []string) error {
+	opts, err := parseCDCInitFlags(args)
+	if err != nil {
+		return err
+	}
+	if opts == nil {
+		return nil
+	}
+	cfg := opts.cfg
 
 	logger, err := buildToolLogger(true)
 	if err != nil {
@@ -131,7 +172,7 @@ func runCDCInit(ctx context.Context, args []string) error { //nolint:funlen // #
 	}
 	defer func() { _ = logger.Sync() }()
 
-	pool, err := buildToolPostgresPool(ctx, pg.databaseConfig("PGPASSWORD", toolPostgresPoolSettings{
+	pool, err := buildToolPostgresPool(ctx, opts.pg.databaseConfig("PGPASSWORD", toolPostgresPoolSettings{
 		maxConnections: 4,
 		timeout:        30 * time.Second,
 	}))
@@ -140,7 +181,7 @@ func runCDCInit(ctx context.Context, args []string) error { //nolint:funlen // #
 	}
 	defer pool.Close()
 
-	registry, err := buildToolSchemaRegistry(ctx, pool, schemaRegistry.table, schemaRegistry.dir)
+	registry, err := buildToolSchemaRegistry(ctx, pool, opts.registry.table, opts.registry.dir)
 	if err != nil {
 		return fmt.Errorf("create schema registry: %w", err)
 	}
@@ -159,17 +200,17 @@ func runCDCInit(ctx context.Context, args []string) error { //nolint:funlen // #
 		zap.Int("estimated_row_bytes", cfg.EstimatedRowBytes),
 		zap.Int("max_batch_size", cfg.MaxBatchSize),
 		zap.Int("fallback_batch_size", cfg.BatchSize),
-		zap.Int("schema_id_filter", *schemaIDFilter),
-		zap.Bool("dry_run", *dryRun),
-		zap.Bool("auto_estimate_row_bytes", autoEstimateRowBytes))
+		zap.Int("schema_id_filter", opts.schemaIDFilter),
+		zap.Bool("dry_run", opts.dryRun),
+		zap.Bool("auto_estimate_row_bytes", opts.autoEstimateRowBytes))
 
 	if _, err := cdc.RunInit(ctx, cdc.InitOptions{
 		Config:               cfg,
 		S3Client:             s3Client,
-		SchemaRegistryTable:  schemaRegistry.table,
-		SchemaIDFilter:       *schemaIDFilter,
-		DryRun:               *dryRun,
-		AutoEstimateRowBytes: autoEstimateRowBytes,
+		SchemaRegistryTable:  opts.registry.table,
+		SchemaIDFilter:       opts.schemaIDFilter,
+		DryRun:               opts.dryRun,
+		AutoEstimateRowBytes: opts.autoEstimateRowBytes,
 		Logger:               logger,
 		SchemaRegistry:       registry,
 	}); err != nil {

--- a/cmd/tools/cdc_init.go
+++ b/cmd/tools/cdc_init.go
@@ -17,7 +17,7 @@ const (
 
 // runCDCInit parses cdc-init CLI flags and delegates the actual base-file
 // export to cdc.RunInit (the driver was extracted into internal/cdc, #173).
-func runCDCInit(ctx context.Context, args []string) error {
+func runCDCInit(ctx context.Context, args []string) error { //nolint:funlen // #319: flag parsing extracted by this plan's Task 3
 	fs := flag.NewFlagSet("cdc-init", flag.ContinueOnError)
 	fs.SetOutput(flag.CommandLine.Output())
 

--- a/cmd/tools/init_db.go
+++ b/cmd/tools/init_db.go
@@ -111,23 +111,19 @@ func initDatabase(ctx context.Context, opts initDBOptions, dbConfig forma.Databa
 	return nil
 }
 
-func ensureTables(ctx context.Context, tx pgx.Tx, opts initDBOptions) error { //nolint:funlen // #319: DDL builders extracted by this plan's Task 4
-	schemaTable := quoteIdentifier(opts.schemaTable)
-	eavTable := quoteIdentifier(opts.eavTable)
-	entityMain := quoteIdentifier(opts.entityMain)
-	changeLog := quoteIdentifier(opts.changeLog)
+// tableDDL pairs one DDL statement with the line init-db prints on success and
+// the label its failure is wrapped with. Splitting the statements out of
+// ensureTables (#319) keeps them testable without a live database.
+type tableDDL struct {
+	statement string
+	announce  string
+	failure   string
+}
 
-	ddlSchema := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-		schema_name TEXT PRIMARY KEY,
-		schema_id SMALLINT UNIQUE NOT NULL
-	)`, schemaTable)
-
-	if _, err := tx.Exec(ctx, ddlSchema); err != nil {
-		return fmt.Errorf("ensure schema registry table: %w", err)
-	}
-	fmt.Printf("Created schema registry table: %s\n", opts.schemaTable)
-
-	ddlMain := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+// entityMainDDL is the hot-field main table: fixed physical columns that the
+// schema metadata maps logical attributes onto.
+func entityMainDDL(entityMain string) string {
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 		ltbase_schema_id   SMALLINT NOT NULL,
 		ltbase_row_id      UUID NOT NULL,
 		text_01            TEXT,
@@ -166,53 +162,75 @@ func ensureTables(ctx context.Context, tx pgx.Tx, opts initDBOptions) error { //
 		ltbase_deleted_by  TEXT,
 		PRIMARY KEY (ltbase_schema_id, ltbase_row_id)
 	)`, entityMain)
+}
 
-	if _, err := tx.Exec(ctx, ddlMain); err != nil {
-		return fmt.Errorf("ensure entity main table: %w", err)
+func coreTableDDL(opts initDBOptions) []tableDDL {
+	schemaTable := quoteIdentifier(opts.schemaTable)
+	eavTable := quoteIdentifier(opts.eavTable)
+	entityMain := quoteIdentifier(opts.entityMain)
+	changeLog := quoteIdentifier(opts.changeLog)
+
+	return []tableDDL{
+		{
+			statement: fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+				schema_name TEXT PRIMARY KEY,
+				schema_id SMALLINT UNIQUE NOT NULL
+			)`, schemaTable),
+			announce: fmt.Sprintf("Created schema registry table: %s\n", opts.schemaTable),
+			failure:  "ensure schema registry table",
+		},
+		{
+			statement: entityMainDDL(entityMain),
+			// No trailing newline: pre-existing tool output, preserved verbatim.
+			announce: fmt.Sprintf("Created entity main table: %s", opts.entityMain),
+			failure:  "ensure entity main table",
+		},
+		{
+			statement: fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+				schema_id      SMALLINT NOT NULL,
+				row_id         UUID NOT NULL,
+				attr_id        SMALLINT NOT NULL,
+				array_indices  TEXT NOT NULL DEFAULT '',
+				value_text     TEXT,
+				value_numeric  NUMERIC,
+				PRIMARY KEY (schema_id, row_id, attr_id, array_indices)
+			)`, eavTable),
+			announce: fmt.Sprintf("Created EAV table: %s\n", opts.eavTable),
+			failure:  "ensure eav table",
+		},
+		{
+			statement: fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+				    schema_id  SMALLINT NOT NULL,
+					row_id     UUID     NOT NULL,
+					flushed_at BIGINT   NOT NULL DEFAULT 0,
+					changed_at BIGINT   NOT NULL,
+					deleted_at BIGINT,
+					primary key (schema_id, row_id, flushed_at)
+				);`, changeLog),
+			announce: fmt.Sprintf("Created change log table: %s\n", opts.changeLog),
+			failure:  "ensure change log table",
+		},
 	}
-	fmt.Printf("Created entity main table: %s", opts.entityMain)
+}
 
-	ddlEAV := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-		schema_id      SMALLINT NOT NULL,
-		row_id         UUID NOT NULL,
-		attr_id        SMALLINT NOT NULL,
-		array_indices  TEXT NOT NULL DEFAULT '',
-		value_text     TEXT,
-		value_numeric  NUMERIC,
-		PRIMARY KEY (schema_id, row_id, attr_id, array_indices)
-	)`, eavTable)
-
-	if _, err := tx.Exec(ctx, ddlEAV); err != nil {
-		return fmt.Errorf("ensure eav table: %w", err)
-	}
-	fmt.Printf("Created EAV table: %s\n", opts.eavTable)
-
-	ddlChangeLog := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-		    schema_id  SMALLINT NOT NULL,
-			row_id     UUID     NOT NULL,
-			flushed_at BIGINT   NOT NULL DEFAULT 0,
-			changed_at BIGINT   NOT NULL,
-			deleted_at BIGINT,
-			primary key (schema_id, row_id, flushed_at)
-		);`, changeLog)
-
-	if _, err := tx.Exec(ctx, ddlChangeLog); err != nil {
-		return fmt.Errorf("ensure change log table: %w", err)
-	}
-	fmt.Printf("Created change log table: %s\n", opts.changeLog)
-
+func eavIndexDDL(opts initDBOptions) []tableDDL {
+	eavTable := quoteIdentifier(opts.eavTable)
 	idxNumeric := quoteIdentifier(makeIndexName(opts.eavTable, "numeric"))
-	createIdxNumeric := fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (schema_id, attr_id, value_numeric, row_id) WHERE value_numeric IS NOT NULL`, idxNumeric, eavTable)
-	if _, err := tx.Exec(ctx, createIdxNumeric); err != nil {
-		return fmt.Errorf("create numeric index: %w", err)
-	}
-
 	idxText := quoteIdentifier(makeIndexName(opts.eavTable, "text"))
-	createIdxText := fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (schema_id, attr_id, value_text, row_id) WHERE value_text IS NOT NULL`, idxText, eavTable)
-	if _, err := tx.Exec(ctx, createIdxText); err != nil {
-		return fmt.Errorf("create text index: %w", err)
+	return []tableDDL{
+		{
+			statement: fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (schema_id, attr_id, value_numeric, row_id) WHERE value_numeric IS NOT NULL`, idxNumeric, eavTable),
+			failure:   "create numeric index",
+		},
+		{
+			statement: fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (schema_id, attr_id, value_text, row_id) WHERE value_text IS NOT NULL`, idxText, eavTable),
+			failure:   "create text index",
+		},
 	}
+}
 
+func mainColumnIndexDDL(opts initDBOptions) []tableDDL {
+	entityMain := quoteIdentifier(opts.entityMain)
 	indexedMainColumns := []string{
 		"text_01", "text_02", "text_03",
 		"smallint_01",
@@ -222,11 +240,31 @@ func ensureTables(ctx context.Context, tx pgx.Tx, opts initDBOptions) error { //
 		"uuid_01",
 	}
 
+	ddl := make([]tableDDL, 0, len(indexedMainColumns))
 	for _, col := range indexedMainColumns {
 		idx := quoteIdentifier(makeIndexName(opts.entityMain, col))
-		stmt := fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (ltbase_schema_id, ltbase_row_id, %s)`, idx, entityMain, quoteIdentifier(col))
-		if _, err := tx.Exec(ctx, stmt); err != nil {
-			return fmt.Errorf("create main index for %s: %w", col, err)
+		ddl = append(ddl, tableDDL{
+			statement: fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON %s (ltbase_schema_id, ltbase_row_id, %s)`, idx, entityMain, quoteIdentifier(col)),
+			failure:   "create main index for " + col,
+		})
+	}
+	return ddl
+}
+
+func ensureTables(ctx context.Context, tx pgx.Tx, opts initDBOptions) error {
+	groups := [][]tableDDL{
+		coreTableDDL(opts),
+		eavIndexDDL(opts),
+		mainColumnIndexDDL(opts),
+	}
+	for _, group := range groups {
+		for _, ddl := range group {
+			if _, err := tx.Exec(ctx, ddl.statement); err != nil {
+				return fmt.Errorf("%s: %w", ddl.failure, err)
+			}
+			if ddl.announce != "" {
+				fmt.Print(ddl.announce)
+			}
 		}
 	}
 

--- a/cmd/tools/init_db.go
+++ b/cmd/tools/init_db.go
@@ -111,7 +111,7 @@ func initDatabase(ctx context.Context, opts initDBOptions, dbConfig forma.Databa
 	return nil
 }
 
-func ensureTables(ctx context.Context, tx pgx.Tx, opts initDBOptions) error {
+func ensureTables(ctx context.Context, tx pgx.Tx, opts initDBOptions) error { //nolint:funlen // #319: DDL builders extracted by this plan's Task 4
 	schemaTable := quoteIdentifier(opts.schemaTable)
 	eavTable := quoteIdentifier(opts.eavTable)
 	entityMain := quoteIdentifier(opts.entityMain)

--- a/cmd/tools/init_db.go
+++ b/cmd/tools/init_db.go
@@ -120,6 +120,39 @@ type tableDDL struct {
 	failure   string
 }
 
+// schemaRegistryDDL constructs the schema registry table.
+func schemaRegistryDDL(schemaTable string) string {
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		schema_name TEXT PRIMARY KEY,
+		schema_id SMALLINT UNIQUE NOT NULL
+	)`, schemaTable)
+}
+
+// eavTableDDL constructs the EAV data table.
+func eavTableDDL(eavTable string) string {
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		schema_id      SMALLINT NOT NULL,
+		row_id         UUID NOT NULL,
+		attr_id        SMALLINT NOT NULL,
+		array_indices  TEXT NOT NULL DEFAULT '',
+		value_text     TEXT,
+		value_numeric  NUMERIC,
+		PRIMARY KEY (schema_id, row_id, attr_id, array_indices)
+	)`, eavTable)
+}
+
+// changeLogDDL constructs the change log table.
+func changeLogDDL(changeLog string) string {
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		    schema_id  SMALLINT NOT NULL,
+			row_id     UUID     NOT NULL,
+			flushed_at BIGINT   NOT NULL DEFAULT 0,
+			changed_at BIGINT   NOT NULL,
+			deleted_at BIGINT,
+			primary key (schema_id, row_id, flushed_at)
+		);`, changeLog)
+}
+
 // entityMainDDL is the hot-field main table: fixed physical columns that the
 // schema metadata maps logical attributes onto.
 func entityMainDDL(entityMain string) string {
@@ -172,12 +205,9 @@ func coreTableDDL(opts initDBOptions) []tableDDL {
 
 	return []tableDDL{
 		{
-			statement: fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-				schema_name TEXT PRIMARY KEY,
-				schema_id SMALLINT UNIQUE NOT NULL
-			)`, schemaTable),
-			announce: fmt.Sprintf("Created schema registry table: %s\n", opts.schemaTable),
-			failure:  "ensure schema registry table",
+			statement: schemaRegistryDDL(schemaTable),
+			announce:  fmt.Sprintf("Created schema registry table: %s\n", opts.schemaTable),
+			failure:   "ensure schema registry table",
 		},
 		{
 			statement: entityMainDDL(entityMain),
@@ -186,29 +216,14 @@ func coreTableDDL(opts initDBOptions) []tableDDL {
 			failure:  "ensure entity main table",
 		},
 		{
-			statement: fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-				schema_id      SMALLINT NOT NULL,
-				row_id         UUID NOT NULL,
-				attr_id        SMALLINT NOT NULL,
-				array_indices  TEXT NOT NULL DEFAULT '',
-				value_text     TEXT,
-				value_numeric  NUMERIC,
-				PRIMARY KEY (schema_id, row_id, attr_id, array_indices)
-			)`, eavTable),
-			announce: fmt.Sprintf("Created EAV table: %s\n", opts.eavTable),
-			failure:  "ensure eav table",
+			statement: eavTableDDL(eavTable),
+			announce:  fmt.Sprintf("Created EAV table: %s\n", opts.eavTable),
+			failure:   "ensure eav table",
 		},
 		{
-			statement: fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-				    schema_id  SMALLINT NOT NULL,
-					row_id     UUID     NOT NULL,
-					flushed_at BIGINT   NOT NULL DEFAULT 0,
-					changed_at BIGINT   NOT NULL,
-					deleted_at BIGINT,
-					primary key (schema_id, row_id, flushed_at)
-				);`, changeLog),
-			announce: fmt.Sprintf("Created change log table: %s\n", opts.changeLog),
-			failure:  "ensure change log table",
+			statement: changeLogDDL(changeLog),
+			announce:  fmt.Sprintf("Created change log table: %s\n", opts.changeLog),
+			failure:   "ensure change log table",
 		},
 	}
 }

--- a/cmd/tools/init_db_ddl_test.go
+++ b/cmd/tools/init_db_ddl_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func testInitDBOptions() initDBOptions {
+	return initDBOptions{
+		schemaTable: "schema_registry",
+		eavTable:    "eav_data",
+		entityMain:  "entity_main",
+		changeLog:   "change_log",
+	}
+}
+
+// TestCoreTableDDLCoversFourTables pins the four CREATE TABLE statements
+// ensureTables issues, in order. Before #319 split them out, a dropped table
+// would only have surfaced against a live database.
+func TestCoreTableDDLCoversFourTables(t *testing.T) {
+	ddl := coreTableDDL(testInitDBOptions())
+	if len(ddl) != 4 {
+		t.Fatalf("coreTableDDL returned %d statements, want 4", len(ddl))
+	}
+	wantTables := []string{"schema_registry", "entity_main", "eav_data", "change_log"}
+	for i, want := range wantTables {
+		if !strings.Contains(ddl[i].statement, want) {
+			t.Errorf("statement %d does not mention %q: %s", i, want, ddl[i].statement)
+		}
+		if !strings.HasPrefix(ddl[i].statement, "CREATE TABLE IF NOT EXISTS") {
+			t.Errorf("statement %d is not an idempotent CREATE: %s", i, ddl[i].statement)
+		}
+	}
+}
+
+// TestCoreTableDDLPreservesEntityMainAnnouncement guards a pre-existing quirk:
+// the entity-main line is printed WITHOUT a trailing newline while the other
+// three have one. #319 is a behaviour-preserving refactor, so the quirk stays;
+// this test is what stops someone "tidying" it and changing tool output.
+func TestCoreTableDDLPreservesEntityMainAnnouncement(t *testing.T) {
+	ddl := coreTableDDL(testInitDBOptions())
+	if got := ddl[1].announce; got != "Created entity main table: entity_main" {
+		t.Errorf("entity main announcement = %q, want no trailing newline", got)
+	}
+	if got := ddl[0].announce; got != "Created schema registry table: schema_registry\n" {
+		t.Errorf("schema registry announcement = %q, want a trailing newline", got)
+	}
+}
+
+// TestMainColumnIndexDDLCoversEveryIndexedColumn pins the ten hot columns that
+// get a covering index, and the per-column failure label ensureTables wraps.
+func TestMainColumnIndexDDLCoversEveryIndexedColumn(t *testing.T) {
+	ddl := mainColumnIndexDDL(testInitDBOptions())
+	if len(ddl) != 10 {
+		t.Fatalf("mainColumnIndexDDL returned %d statements, want 10", len(ddl))
+	}
+	wantCols := []string{
+		"text_01", "text_02", "text_03",
+		"smallint_01",
+		"integer_01",
+		"bigint_01", "bigint_02",
+		"double_01", "double_02",
+		"uuid_01",
+	}
+	for i, col := range wantCols {
+		if !strings.Contains(ddl[i].statement, col) {
+			t.Errorf("statement %d does not mention column %q: %s", i, col, ddl[i].statement)
+		}
+		if want := "create main index for " + col; ddl[i].failure != want {
+			t.Errorf("failure label %d = %q, want %q", i, ddl[i].failure, want)
+		}
+	}
+}
+
+// TestEAVIndexDDLCoversNumericAndText pins the two partial EAV indexes and
+// their WHERE guards — dropping a guard would silently index NULL rows.
+func TestEAVIndexDDLCoversNumericAndText(t *testing.T) {
+	ddl := eavIndexDDL(testInitDBOptions())
+	if len(ddl) != 2 {
+		t.Fatalf("eavIndexDDL returned %d statements, want 2", len(ddl))
+	}
+	if !strings.Contains(ddl[0].statement, "value_numeric IS NOT NULL") {
+		t.Errorf("numeric index lost its partial guard: %s", ddl[0].statement)
+	}
+	if !strings.Contains(ddl[1].statement, "value_text IS NOT NULL") {
+		t.Errorf("text index lost its partial guard: %s", ddl[1].statement)
+	}
+	if ddl[0].failure != "create numeric index" {
+		t.Errorf("numeric failure label = %q", ddl[0].failure)
+	}
+	if ddl[1].failure != "create text index" {
+		t.Errorf("text failure label = %q", ddl[1].failure)
+	}
+}

--- a/cmd/tools/init_db_ddl_test.go
+++ b/cmd/tools/init_db_ddl_test.go
@@ -92,3 +92,106 @@ func TestEAVIndexDDLCoversNumericAndText(t *testing.T) {
 		t.Errorf("text failure label = %q", ddl[1].failure)
 	}
 }
+
+// TestEntityMainDDLGolden pins the complete 37-line schema definition.
+// This catches mutations to column types (e.g., bigint_01 TEXT), dropped
+// constraints (e.g., NOT NULL, PRIMARY KEY), and missing columns (e.g., text_05).
+func TestEntityMainDDLGolden(t *testing.T) {
+	stmt := entityMainDDL(`"entity_main"`)
+
+	// Critical columns and constraints that must not change
+	criticalChecks := []string{
+		"bigint_01          BIGINT",
+		"ltbase_created_at  BIGINT NOT NULL",
+		"PRIMARY KEY (ltbase_schema_id, ltbase_row_id)",
+		"text_05            TEXT",
+		"ltbase_schema_id   SMALLINT NOT NULL",
+		"ltbase_row_id      UUID NOT NULL",
+	}
+
+	for _, check := range criticalChecks {
+		if !strings.Contains(stmt, check) {
+			t.Errorf("entityMainDDL missing critical definition: %q\nGot:\n%s", check, stmt)
+		}
+	}
+}
+
+// TestCoreTableDDLGolden pins all four table definitions and announcement strings
+// to catch mutations in column definitions, constraints, and output text.
+func TestCoreTableDDLGolden(t *testing.T) {
+	opts := testInitDBOptions()
+	ddl := coreTableDDL(opts)
+
+	// Check schema registry table
+	if !strings.Contains(ddl[0].statement, "schema_name TEXT PRIMARY KEY") {
+		t.Errorf("schema registry table: missing schema_name PRIMARY KEY\n%s", ddl[0].statement)
+	}
+	if !strings.Contains(ddl[0].statement, "schema_id SMALLINT UNIQUE NOT NULL") {
+		t.Errorf("schema registry table: missing schema_id UNIQUE NOT NULL\n%s", ddl[0].statement)
+	}
+
+	// Check entity main table (via entityMainDDL)
+	if !strings.Contains(ddl[1].statement, "PRIMARY KEY (ltbase_schema_id, ltbase_row_id)") {
+		t.Errorf("entity main table: missing composite PRIMARY KEY\n%s", ddl[1].statement)
+	}
+	if !strings.Contains(ddl[1].statement, "bigint_01          BIGINT") {
+		t.Errorf("entity main table: bigint_01 must be BIGINT type\n%s", ddl[1].statement)
+	}
+	if !strings.Contains(ddl[1].statement, "ltbase_created_at  BIGINT NOT NULL") {
+		t.Errorf("entity main table: ltbase_created_at must be NOT NULL\n%s", ddl[1].statement)
+	}
+
+	// Check EAV table
+	if !strings.Contains(ddl[2].statement, "PRIMARY KEY (schema_id, row_id, attr_id, array_indices)") {
+		t.Errorf("EAV table: primary key narrowed to fewer than 4 columns\n%s", ddl[2].statement)
+	}
+	if !strings.Contains(ddl[2].statement, "attr_id        SMALLINT NOT NULL") {
+		t.Errorf("EAV table: missing attr_id column\n%s", ddl[2].statement)
+	}
+
+	// Check change log table
+	if !strings.Contains(ddl[3].statement, "primary key (schema_id, row_id, flushed_at)") {
+		t.Errorf("change log table: missing composite primary key\n%s", ddl[3].statement)
+	}
+
+	// Check announcements
+	if ddl[0].announce != "Created schema registry table: schema_registry\n" {
+		t.Errorf("schema registry announcement = %q", ddl[0].announce)
+	}
+	if ddl[1].announce != "Created entity main table: entity_main" {
+		t.Errorf("entity main announcement = %q", ddl[1].announce)
+	}
+	if ddl[2].announce != "Created EAV table: eav_data\n" {
+		t.Errorf("EAV announcement = %q, want 'Created EAV table: eav_data\\n'", ddl[2].announce)
+	}
+	if ddl[3].announce != "Created change log table: change_log\n" {
+		t.Errorf("change log announcement = %q", ddl[3].announce)
+	}
+}
+
+// TestMainColumnIndexDDLGolden pins the presence of ltbase_schema_id in all
+// main indexes — dropping it would change query performance characteristics.
+func TestMainColumnIndexDDLGolden(t *testing.T) {
+	ddl := mainColumnIndexDDL(testInitDBOptions())
+	for i, stmt := range ddl {
+		if !strings.Contains(stmt.statement, "ltbase_schema_id") {
+			t.Errorf("main index %d statement missing ltbase_schema_id: %s", i, stmt.statement)
+		}
+	}
+}
+
+// TestEAVIndexDDLGolden pins the exact key columns for both EAV indexes,
+// particularly attr_id which is essential for attribute filtering.
+func TestEAVIndexDDLGolden(t *testing.T) {
+	ddl := eavIndexDDL(testInitDBOptions())
+
+	// Numeric index must include attr_id in the key
+	if !strings.Contains(ddl[0].statement, "schema_id, attr_id, value_numeric, row_id") {
+		t.Errorf("numeric index key missing attr_id: %s", ddl[0].statement)
+	}
+
+	// Text index must include attr_id in the key
+	if !strings.Contains(ddl[1].statement, "schema_id, attr_id, value_text, row_id") {
+		t.Errorf("text index key missing attr_id: %s", ddl[1].statement)
+	}
+}

--- a/cmd/tools/init_db_ddl_test.go
+++ b/cmd/tools/init_db_ddl_test.go
@@ -14,6 +14,172 @@ func testInitDBOptions() initDBOptions {
 	}
 }
 
+// allDDLStatements flattens the three builder groups in the exact order
+// ensureTables executes them: 4 core tables, 2 EAV indexes, 10 main-column
+// indexes.
+func allDDLStatements(opts initDBOptions) []tableDDL {
+	var all []tableDDL
+	for _, group := range [][]tableDDL{coreTableDDL(opts), eavIndexDDL(opts), mainColumnIndexDDL(opts)} {
+		all = append(all, group...)
+	}
+	return all
+}
+
+// wantDDLStatements is the golden text of every statement init-db issues,
+// captured from the pre-#319 ensureTables and verified byte-for-byte against
+// `git show 4b58a14:cmd/tools/init_db.go`.
+//
+// These are INDEPENDENT literals on purpose: never rebuild them by calling the
+// builders, or the test asserts nothing.
+//
+// The whitespace inside these raw strings is data, not source formatting. The
+// change_log literal genuinely mixes four-space and tab indentation; that is a
+// pre-existing quirk #319 preserved deliberately. Do not "tidy" it — gofmt will
+// not, and the DDL Postgres receives would change.
+func wantDDLStatements() []string {
+	return []string{
+		// schema_registry table
+		`CREATE TABLE IF NOT EXISTS "schema_registry" (
+		schema_name TEXT PRIMARY KEY,
+		schema_id SMALLINT UNIQUE NOT NULL
+	)`,
+		// entity_main table
+		`CREATE TABLE IF NOT EXISTS "entity_main" (
+		ltbase_schema_id   SMALLINT NOT NULL,
+		ltbase_row_id      UUID NOT NULL,
+		text_01            TEXT,
+		text_02            TEXT,
+		text_03            TEXT,
+		text_04            TEXT,
+		text_05            TEXT,
+		text_06            TEXT,
+		text_07            TEXT,
+		text_08            TEXT,
+		text_09            TEXT,
+		text_10            TEXT,
+		smallint_01        SMALLINT,
+		smallint_02        SMALLINT,
+		smallint_03        SMALLINT,
+		integer_01         INTEGER,
+		integer_02         INTEGER,
+		integer_03         INTEGER,
+		bigint_01          BIGINT,
+		bigint_02          BIGINT,
+		bigint_03          BIGINT,
+		bigint_04          BIGINT,
+		bigint_05          BIGINT,
+		double_01          DOUBLE PRECISION,
+		double_02          DOUBLE PRECISION,
+		double_03          DOUBLE PRECISION,
+		double_04          DOUBLE PRECISION,
+		double_05          DOUBLE PRECISION,
+		uuid_01            UUID,
+		uuid_02            UUID,
+		ltbase_created_at  BIGINT NOT NULL,
+		ltbase_updated_at  BIGINT NOT NULL,
+		ltbase_deleted_at  BIGINT,
+		ltbase_created_by  TEXT,
+		ltbase_updated_by  TEXT,
+		ltbase_deleted_by  TEXT,
+		PRIMARY KEY (ltbase_schema_id, ltbase_row_id)
+	)`,
+		// eav_data table
+		`CREATE TABLE IF NOT EXISTS "eav_data" (
+		schema_id      SMALLINT NOT NULL,
+		row_id         UUID NOT NULL,
+		attr_id        SMALLINT NOT NULL,
+		array_indices  TEXT NOT NULL DEFAULT '',
+		value_text     TEXT,
+		value_numeric  NUMERIC,
+		PRIMARY KEY (schema_id, row_id, attr_id, array_indices)
+	)`,
+		// change_log table
+		`CREATE TABLE IF NOT EXISTS "change_log" (
+		    schema_id  SMALLINT NOT NULL,
+			row_id     UUID     NOT NULL,
+			flushed_at BIGINT   NOT NULL DEFAULT 0,
+			changed_at BIGINT   NOT NULL,
+			deleted_at BIGINT,
+			primary key (schema_id, row_id, flushed_at)
+		);`,
+		// eav numeric index
+		"CREATE INDEX IF NOT EXISTS \"eav_data_numeric_idx\" ON \"eav_data\" (schema_id, attr_id, value_numeric, row_id) WHERE value_numeric IS NOT NULL",
+		// eav text index
+		"CREATE INDEX IF NOT EXISTS \"eav_data_text_idx\" ON \"eav_data\" (schema_id, attr_id, value_text, row_id) WHERE value_text IS NOT NULL",
+		// main index on text_01
+		"CREATE INDEX IF NOT EXISTS \"entity_main_text_01_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"text_01\")",
+		// main index on text_02
+		"CREATE INDEX IF NOT EXISTS \"entity_main_text_02_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"text_02\")",
+		// main index on text_03
+		"CREATE INDEX IF NOT EXISTS \"entity_main_text_03_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"text_03\")",
+		// main index on smallint_01
+		"CREATE INDEX IF NOT EXISTS \"entity_main_smallint_01_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"smallint_01\")",
+		// main index on integer_01
+		"CREATE INDEX IF NOT EXISTS \"entity_main_integer_01_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"integer_01\")",
+		// main index on bigint_01
+		"CREATE INDEX IF NOT EXISTS \"entity_main_bigint_01_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"bigint_01\")",
+		// main index on bigint_02
+		"CREATE INDEX IF NOT EXISTS \"entity_main_bigint_02_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"bigint_02\")",
+		// main index on double_01
+		"CREATE INDEX IF NOT EXISTS \"entity_main_double_01_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"double_01\")",
+		// main index on double_02
+		"CREATE INDEX IF NOT EXISTS \"entity_main_double_02_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"double_02\")",
+		// main index on uuid_01
+		"CREATE INDEX IF NOT EXISTS \"entity_main_uuid_01_idx\" ON \"entity_main\" (ltbase_schema_id, ltbase_row_id, \"uuid_01\")",
+	}
+}
+
+// wantCoreAnnouncements is the golden text of the four lines init-db prints on
+// success. Independent literals, captured the same way as the statements.
+//
+// Note the entity-main line has NO trailing newline while the other three do.
+// That asymmetry is pre-existing tool output that #319 preserved verbatim.
+func wantCoreAnnouncements() []string {
+	return []string{
+		"Created schema registry table: schema_registry\n",
+		"Created entity main table: entity_main",
+		"Created EAV table: eav_data\n",
+		"Created change log table: change_log\n",
+	}
+}
+
+// TestDDLStatementsGolden compares every statement init-db issues against its
+// full expected text. Spot-checking substrings lets whole columns and defaults
+// be mutated undetected; this is the backstop that does not.
+func TestDDLStatementsGolden(t *testing.T) {
+	got := allDDLStatements(testInitDBOptions())
+	want := wantDDLStatements()
+	if len(got) != len(want) {
+		t.Fatalf("init-db issues %d statements, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].statement != want[i] {
+			t.Errorf("statement %d differs from golden:\n got: %q\nwant: %q", i, got[i].statement, want[i])
+		}
+	}
+}
+
+// TestCoreTableAnnouncementsGolden compares each success line against its full
+// expected text, and pins that the index statements announce nothing.
+func TestCoreTableAnnouncementsGolden(t *testing.T) {
+	opts := testInitDBOptions()
+	core := coreTableDDL(opts)
+	want := wantCoreAnnouncements()
+	if len(core) != len(want) {
+		t.Fatalf("coreTableDDL returned %d statements, want %d", len(core), len(want))
+	}
+	for i := range want {
+		if core[i].announce != want[i] {
+			t.Errorf("announcement %d differs from golden:\n got: %q\nwant: %q", i, core[i].announce, want[i])
+		}
+	}
+	for i, ddl := range append(eavIndexDDL(opts), mainColumnIndexDDL(opts)...) {
+		if ddl.announce != "" {
+			t.Errorf("index statement %d announces %q, want silence", i, ddl.announce)
+		}
+	}
+}
+
 // TestCoreTableDDLCoversFourTables pins the four CREATE TABLE statements
 // ensureTables issues, in order. Before #319 split them out, a dropped table
 // would only have surfaced against a live database.
@@ -29,6 +195,17 @@ func TestCoreTableDDLCoversFourTables(t *testing.T) {
 		}
 		if !strings.HasPrefix(ddl[i].statement, "CREATE TABLE IF NOT EXISTS") {
 			t.Errorf("statement %d is not an idempotent CREATE: %s", i, ddl[i].statement)
+		}
+	}
+	wantFailures := []string{
+		"ensure schema registry table",
+		"ensure entity main table",
+		"ensure eav table",
+		"ensure change log table",
+	}
+	for i, want := range wantFailures {
+		if ddl[i].failure != want {
+			t.Errorf("failure label %d = %q, want %q", i, ddl[i].failure, want)
 		}
 	}
 }
@@ -90,108 +267,5 @@ func TestEAVIndexDDLCoversNumericAndText(t *testing.T) {
 	}
 	if ddl[1].failure != "create text index" {
 		t.Errorf("text failure label = %q", ddl[1].failure)
-	}
-}
-
-// TestEntityMainDDLGolden pins the complete 37-line schema definition.
-// This catches mutations to column types (e.g., bigint_01 TEXT), dropped
-// constraints (e.g., NOT NULL, PRIMARY KEY), and missing columns (e.g., text_05).
-func TestEntityMainDDLGolden(t *testing.T) {
-	stmt := entityMainDDL(`"entity_main"`)
-
-	// Critical columns and constraints that must not change
-	criticalChecks := []string{
-		"bigint_01          BIGINT",
-		"ltbase_created_at  BIGINT NOT NULL",
-		"PRIMARY KEY (ltbase_schema_id, ltbase_row_id)",
-		"text_05            TEXT",
-		"ltbase_schema_id   SMALLINT NOT NULL",
-		"ltbase_row_id      UUID NOT NULL",
-	}
-
-	for _, check := range criticalChecks {
-		if !strings.Contains(stmt, check) {
-			t.Errorf("entityMainDDL missing critical definition: %q\nGot:\n%s", check, stmt)
-		}
-	}
-}
-
-// TestCoreTableDDLGolden pins all four table definitions and announcement strings
-// to catch mutations in column definitions, constraints, and output text.
-func TestCoreTableDDLGolden(t *testing.T) {
-	opts := testInitDBOptions()
-	ddl := coreTableDDL(opts)
-
-	// Check schema registry table
-	if !strings.Contains(ddl[0].statement, "schema_name TEXT PRIMARY KEY") {
-		t.Errorf("schema registry table: missing schema_name PRIMARY KEY\n%s", ddl[0].statement)
-	}
-	if !strings.Contains(ddl[0].statement, "schema_id SMALLINT UNIQUE NOT NULL") {
-		t.Errorf("schema registry table: missing schema_id UNIQUE NOT NULL\n%s", ddl[0].statement)
-	}
-
-	// Check entity main table (via entityMainDDL)
-	if !strings.Contains(ddl[1].statement, "PRIMARY KEY (ltbase_schema_id, ltbase_row_id)") {
-		t.Errorf("entity main table: missing composite PRIMARY KEY\n%s", ddl[1].statement)
-	}
-	if !strings.Contains(ddl[1].statement, "bigint_01          BIGINT") {
-		t.Errorf("entity main table: bigint_01 must be BIGINT type\n%s", ddl[1].statement)
-	}
-	if !strings.Contains(ddl[1].statement, "ltbase_created_at  BIGINT NOT NULL") {
-		t.Errorf("entity main table: ltbase_created_at must be NOT NULL\n%s", ddl[1].statement)
-	}
-
-	// Check EAV table
-	if !strings.Contains(ddl[2].statement, "PRIMARY KEY (schema_id, row_id, attr_id, array_indices)") {
-		t.Errorf("EAV table: primary key narrowed to fewer than 4 columns\n%s", ddl[2].statement)
-	}
-	if !strings.Contains(ddl[2].statement, "attr_id        SMALLINT NOT NULL") {
-		t.Errorf("EAV table: missing attr_id column\n%s", ddl[2].statement)
-	}
-
-	// Check change log table
-	if !strings.Contains(ddl[3].statement, "primary key (schema_id, row_id, flushed_at)") {
-		t.Errorf("change log table: missing composite primary key\n%s", ddl[3].statement)
-	}
-
-	// Check announcements
-	if ddl[0].announce != "Created schema registry table: schema_registry\n" {
-		t.Errorf("schema registry announcement = %q", ddl[0].announce)
-	}
-	if ddl[1].announce != "Created entity main table: entity_main" {
-		t.Errorf("entity main announcement = %q", ddl[1].announce)
-	}
-	if ddl[2].announce != "Created EAV table: eav_data\n" {
-		t.Errorf("EAV announcement = %q, want 'Created EAV table: eav_data\\n'", ddl[2].announce)
-	}
-	if ddl[3].announce != "Created change log table: change_log\n" {
-		t.Errorf("change log announcement = %q", ddl[3].announce)
-	}
-}
-
-// TestMainColumnIndexDDLGolden pins the presence of ltbase_schema_id in all
-// main indexes — dropping it would change query performance characteristics.
-func TestMainColumnIndexDDLGolden(t *testing.T) {
-	ddl := mainColumnIndexDDL(testInitDBOptions())
-	for i, stmt := range ddl {
-		if !strings.Contains(stmt.statement, "ltbase_schema_id") {
-			t.Errorf("main index %d statement missing ltbase_schema_id: %s", i, stmt.statement)
-		}
-	}
-}
-
-// TestEAVIndexDDLGolden pins the exact key columns for both EAV indexes,
-// particularly attr_id which is essential for attribute filtering.
-func TestEAVIndexDDLGolden(t *testing.T) {
-	ddl := eavIndexDDL(testInitDBOptions())
-
-	// Numeric index must include attr_id in the key
-	if !strings.Contains(ddl[0].statement, "schema_id, attr_id, value_numeric, row_id") {
-		t.Errorf("numeric index key missing attr_id: %s", ddl[0].statement)
-	}
-
-	// Text index must include attr_id in the key
-	if !strings.Contains(ddl[1].statement, "schema_id, attr_id, value_text, row_id") {
-		t.Errorf("text index key missing attr_id: %s", ddl[1].statement)
 	}
 }

--- a/internal/e2e_harness/federated/benchmark/execute.go
+++ b/internal/e2e_harness/federated/benchmark/execute.go
@@ -94,7 +94,7 @@ func (r *Runner) executeServiceWorkload(ctx context.Context, h *federated.Federa
 	return run, records, nil
 }
 
-func (r *Runner) executeKeysetServiceQuery(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition) (*forma.QueryResult, []*model.PersistentRecord, *model.ExecutionPlan, error) { //nolint:funlen // #319 follow-up: benchmark harness split, tracked separately
+func (r *Runner) executeKeysetServiceQuery(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition) (*forma.QueryResult, []*model.PersistentRecord, *model.ExecutionPlan, error) { //nolint:funlen // #437: benchmark harness split
 	if h == nil || h.PGDSN == "" {
 		return nil, nil, nil, fmt.Errorf("benchmark harness postgres DSN is required")
 	}
@@ -353,7 +353,7 @@ func executeServiceQuery(ctx context.Context, h *federated.FederatedTestHarness,
 	return result, records, nil
 }
 
-func executeServiceQueryWithPlan(ctx context.Context, h *federated.FederatedTestHarness, req *forma.QueryRequest, defaultPageSize int, capturePlan bool, planCache *queryplan.Cache) (*forma.QueryResult, []*model.PersistentRecord, *model.ExecutionPlan, error) { //nolint:funlen // #319 follow-up: benchmark harness split, tracked separately
+func executeServiceQueryWithPlan(ctx context.Context, h *federated.FederatedTestHarness, req *forma.QueryRequest, defaultPageSize int, capturePlan bool, planCache *queryplan.Cache) (*forma.QueryResult, []*model.PersistentRecord, *model.ExecutionPlan, error) { //nolint:funlen // #437: benchmark harness split
 	if h == nil || h.PGDSN == "" {
 		return nil, nil, nil, fmt.Errorf("benchmark harness postgres DSN is required")
 	}

--- a/internal/e2e_harness/federated/benchmark/execute.go
+++ b/internal/e2e_harness/federated/benchmark/execute.go
@@ -94,7 +94,7 @@ func (r *Runner) executeServiceWorkload(ctx context.Context, h *federated.Federa
 	return run, records, nil
 }
 
-func (r *Runner) executeKeysetServiceQuery(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition) (*forma.QueryResult, []*model.PersistentRecord, *model.ExecutionPlan, error) {
+func (r *Runner) executeKeysetServiceQuery(ctx context.Context, h *federated.FederatedTestHarness, workload WorkloadDefinition) (*forma.QueryResult, []*model.PersistentRecord, *model.ExecutionPlan, error) { //nolint:funlen // #319 follow-up: benchmark harness split, tracked separately
 	if h == nil || h.PGDSN == "" {
 		return nil, nil, nil, fmt.Errorf("benchmark harness postgres DSN is required")
 	}
@@ -353,7 +353,7 @@ func executeServiceQuery(ctx context.Context, h *federated.FederatedTestHarness,
 	return result, records, nil
 }
 
-func executeServiceQueryWithPlan(ctx context.Context, h *federated.FederatedTestHarness, req *forma.QueryRequest, defaultPageSize int, capturePlan bool, planCache *queryplan.Cache) (*forma.QueryResult, []*model.PersistentRecord, *model.ExecutionPlan, error) {
+func executeServiceQueryWithPlan(ctx context.Context, h *federated.FederatedTestHarness, req *forma.QueryRequest, defaultPageSize int, capturePlan bool, planCache *queryplan.Cache) (*forma.QueryResult, []*model.PersistentRecord, *model.ExecutionPlan, error) { //nolint:funlen // #319 follow-up: benchmark harness split, tracked separately
 	if h == nil || h.PGDSN == "" {
 		return nil, nil, nil, fmt.Errorf("benchmark harness postgres DSN is required")
 	}

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -176,7 +176,7 @@ func (r *Runner) Run(ctx context.Context) (*RunResult, error) {
 }
 
 // RunWithHarness executes supported benchmark workloads against a live federated harness.
-func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestHarness, profile TierMixProfile) (*RunResult, error) { //nolint:funlen // #319 follow-up: benchmark harness split, tracked separately
+func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestHarness, profile TierMixProfile) (*RunResult, error) { //nolint:funlen // #437: benchmark harness split
 	if h == nil {
 		return nil, fmt.Errorf("federated harness cannot be nil")
 	}

--- a/internal/e2e_harness/federated/benchmark/runner.go
+++ b/internal/e2e_harness/federated/benchmark/runner.go
@@ -176,7 +176,7 @@ func (r *Runner) Run(ctx context.Context) (*RunResult, error) {
 }
 
 // RunWithHarness executes supported benchmark workloads against a live federated harness.
-func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestHarness, profile TierMixProfile) (*RunResult, error) {
+func (r *Runner) RunWithHarness(ctx context.Context, h *federated.FederatedTestHarness, profile TierMixProfile) (*RunResult, error) { //nolint:funlen // #319 follow-up: benchmark harness split, tracked separately
 	if h == nil {
 		return nil, fmt.Errorf("federated harness cannot be nil")
 	}

--- a/internal/e2e_harness/federated/benchmark/workload.go
+++ b/internal/e2e_harness/federated/benchmark/workload.go
@@ -48,7 +48,7 @@ type WorkloadDefinition struct {
 }
 
 // DefaultWorkloads returns the initial declarative workload matrix.
-func DefaultWorkloads() []WorkloadDefinition {
+func DefaultWorkloads() []WorkloadDefinition { //nolint:funlen // permanent: a flat workload table literal; splitting it would hide the data, not simplify it
 	return []WorkloadDefinition{
 		{
 			Name:                  "baseline-page-1",

--- a/internal/e2e_harness/federated/harness.go
+++ b/internal/e2e_harness/federated/harness.go
@@ -166,7 +166,7 @@ func WithDuckDBResources(threads, memoryLimitMB, maxConnections int) HarnessOpti
 }
 
 // NewFederatedTestHarness creates a new federated test harness with all dependencies.
-func NewFederatedTestHarness(ctx context.Context, opts ...HarnessOption) (*FederatedTestHarness, error) {
+func NewFederatedTestHarness(ctx context.Context, opts ...HarnessOption) (*FederatedTestHarness, error) { //nolint:funlen // refs #431: splitting this is that issue's job, which also widens the AST guard to harness*.go
 	options := harnessOptions{}
 	for _, opt := range opts {
 		opt(&options)

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -72,24 +72,7 @@ func (e *DBFederatedQueryEngine) ExecuteFederatedPaginatedQuery(
 		return nil, 0, fmt.Errorf("fetch postgres records: %w", err)
 	}
 	// Record Postgres source info if execution plan requested
-	if opts != nil && opts.IncludeExecutionPlan && opts.ExecutionPlan != nil {
-		dp := model.DataSourcePlan{
-			Tier:   model.DataTierHot,
-			Engine: "postgres",
-			// The full optimized SQL is rendered inside RunOptimizedQuery;
-			// the hybrid WHERE clause and its parameters are what the
-			// coordinator can capture here.
-			SQL:               clause,
-			Params:            formatPlanParams(args),
-			RowEstimate:       0,
-			PredicatePushdown: fq.UseMainAsAnchor,
-			ActualRows:        int64(len(pgRecs)),
-			DurationMs:        pgDuration,
-			Reason:            "postgres optimized query",
-		}
-		opts.ExecutionPlan.Sources = append(opts.ExecutionPlan.Sources, dp)
-		opts.ExecutionPlan.Timings["postgres_fetch"] = pgDuration
-	}
+	recordPostgresSourcePlan(opts, fq, clause, args, len(pgRecs), pgDuration)
 
 	// Fetch from DuckDB (warm/cold)
 	duckRecs, _, err := e.ExecuteDuckDBFederatedQuery(ctx, tables, fq, maxRows, 0, attributeOrders, opts)
@@ -111,16 +94,7 @@ func (e *DBFederatedQueryEngine) ExecuteFederatedPaginatedQuery(
 		return nil, 0, fmt.Errorf("merge records by tier: %w", err)
 	}
 	// Record merge plan if requested
-	if opts != nil && opts.IncludeExecutionPlan && opts.ExecutionPlan != nil {
-		opts.ExecutionPlan.Merge = model.MergePlan{
-			Strategy:   model.MergeStrategyLastWriteWins,
-			PreferHot:  fq.PreferHot,
-			DedupKeys:  []string{"SchemaID:RowID"},
-			DurationMs: mergeMs,
-			Notes:      []string{"attribute-level deduplication applied"},
-		}
-		opts.ExecutionPlan.Timings["merge"] = mergeMs
-	}
+	recordMergePlan(opts, fq.PreferHot, mergeMs)
 
 	total := int64(len(merged))
 
@@ -133,6 +107,47 @@ func (e *DBFederatedQueryEngine) ExecuteFederatedPaginatedQuery(
 	page := merged[start:end]
 
 	return page, total, nil
+}
+
+// recordPostgresSourcePlan appends the hot-tier source entry for one paginated
+// fetch. It no-ops unless the caller asked for a plan, so the call site stays
+// a single line (#319).
+func recordPostgresSourcePlan(opts *model.FederatedQueryOptions, fq *model.FederatedAttributeQuery, clause string, args []any, rowCount int, durationMs int64) {
+	if opts == nil || !opts.IncludeExecutionPlan || opts.ExecutionPlan == nil {
+		return
+	}
+	dp := model.DataSourcePlan{
+		Tier:   model.DataTierHot,
+		Engine: "postgres",
+		// The full optimized SQL is rendered inside RunOptimizedQuery;
+		// the hybrid WHERE clause and its parameters are what the
+		// coordinator can capture here.
+		SQL:               clause,
+		Params:            formatPlanParams(args),
+		RowEstimate:       0,
+		PredicatePushdown: fq.UseMainAsAnchor,
+		ActualRows:        int64(rowCount),
+		DurationMs:        durationMs,
+		Reason:            "postgres optimized query",
+	}
+	opts.ExecutionPlan.Sources = append(opts.ExecutionPlan.Sources, dp)
+	opts.ExecutionPlan.Timings["postgres_fetch"] = durationMs
+}
+
+// recordMergePlan records the tier-merge step of one paginated fetch. Like
+// recordPostgresSourcePlan it no-ops unless a plan was requested (#319).
+func recordMergePlan(opts *model.FederatedQueryOptions, preferHot bool, durationMs int64) {
+	if opts == nil || !opts.IncludeExecutionPlan || opts.ExecutionPlan == nil {
+		return
+	}
+	opts.ExecutionPlan.Merge = model.MergePlan{
+		Strategy:   model.MergeStrategyLastWriteWins,
+		PreferHot:  preferHot,
+		DedupKeys:  []string{"SchemaID:RowID"},
+		DurationMs: durationMs,
+		Notes:      []string{"attribute-level deduplication applied"},
+	}
+	opts.ExecutionPlan.Timings["merge"] = durationMs
 }
 
 // executeFederatedKeysetQuery performs a keyset-cursor-based federated query.

--- a/internal/federated/pagination_plan_test.go
+++ b/internal/federated/pagination_plan_test.go
@@ -1,0 +1,93 @@
+package federated
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecuteFederatedPaginatedQueryRecordsExecutionPlan is the first coverage
+// ExecuteFederatedPaginatedQuery has ever had: its only caller is the keyset
+// benchmark path (benchmark/execute.go), so neither the unit suite nor the
+// federated e2e suite reached it. #319 splits its two plan-recording blocks
+// out for headroom, and this is what makes that split verifiable.
+func TestExecuteFederatedPaginatedQueryRecordsExecutionPlan(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &sequencedDuckDBExecutor{rows: []duckDBRowsIterator{&emptyDuckDBRows{}}}
+	var built []model.FederatedAttributeQuery
+	engine := newEmptyPageTestEngine(t, &fakePostgresFederatedSource{}, duck, &built)
+
+	opts := &model.FederatedQueryOptions{
+		IncludeExecutionPlan: true,
+		ExecutionPlan:        &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
+	}
+
+	recs, total, err := engine.ExecuteFederatedPaginatedQuery(
+		context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		&model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7},
+		},
+		10, 0, nil, opts)
+
+	require.NoError(t, err)
+	require.Empty(t, recs)
+	require.Zero(t, total)
+
+	// The Postgres source is recorded with the hybrid WHERE clause the
+	// coordinator can see, not the full optimized SQL rendered downstream.
+	// It is the FIRST entry: the downstream ExecuteDuckDBFederatedQuery call
+	// appends its own source entries (dirty id set, pushdown fragment, duckdb
+	// template) onto the same plan afterwards, so the slice is not length 1.
+	require.NotEmpty(t, opts.ExecutionPlan.Sources)
+	var optimizedQuerySources int
+	for _, src := range opts.ExecutionPlan.Sources {
+		if src.Reason == "postgres optimized query" {
+			optimizedQuerySources++
+		}
+	}
+	require.Equal(t, 1, optimizedQuerySources,
+		"the coordinator records exactly one postgres optimized query source: %+v",
+		opts.ExecutionPlan.Sources)
+	require.Equal(t, model.DataTierHot, opts.ExecutionPlan.Sources[0].Tier)
+	require.Equal(t, "postgres", opts.ExecutionPlan.Sources[0].Engine)
+	require.Equal(t, "1=1", opts.ExecutionPlan.Sources[0].SQL)
+	require.Equal(t, "postgres optimized query", opts.ExecutionPlan.Sources[0].Reason)
+	require.Contains(t, opts.ExecutionPlan.Timings, "postgres_fetch")
+
+	require.Equal(t, model.MergeStrategyLastWriteWins, opts.ExecutionPlan.Merge.Strategy)
+	require.Equal(t, []string{"SchemaID:RowID"}, opts.ExecutionPlan.Merge.DedupKeys)
+	require.Contains(t, opts.ExecutionPlan.Timings, "merge")
+}
+
+// TestExecuteFederatedPaginatedQuerySkipsPlanWhenNotRequested guards the other
+// half: without IncludeExecutionPlan the recorders must stay silent rather
+// than write into a plan the caller never asked for.
+func TestExecuteFederatedPaginatedQuerySkipsPlanWhenNotRequested(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	duck := &sequencedDuckDBExecutor{rows: []duckDBRowsIterator{&emptyDuckDBRows{}}}
+	var built []model.FederatedAttributeQuery
+	engine := newEmptyPageTestEngine(t, &fakePostgresFederatedSource{}, duck, &built)
+
+	opts := &model.FederatedQueryOptions{
+		ExecutionPlan: &model.ExecutionPlan{Timings: map[string]int64{}, Notes: []string{}},
+	}
+
+	_, _, err := engine.ExecuteFederatedPaginatedQuery(
+		context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+		&model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7},
+		},
+		10, 0, nil, opts)
+
+	require.NoError(t, err)
+	require.Empty(t, opts.ExecutionPlan.Sources)
+	require.Empty(t, opts.ExecutionPlan.Timings)
+}

--- a/internal/federated/pagination_plan_test.go
+++ b/internal/federated/pagination_plan_test.go
@@ -31,6 +31,12 @@ func TestExecuteFederatedPaginatedQueryRecordsExecutionPlan(t *testing.T) {
 		model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
 		&model.FederatedAttributeQuery{
 			AttributeQuery: model.AttributeQuery{SchemaID: 7},
+			// PreferHot is the one value the #319 extraction actually
+			// rewired: it went from an in-body fq.PreferHot reference to an
+			// argument passed at the call site. Setting it true (rather than
+			// leaving the zero value) is what makes the assertion below able
+			// to tell a correct hand-off from a dropped or inverted one.
+			PreferHot: true,
 		},
 		10, 0, nil, opts)
 
@@ -53,14 +59,27 @@ func TestExecuteFederatedPaginatedQueryRecordsExecutionPlan(t *testing.T) {
 	require.Equal(t, 1, optimizedQuerySources,
 		"the coordinator records exactly one postgres optimized query source: %+v",
 		opts.ExecutionPlan.Sources)
+	// These index into Sources[0] rather than into the entry matched by Reason
+	// above, which couples them to append order: ExecuteDuckDBFederatedQuery
+	// appends three further sources (dirty id set, pushdown fragment, duckdb
+	// template) onto this same opts after the coordinator records the postgres
+	// one, so index 0 is the postgres entry only because it is recorded first.
 	require.Equal(t, model.DataTierHot, opts.ExecutionPlan.Sources[0].Tier)
 	require.Equal(t, "postgres", opts.ExecutionPlan.Sources[0].Engine)
 	require.Equal(t, "1=1", opts.ExecutionPlan.Sources[0].SQL)
 	require.Equal(t, "postgres optimized query", opts.ExecutionPlan.Sources[0].Reason)
+	// Both are deterministic in this fixture: RunOptimizedQuery returns no
+	// records, and BuildHybridConditions returns no args.
+	require.Zero(t, opts.ExecutionPlan.Sources[0].ActualRows)
+	require.Empty(t, opts.ExecutionPlan.Sources[0].Params)
 	require.Contains(t, opts.ExecutionPlan.Timings, "postgres_fetch")
 
 	require.Equal(t, model.MergeStrategyLastWriteWins, opts.ExecutionPlan.Merge.Strategy)
 	require.Equal(t, []string{"SchemaID:RowID"}, opts.ExecutionPlan.Merge.DedupKeys)
+	require.Equal(t, []string{"attribute-level deduplication applied"}, opts.ExecutionPlan.Merge.Notes)
+	// The rewired argument, pinned: a dropped hand-off (recordMergePlan(opts,
+	// false, ...)) or an inverted one (PreferHot: !preferHot) both fail here.
+	require.True(t, opts.ExecutionPlan.Merge.PreferHot)
 	require.Contains(t, opts.ExecutionPlan.Timings, "merge")
 }
 

--- a/internal/postgres_persistent_repository_query.go
+++ b/internal/postgres_persistent_repository_query.go
@@ -13,6 +13,59 @@ import (
 	"go.uber.org/zap"
 )
 
+// renderOptimizedQuerySQL renders (or reuses a cached render of) the optimized
+// OLTP query for one shape. Extracted from StreamOptimizedQuery (#319), which
+// sat one line under the 100-line cap.
+func (r *DBPersistentRecordRepository) renderOptimizedQuerySQL(
+	tables model.StorageTables,
+	schemaID int16,
+	clause string,
+	argCount int,
+	attributeOrders []model.AttributeOrder,
+	useMainTableAsAnchor bool,
+) (string, error) {
+	sqlParams := map[string]any{
+		"EAVTable":             sanitizeIdentifier(tables.EAVData),
+		"MainTable":            sanitizeIdentifier(tables.EntityMain),
+		"ChangeLogTable":       sanitizeIdentifier(tables.ChangeLog),
+		"MainProjection":       model.EntityMainProjection,
+		"SchemaID":             "$1",
+		"UseMainTableAsAnchor": useMainTableAsAnchor,
+		"Anchor": map[string]any{
+			"Condition": clause,
+		},
+		"SortKeys": attributeOrders,
+		"Limit":    fmt.Sprintf("$%d", argCount+2),
+		"Offset":   fmt.Sprintf("$%d", argCount+3),
+		"PageSize": fmt.Sprintf("$%d", argCount+2),
+	}
+
+	// SchemaVersion is defense-in-depth (PR #148 review): today every render
+	// input derives from key-covered values (metadata reaches the skeleton
+	// only through clause text and attributeOrders), but fingerprinting keeps
+	// the key correct if the template ever consumes metadata directly.
+	fingerprint := ""
+	if r.metadataCache != nil {
+		fingerprint, _ = r.metadataCache.SchemaFingerprint(schemaID)
+	}
+	renderKey := queryplan.Key{
+		Kind:          "postgres_optimized_template",
+		SchemaVersion: fingerprint,
+		SchemaID:      schemaID,
+		ShapeHash:     strconv.FormatUint(optimizedQueryShapeKey(tables, useMainTableAsAnchor, clause, argCount, attributeOrders), 16),
+	}
+	queryAny, cacheHit, err := r.planCache.GetOrBuild(renderKey, func() (any, error) {
+		return renderTemplate(optimizedQuerySQLTemplate, sqlParams)
+	})
+	if err != nil {
+		return "", fmt.Errorf("build optimized query: %w", err)
+	}
+	if !cacheHit {
+		zap.S().Debugw("optimized query render cache miss", "schemaID", schemaID)
+	}
+	return queryAny.(string), nil
+}
+
 func (r *DBPersistentRecordRepository) StreamOptimizedQuery(
 	ctx context.Context,
 	tables model.StorageTables,
@@ -37,45 +90,9 @@ func (r *DBPersistentRecordRepository) StreamOptimizedQuery(
 		offset = 0
 	}
 
-	sqlParams := map[string]any{
-		"EAVTable":             sanitizeIdentifier(tables.EAVData),
-		"MainTable":            sanitizeIdentifier(tables.EntityMain),
-		"ChangeLogTable":       sanitizeIdentifier(tables.ChangeLog),
-		"MainProjection":       model.EntityMainProjection,
-		"SchemaID":             "$1",
-		"UseMainTableAsAnchor": useMainTableAsAnchor,
-		"Anchor": map[string]any{
-			"Condition": clause,
-		},
-		"SortKeys": attributeOrders,
-		"Limit":    fmt.Sprintf("$%d", len(args)+2),
-		"Offset":   fmt.Sprintf("$%d", len(args)+3),
-		"PageSize": fmt.Sprintf("$%d", len(args)+2),
-	}
-
-	// SchemaVersion is defense-in-depth (PR #148 review): today every render
-	// input derives from key-covered values (metadata reaches the skeleton
-	// only through clause text and attributeOrders), but fingerprinting keeps
-	// the key correct if the template ever consumes metadata directly.
-	fingerprint := ""
-	if r.metadataCache != nil {
-		fingerprint, _ = r.metadataCache.SchemaFingerprint(schemaID)
-	}
-	renderKey := queryplan.Key{
-		Kind:          "postgres_optimized_template",
-		SchemaVersion: fingerprint,
-		SchemaID:      schemaID,
-		ShapeHash:     strconv.FormatUint(optimizedQueryShapeKey(tables, useMainTableAsAnchor, clause, len(args), attributeOrders), 16),
-	}
-	queryAny, cacheHit, err := r.planCache.GetOrBuild(renderKey, func() (any, error) {
-		return renderTemplate(optimizedQuerySQLTemplate, sqlParams)
-	})
+	query, err := r.renderOptimizedQuerySQL(tables, schemaID, clause, len(args), attributeOrders, useMainTableAsAnchor)
 	if err != nil {
-		return 0, fmt.Errorf("build optimized query: %w", err)
-	}
-	query := queryAny.(string)
-	if !cacheHit {
-		zap.S().Debugw("optimized query render cache miss", "schemaID", schemaID)
+		return 0, err
 	}
 
 	queryArgs := make([]any, 0, len(args)+3)

--- a/internal/postgres_persistent_repository_query.go
+++ b/internal/postgres_persistent_repository_query.go
@@ -90,6 +90,11 @@ func (r *DBPersistentRecordRepository) StreamOptimizedQuery(
 		offset = 0
 	}
 
+	// Deliberately a bare return rather than AGENTS.md's usual wrap-with-context:
+	// renderOptimizedQuerySQL already wraps as "build optimized query: %w", which
+	// is the exact text this call site produced before #319 extracted it. Adding a
+	// second layer here would both duplicate the context and change the
+	// caller-visible message, which this behaviour-preserving refactor must not do.
 	query, err := r.renderOptimizedQuerySQL(tables, schemaID, clause, len(args), attributeOrders, useMainTableAsAnchor)
 	if err != nil {
 		return 0, err

--- a/internal/postgres_persistent_repository_test.go
+++ b/internal/postgres_persistent_repository_test.go
@@ -269,6 +269,39 @@ func TestStreamOptimizedQueryRenderCache(t *testing.T) {
 	require.Equal(t, int64(2), misses)
 }
 
+// TestStreamOptimizedQueryRenderCacheDifferentArgCount pins #319: the argCount
+// parameter must be correctly passed to optimizedQueryShapeKey. Two calls with
+// identical shapes but different len(args) must produce two cache misses, not
+// a hit on the second call — because their placeholder numbering differs.
+func TestStreamOptimizedQueryRenderCacheDifferentArgCount(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, nil)
+	tables := model.StorageTables{EntityMain: "main_t", EAVData: "eav_t", ChangeLog: "cl_t"}
+
+	// First call with len(args) = 1
+	mock.ExpectQuery("WITH").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"row_id"}))
+	_, err = repo.StreamOptimizedQuery(ctx, tables, 1, "m.\"integer_01\" > $2", []any{int64(5)}, 10, 0, nil, true, nil)
+	require.NoError(t, err)
+
+	// Second call with identical clause but len(args) = 2
+	// This should produce a MISS, not a HIT, because the argCount differs
+	mock.ExpectQuery("WITH").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"row_id"}))
+	_, err = repo.StreamOptimizedQuery(ctx, tables, 1, "m.\"integer_01\" > $2", []any{int64(5), "extra"}, 10, 0, nil, true, nil)
+	require.NoError(t, err)
+
+	hits, misses := repo.planCache.Stats()
+	require.Equal(t, int64(0), hits, "different argCount must not share cache entry")
+	require.Equal(t, int64(2), misses, "each different argCount must render template once")
+}
+
 // TestOptimizedQueryShapeKey pins that every render-affecting input changes
 // the key and that values do not participate.
 func TestOptimizedQueryShapeKey(t *testing.T) {

--- a/internal/postgres_persistent_repository_test.go
+++ b/internal/postgres_persistent_repository_test.go
@@ -302,6 +302,49 @@ func TestStreamOptimizedQueryRenderCacheDifferentArgCount(t *testing.T) {
 	require.Equal(t, int64(2), misses, "each different argCount must render template once")
 }
 
+// TestStreamOptimizedQueryArgCountKeyPin pins #319: the argCount parameter must
+// reach optimizedQueryShapeKey with the correct value. Pre-seeds the render cache
+// with the expected key and asserts the production call hits it. Under mutation
+// (argCount → argCount+1), the production code computes a different key, misses,
+// and the test fails.
+func TestStreamOptimizedQueryArgCountKeyPin(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, nil)
+	tables := model.StorageTables{EntityMain: "main_t", EAVData: "eav_t", ChangeLog: "cl_t"}
+	clause := "m.\"integer_01\" > $2"
+	argCount := 1 // len(args) in the call below
+
+	// Build the expected cache key independently
+	expectedShapeHash := strconv.FormatUint(optimizedQueryShapeKey(tables, true, clause, argCount, nil), 16)
+	expectedKey := queryplan.Key{
+		Kind:      "postgres_optimized_template",
+		SchemaID:  1,
+		ShapeHash: expectedShapeHash,
+	}
+
+	// Pre-seed the cache with a sentinel query under the expected key
+	sentinelQuery := "SELECT 'sentinel' AS sentinel"
+	_, _, err = repo.planCache.GetOrBuild(expectedKey, func() (any, error) {
+		return sentinelQuery, nil
+	})
+	require.NoError(t, err)
+
+	// Now call StreamOptimizedQuery with matching argCount
+	// It should compute the same key and get a HIT, returning the sentinel
+	mock.ExpectQuery("SELECT").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"sentinel"}))
+	_, err = repo.StreamOptimizedQuery(ctx, tables, 1, clause, []any{int64(5)}, 10, 0, nil, true, nil)
+	require.NoError(t, err)
+
+	hits, _ := repo.planCache.Stats()
+	require.Equal(t, int64(1), hits, "StreamOptimizedQuery must hit pre-seeded key with correct argCount")
+}
+
 // TestOptimizedQueryShapeKey pins that every render-affecting input changes
 // the key and that values do not participate.
 func TestOptimizedQueryShapeKey(t *testing.T) {

--- a/internal/schemameta/parser_test.go
+++ b/internal/schemameta/parser_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseAttributeMetadata(t *testing.T) { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
+func TestParseAttributeMetadata(t *testing.T) { //nolint:funlen // #438: oversized test functions
 	source := "test-source"
 	tests := []struct {
 		name      string

--- a/internal/schemameta/parser_test.go
+++ b/internal/schemameta/parser_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseAttributeMetadata(t *testing.T) {
+func TestParseAttributeMetadata(t *testing.T) { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
 	source := "test-source"
 	tests := []struct {
 		name      string

--- a/internal/transform/attribute_value_extraction_test.go
+++ b/internal/transform/attribute_value_extraction_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lychee-technology/forma/internal/model"
 )
 
-func TestExtractValueFromEAVRecord(t *testing.T) {
+func TestExtractValueFromEAVRecord(t *testing.T) { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
 	textVal := "hello"
 	numericVal := 42.0
 	uuidVal := uuid.New()

--- a/internal/transform/attribute_value_extraction_test.go
+++ b/internal/transform/attribute_value_extraction_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lychee-technology/forma/internal/model"
 )
 
-func TestExtractValueFromEAVRecord(t *testing.T) { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
+func TestExtractValueFromEAVRecord(t *testing.T) { //nolint:funlen // #438: oversized test functions
 	textVal := "hello"
 	numericVal := 42.0
 	uuidVal := uuid.New()

--- a/internal/transform/persistent_record_test.go
+++ b/internal/transform/persistent_record_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPersistentTransformerRegistry() *stubSchemaRegistry { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
+func newPersistentTransformerRegistry() *stubSchemaRegistry { //nolint:funlen // #438: oversized test functions
 	return &stubSchemaRegistry{
 		schemaID:   201,
 		schemaName: "persistent_test",
@@ -119,7 +119,7 @@ func newPersistentTransformerRegistry() *stubSchemaRegistry { //nolint:funlen //
 	}
 }
 
-func TestPersistentRecordTransformer_RoundTrip(t *testing.T) { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
+func TestPersistentRecordTransformer_RoundTrip(t *testing.T) { //nolint:funlen // #438: oversized test functions
 	ctx := context.Background()
 	registry := newPersistentTransformerRegistry()
 	transformer := NewPersistentRecordTransformer(registry)

--- a/internal/transform/persistent_record_test.go
+++ b/internal/transform/persistent_record_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPersistentTransformerRegistry() *stubSchemaRegistry {
+func newPersistentTransformerRegistry() *stubSchemaRegistry { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
 	return &stubSchemaRegistry{
 		schemaID:   201,
 		schemaName: "persistent_test",
@@ -119,7 +119,7 @@ func newPersistentTransformerRegistry() *stubSchemaRegistry {
 	}
 }
 
-func TestPersistentRecordTransformer_RoundTrip(t *testing.T) {
+func TestPersistentRecordTransformer_RoundTrip(t *testing.T) { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
 	ctx := context.Background()
 	registry := newPersistentTransformerRegistry()
 	transformer := NewPersistentRecordTransformer(registry)

--- a/types_query_request_test.go
+++ b/types_query_request_test.go
@@ -13,7 +13,7 @@ import (
 // QueryRequest JSON Tests
 // =============================================================================
 
-func TestQueryRequest_UnmarshalJSON(t *testing.T) {
+func TestQueryRequest_UnmarshalJSON(t *testing.T) { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
 	rowID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 
 	tests := []struct {

--- a/types_query_request_test.go
+++ b/types_query_request_test.go
@@ -13,7 +13,7 @@ import (
 // QueryRequest JSON Tests
 // =============================================================================
 
-func TestQueryRequest_UnmarshalJSON(t *testing.T) { //nolint:funlen // #319 follow-up: oversized test functions, tracked separately
+func TestQueryRequest_UnmarshalJSON(t *testing.T) { //nolint:funlen // #438: oversized test functions
 	rowID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 
 	tests := []struct {


### PR DESCRIPTION
Closes #319

`coding-standard.md` and `AGENTS.md` both document a 100-line function cap and
nothing enforced it: `.golangci.yml` kept golangci-lint's default set, which has
no `funlen`. During #314 a function reached 110 lines and passed `make lint`
twice.

## What this turns on

`funlen` at **100 lines with comments excluded**, plus `nolintlint` with
`require-explanation` / `require-specific` / `allow-unused: false` so every
exemption carries a reason and a stale one turns the build red. That last
property was probed directly rather than assumed: a redundant `//nolint:funlen`
on the non-violating `schemaRegistryFlags.register` produced
`directive ... is unused for linter "funlen" (nolintlint)`.

**Scope: the root module only.** `make lint` and CI both run `golangci-lint run`
from the repository root with no path arguments, so the gate reaches the packages
of the root `github.com/lychee-technology/forma` module and nothing else.
`infra/` is a separate module — `infra/go.mod` declares
`github.com/lychee-technology/forma/infra` — and golangci-lint does not descend
into it, so `funlen` does not apply there at all.
`infra/components/serverless.go: NewServerless` measures 180 code lines against
the same 100-line limit and is ungated; running the pinned linter from inside the
module reports `(180 > 100) (funlen)` while a root-level `make lint` on the same
tree exits 0. This PR does not change that — the gap is recorded as #444, which
also lays out the two ways to close it.

Two traps are pinned in `.golangci.yml` comments because the pin cannot move:

- **`ignore-comments` is inverted in v1.64.8.** `pkg/golinters/funlen/funlen.go:23`
  is `cfg.ignoreComments = !settings.IgnoreComments` before handing off to
  `ultraware/funlen@v0.2.0`, whose parameter subtracts comments when *true*. So
  under this pinned version `false` is what excludes comments. Verified
  empirically, not only by reading the source — see the third verification leg
  below.
- **`statements` must be `-1`.** `funlen.go:20` treats `0` as unset and falls
  back to the default 40-statement cap.

Comments are excluded because this codebase's comments are load-bearing causal
records: `internal/federated/engine.go: Query` is 103 physical lines of which 27
are the #348/#183/#184 rationale — 76 lines of code. Counting comments would
penalise writing them.

## Refactored (6)

Four were violations; two were at 99 and 100 code lines with no headroom, so the
next unrelated edit would have turned a stranger's PR red.

| function | before | after |
|---|---|---|
| `cmd/sample/main.go: main` | 171 | 35 |
| `cmd/tools/cdc_init.go: runCDCInit` | 155 | 61 |
| `cmd/tools/cdc_flush.go: runCDCFlush` | 148 | 49 |
| `cmd/tools/init_db.go: ensureTables` | 125 | 23 |
| `internal/federated/pagination.go: ExecuteFederatedPaginatedQuery` | 100 (headroom) | 77 |
| `internal/postgres_persistent_repository_query.go: StreamOptimizedQuery` | 99 (headroom) | 67 |

Three of these had **no test coverage at all** before this PR; the refactors
brought their first tests with them (`cmd/tools/cdc_flags_test.go`,
`cmd/tools/init_db_ddl_test.go`, `internal/federated/pagination_plan_test.go`).

**Two deliberate exceptions, stated so the numbers are on the record.**
`parseCDCFlushFlags` (81) and `parseCDCInitFlags` (86) sit above
`coding-standard.md` §7's advisory >80 SUGGEST trigger while well under the 100
hard cap. Each body is one flat flag-registration sequence with no
non-arbitrary seam — the only real seam, the config literal, is already
extracted, and the next one would be a 12-field pointer struct: churn plus
indirection for no legibility gain. Two reviewers reached this independently;
accepted as a judgement, not an oversight.

## What actually gates the two riskiest refactors

Both were claimed by the plan to be covered by suites that do not in fact reach
them. Corrected here rather than shipped:

- **`ensureTables` (the `init-db` DDL) is not covered by e2e.** The production
  harness carries its **own** `productionDDL` copy, `ensureTables` has exactly
  one caller (`init_db.go:105`), and no Go test reaches it — the only execution
  path is `./build/tools init-db` from `scripts/*.sh`. Its real gate is a
  **full-text golden test**: 16 statements plus 4 announcement strings asserted
  in full, proven independent (the test file imports only `strings` and
  `testing`, so it re-renders no template and calls no builder), and
  mutation-verified 12/12 killed. All four DDL literals are byte-identical to
  the pre-refactor text (103/1191/288/250 bytes), including `change_log`'s
  original mixed 4-space/tab quirk.
  *Caveat for future readers:* re-capturing those goldens **from the builders**
  after a schema change would launder a mutation. Diff the literal; do not
  regenerate it.
- **`ExecuteFederatedPaginatedQuery` is not covered by `make benchmark-smoke`.**
  `benchmark/runner.go:159` shows `ExecutionModeSmoke`'s own notes end with
  `"smoke mode stops before query execution"`. Its real gate is the new
  characterization test plus a mutation probe. Worse: **its body is unreachable
  from its only caller** — `benchmark/execute.go:243` always sets
  `KeysetEnabled: true` with a populated cursor, so `pagination.go:36`
  early-returns into `executeFederatedKeysetQuery` and everything below,
  including both blocks this PR extracted, never runs in production. The
  refactor is kept because it is behaviour-preserving and gave a zero-coverage
  function its first tests, but it protects **test-only code**. Retire-or-wire is
  #442.

## Carried on //nolint:funlen (10)

`NewFederatedTestHarness` (refs #431), `DefaultWorkloads` (permanent — a flat
workload table literal), three benchmark functions (#437) and five test
functions (#438), each with a stated reason and a follow-up issue.
`cmd/` is completely clean.

## Verification

- `make fmt-check` and `make lint` exit 0 and silent.
- `go test -race . ./cdc ./cmd/... ./factory ./internal/...` — 35 packages ok,
  0 failures, no race reports.
- `make test-e2e-production` — **130 PASS / 0 FAIL / 0 SKIP** in 148s with real
  containers.
- Untagged `./internal/e2e_harness/... -count=1` — 4 packages ok with real
  `postgres:16` + `rustfs` containers. *This is not evidence the `cmd/tools` DDL
  executes* — only the root package starts containers and it seeds from its own
  hand-written DDL (`fixtures.go:22`).

The gate itself was verified three ways, because the number alone does not prove
the dialect: a 101-code-line probe must fail `(101 > 100)`, a 100-line one must
pass, and a 121-body-line function whose 21 comment lines bring it to 100 must
pass. That third leg is what actually proves comment exclusion; a counterfactual
run with `ignore-comments: true` reports `(121 > 100)` on the same probe. The
reverse direction was checked too — stripping `DefaultWorkloads`' nolint makes
the gate fire at `(292 > 100)`.

**Re-proved at final HEAD**, after all commits had landed, so no later change
could have quietly switched it off: a fresh 101-line probe made `make lint` exit
2 with `(101 > 100) (funlen)`; removing it returned exit 0 with a clean tree.

The full implementation record — including three gate premises in the approved
plan that turned out to be false, and a process note about fabricated
verification evidence that independent review caught — is posted on
#319 (issuecomment-5374975497).

## Follow-ups

| # | |
|---|---|
| #436 | `make lint` and CI skip 96 e2e-tagged files — add `--build-tags e2e`; 6 pre-existing non-funlen violations, **0 funlen** |
| #437 | three benchmark-harness functions past the cap (plus `summarizeWorkloads` at exactly 100, zero headroom, unable to carry a nolint) |
| #438 | five oversized test functions |
| #439 | `cmd/sample` `-verbose` is a no-op — `flag.Parse()` runs after the logger reads it |
| #440 | the production table DDL has four hand-maintained copies (this branch added the fourth, deliberately) and nothing checks they agree |
| #441 | the optimized-query plan-cache key is only partially pinned — `Kind` and the error path survive mutation |
| #442 | `ExecuteFederatedPaginatedQuery`'s body is unreachable from its only caller — retire it or wire a real caller |
| #444 | `funlen` does not reach the `infra/` module (separate `go.mod`) — `NewServerless` is 180 lines and ungated |
| #445 | `buildCDCConfig` / `buildCDCInitConfig` duplicate 24 identical field assignments (pre-existing, made visible by this PR's extraction) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCSCNgQmz3EWokjH4G3C7h




