### PR TITLE
ci: extend the lint/build/vet gates to the infra/ module (#444)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          # The lint job is the one job that also builds the infra/ module
+          # (make check-infra, #444); key the module cache on both go.sums.
+          cache-dependency-path: |
+            go.sum
+            infra/go.sum
 
       - name: Check gofmt
         run: make fmt-check
@@ -33,6 +38,12 @@ jobs:
       # this shape.
       - name: Run linter
         run: make lint
+
+      # Build + vet the infra/ module (#444) — a separate Go module the root
+      # gates never reach. Same single-definition rationale as `make lint`
+      # above (#454); TestCILintJobChecksInfraModule guards the invocation.
+      - name: Build and vet infra module
+        run: make check-infra
 
   test:
     name: Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Forma is a general-purpose data management system on PostgreSQL. Entities are de
 ```bash
 make test          # unit tests (wraps: go test . ./cdc ./cmd/... ./factory ./internal/...)
 make fmt-check     # gofmt gate over git-listed Go files — CI runs it ahead of the linter
-make lint          # golangci-lint, pinned to v1.64.8 — same as CI; do not upgrade the pin
+make lint          # golangci-lint, pinned to v1.64.8 — same as CI; covers the root AND infra/ modules; do not upgrade the pin
+make check-infra   # build + vet the infra/ Pulumi module (a separate Go module the root gates never reach)
 make coverage      # unit tests + coverage report in build/
 make build-all     # build server/tools/sample into build/ with platform symlinks
 ./scripts/test_with_container_runtime.sh  # auto-detect Docker/Podman, configure E2E, run make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit test-e2e-production fmt-check lint coverage build build-tools build-benchmark benchmark-smoke benchmark-regression benchmark-heavy benchmark-heavy-live build-all build-lambda clean all create-build-dir link validate-schema-consistency
+.PHONY: test test-unit test-e2e-production fmt-check lint check-infra coverage build build-tools build-benchmark benchmark-smoke benchmark-regression benchmark-heavy benchmark-heavy-live build-all build-lambda clean all create-build-dir link validate-schema-consistency
 
 # Binary names
 BINARY_SERVER=server
@@ -98,11 +98,29 @@ fmt-check:
 # files in scope (#436) — without it golangci-lint never loads them at all;
 # TestLintRecipeCoversE2ETag guards the flag, and the timeout is 10m because
 # the tag roughly doubles the analyzed file set.
+#
+# infra/ is a separate Go module (#444), invisible to the root run's ./... —
+# so a second run executes inside it (guarded by TestLintRecipeCoversInfraModule).
+# It reuses the root .golangci.yml via golangci-lint's upward config search.
+# --build-tags e2e is inert there today (no tagged files) but keeps every run
+# line uniform under TestLintRecipeCoversE2ETag.
 lint:
 	@echo "Installing golangci-lint..."
 	@$(GOENV) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 	@echo "Running golangci-lint..."
 	@$(GOENV) PATH="$$($(GOENV) go env GOPATH)/bin:$$PATH" golangci-lint run --build-tags e2e --timeout=10m
+	@echo "Running golangci-lint (infra module)..."
+	@cd infra && $(GOENV) PATH="$$($(GOENV) go env GOPATH)/bin:$$PATH" golangci-lint run --build-tags e2e --timeout=10m
+
+# Build + vet the infra/ Pulumi module (#444). infra/ is its own Go module
+# (github.com/lychee-technology/forma/infra), so the root gates' ./... never
+# reaches it; before this target it was never built, vetted, or linted in CI.
+# CI's lint job runs this recipe (TestCILintJobChecksInfraModule guards that).
+check-infra:
+	@echo "Building infra module..."
+	@cd infra && $(GOENV) go build ./...
+	@echo "Vetting infra module..."
+	@cd infra && $(GOENV) go vet ./...
 
 # Run unit tests with coverage report
 coverage: create-build-dir

--- a/infra/components/serverless.go
+++ b/infra/components/serverless.go
@@ -63,13 +63,55 @@ func NewServerless(ctx *pulumi.Context, config *ServerlessConfig) (*ServerlessOu
 	namePrefix := fmt.Sprintf("forma-%s", config.Environment)
 	lambdaFunctionName := fmt.Sprintf("%s-api", namePrefix)
 
-	// Create S3 bucket for Lambda deployment artifacts
+	deploymentBucket, err := newDeploymentBucket(ctx, namePrefix, config.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create deployment bucket resources: %w", err)
+	}
+
+	lambdaRole, err := newLambdaRole(ctx, namePrefix, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Lambda role resources: %w", err)
+	}
+
+	// Create CloudWatch Log Group for Lambda
+	logGroup, err := cloudwatch.NewLogGroup(ctx, namePrefix+"-lambda-logs", &cloudwatch.LogGroupArgs{
+		Name:            pulumi.Sprintf("/aws/lambda/%s", lambdaFunctionName),
+		RetentionInDays: pulumi.Int(14),
+		Tags: pulumi.StringMap{
+			"Name":        pulumi.String(namePrefix + "-lambda-logs"),
+			"Environment": pulumi.String(config.Environment),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CloudWatch log group: %w", err)
+	}
+
+	api, stage, err := newAPIGateway(ctx, namePrefix, config.Environment, logGroup)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API Gateway resources: %w", err)
+	}
+
+	return &ServerlessOutput{
+		DeploymentBucketName:   deploymentBucket.Bucket,
+		LambdaRoleArn:          lambdaRole.Arn,
+		LogGroupName:           logGroup.Name,
+		LogGroupArn:            logGroup.Arn,
+		ApiGatewayID:           api.ID().ToStringOutput(),
+		ApiGatewayExecutionArn: api.ExecutionArn,
+		ApiEndpoint:            stage.InvokeUrl,
+		LambdaFunctionName:     lambdaFunctionName,
+	}, nil
+}
+
+// newDeploymentBucket creates the S3 bucket for Lambda deployment artifacts,
+// with public access blocked.
+func newDeploymentBucket(ctx *pulumi.Context, namePrefix, environment string) (*s3.Bucket, error) {
 	deploymentBucket, err := s3.NewBucket(ctx, namePrefix+"-lambda-deployments", &s3.BucketArgs{
 		Bucket:       pulumi.String(namePrefix + "-lambda-deployments"),
 		ForceDestroy: pulumi.Bool(true),
 		Tags: pulumi.StringMap{
 			"Name":        pulumi.String(namePrefix + "-lambda-deployments"),
-			"Environment": pulumi.String(config.Environment),
+			"Environment": pulumi.String(environment),
 			"Purpose":     pulumi.String("lambda-deployments"),
 		},
 	})
@@ -77,7 +119,6 @@ func NewServerless(ctx *pulumi.Context, config *ServerlessConfig) (*ServerlessOu
 		return nil, fmt.Errorf("failed to create deployment bucket: %w", err)
 	}
 
-	// Block public access on deployment bucket
 	_, err = s3.NewBucketPublicAccessBlock(ctx, namePrefix+"-lambda-deployments-pab", &s3.BucketPublicAccessBlockArgs{
 		Bucket:                deploymentBucket.ID(),
 		BlockPublicAcls:       pulumi.Bool(true),
@@ -88,8 +129,12 @@ func NewServerless(ctx *pulumi.Context, config *ServerlessConfig) (*ServerlessOu
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure deployment bucket public access block: %w", err)
 	}
+	return deploymentBucket, nil
+}
 
-	// Create IAM role for Lambda
+// newLambdaRole creates the Lambda execution role with its three policies:
+// basic execution (CloudWatch Logs), Aurora DSQL connect, and data-lake S3 access.
+func newLambdaRole(ctx *pulumi.Context, namePrefix string, config *ServerlessConfig) (*iam.Role, error) {
 	assumeRolePolicy := `{
 		"Version": "2012-10-17",
 		"Statement": [{
@@ -122,7 +167,6 @@ func NewServerless(ctx *pulumi.Context, config *ServerlessConfig) (*ServerlessOu
 		return nil, fmt.Errorf("failed to attach basic execution policy: %w", err)
 	}
 
-	// Create custom policy for Aurora DSQL access
 	// Lambda needs dsql:DbConnectAdmin to generate auth tokens and connect
 	dsqlPolicy := config.DSQLClusterArn.ApplyT(func(arn string) string {
 		return fmt.Sprintf(`{
@@ -146,7 +190,7 @@ func NewServerless(ctx *pulumi.Context, config *ServerlessConfig) (*ServerlessOu
 		return nil, fmt.Errorf("failed to create DSQL policy: %w", err)
 	}
 
-	// Create custom policy for S3 access (data lake bucket)
+	// S3 access covers the data lake bucket the API reads and writes
 	s3Policy := config.S3Bucket.ApplyT(func(bucket string) string {
 		return fmt.Sprintf(`{
 			"Version": "2012-10-17",
@@ -174,26 +218,16 @@ func NewServerless(ctx *pulumi.Context, config *ServerlessConfig) (*ServerlessOu
 	if err != nil {
 		return nil, fmt.Errorf("failed to create S3 policy: %w", err)
 	}
+	return lambdaRole, nil
+}
 
-	// Create CloudWatch Log Group for Lambda
-	logGroup, err := cloudwatch.NewLogGroup(ctx, namePrefix+"-lambda-logs", &cloudwatch.LogGroupArgs{
-		Name:            pulumi.Sprintf("/aws/lambda/%s", lambdaFunctionName),
-		RetentionInDays: pulumi.Int(14),
-		Tags: pulumi.StringMap{
-			"Name":        pulumi.String(namePrefix + "-lambda-logs"),
-			"Environment": pulumi.String(config.Environment),
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create CloudWatch log group: %w", err)
-	}
-
-	// Create API Gateway HTTP API
-	// Note: Integration and route will be created by CD workflow after Lambda is deployed
+// newAPIGateway creates the HTTP API and its $default auto-deploy stage.
+// Integration and route are created by the CD workflow after Lambda is deployed.
+func newAPIGateway(ctx *pulumi.Context, namePrefix, environment string, logGroup *cloudwatch.LogGroup) (*apigatewayv2.Api, *apigatewayv2.Stage, error) {
 	api, err := apigatewayv2.NewApi(ctx, namePrefix+"-api-gw", &apigatewayv2.ApiArgs{
 		Name:         pulumi.String(namePrefix + "-api"),
 		ProtocolType: pulumi.String("HTTP"),
-		Description:  pulumi.String(fmt.Sprintf("API Gateway for Forma %s", config.Environment)),
+		Description:  pulumi.String(fmt.Sprintf("API Gateway for Forma %s", environment)),
 		CorsConfiguration: &apigatewayv2.ApiCorsConfigurationArgs{
 			AllowHeaders: pulumi.StringArray{
 				pulumi.String("Content-Type"),
@@ -216,15 +250,15 @@ func NewServerless(ctx *pulumi.Context, config *ServerlessConfig) (*ServerlessOu
 		},
 		Tags: pulumi.StringMap{
 			"Name":        pulumi.String(namePrefix + "-api"),
-			"Environment": pulumi.String(config.Environment),
+			"Environment": pulumi.String(environment),
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create API Gateway: %w", err)
+		return nil, nil, fmt.Errorf("failed to create API Gateway: %w", err)
 	}
 
-	// Create stage with auto-deploy
-	// Note: Access logs use the log group ARN, which is available before Lambda
+	// Create stage with auto-deploy.
+	// Access logs use the log group ARN, which is available before Lambda.
 	stage, err := apigatewayv2.NewStage(ctx, namePrefix+"-api-stage", &apigatewayv2.StageArgs{
 		ApiId:      api.ID(),
 		Name:       pulumi.String("$default"),
@@ -235,21 +269,11 @@ func NewServerless(ctx *pulumi.Context, config *ServerlessConfig) (*ServerlessOu
 		},
 		Tags: pulumi.StringMap{
 			"Name":        pulumi.String(namePrefix + "-api-stage"),
-			"Environment": pulumi.String(config.Environment),
+			"Environment": pulumi.String(environment),
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create API Gateway stage: %w", err)
+		return nil, nil, fmt.Errorf("failed to create API Gateway stage: %w", err)
 	}
-
-	return &ServerlessOutput{
-		DeploymentBucketName:   deploymentBucket.Bucket,
-		LambdaRoleArn:          lambdaRole.Arn,
-		LogGroupName:           logGroup.Name,
-		LogGroupArn:            logGroup.Arn,
-		ApiGatewayID:           api.ID().ToStringOutput(),
-		ApiGatewayExecutionArn: api.ExecutionArn,
-		ApiEndpoint:            stage.InvokeUrl,
-		LambdaFunctionName:     lambdaFunctionName,
-	}, nil
+	return api, stage, nil
 }

--- a/infra/go.mod
+++ b/infra/go.mod
@@ -1,6 +1,10 @@
 module github.com/lychee-technology/forma/infra
 
-go 1.25.5
+// Tracks the root module's go directive (#444). Make-driven gates run this
+// module under the Makefile's GOTOOLCHAIN=go1.26.0+auto pin, whose floor
+// outranks any lower directive here — so an independent older version only
+// creates a second, drifting language-version surface.
+go 1.26
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.83.2

--- a/infra_gate_guard_test.go
+++ b/infra_gate_guard_test.go
@@ -1,0 +1,63 @@
+package forma
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLintRecipeCoversInfraModule pins the #444 fix: infra/ is a separate Go
+// module, so the root `golangci-lint run` never descends into it — the funlen
+// gate (#319) was module-wide, not repo-wide, and NewServerless sat at 180
+// code lines ungated. The lint recipe must therefore carry a second run line
+// executed inside infra/. Matching "cd infra" on a golangci-lint run line is
+// the minimal shape that proves the linter runs in the module's own root;
+// the sibling guards in toolchain_guard_test.go already hold that same line
+// to the $(GOENV) prefix and --build-tags flag, since they scan every
+// golangci-lint run line.
+func TestLintRecipeCoversInfraModule(t *testing.T) {
+	mk, err := os.ReadFile("Makefile")
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	for _, line := range strings.Split(string(mk), "\n") {
+		if strings.Contains(line, "golangci-lint run") && strings.Contains(line, "cd infra") {
+			return
+		}
+	}
+	t.Error("Makefile has no golangci-lint run line executed inside infra/: the infra module would silently drop out of linting again (#444)")
+}
+
+// TestMakefileHasCheckInfraTarget pins the build+vet half of #444: infra/ had
+// no CI coverage of any kind — never built, vetted, or tested. The check-infra
+// recipe must build and vet the module under $(GOENV) so the toolchain pin
+// (#448) reaches it; CI's side of the wiring is guarded separately by
+// TestCILintJobChecksInfraModule.
+func TestMakefileHasCheckInfraTarget(t *testing.T) {
+	mk, err := os.ReadFile("Makefile")
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	text := string(mk)
+	if !strings.Contains(text, "\ncheck-infra:") {
+		t.Fatal("Makefile has no check-infra target: infra/ would go back to being never built or vetted (#444)")
+	}
+	var hasBuild, hasVet bool
+	for _, line := range strings.Split(text, "\n") {
+		if !strings.Contains(line, "cd infra") || !strings.Contains(line, "$(GOENV)") {
+			continue
+		}
+		if strings.Contains(line, "go build ./...") {
+			hasBuild = true
+		}
+		if strings.Contains(line, "go vet ./...") {
+			hasVet = true
+		}
+	}
+	if !hasBuild {
+		t.Error("no `cd infra && $(GOENV) ... go build ./...` line in Makefile: check-infra must build the module under the pinned toolchain (#444)")
+	}
+	if !hasVet {
+		t.Error("no `cd infra && $(GOENV) ... go vet ./...` line in Makefile: check-infra must vet the module under the pinned toolchain (#444)")
+	}
+}

--- a/infra_gate_guard_test.go
+++ b/infra_gate_guard_test.go
@@ -2,6 +2,7 @@ package forma
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -60,4 +61,27 @@ func TestMakefileHasCheckInfraTarget(t *testing.T) {
 	if !hasVet {
 		t.Error("no `cd infra && $(GOENV) ... go vet ./...` line in Makefile: check-infra must vet the module under the pinned toolchain (#444)")
 	}
+}
+
+// TestCILintJobChecksInfraModule pins the CI side of #444's build+vet gate:
+// the lint job must run `make check-infra`, the single definition of the
+// infra build+vet wiring (same #454 rationale as TestCILintJobRunsMakeLint —
+// an open-coded copy would drop GOENV and the toolchain pin). Comment lines
+// are skipped so prose never satisfies the guard.
+func TestCILintJobChecksInfraModule(t *testing.T) {
+	ci, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("read .github/workflows/ci.yml: %v", err)
+	}
+	runCheckInfra := regexp.MustCompile(`^run:\s*make check-infra\s*$`)
+	for _, line := range strings.Split(ciLintJobBlock(t, string(ci)), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if runCheckInfra.MatchString(trimmed) {
+			return
+		}
+	}
+	t.Error("ci.yml's lint job has no `run: make check-infra` directive: the infra module would go back to having no CI build/vet coverage (#444)")
 }

--- a/infra_gate_guard_test.go
+++ b/infra_gate_guard_test.go
@@ -15,13 +15,17 @@ import (
 // the minimal shape that proves the linter runs in the module's own root;
 // the sibling guards in toolchain_guard_test.go already hold that same line
 // to the $(GOENV) prefix and --build-tags flag, since they scan every
-// golangci-lint run line.
+// golangci-lint run line. Comment lines are skipped so prose never satisfies
+// a positive guard (#485 review; same hardening as the ci.yml guards, #482).
 func TestLintRecipeCoversInfraModule(t *testing.T) {
 	mk, err := os.ReadFile("Makefile")
 	if err != nil {
 		t.Fatalf("read Makefile: %v", err)
 	}
 	for _, line := range strings.Split(string(mk), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
 		if strings.Contains(line, "golangci-lint run") && strings.Contains(line, "cd infra") {
 			return
 		}
@@ -45,6 +49,11 @@ func TestMakefileHasCheckInfraTarget(t *testing.T) {
 	}
 	var hasBuild, hasVet bool
 	for _, line := range strings.Split(text, "\n") {
+		// Skip comments for the same reason as TestLintRecipeCoversInfraModule:
+		// a positive guard must never be satisfied by prose (#485 review).
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
 		if !strings.Contains(line, "cd infra") || !strings.Contains(line, "$(GOENV)") {
 			continue
 		}

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -62,12 +62,18 @@ func TestLintRecipeInheritsGOENV(t *testing.T) {
 		t.Fatalf("read Makefile: %v", err)
 	}
 	found := false
+	// A per-module run line may lead with `cd <dir> && ` (#444) — golangci-lint
+	// v1.64.8 has no chdir flag, and a leading cd does not keep the $(GOENV)
+	// assignments that follow it from reaching the linter process. Strip that
+	// prefix, then require $(GOENV) exactly as before.
+	cdPrefix := regexp.MustCompile(`^cd \S+ && `)
 	for _, line := range strings.Split(string(mk), "\n") {
 		if !strings.Contains(line, "golangci-lint run") {
 			continue
 		}
 		found = true
-		if !strings.HasPrefix(strings.TrimLeft(line, "\t@"), "$(GOENV) ") {
+		trimmed := cdPrefix.ReplaceAllString(strings.TrimLeft(line, "\t@"), "")
+		if !strings.HasPrefix(trimmed, "$(GOENV) ") {
 			t.Errorf("lint recipe line %q does not lead with $(GOENV): golangci-lint would run its go list on the ambient toolchain, reviving the spurious typecheck errors of #448", line)
 		}
 	}

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -63,9 +63,9 @@ func TestLintRecipeInheritsGOENV(t *testing.T) {
 	}
 	found := false
 	// A per-module run line may lead with `cd <dir> && ` (#444) — golangci-lint
-	// v1.64.8 has no chdir flag, and a leading cd does not keep the $(GOENV)
-	// assignments that follow it from reaching the linter process. Strip that
-	// prefix, then require $(GOENV) exactly as before.
+	// v1.64.8 has no chdir flag, and a leading cd does not prevent the
+	// following $(GOENV) assignments from reaching the linter process. Strip
+	// that prefix, then require $(GOENV) exactly as before.
 	cdPrefix := regexp.MustCompile(`^cd \S+ && `)
 	for _, line := range strings.Split(string(mk), "\n") {
 		if !strings.Contains(line, "golangci-lint run") {


### PR DESCRIPTION
Closes #444.

`infra/` is a separate Go module (`github.com/lychee-technology/forma/infra`), so every root-level `./...` gate silently excluded it — no build, no vet, no lint in CI, leaving `NewServerless` at 180 code lines against the 100-line funlen limit (#319) and the module on an unpinned toolchain surface (#448's second axis).

## Changes (one commit per task)

1. **refactor(infra): split `NewServerless` into per-resource helpers** — `newDeploymentBucket`, `newLambdaRole`, `newAPIGateway`. Pure motion refactor: Pulumi resource names, arguments, and error-wrap messages unchanged (resource names are state identity — renaming would plan a destroy/replace). Chosen over `//nolint:funlen` per coding-standard.md's "refactor instead".
2. **build(infra): `go.mod` tracks the root go directive** (`go 1.25.5` → `go 1.26`), with an in-file comment recording the decision (issue's third criterion): make-driven gates run the module under `GOTOOLCHAIN=go1.26.0+auto` anyway, so an independent older directive was only a second, drifting language-version surface.
3. **build: `make lint` covers `infra/`; new `make check-infra`** (build + vet under `$(GOENV)`). Guards: `TestLintRecipeCoversInfraModule`, `TestMakefileHasCheckInfraTarget`; `TestLintRecipeInheritsGOENV` learns the `cd <dir> && ` prefix (a leading cd does not keep the GOENV assignments from reaching the linter). The infra run line carries `--build-tags e2e` — inert there today, but keeps every run line uniform under `TestLintRecipeCoversE2ETag`.
4. **ci: lint job runs `make check-infra`** after `make lint` (single-definition rationale of #454), guarded by `TestCILintJobChecksInfraModule`; setup-go's module cache keyed on both `go.sum`s so the Pulumi dependency set is cached.

## Acceptance criteria (issue comment at dd58a69)

- [x] CI builds + vets `infra/` — `make check-infra` in the lint job.
- [x] `make lint` runs golangci-lint over `infra/` — RED reproduced first (`components/serverless.go:62:6: Function 'NewServerless' is too long (180 > 100) (funlen)`), then GREEN after the split.
- [x] Toolchain decision made and documented: tracks the root pin.

## Verification

- `./scripts/test_with_container_runtime.sh` (full unit suite): green.
- `make fmt-check && make check-infra && make lint`: green (lint now runs over both modules).
- Issue's exact measurement re-run: `cd infra && golangci-lint run --disable-all --enable=funlen ./components/...` → 0 findings.
- Full root-package guard suite (`go test .`) green, including the three new guards (each verified failing before its fix landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBPuvC3fBbKrLxxwqwcyb4