### PR TITLE
chore(build): #448 pin GOTOOLCHAIN so newer local Go cannot break the gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ The Makefile pins `GOTOOLCHAIN` to go.mod's `go` directive (#448): `GOTOOLCHAIN=
 never downgrades, so a newer local Go breaks `make lint` (golangci-lint v1.64.8 cannot
 read newer export data) and `make test` (stdlib error-text assertions). Direct `go test`
 invocations bypass the Makefile, so set it yourself as above. Probe a newer toolchain
-deliberately with `GOTOOLCHAIN=auto make test`. On a machine whose local Go is newer, the first pinned run downloads the go1.26.0 toolchain once.
+deliberately with `GOTOOLCHAIN=auto make test`. On a machine whose local Go is newer, the first pinned run downloads the go1.26.0 toolchain once. The `go1.26.0` in the example above matches go.mod's `go` directive — update the two together.
 
 E2E (requires Docker; testcontainers-based):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ The Makefile pins `GOTOOLCHAIN` to go.mod's `go` directive (#448): `GOTOOLCHAIN=
 never downgrades, so a newer local Go breaks `make lint` (golangci-lint v1.64.8 cannot
 read newer export data) and `make test` (stdlib error-text assertions). Direct `go test`
 invocations bypass the Makefile, so set it yourself as above. Probe a newer toolchain
-deliberately with `GOTOOLCHAIN=auto make test`.
+deliberately with `GOTOOLCHAIN=auto make test`. On a machine whose local Go is newer, the first pinned run downloads the go1.26.0 toolchain once.
 
 E2E (requires Docker; testcontainers-based):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,17 @@ make coverage      # unit tests + coverage report in build/
 make build-all     # build server/tools/sample into build/ with platform symlinks
 ```
 
-Run a single test (mirror the Makefile's env to avoid sandbox cache/VCS errors):
+Run a single test (mirror the Makefile's env — GOTOOLCHAIN included, see the note below):
 
 ```bash
-GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false go test ./internal/sqlgen -run TestName -v
+GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false GOTOOLCHAIN=go1.26.0 go test ./internal/sqlgen -run TestName -v
 ```
+
+The Makefile pins `GOTOOLCHAIN` to go.mod's `go` directive (#448): `GOTOOLCHAIN=auto`
+never downgrades, so a newer local Go breaks `make lint` (golangci-lint v1.64.8 cannot
+read newer export data) and `make test` (stdlib error-text assertions). Direct `go test`
+invocations bypass the Makefile, so set it yourself as above. Probe a newer toolchain
+deliberately with `GOTOOLCHAIN=auto make test`.
 
 E2E (requires Docker; testcontainers-based):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ deliberately with `GOTOOLCHAIN=auto make test`. On a machine whose local Go is n
 E2E (requires Docker; testcontainers-based):
 
 ```bash
-go test -v ./internal/e2e_harness/... -timeout=5m                          # infra smoke
-go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=30m     # full federated suite
+GOTOOLCHAIN=go1.26.0 go test -v ./internal/e2e_harness/... -timeout=5m                      # infra smoke
+GOTOOLCHAIN=go1.26.0 go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=30m # full federated suite
 make test-e2e-production                                                    # production harness + oracle
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,14 @@ MAIN_LAMBDA=./cmd/lambda
 GOCACHE?=$(CURDIR)/.gocache
 # Disable VCS stamping by default to prevent stat-cache permission warnings in sandboxed builds.
 GOFLAGS?=-buildvcs=false
-GOENV=GOCACHE=$(GOCACHE) GOFLAGS="$(GOFLAGS)"
+# Pin the toolchain the gates run under to go.mod's go directive (#448).
+# GOTOOLCHAIN=auto only ever upgrades — a toolchain directive in go.mod is a
+# floor, not a ceiling — so a newer local Go silently replaces CI's pinned
+# version: golangci-lint v1.64.8 then reports ~46 spurious typecheck errors
+# (it cannot read the newer export data) and schemavalidate trips on changed
+# stdlib error text. ?= keeps deliberate probes possible: GOTOOLCHAIN=auto make test.
+GOTOOLCHAIN?=go$(shell sed -n 's/^go //p' go.mod)
+GOENV=GOCACHE=$(GOCACHE) GOFLAGS="$(GOFLAGS)" GOTOOLCHAIN=$(GOTOOLCHAIN)
 
 GOOS=$(shell $(GOENV) go env GOOS)
 GOARCH=$(shell $(GOENV) go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ lint:
 	@echo "Installing golangci-lint..."
 	@$(GOENV) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 	@echo "Running golangci-lint..."
-	@PATH="$$($(GOENV) go env GOPATH)/bin:$$PATH" golangci-lint run --timeout=5m
+	@$(GOENV) PATH="$$($(GOENV) go env GOPATH)/bin:$$PATH" golangci-lint run --timeout=5m
 
 # Run unit tests with coverage report
 coverage: create-build-dir

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,15 @@ MAIN_LAMBDA=./cmd/lambda
 GOCACHE?=$(CURDIR)/.gocache
 # Disable VCS stamping by default to prevent stat-cache permission warnings in sandboxed builds.
 GOFLAGS?=-buildvcs=false
-# Pin the toolchain the gates run under to go.mod's go directive (#448).
+# Pin the toolchain the go-based gates run under to go.mod's go directive (#448).
 # GOTOOLCHAIN=auto only ever upgrades — a toolchain directive in go.mod is a
 # floor, not a ceiling — so a newer local Go silently replaces CI's pinned
 # version: golangci-lint v1.64.8 then reports ~46 spurious typecheck errors
 # (it cannot read the newer export data) and schemavalidate trips on changed
 # stdlib error text. ?= keeps deliberate probes possible: GOTOOLCHAIN=auto make test.
+# fmt-check is not covered: it calls the local gofmt binary directly. The
+# derivation needs go.mod's go directive to stay a full x.y.z — a patchless
+# "go 1.27" would derive go1.27, which is not a valid toolchain name.
 GOTOOLCHAIN?=go$(shell sed -n 's/^go //p' go.mod)
 GOENV=GOCACHE=$(GOCACHE) GOFLAGS="$(GOFLAGS)" GOTOOLCHAIN=$(GOTOOLCHAIN)
 

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -27,9 +27,14 @@ func TestGatesRunUnderPinnedToolchain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
 	}
-	match := regexp.MustCompile(`(?m)^go (\d+\.\d+)`).FindSubmatch(mod)
+	// The directive must carry a full x.y.z: the Makefile's sed derives
+	// GOTOOLCHAIN from it verbatim, and a patchless "go 1.26" would derive
+	// go1.26 — not a valid toolchain name. Requiring the patch segment here
+	// makes this guard red on the same precondition, while capturing only
+	// major.minor so patch-level toolchain divergence stays tolerated.
+	match := regexp.MustCompile(`(?m)^go (\d+\.\d+)\.\d+`).FindSubmatch(mod)
 	if match == nil {
-		t.Fatal("no go directive found in go.mod")
+		t.Fatal("no full x.y.z go directive found in go.mod: the Makefile's GOTOOLCHAIN derivation needs one (#448)")
 	}
 	want := "go" + string(match[1])
 	got := runtime.Version()

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -15,7 +15,7 @@ import (
 // schemavalidate assertion on changed stdlib error text under go1.27 —
 // because GOTOOLCHAIN=auto upgrades to a newer local toolchain but never
 // downgrades to the pinned one. The Makefile pins GOTOOLCHAIN for every
-// gate; this test is what goes red first if that wiring is ever removed.
+// gate; this test goes red first if the pin leaves GOENV, and it also ties CI to the pin: CI's test job runs go test under setup-go's GO_VERSION, so bumping ci.yml's GO_VERSION without go.mod (or vice versa) fails here by design. It observes only the binary that compiled it — the lint gate's wiring is pinned separately by TestLintRecipeInheritsGOENV.
 func TestGatesRunUnderPinnedToolchain(t *testing.T) {
 	mod, err := os.ReadFile("go.mod")
 	if err != nil {
@@ -29,5 +29,32 @@ func TestGatesRunUnderPinnedToolchain(t *testing.T) {
 	got := runtime.Version()
 	if got != want && !strings.HasPrefix(got, want+".") {
 		t.Fatalf("test binary built by %s, but go.mod pins %s.x (#448): run gates through make, which sets GOTOOLCHAIN, or export GOTOOLCHAIN yourself", got, want)
+	}
+}
+
+// TestLintRecipeInheritsGOENV pins the other half of the #448 wiring: the
+// lint gate. golangci-lint spawns its own `go list`, which reads GOTOOLCHAIN
+// from the environment, so the Makefile's lint run line must lead with
+// $(GOENV). TestGatesRunUnderPinnedToolchain cannot see this gate, and the
+// branch that introduced the pin shipped exactly this omission until review
+// caught it (commit 78f003a) — a $(GOENV) buried inside the GOPATH command
+// substitution does not reach the linter process, so a prefix is required.
+func TestLintRecipeInheritsGOENV(t *testing.T) {
+	mk, err := os.ReadFile("Makefile")
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	found := false
+	for _, line := range strings.Split(string(mk), "\n") {
+		if !strings.Contains(line, "golangci-lint run") {
+			continue
+		}
+		found = true
+		if !strings.HasPrefix(strings.TrimLeft(line, "\t@"), "$(GOENV) ") {
+			t.Errorf("lint recipe line %q does not lead with $(GOENV): golangci-lint would run its go list on the ambient toolchain, reviving the spurious typecheck errors of #448", line)
+		}
+	}
+	if !found {
+		t.Fatal("no golangci-lint run line found in Makefile: the lint-pin guard has lost its target")
 	}
 }

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -1,0 +1,33 @@
+package forma
+
+import (
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestGatesRunUnderPinnedToolchain fails with a named diagnosis when the
+// test binary was compiled by a toolchain whose major.minor differs from
+// go.mod's go directive (#448). Without it the drift surfaces as unrelated
+// packages going red — 46 spurious golangci-lint typecheck errors and a
+// schemavalidate assertion on changed stdlib error text under go1.27 —
+// because GOTOOLCHAIN=auto upgrades to a newer local toolchain but never
+// downgrades to the pinned one. The Makefile pins GOTOOLCHAIN for every
+// gate; this test is what goes red first if that wiring is ever removed.
+func TestGatesRunUnderPinnedToolchain(t *testing.T) {
+	mod, err := os.ReadFile("go.mod")
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	match := regexp.MustCompile(`(?m)^go (\d+\.\d+)`).FindSubmatch(mod)
+	if match == nil {
+		t.Fatal("no go directive found in go.mod")
+	}
+	want := "go" + string(match[1])
+	got := runtime.Version()
+	if got != want && !strings.HasPrefix(got, want+".") {
+		t.Fatalf("test binary built by %s, but go.mod pins %s.x (#448): run gates through make, which sets GOTOOLCHAIN, or export GOTOOLCHAIN yourself", got, want)
+	}
+}

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -15,7 +15,13 @@ import (
 // schemavalidate assertion on changed stdlib error text under go1.27 —
 // because GOTOOLCHAIN=auto upgrades to a newer local toolchain but never
 // downgrades to the pinned one. The Makefile pins GOTOOLCHAIN for every
-// gate; this test goes red first if the pin leaves GOENV, and it also ties CI to the pin: CI's test job runs go test under setup-go's GO_VERSION, so bumping ci.yml's GO_VERSION without go.mod (or vice versa) fails here by design. It observes only the binary that compiled it — the lint gate's wiring is pinned separately by TestLintRecipeInheritsGOENV.
+// gate; this test goes red first if the pin leaves GOENV. It also ties CI
+// to the pin in one direction: CI's test job runs go test under setup-go's
+// GO_VERSION with no GOTOOLCHAIN set, so a GO_VERSION on a newer major.minor
+// than go.mod's directive fails here, while a go.mod-only bump auto-upgrades
+// CI's toolchain and passes, and patch-level divergence is tolerated. The
+// test observes only the binary that compiled it — the lint gate's wiring is
+// pinned separately by TestLintRecipeInheritsGOENV.
 func TestGatesRunUnderPinnedToolchain(t *testing.T) {
 	mod, err := os.ReadFile("go.mod")
 	if err != nil {

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -11,11 +11,12 @@ import (
 // TestGatesRunUnderPinnedToolchain fails with a named diagnosis when the
 // test binary was compiled by a toolchain whose major.minor differs from
 // go.mod's go directive (#448). Without it the drift surfaces as unrelated
-// packages going red — 46 spurious golangci-lint typecheck errors and a
+// packages going red — ~46 spurious golangci-lint typecheck errors and a
 // schemavalidate assertion on changed stdlib error text under go1.27 —
 // because GOTOOLCHAIN=auto upgrades to a newer local toolchain but never
 // downgrades to the pinned one. The Makefile pins GOTOOLCHAIN for every
-// gate; this test goes red first if the pin leaves GOENV. It also ties CI
+// go-based gate (fmt-check excepted — it calls the local gofmt binary);
+// this test goes red if the pin leaves GOENV. It also ties CI
 // to the pin in one direction: CI's test job runs go test under setup-go's
 // GO_VERSION with no GOTOOLCHAIN set, so a GO_VERSION on a newer major.minor
 // than go.mod's directive fails here, while a go.mod-only bump auto-upgrades


### PR DESCRIPTION
Closes #448.

## What

- **Makefile**: derive `GOTOOLCHAIN` from go.mod's `go` directive and thread it through `GOENV` (all 22 go invocations). `?=` keeps `GOTOOLCHAIN=auto make test` probes possible. A follow-up commit (78f003a) also prefixes the lint recipe's run line itself with `$(GOENV)` — task review caught that the linter process otherwise inherited no `GOTOOLCHAIN` (it only appeared inside the GOPATH command substitution), which would have left the 46 spurious typecheck errors alive.
- **Guard tests** (root package, `toolchain_guard_test.go`):
  - `TestGatesRunUnderPinnedToolchain` — fails with a named diagnosis when the test binary was built by a toolchain whose major.minor differs from go.mod's `go` directive, instead of the drift surfacing as spurious lint errors plus an unrelated schemavalidate FAIL.
  - `TestLintRecipeInheritsGOENV` — pins the lint gate's wiring: the `golangci-lint run` line must lead with `$(GOENV)`. Mutation-verified: stripping the prefix makes the test fail naming the offending line.
- **AGENTS.md**: single-test command now includes `GOTOOLCHAIN=go1.26.0`; pin rationale, deliberate-probe path, and first-run toolchain download documented.

## Why not the issue's Option 1 (`toolchain go1.26.0` in go.mod)

Probe-verified during planning: `GOTOOLCHAIN=auto` picks the newest of {local, `go` line, `toolchain` line} — the directive is a floor, not a ceiling, so local 1.27 still runs. Details in the planning comment on #448. go.mod is untouched.

## Verification (local go1.27.0 darwin/arm64, all commands with GOTOOLCHAIN unset)

| gate | before (clean main) | after (this branch) |
|---|---|---|
| `make lint` | 46 spurious typecheck errors | EXIT=0, clean |
| `make test` | 1 FAIL (schemavalidate) | 33 packages ok, 0 FAIL |
| `make fmt-check` | clean | clean |

CI impact: none — CI's jobs run under setup-go 1.26.0 where the pin is a no-op; the new guard additionally makes CI's test job fail if `GO_VERSION` ever moves to a newer major.minor than go.mod's directive.

## Known limits (deliberate)

- `fmt-check` calls the local `gofmt` binary and is not covered by `GOTOOLCHAIN` (noted in the Makefile comment; no gofmt drift observed).
- The lint guard pins the exact `$(GOENV) ` prefix idiom; an equivalent rewrite of that line would fail it loudly — intentional strictness.
- A `devel` self-built toolchain false-reds the toolchain guard; the message still points at the right lever.

## Follow-ups filed

- #453 — schemavalidate's stdlib-error-text assertion (deferred by #448's own scoping; also product-facing 4xx wording).
- #454 — CI lint job open-codes install+run instead of `make lint`; parity now relies on version coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrPj1XrHVcPwHVK3zoUibY