### PR TITLE
test(e2e): #369 widen the federated file-size guard from query*.go+harness*.go to *.go

### DIFF
--- a/internal/e2e_harness/federated/query_file_size_test.go
+++ b/internal/e2e_harness/federated/query_file_size_test.go
@@ -30,7 +30,8 @@ func TestListGuardedSourceFilesCoversEveryNonTestSource(t *testing.T) {
 	guarded := make(map[string]bool, len(files))
 	for _, name := range files {
 		if strings.HasSuffix(name, "_test.go") {
-			t.Fatalf("test file %s included in source guard", name)
+			t.Errorf("test file %s included in source guard", name)
+			continue
 		}
 		guarded[name] = true
 	}

--- a/internal/e2e_harness/federated/query_file_size_test.go
+++ b/internal/e2e_harness/federated/query_file_size_test.go
@@ -16,18 +16,43 @@ func TestCountSourceLinesIncludesFinalUnterminatedLine(t *testing.T) {
 	}
 }
 
-func TestListGuardedSourceFilesExcludesTests(t *testing.T) {
+// TestListGuardedSourceFilesCoversEveryNonTestSource pins the guard's scope to
+// the whole package: every non-test source file is watched, and no test file is.
+// Listing the directory independently is what makes the first half real, and it
+// is what a pattern list cannot satisfy — a file whose name stops matching a
+// pattern drops out of a pattern-based guard in silence (#369).
+func TestListGuardedSourceFilesCoversEveryNonTestSource(t *testing.T) {
 	files, err := listGuardedSourceFiles()
 	if err != nil {
 		t.Fatalf("list guarded source files: %v", err)
 	}
-	if len(files) == 0 {
-		t.Fatal("expected guarded source files")
-	}
+
+	guarded := make(map[string]bool, len(files))
 	for _, name := range files {
 		if strings.HasSuffix(name, "_test.go") {
 			t.Fatalf("test file %s included in source guard", name)
 		}
+		guarded[name] = true
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package directory: %v", err)
+	}
+
+	sources := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sources++
+		if !guarded[name] {
+			t.Errorf("%s is outside the file-size guard", name)
+		}
+	}
+	if sources == 0 {
+		t.Fatal("expected package source files")
 	}
 }
 
@@ -65,12 +90,16 @@ func listNonTestSources(patterns ...string) ([]string, error) {
 	return files, nil
 }
 
+// listGuardedSourceFiles scopes the file-size guard to the whole package rather
+// than to a list of name patterns. Every non-test file is watched, so a new one
+// arrives guarded and a renamed one cannot slip out (#369).
 func listGuardedSourceFiles() ([]string, error) {
-	return listNonTestSources("query*.go", "harness*.go")
+	return listNonTestSources("*.go")
 }
 
-// TestGuardedSourcesStayWithinFileSizeLimit prevents query assembly and harness
-// infrastructure concerns from accumulating back into oversized source files (#220).
+// TestGuardedSourcesStayWithinFileSizeLimit prevents any concern in this harness
+// package — query assembly, seeding, assertions, infrastructure — from
+// accumulating back into an oversized source file (#220, #369).
 func TestGuardedSourcesStayWithinFileSizeLimit(t *testing.T) {
 	names, err := listGuardedSourceFiles()
 	if err != nil {

--- a/internal/e2e_harness/federated/query_function_size_test.go
+++ b/internal/e2e_harness/federated/query_function_size_test.go
@@ -46,10 +46,13 @@ func measureFunctionLines(filename string, source []byte) ([]guardedFunction, er
 }
 
 // listFunctionGuardedSourceFiles scans a narrower set than the file-size guard,
-// which also covers harness*.go: NewFederatedTestHarness there is already past
-// the 100-line hard limit, so including it would make this guard unsatisfiable
-// without a harness.go refactor this change does not own. Widening the scope to
-// match is #431's job, at which point both guards can share one pattern list.
+// which since #369 covers the whole package: two functions outside query*.go are
+// over the trigger and would make this guard unsatisfiable on arrival —
+// NewFederatedTestHarness in harness.go at 131 lines, past even AGENTS.md's
+// 100-line hard limit (#431), and loadExternalFederatedConfigFromEnv in
+// helpers.go at 84. Each needs a refactor this guard does not own, so the scope
+// widens one file group at a time; only once both are under the trigger can this
+// guard drop its pattern list and share listGuardedSourceFiles.
 func listFunctionGuardedSourceFiles() ([]string, error) {
 	return listNonTestSources("query*.go")
 }


### PR DESCRIPTION
Closes #369. Refs #220, #367, #431.

The federated file-size guard enumerated `query*.go` + `harness*.go`; it now globs `*.go`. Seven non-test files were unwatched, two of them (`seeding.go` 425, `assertions.go` 418) already at 83–85% of the 500-line cap. All thirteen non-test files in the package are under the cap today, so the widening lands green.

## What changed

**`query_file_size_test.go`** — `listGuardedSourceFiles` returns `listNonTestSources("*.go")`. `TestListGuardedSourceFilesExcludesTests` becomes `TestListGuardedSourceFilesCoversEveryNonTestSource`, asserting both directions against an independent `os.ReadDir(".")` listing: no test file inside the guarded set, and no non-test source outside it.

**`query_function_size_test.go`** — comment-only. `listFunctionGuardedSourceFiles` described the file guard as covering `harness*.go`, false as of the first commit here, and named `NewFederatedTestHarness` as the only thing between the two guards and a shared file list.

## Pre-flight findings

**`listNonTestSources` stays variadic.** Parsing every non-test file in the package with `go/ast`, the functions over the 80-line refactoring trigger are:

| lines | file | function |
|------:|------|----------|
| 131 | `harness.go` | `NewFederatedTestHarness` |
| 84 | `helpers.go` | `loadExternalFederatedConfigFromEnv` |

So even after #431 fixes `NewFederatedTestHarness`, the function guard cannot use a bare `*.go` — `helpers.go` blocks it, and the realistic next scope is two patterns. Collapsing the shared helper to a single-pattern parameter would have to be undone. This also means #431's body understates its own blocker; a note goes to that issue once this merges.

**Nothing to reconcile in `docs/`.** Grepped `*.md` for the test names, helper names, pattern strings, and `500-line`; the A-GI indexes carry no entry for either size guard.

**No third copy.** #367 recorded a YAGNI ruling with a "third copy forces extraction" tripwire for `countSourceLines` and the listing helper. This change adds none — `internal/httpapi` and `internal/e2e_harness/federated` stay at two.

## The emptiness edge

`listNonTestSources` rejects only a *collectively* empty result, so under a pattern list a pattern that stops matching anything drops out of the guard in silence — the edge #367's review trail asked to dissolve. With one glob there is no pattern that can drop out, and the new completeness assertion is what a pattern list could not have satisfied, so a future re-narrowing turns the test red instead of going unnoticed.

The edge dissolves for the *file* guard only. The function guard still passes a pattern list and still carries the latent behaviour; it is out of scope here for the reason in the table above.

## Verification

**1. Red first** — completeness assertion run against the old `query*.go` + `harness*.go` glob:

```
=== RUN   TestListGuardedSourceFilesCoversEveryNonTestSource
    query_file_size_test.go:51: assertions.go is outside the file-size guard
    query_file_size_test.go:51: cdc.go is outside the file-size guard
    query_file_size_test.go:51: fixtures.go is outside the file-size guard
    query_file_size_test.go:51: helpers.go is outside the file-size guard
    query_file_size_test.go:51: s3_operations.go is outside the file-size guard
    query_file_size_test.go:51: seeding.go is outside the file-size guard
    query_file_size_test.go:51: validation.go is outside the file-size guard
--- FAIL: TestListGuardedSourceFilesCoversEveryNonTestSource (0.00s)
```

Exactly the seven files #369 named.

**2. Green after the glob swap** — all six guard tests in the package, `-count=1`, including both function-guard tests to confirm the shared helper is unaffected:

```
--- PASS: TestCountSourceLinesIncludesFinalUnterminatedLine (0.00s)
--- PASS: TestListGuardedSourceFilesCoversEveryNonTestSource (0.00s)
--- PASS: TestGuardedSourcesStayWithinFileSizeLimit (0.00s)
--- PASS: TestMeasureFunctionLinesSpansFuncKeywordToClosingBrace (0.00s)
--- PASS: TestListFunctionGuardedSourceFilesScopesToQuerySources (0.00s)
--- PASS: TestGuardedFunctionsStayWithinRefactoringTrigger (0.00s)
```

**3. Bite probe — physical on-disk mutation, not `go test -overlay`.** Per #324, this guard reads source at runtime through `os.ReadFile`, and `-overlay` only affects compilation, so an overlay probe would be a false green. 101 comment lines appended to `seeding.go` on disk (425 → 526), a file the old guard could not see:

```
=== RUN   TestGuardedSourcesStayWithinFileSizeLimit
    query_file_size_test.go:116: seeding.go has 526 lines, exceeds the 500-line source-file limit
--- FAIL: TestGuardedSourcesStayWithinFileSizeLimit (0.00s)
```

Reverted with `git checkout --`; `git status` clean afterwards. The completeness test proves the scope widened, this proves the widened scope bites.

**4. Gates** — `make fmt-check`, `make lint` (golangci-lint v1.64.8), `make test`: all pass, no cached results.

**5. No local e2e run.** This guard is untagged and container-free (0.5s, no Docker). CI's e2e jobs run regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCSCNgQmz3EWokjH4G3C7h
