### PR TITLE
lint: make lint covers e2e-tagged files via --build-tags e2e (#436)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,15 @@ fmt-check:
 		exit 1; \
 	fi
 
-# Run linter (same as CI lint job)
+# Run linter (same as CI lint job). --build-tags e2e keeps the //go:build e2e
+# files in scope (#436) — without it golangci-lint never loads them at all;
+# TestLintRecipeCoversE2ETag guards the flag, and the timeout is 10m because
+# the tag roughly doubles the analyzed file set.
 lint:
 	@echo "Installing golangci-lint..."
 	@$(GOENV) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 	@echo "Running golangci-lint..."
-	@$(GOENV) PATH="$$($(GOENV) go env GOPATH)/bin:$$PATH" golangci-lint run --timeout=5m
+	@$(GOENV) PATH="$$($(GOENV) go env GOPATH)/bin:$$PATH" golangci-lint run --build-tags e2e --timeout=10m
 
 # Run unit tests with coverage report
 coverage: create-build-dir

--- a/internal/e2e_harness/federated/benchmark/truthpass_batch_e2e_test.go
+++ b/internal/e2e_harness/federated/benchmark/truthpass_batch_e2e_test.go
@@ -22,7 +22,7 @@ func TestTruthPassBatchEqualsPerCandidate(t *testing.T) {
 
 	h, err := federated.NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	runner, err := NewRunner(Config{
 		Mode:          ExecutionModePlan,

--- a/internal/e2e_harness/federated/benchmark/truthpass_eav_low_selectivity_e2e_test.go
+++ b/internal/e2e_harness/federated/benchmark/truthpass_eav_low_selectivity_e2e_test.go
@@ -27,7 +27,7 @@ func TestTruthPassOracleFiltersPureEAVAttribute(t *testing.T) {
 
 	h, err := federated.NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Hotspot distribution is required: it appends updated records that rewrite
 	// orderChannel and land in the hot tier, which is where the reconstruction

--- a/internal/e2e_harness/federated/benchmark_scaffold_test.go
+++ b/internal/e2e_harness/federated/benchmark_scaffold_test.go
@@ -18,7 +18,7 @@ func TestBenchmarkScaffold_SchemaRegistration(t *testing.T) {
 
 	h, err := federated.NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	runner, err := bench.NewRunner(bench.DefaultConfig())
 	require.NoError(t, err)

--- a/internal/e2e_harness/federated/benchmark_tier_load_test.go
+++ b/internal/e2e_harness/federated/benchmark_tier_load_test.go
@@ -18,7 +18,7 @@ func TestBenchmarkTierLoad_SmallDataset(t *testing.T) {
 
 	h, err := federated.NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	g, err := bench.NewGenerator(bench.GeneratorConfig{
 		Scale:         bench.ScaleSmall,

--- a/internal/e2e_harness/federated/benchmark_workload_execution_test.go
+++ b/internal/e2e_harness/federated/benchmark_workload_execution_test.go
@@ -61,7 +61,7 @@ func TestBenchmarkWorkloadExecution_RunWithHarness(t *testing.T) {
 
 	h, err := federated.NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	runner, err := bench.NewRunner(bench.Config{
 		Mode:          bench.ExecutionModePlan,
@@ -219,7 +219,7 @@ func TestBenchmarkTruthPassSampledSpotCheck_RunWithHarness(t *testing.T) {
 
 	h, err := federated.NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	runner, err := bench.NewRunner(bench.Config{
 		Mode:               bench.ExecutionModeLive,

--- a/internal/e2e_harness/federated/cdc_flush_test.go
+++ b/internal/e2e_harness/federated/cdc_flush_test.go
@@ -29,7 +29,7 @@ func TestCDCFlush_MinRecordsThreshold(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("below_threshold_no_flush", func(t *testing.T) {
 		// Clear existing data
@@ -99,7 +99,7 @@ func TestCDCFlush_MaxAgeThreshold(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("recent_records_no_age_trigger", func(t *testing.T) {
 		// Clear existing data
@@ -159,7 +159,7 @@ func TestCDCFlush_AdvisoryLockPreventsConurrent(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -209,7 +209,7 @@ func TestCDCFlush_RecordsMarkedFlushed(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -263,7 +263,7 @@ func TestCDCFlush_DeltaFileNaming(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -298,7 +298,7 @@ func TestCDCFlush_BatchSizeRespected(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Set a specific batch size
 	h.CDCConfig.BatchSize = 100
@@ -333,7 +333,7 @@ func TestCDCFlush_MultipleFlushesComplete(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Set small batch size for multiple iterations
 	h.CDCConfig.BatchSize = 50

--- a/internal/e2e_harness/federated/compaction_test.go
+++ b/internal/e2e_harness/federated/compaction_test.go
@@ -28,7 +28,7 @@ func TestCompaction_NewDataAppendsToDeltas(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed initial base data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -70,7 +70,7 @@ func TestCompaction_LowDirtyRatioSkipsCompaction(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed base data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -115,7 +115,7 @@ func TestCompaction_HighDirtyRatioTriggersRewrite(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed base data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -155,7 +155,7 @@ func TestCompaction_MergesMultipleDeltaFiles(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -206,7 +206,7 @@ func TestCompaction_PreservesDeduplication(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -248,7 +248,7 @@ func TestCompaction_FileSizeRotation(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -286,7 +286,7 @@ func TestCompaction_PreservesSoftDeletes(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -323,7 +323,7 @@ func TestCompaction_DurationWithinThreshold(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -362,7 +362,7 @@ func TestCompaction_EmptyDeltaNoOp(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear all data (no delta files)
 	require.NoError(t, h.ClearAllData(ctx))

--- a/internal/e2e_harness/federated/consistency_test.go
+++ b/internal/e2e_harness/federated/consistency_test.go
@@ -308,7 +308,6 @@ func TestConsistency_AfterCompaction(t *testing.T) {
 	require.NoError(t, h.ClearAllData(ctx))
 
 	// Create delta files
-	var allRecords []TestRecord
 	for i := 0; i < 5; i++ {
 		records := GenerateTestRecords(100, &GeneratorOptions{
 			SchemaID:       h.SchemaID,
@@ -318,7 +317,6 @@ func TestConsistency_AfterCompaction(t *testing.T) {
 		})
 		err = h.WriteParquet(ctx, "delta", "consistency_delta_"+string(rune('a'+i))+".parquet", records)
 		require.NoError(t, err)
-		allRecords = append(allRecords, records...)
 	}
 
 	// Get pre-compaction state

--- a/internal/e2e_harness/federated/consistency_test.go
+++ b/internal/e2e_harness/federated/consistency_test.go
@@ -29,7 +29,7 @@ func TestConsistency_CountMatch(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("hot_buffer_only", func(t *testing.T) {
 		// Clear data and seed only hot buffer
@@ -109,7 +109,7 @@ func TestConsistency_AttributeValueMatch(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed specific test data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -179,7 +179,7 @@ func TestConsistency_ChecksumValidation(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("same_data_same_checksum", func(t *testing.T) {
 		// Clear and seed data
@@ -259,7 +259,7 @@ func TestConsistency_AfterCDCFlush(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -302,7 +302,7 @@ func TestConsistency_AfterCompaction(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed multiple delta files
 	require.NoError(t, h.ClearAllData(ctx))
@@ -357,7 +357,7 @@ func TestConsistency_RowIDExistence(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -395,7 +395,7 @@ func TestConsistency_MissingRecordDetection(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -443,7 +443,7 @@ func TestConsistency_DeduplicationAcrossComparison(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -480,7 +480,7 @@ func TestConsistency_TimestampOrdering(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear and seed data with known timestamps
 	require.NoError(t, h.ClearAllData(ctx))

--- a/internal/e2e_harness/federated/data_tier_test.go
+++ b/internal/e2e_harness/federated/data_tier_test.go
@@ -24,7 +24,7 @@ func TestDataTier_S3BaseFilesOnly(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed only base records
 	baseRecords, err := h.SeedBaseRecords(ctx, 100)
@@ -63,7 +63,7 @@ func TestDataTier_S3DeltaFilesOnly(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed only delta records
 	deltaRecords, err := h.SeedDeltaRecords(ctx, 50)
@@ -101,7 +101,7 @@ func TestDataTier_PostgresHotBufferOnly(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed only hot records (unflushed)
 	hotRecords, err := h.SeedHotRecords(ctx, 25)
@@ -136,7 +136,7 @@ func TestDataTier_AllThreeTiers(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Use preset scenario for non-overlapping data
 	scenarios := PresetScenarios{}
@@ -181,7 +181,7 @@ func TestDataTier_TierPriorityOrder(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed all tiers
 	require.NoError(t, h.SeedAllTiers(ctx, 100, 50, 25))
@@ -212,7 +212,7 @@ func TestDataTier_EmptyTiers(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear all data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -237,7 +237,7 @@ func TestDataTier_LargeLimitPagination(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed data to all tiers
 	require.NoError(t, h.SeedAllTiers(ctx, 500, 300, 100))

--- a/internal/e2e_harness/federated/deduplication_test.go
+++ b/internal/e2e_harness/federated/deduplication_test.go
@@ -24,7 +24,7 @@ func TestDeduplication_SameTier(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	rowID := uuid.Must(uuid.NewV7())
 	baseTime := time.Now()
@@ -78,7 +78,7 @@ func TestDeduplication_CrossTier(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	rowID := uuid.Must(uuid.NewV7())
 	baseTime := time.Now()
@@ -133,7 +133,7 @@ func TestDeduplication_BulkPerformance(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Generate 10K records with 30% duplicates
 	totalRecords := 10000
@@ -179,7 +179,7 @@ func TestDeduplication_UUIDv7TimeOrdering(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Generate UUIDs with time gaps
 	var uuids []uuid.UUID
@@ -229,7 +229,7 @@ func TestDeduplication_NoFalsePositives(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Create 100 unique records (no duplicates)
 	uniqueRecords := GenerateTestRecords(100, &GeneratorOptions{
@@ -262,7 +262,7 @@ func TestDeduplication_MultipleRowsWithVersions(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	numDistinctRows := 20
 	versionsPerRow := 3

--- a/internal/e2e_harness/federated/failure_modes_test.go
+++ b/internal/e2e_harness/federated/failure_modes_test.go
@@ -27,7 +27,7 @@ func TestFailureMode_S3Unavailable(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("fallback_to_postgres_only", func(t *testing.T) {
 		// Clear data and seed both S3 and Postgres
@@ -93,7 +93,7 @@ func TestFailureMode_PostgresUnavailable(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("error_on_pg_failure", func(t *testing.T) {
 		// Clear and seed S3 data only
@@ -141,7 +141,7 @@ func TestFailureMode_CorruptedParquet(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("handles_missing_parquet", func(t *testing.T) {
 		// Clear all data (no parquet files)
@@ -184,7 +184,7 @@ func TestFailureMode_QueryTimeout(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("context_deadline_exceeded", func(t *testing.T) {
 		// Seed data
@@ -236,7 +236,7 @@ func TestFailureMode_PartialFailureRecovery(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("partial_flush_recovery", func(t *testing.T) {
 		// Seed hot buffer with multiple batches worth of data
@@ -295,7 +295,7 @@ func TestFailureMode_GracefulDegradation(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("query_hot_buffer_when_s3_fails", func(t *testing.T) {
 		// Clear and seed only hot buffer
@@ -347,7 +347,7 @@ func TestFailureMode_ConcurrentFailures(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("concurrent_queries_with_intermittent_failures", func(t *testing.T) {
 		// Seed data
@@ -397,7 +397,7 @@ func TestFailureMode_DataIntegrityAfterFailure(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	t.Run("no_data_loss_after_s3_failure", func(t *testing.T) {
 		// Clear and seed data

--- a/internal/e2e_harness/federated/filter_lww_regression_test.go
+++ b/internal/e2e_harness/federated/filter_lww_regression_test.go
@@ -40,7 +40,7 @@ func runFilterAfterLWWScenario(t *testing.T, sc filterLWWScenario) {
 
 	h, err := federated.NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 	require.NoError(t, h.SetupSchema(sc.schemaID, sc.schemaName))
 
 	rowID := uuid.Must(uuid.NewV7())

--- a/internal/e2e_harness/federated/harness.go
+++ b/internal/e2e_harness/federated/harness.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/lychee-technology/forma/internal/model"
@@ -407,6 +408,16 @@ func (h *FederatedTestHarness) Cleanup(ctx context.Context) error {
 		return fmt.Errorf("cleanup errors: %v", errs)
 	}
 	return nil
+}
+
+// CleanupOrLog releases all resources like Cleanup, reporting any failure
+// through tb instead of returning it. Deferred call sites cannot act on the
+// error, but it must not be silently discarded (errcheck, #436).
+func (h *FederatedTestHarness) CleanupOrLog(ctx context.Context, tb testing.TB) {
+	tb.Helper()
+	if err := h.Cleanup(ctx); err != nil {
+		tb.Logf("harness cleanup failed: %v", err)
+	}
 }
 
 // SetupSchema configures the schema for testing.

--- a/internal/e2e_harness/federated/harness.go
+++ b/internal/e2e_harness/federated/harness.go
@@ -299,6 +299,9 @@ func NewFederatedTestHarness(ctx context.Context, opts ...HarnessOption) (*Feder
 
 	// Initialize database schema
 	if err := h.initDatabaseSchema(ctx); err != nil {
+		// Best-effort: construction is already failing, and the schema error
+		// below is the one the caller must see. No testing.TB exists here, so
+		// CleanupOrLog does not apply.
 		_ = h.Cleanup(ctx)
 		return nil, fmt.Errorf("init database schema: %w", err)
 	}

--- a/internal/e2e_harness/federated/merge_on_read_test.go
+++ b/internal/e2e_harness/federated/merge_on_read_test.go
@@ -24,7 +24,7 @@ func TestMergeOnRead_UnionAllCorrectness(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed non-overlapping data to each tier
 	baseRecords, err := h.SeedBaseRecords(ctx, 1000)
@@ -57,7 +57,7 @@ func TestMergeOnRead_OverlappingRecords(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Use preset deduplication scenario
 	scenarios := PresetScenarios{}
@@ -96,7 +96,7 @@ func TestMergeOnRead_LastWriteWins(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	rowID := uuid.Must(uuid.NewV7())
 	baseTime := time.Now()
@@ -163,7 +163,7 @@ func TestMergeOnRead_DirtyIDExclusion(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	rowID := uuid.Must(uuid.NewV7())
 
@@ -221,7 +221,7 @@ func TestMergeOnRead_MultipleOverlappingRecords(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Create 5 different row_ids, each with 3 versions
 	numRows := 5
@@ -257,7 +257,7 @@ func TestMergeOnRead_MixedCleanAndDirty(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Create 100 base records (clean - already flushed)
 	cleanRecords := GenerateTestRecords(100, &GeneratorOptions{
@@ -303,7 +303,7 @@ func TestMergeOnRead_TimeSlotOrdering(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	baseTime := time.Now()
 

--- a/internal/e2e_harness/federated/performance_test.go
+++ b/internal/e2e_harness/federated/performance_test.go
@@ -71,7 +71,7 @@ func TestPerformance_SimplePagination(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed medium-scale data (using smaller dataset for CI)
 	require.NoError(t, h.ClearAllData(ctx))
@@ -136,7 +136,7 @@ func TestPerformance_ComplexFilter(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -189,7 +189,7 @@ func TestPerformance_FullTableScan(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed larger dataset
 	require.NoError(t, h.ClearAllData(ctx))
@@ -242,7 +242,7 @@ func TestPerformance_ConcurrentQueries(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -326,7 +326,7 @@ func TestPerformance_CDCFlush(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed hot buffer with records to flush
 	require.NoError(t, h.ClearAllData(ctx))
@@ -390,7 +390,7 @@ func TestPerformance_Compaction(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Create multiple delta files to compact
 	require.NoError(t, h.ClearAllData(ctx))
@@ -442,7 +442,7 @@ func TestPerformance_QueryLatencyDistribution(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed data
 	require.NoError(t, h.ClearAllData(ctx))
@@ -524,7 +524,7 @@ func TestPerformance_MemoryUsage(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err)
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Seed data
 	require.NoError(t, h.ClearAllData(ctx))

--- a/internal/e2e_harness/federated/soft_delete_test.go
+++ b/internal/e2e_harness/federated/soft_delete_test.go
@@ -24,7 +24,7 @@ func TestSoftDelete_ExcludeDeleted(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Use preset soft delete scenario
 	scenarios := PresetScenarios{}
@@ -54,7 +54,7 @@ func TestSoftDelete_NullVsZeroDeletedAt(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	now := time.Now().UnixMilli()
 
@@ -100,7 +100,7 @@ func TestSoftDelete_RestoreAfterDelete(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	rowID := uuid.Must(uuid.NewV7())
 	baseTime := time.Now()
@@ -161,7 +161,7 @@ func TestSoftDelete_DeleteThenReuse(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Create two different row_ids
 	deletedRowID := uuid.Must(uuid.NewV7())
@@ -208,7 +208,7 @@ func TestSoftDelete_AllTiersDeleted(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	now := time.Now().UnixMilli()
 
@@ -270,7 +270,7 @@ func TestSoftDelete_HotDeleteShadowsParquetVersion(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	rowID := uuid.Must(uuid.NewV7())
 	baseTime := time.Now()
@@ -324,7 +324,7 @@ func TestSoftDelete_BulkDeletedExclusion(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Generate records with 50% deleted
 	totalRecords := 1000
@@ -373,7 +373,7 @@ func TestSoftDelete_DeletedAtTimestampPrecision(t *testing.T) {
 
 	h, err := NewFederatedTestHarness(ctx)
 	require.NoError(t, err, "failed to create harness")
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	now := time.Now()
 	nowMs := now.UnixMilli()

--- a/internal/e2e_harness/federated/suite_test.go
+++ b/internal/e2e_harness/federated/suite_test.go
@@ -258,23 +258,3 @@ func BenchmarkCDCFlush(b *testing.B) {
 		}
 	}
 }
-
-// Test categories for organization
-var testCategories = map[string]string{
-	"TC-01": "Three-tier data architecture",
-	"TC-02": "Merge-on-Read logic",
-	"TC-03": "Global deduplication",
-	"TC-04": "Soft delete filtering",
-	"TC-05": "CDC Smart Flushing",
-	"TC-06": "Compaction strategy",
-	"TC-07": "Data consistency",
-	"TC-08": "Performance benchmarks",
-	"TC-09": "Failure modes",
-}
-
-// printTestCategories outputs the test categories for documentation.
-func printTestCategories() {
-	for id, desc := range testCategories {
-		println(id + ": " + desc)
-	}
-}

--- a/internal/e2e_harness/federated/suite_test.go
+++ b/internal/e2e_harness/federated/suite_test.go
@@ -62,7 +62,7 @@ func TestSuite_Smoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test harness: %v", err)
 	}
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Verify basic operations
 	t.Run("harness_initialization", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestSuite_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test harness: %v", err)
 	}
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, t)
 
 	// Clear data
 	if err := h.ClearAllData(ctx); err != nil {
@@ -202,7 +202,7 @@ func BenchmarkFederatedQuery(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create test harness: %v", err)
 	}
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, b)
 
 	// Seed data
 	if err := h.ClearAllData(ctx); err != nil {
@@ -236,7 +236,7 @@ func BenchmarkCDCFlush(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create test harness: %v", err)
 	}
-	defer h.Cleanup(ctx)
+	defer h.CleanupOrLog(ctx, b)
 
 	b.ResetTimer()
 

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -76,6 +76,32 @@ func TestLintRecipeInheritsGOENV(t *testing.T) {
 	}
 }
 
+// TestLintRecipeCoversE2ETag pins the #436 fix: the Makefile's lint recipe
+// must pass --build-tags e2e, or the 96 //go:build e2e files silently drop
+// out of linting again — golangci-lint only loads packages matching the
+// active build tags, so without the flag those files are never analyzed
+// (that gap hid 83 pre-existing violations). CI inherits this line via
+// `make lint` (#454), so this one guard covers both gates.
+func TestLintRecipeCoversE2ETag(t *testing.T) {
+	mk, err := os.ReadFile("Makefile")
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	found := false
+	for _, line := range strings.Split(string(mk), "\n") {
+		if !strings.Contains(line, "golangci-lint run") {
+			continue
+		}
+		found = true
+		if !strings.Contains(line, "--build-tags e2e") {
+			t.Errorf("lint recipe line %q lacks --build-tags e2e: the e2e-tagged files would silently stop being linted (#436)", line)
+		}
+	}
+	if !found {
+		t.Fatal("no golangci-lint run line found in Makefile: the e2e-tag guard has lost its target")
+	}
+}
+
 // TestCILintJobRunsMakeLint pins the CI side of the #448 wiring (#454): the
 // lint job must invoke `make lint` rather than open-coding the golangci-lint
 // install+run. An open-coded invocation carries none of the Makefile's GOENV


### PR DESCRIPTION
Closes #436.

`make lint` — and CI, which runs `make lint` since #454 — invoked golangci-lint without build tags, so the 96 `//go:build e2e` files were never analyzed. This adds `--build-tags e2e` to the lint recipe after clearing every violation the tag exposes, and pins the flag with a guard test.

## Corrected baseline: 83 violations, not 6

The issue's count of 6 was an artifact of golangci-lint's default output caps (`max-same-issues: 3`). With `--max-same-issues=0 --max-issues-per-linter=0` the true baseline at main (94b042e) was **83**:

- `errcheck` ×80 — all one shape: `defer h.Cleanup(ctx)` discarding the harness `Cleanup(ctx) error` return, across 17 files in `internal/e2e_harness/federated/` (incl. its `benchmark/` subpackage). Fixing only the 3 listed lines would have left CI red, revealing 3 more per run.
- `unused` ×2 — `suite_test.go`: `testCategories`, `printTestCategories`.
- staticcheck SA4010 ×1 — `consistency_test.go`: `allRecords` appended, never read.
- `funlen` ×0 — confirmed, matching the issue's measurement.

## Changes (one commit each)

1. **errcheck ×80** — new harness method `CleanupOrLog(ctx, tb testing.TB)` routes the cleanup failure through `tb.Logf` instead of dropping it; all defer sites switched (`t` in tests, `b` in the two `suite_test.go` benchmarks). `testing.TB` keeps one helper serving both packages.
2. **Dead code** — deleted `testCategories`/`printTestCategories` and the `allRecords` accumulation.
3. **Flip + guard** — lint recipe becomes `golangci-lint run --build-tags e2e --timeout=10m` (timeout raised for the larger file set; `$(GOENV)` prefix kept for `TestLintRecipeInheritsGOENV`). New guard `TestLintRecipeCoversE2ETag` fails if the flag ever disappears.

## Why `.github/workflows/ci.yml` is untouched

The issue predates #454. CI's lint job now runs `make lint`, so the Makefile change covers CI by construction — and `TestCILintJobRunsMakeLint` forbids ci.yml from mentioning golangci-lint at all. The Makefile pin stays at v1.64.8.

## Verification

- `make lint` (now tag-covering): exit 0; with output caps disabled: 0 findings.
- `make fmt-check`: pass.
- Guards `TestGatesRunUnderPinnedToolchain`, `TestLintRecipeInheritsGOENV`, `TestCILintJobRunsMakeLint`, `TestLintRecipeCoversE2ETag`: all pass.
- Full `make test` via `./scripts/test_with_container_runtime.sh`: exit 0, all packages ok.
- TDD: the guard test was written first and observed failing against the old recipe line before the Makefile flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5JUwtpzMhkEfybyKSd2Sm
