### PR TITLE
ci: lint job runs make lint, restoring local/CI parity (#454)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,13 @@ jobs:
       - name: Check gofmt
         run: make fmt-check
 
-      - name: Run golangci-lint
-        run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
-          golangci-lint run --timeout=5m
+      # Run the Makefile recipe, not an open-coded install+run: the recipe is
+      # the single definition of the linter version pin and of GOENV
+      # (GOTOOLCHAIN=go1.26.0+auto, GOCACHE, GOFLAGS), so local `make lint`
+      # and CI stay byte-identical (#454). TestCILintJobRunsMakeLint guards
+      # this shape.
+      - name: Run linter
+        run: make lint
 
   test:
     name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,9 @@
 # dereference after `if x == nil { t.Fatal(...) }` is unreachable — but some
 # Go-toolchain/golangci-lint combinations lose that fact and demand dead
 # `return` statements after t.Fatal (this bit PRs #132 and #133). The linter
-# version is pinned in Makefile and .github/workflows/ci.yml for the same
-# reason: keep local `make lint` and CI byte-identical.
+# version is pinned in the Makefile's lint recipe alone for the same reason:
+# keep local `make lint` and CI byte-identical — CI's lint job reaches the pin
+# by running `make lint` (#454), a shape TestCILintJobRunsMakeLint guards.
 issues:
   exclude-rules:
     - path: _test\.go$

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -90,8 +90,25 @@ func TestCILintJobRunsMakeLint(t *testing.T) {
 		t.Fatalf("read .github/workflows/ci.yml: %v", err)
 	}
 	text := string(ci)
-	if !strings.Contains(text, "make lint") {
-		t.Error("ci.yml has no `make lint` step: the lint job must run the Makefile recipe so the golangci-lint pin and GOENV have one definition (#454)")
+	// The positive half must match a real run directive, not prose: ci.yml's
+	// explanatory comment also says "make lint", so a bare substring search
+	// stays green even with the invocation deleted (#482 review). Comment
+	// lines are skipped explicitly so prose never counts, whatever shape the
+	// directive pattern takes in the future.
+	runMakeLint := regexp.MustCompile(`^run:\s*make lint\s*$`)
+	found := false
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if runMakeLint.MatchString(trimmed) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ci.yml has no `run: make lint` directive: the lint job must run the Makefile recipe so the golangci-lint pin and GOENV have one definition (#454)")
 	}
 	if strings.Contains(text, "golangci-lint") {
 		t.Error("ci.yml mentions golangci-lint directly: the install+run belong to the Makefile lint recipe alone — an open-coded copy drops the GOTOOLCHAIN pin and re-splits the version pin (#454)")

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -75,3 +75,25 @@ func TestLintRecipeInheritsGOENV(t *testing.T) {
 		t.Fatal("no golangci-lint run line found in Makefile: the lint-pin guard has lost its target")
 	}
 }
+
+// TestCILintJobRunsMakeLint pins the CI side of the #448 wiring (#454): the
+// lint job must invoke `make lint` rather than open-coding the golangci-lint
+// install+run. An open-coded invocation carries none of the Makefile's GOENV
+// (GOTOOLCHAIN pin, GOCACHE, GOFLAGS), so local/CI parity would hold only
+// while setup-go's GO_VERSION coincidentally equals the Makefile's toolchain
+// floor — the same coincidence #448 proved unreliable. Asserting the absence
+// of "golangci-lint" in the workflow catches both halves of a regression:
+// re-adding the install line or the run line.
+func TestCILintJobRunsMakeLint(t *testing.T) {
+	ci, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("read .github/workflows/ci.yml: %v", err)
+	}
+	text := string(ci)
+	if !strings.Contains(text, "make lint") {
+		t.Error("ci.yml has no `make lint` step: the lint job must run the Makefile recipe so the golangci-lint pin and GOENV have one definition (#454)")
+	}
+	if strings.Contains(text, "golangci-lint") {
+		t.Error("ci.yml mentions golangci-lint directly: the install+run belong to the Makefile lint recipe alone — an open-coded copy drops the GOTOOLCHAIN pin and re-splits the version pin (#454)")
+	}
+}

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -82,22 +82,23 @@ func TestLintRecipeInheritsGOENV(t *testing.T) {
 // (GOTOOLCHAIN pin, GOCACHE, GOFLAGS), so local/CI parity would hold only
 // while setup-go's GO_VERSION coincidentally equals the Makefile's toolchain
 // floor — the same coincidence #448 proved unreliable. Asserting the absence
-// of "golangci-lint" in the workflow catches both halves of a regression:
-// re-adding the install line or the run line.
+// of "golangci-lint" in the whole workflow catches both halves of a
+// regression: re-adding the install line or the run line.
 func TestCILintJobRunsMakeLint(t *testing.T) {
 	ci, err := os.ReadFile(".github/workflows/ci.yml")
 	if err != nil {
 		t.Fatalf("read .github/workflows/ci.yml: %v", err)
 	}
 	text := string(ci)
-	// The positive half must match a real run directive, not prose: ci.yml's
-	// explanatory comment also says "make lint", so a bare substring search
-	// stays green even with the invocation deleted (#482 review). Comment
-	// lines are skipped explicitly so prose never counts, whatever shape the
-	// directive pattern takes in the future.
+	// The positive half must match a real run directive, not prose, and only
+	// inside the lint job (#482 review, both rounds): ci.yml's explanatory
+	// comment also says "make lint", and another job legitimately running the
+	// same command must not satisfy a guard about the lint job's wiring.
+	// Comment lines are skipped explicitly so prose never counts, whatever
+	// shape the directive pattern takes in the future.
 	runMakeLint := regexp.MustCompile(`^run:\s*make lint\s*$`)
 	found := false
-	for _, line := range strings.Split(text, "\n") {
+	for _, line := range strings.Split(ciLintJobBlock(t, text), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "#") {
 			continue
@@ -108,9 +109,47 @@ func TestCILintJobRunsMakeLint(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("ci.yml has no `run: make lint` directive: the lint job must run the Makefile recipe so the golangci-lint pin and GOENV have one definition (#454)")
+		t.Error("ci.yml's lint job has no `run: make lint` directive: the lint job must run the Makefile recipe so the golangci-lint pin and GOENV have one definition (#454)")
 	}
 	if strings.Contains(text, "golangci-lint") {
 		t.Error("ci.yml mentions golangci-lint directly: the install+run belong to the Makefile lint recipe alone — an open-coded copy drops the GOTOOLCHAIN pin and re-splits the version pin (#454)")
 	}
+}
+
+// ciLintJobBlock cuts the `lint:` job's body out of ci.yml by indentation: it
+// starts after the two-space `lint:` key under the top-level `jobs:` key and
+// ends at the next non-blank line indented two spaces or less (the next job,
+// or a later top-level key). Deliberately not a YAML parser — a yaml
+// dependency buys nothing here (#482 review round 1), and the sibling guards
+// in this file are plain text scans for the same reason. If the workflow's
+// job indentation ever changes shape, this fails loudly via t.Fatal rather
+// than passing on an empty block.
+func ciLintJobBlock(t *testing.T, text string) string {
+	t.Helper()
+	lines := strings.Split(text, "\n")
+	inJobs := false
+	start := -1
+	for i, line := range lines {
+		if line == "jobs:" {
+			inJobs = true
+			continue
+		}
+		if !inJobs {
+			continue
+		}
+		if start == -1 {
+			if line == "  lint:" {
+				start = i + 1
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(line, "    ") {
+			return strings.Join(lines[start:i], "\n")
+		}
+	}
+	if start == -1 {
+		t.Fatal("ci.yml has no `lint:` job under `jobs:`: this guard scopes its run-directive check to that job and has lost its target (#454)")
+	}
+	return strings.Join(lines[start:], "\n")
 }


### PR DESCRIPTION
## Summary

- CI's lint job now runs `make lint` instead of open-coding the golangci-lint install+run. The Makefile recipe is the single definition of the linter version pin (v1.64.8) and of `GOENV` (`GOTOOLCHAIN=go1.26.0+auto`, `GOCACHE`, `GOFLAGS`) — previously parity held only because setup-go's `GO_VERSION` coincidentally equaled the toolchain floor, the same coincidence #448 proved unreliable locally.
- New root-package guard `TestCILintJobRunsMakeLint` covers the lint job's invocation shape (the gap the issue named): `ci.yml` must contain `make lint` and must not mention `golangci-lint` directly, so re-adding either the install line or the run line fails CI's test job. It sits beside the two existing #448 guards in `toolchain_guard_test.go`.
- `.golangci.yml`'s header no longer claims the version is pinned in two places; it now points at the Makefile recipe and the new guard. The workflow step was renamed `Run linter` because the guard rejects any direct `golangci-lint` mention in `ci.yml` (the step name included).

## Known tradeoff

`make lint` sets `GOCACHE` to `$PWD/.gocache`, which setup-go's default cache step does not save/restore (it queries the ambient `go env GOCACHE`). The lint job therefore loses build-cache reuse across runs — accepted: parity is the point of the change, and the job already reinstalled golangci-lint on every run.

## Verification

- `TestCILintJobRunsMakeLint` written first and observed failing on both branches against the old workflow (TDD); root package `go test .` now passes.
- `make fmt-check && make lint` green locally — the exact pair CI's lint job now runs.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196sNgz4EfzUQ3xS667Fb2R