### PR TITLE
test: integration suites read DB_*/DATABASE_URL env and fail closed in CI (#385)

### DIFF
--- a/factory/factory_schema_registry_test.go
+++ b/factory/factory_schema_registry_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lychee-technology/forma/internal/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ func TestNewFileSchemaRegistry_Integration_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 
 	// Create schema registry table
 	suffix := time.Now().UnixNano()
@@ -79,7 +80,7 @@ func TestNewFileSchemaRegistry_Integration_EmptyRegistry(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 
 	// Create empty schema registry table
 	suffix := time.Now().UnixNano()
@@ -112,7 +113,7 @@ func TestNewFileSchemaRegistry_Integration_InvalidDirectory(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 
 	// Create schema registry table with a schema entry
 	suffix := time.Now().UnixNano()
@@ -150,7 +151,7 @@ func TestNewFileSchemaRegistry_Integration_MissingAttributesFile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 
 	// Create schema registry table
 	suffix := time.Now().UnixNano()
@@ -191,7 +192,7 @@ func TestNewFileSchemaRegistry_Integration_DuplicateSchemaIDFails(t *testing.T) 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 
 	suffix := time.Now().UnixNano()
 	tableName := fmt.Sprintf("schema_registry_dup_id_%d", suffix)

--- a/factory/factory_test.go
+++ b/factory/factory_test.go
@@ -36,15 +36,6 @@ func writeSchemaFile(t *testing.T, dir, schemaName string, schema map[string]any
 	require.NoError(t, err)
 }
 
-// connectTestPostgres establishes a connection to the test PostgreSQL
-// database. DATABASE_URL still wins when set; otherwise the DSN comes from
-// DB_* env with local defaults, and an unreachable database fails (CI) or
-// skips (local) — see internal/testdb (#385).
-func connectTestPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
-	t.Helper()
-	return testdb.Connect(t, ctx)
-}
-
 // createTempTables creates temporary tables for testing and returns their names.
 func createTempTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (schemaRegistryTable, entityMainTable, eavDataTable string) {
 	t.Helper()
@@ -135,7 +126,7 @@ func TestNewEntityManagerWithConfig_Integration_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	schemaRegistryTable, entityMainTable, eavDataTable := createTempTables(t, ctx, pool)
 
 	// Create temp schema directory
@@ -182,7 +173,7 @@ func TestNewEntityManagerWithConfig_Integration_MissingTables(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 
 	// Use non-existent table names
 	config := forma.DefaultConfig(newMockSchemaRegistry())
@@ -203,7 +194,7 @@ func TestNewEntityManagerWithConfig_Integration_NilSchemaRegistry(t *testing.T) 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	schemaRegistryTable, entityMainTable, eavDataTable := createTempTables(t, ctx, pool)
 
 	// Create temp schema directory
@@ -245,7 +236,7 @@ func TestNewEntityManagerWithConfig_Integration_MetadataLoaderError(t *testing.T
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	schemaRegistryTable, entityMainTable, eavDataTable := createTempTables(t, ctx, pool)
 
 	// Don't insert any schemas - this will cause metadata loader to fail

--- a/factory/factory_test.go
+++ b/factory/factory_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,24 +36,13 @@ func writeSchemaFile(t *testing.T, dir, schemaName string, schema map[string]any
 	require.NoError(t, err)
 }
 
-// connectTestPostgres establishes a connection to the test PostgreSQL database.
-// Skips the test if DATABASE_URL is not set.
+// connectTestPostgres establishes a connection to the test PostgreSQL
+// database. DATABASE_URL still wins when set; otherwise the DSN comes from
+// DB_* env with local defaults, and an unreachable database fails (CI) or
+// skips (local) — see internal/testdb (#385).
 func connectTestPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
-
-	dbURL := os.Getenv("DATABASE_URL")
-	if dbURL == "" {
-		t.Skip("DATABASE_URL not set; skipping integration test")
-	}
-
-	pool, err := pgxpool.New(ctx, dbURL)
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		pool.Close()
-	})
-
-	return pool
+	return testdb.Connect(t, ctx)
 }
 
 // createTempTables creates temporary tables for testing and returns their names.

--- a/internal/integration_suite_test.go
+++ b/internal/integration_suite_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemameta"
+	"github.com/lychee-technology/forma/internal/testdb"
 	"github.com/lychee-technology/forma/internal/transform"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -35,7 +36,7 @@ func setupIntegrationEnv(t *testing.T) *integrationEnv {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	t.Cleanup(cancel)
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	tables := createTempPersistentTables(t, ctx, pool)
 	schemaRegistryTable := createSchemaRegistryTable(t, ctx, pool)
 

--- a/internal/postgres_persistent_repository_integration_test.go
+++ b/internal/postgres_persistent_repository_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemameta"
+	"github.com/lychee-technology/forma/internal/testdb"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -185,30 +186,7 @@ func TestRunOptimizedQueryIntegration(t *testing.T) {
 
 func connectTestPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
-
-	dsn := "postgres://postgres:postgres@localhost:5432/forma?sslmode=disable"
-
-	cfg, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		t.Fatalf("invalid postgres dsn: %v", err)
-	}
-	cfg.ConnConfig.ConnectTimeout = 2 * time.Second
-
-	pool, err := pgxpool.NewWithConfig(ctx, cfg)
-	if err != nil {
-		t.Skipf("skipping integration test, cannot connect to postgres: %v", err)
-	}
-
-	if err := pool.Ping(ctx); err != nil {
-		pool.Close()
-		t.Skipf("skipping integration test, postgres not reachable: %v", err)
-	}
-
-	t.Cleanup(func() {
-		pool.Close()
-	})
-
-	return pool
+	return testdb.Connect(t, ctx)
 }
 
 func createTempPersistentTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) model.StorageTables {

--- a/internal/postgres_persistent_repository_integration_test.go
+++ b/internal/postgres_persistent_repository_integration_test.go
@@ -23,7 +23,7 @@ func TestInsertPersistentRecordIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	tables := createTempPersistentTables(t, ctx, pool)
 
 	repo := NewDBPersistentRecordRepository(pool, nil)
@@ -93,7 +93,7 @@ func TestChangeLogWritesOnUpdateAndDeleteIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	tables := createTempPersistentTables(t, ctx, pool)
 
 	// The update path scopes its EAV delete to current-schema attributeIDs
@@ -147,7 +147,7 @@ func TestRunOptimizedQueryIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	tables := createTempPersistentTables(t, ctx, pool)
 
 	repo := NewDBPersistentRecordRepository(pool, nil)
@@ -182,11 +182,6 @@ func TestRunOptimizedQueryIntegration(t *testing.T) {
 	assert.Equal(t, record.RowID, records[0].RowID)
 	assert.Equal(t, record.TextItems, records[0].TextItems)
 	assert.Nil(t, records[0].OtherAttributes)
-}
-
-func connectTestPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
-	t.Helper()
-	return testdb.Connect(t, ctx)
 }
 
 func createTempPersistentTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) model.StorageTables {

--- a/internal/postgres_persistent_repository_version_integration_test.go
+++ b/internal/postgres_persistent_repository_version_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemameta"
+	"github.com/lychee-technology/forma/internal/testdb"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -32,7 +33,7 @@ func TestSameMillisecondWritesStayStrictlyOrderedIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	tables := createTempPersistentTables(t, ctx, pool)
 
 	mc := schemameta.NewMetadataCache()
@@ -98,7 +99,7 @@ func TestRecreateOutranksClockAheadTombstoneIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	tables := createTempPersistentTables(t, ctx, pool)
 
 	mc := schemameta.NewMetadataCache()
@@ -164,7 +165,7 @@ func TestConcurrentDeleteRecreateSerializesIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancel()
 
-	pool := connectTestPostgres(t, ctx)
+	pool := testdb.Connect(t, ctx)
 	tables := createTempPersistentTables(t, ctx, pool)
 
 	mc := schemameta.NewMetadataCache()

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -74,7 +74,7 @@ func Connect(t testing.TB, ctx context.Context) *pgxpool.Pool {
 		if FailOnUnreachable() {
 			t.Fatalf("integration database unreachable in CI — the workflow provisions Postgres on purpose, so this is a failure, not a skip (#385): %v", err)
 		}
-		t.Skipf("skipping: no local Postgres (%v)", err)
+		t.Skipf("skipping: integration Postgres unreachable (%v)", err)
 	}
 
 	t.Cleanup(pool.Close)

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -11,9 +11,11 @@ package testdb
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/url"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -38,7 +40,7 @@ func ResolveDSN() string {
 		),
 		Host:     net.JoinHostPort(bootstrap.Env("DB_HOST", "localhost"), bootstrap.Env("DB_PORT", "5432")),
 		Path:     "/" + bootstrap.Env("DB_NAME", "forma"),
-		RawQuery: "sslmode=" + bootstrap.Env("DB_SSL_MODE", "disable"),
+		RawQuery: "sslmode=" + url.QueryEscape(bootstrap.Env("DB_SSL_MODE", "disable")),
 	}
 	return u.String()
 }
@@ -51,10 +53,34 @@ func FailOnUnreachable() bool {
 	return os.Getenv("CI") != ""
 }
 
-// Connect opens and pings a pgxpool for the resolved DSN. When the database
-// is unreachable it fails the test in CI (the service is provisioned on
-// purpose — a skip would go dark, #385) and skips on developer machines
-// without a local Postgres. The pool is closed via t.Cleanup.
+// unreachable reports whether err indicates network-level absence of the
+// database — nothing listening, unknown host, connect timeout. A server that
+// answered and rejected us (bad credentials, missing database, protocol/TLS
+// failure) is deliberately excluded: that is misconfiguration, which must
+// fail loudly rather than skip, even off-CI (#486 review P2).
+func unreachable(err error) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return errors.Is(err, context.DeadlineExceeded)
+}
+
+// Connect opens and pings a pgxpool for the resolved DSN. Connection failures
+// split three ways: in CI every failure is fatal (the service is provisioned
+// on purpose — a skip would go dark, #385); locally, network-level absence
+// skips (a developer without Postgres), while a server that answered and
+// rejected the connection is misconfiguration and fails loudly (#486 review
+// P2). The pool is closed via t.Cleanup.
 func Connect(t testing.TB, ctx context.Context) *pgxpool.Pool {
 	t.Helper()
 
@@ -72,7 +98,10 @@ func Connect(t testing.TB, ctx context.Context) *pgxpool.Pool {
 	}
 	if err != nil {
 		if FailOnUnreachable() {
-			t.Fatalf("integration database unreachable in CI — the workflow provisions Postgres on purpose, so this is a failure, not a skip (#385): %v", err)
+			t.Fatalf("integration database connection failed in CI — the workflow provisions Postgres on purpose, so this is a failure, not a skip (#385): %v", err)
+		}
+		if !unreachable(err) {
+			t.Fatalf("integration Postgres answered but rejected the connection — misconfiguration, not absence; fix DATABASE_URL / DB_* env (#486 review): %v", err)
 		}
 		t.Skipf("skipping: integration Postgres unreachable (%v)", err)
 	}

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -45,11 +45,12 @@ func ResolveDSN() string {
 	return u.String()
 }
 
-// FailOnUnreachable reports whether an unreachable database is a failure
-// rather than a skip. GitHub Actions sets CI on every hosted runner, so this
-// needs no workflow wiring and stays correct if more jobs provision Postgres
-// (#385).
-func FailOnUnreachable() bool {
+// InCI reports whether the tests run under CI, where a database is
+// provisioned on purpose and therefore every connection failure — not only
+// unreachability — is fatal rather than skippable. GitHub Actions sets CI on
+// every hosted runner, so this needs no workflow wiring and stays correct if
+// more jobs provision Postgres (#385).
+func InCI() bool {
 	return os.Getenv("CI") != ""
 }
 
@@ -86,6 +87,9 @@ func unreachable(err error) bool {
 			// The op tells where the failure happened: "dial" is absence
 			// (refused, unreachable, DNS, dial timeout all surface here);
 			// "read"/"write" mean the server accepted the connection first.
+			// Deliberately errno-blind at dial time: nothing was accepted
+			// yet, so any dial failure reads as absence (#486 review round
+			// 4, recorded as intended breadth).
 			return e.Op == "dial"
 		case *net.DNSError:
 			return true
@@ -122,11 +126,11 @@ func Connect(t testing.TB, ctx context.Context) *pgxpool.Pool {
 		}
 	}
 	if err != nil {
-		if FailOnUnreachable() {
+		if InCI() {
 			t.Fatalf("integration database connection failed in CI — the workflow provisions Postgres on purpose, so this is a failure, not a skip (#385): %v", err)
 		}
 		if !unreachable(err) {
-			t.Fatalf("integration Postgres answered but rejected the connection — misconfiguration, not absence; fix DATABASE_URL / DB_* env (#486 review): %v", err)
+			t.Fatalf("integration database connection failed for a reason other than network absence — misconfiguration, not a missing Postgres; fix DATABASE_URL / DB_* env (#486 review): %v", err)
 		}
 		t.Skipf("skipping: integration Postgres unreachable (%v)", err)
 	}

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -53,26 +53,51 @@ func FailOnUnreachable() bool {
 	return os.Getenv("CI") != ""
 }
 
-// unreachable reports whether err indicates network-level absence of the
-// database — nothing listening, unknown host, connect timeout. A server that
-// answered and rejected us (bad credentials, missing database, protocol/TLS
-// failure) is deliberately excluded: that is misconfiguration, which must
-// fail loudly rather than skip, even off-CI (#486 review P2).
+// unreachable reports whether err denotes network-level absence of the
+// database for every connection attempt it carries. Absence means the
+// failure originated at dial time: connection refused, unreachable
+// host/network, DNS resolution, dial timeout. Anything after an accepted
+// connection — server rejection, protocol/TLS failure, handshake or startup
+// timeout — is misconfiguration and must fail loudly, even off-CI (#486
+// review P2).
+//
+// The walk is manual rather than errors.Is/As because pgx joins per-address
+// results (errors.Join inside pgconn.ConnectError), and errors.Is matches
+// when ANY joined branch matches: a mixed outcome — one address refused,
+// another answered and rejected us — would classify as absence and skip away
+// the actionable server-side error. Every joined branch must be absence on
+// its own (#486 review round 3).
 func unreachable(err error) bool {
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
-		return true
+	for err != nil {
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			branches := joined.Unwrap()
+			if len(branches) == 0 {
+				return false
+			}
+			for _, branch := range branches {
+				if !unreachable(branch) {
+					return false
+				}
+			}
+			return true
+		}
+		switch e := err.(type) {
+		case *net.OpError:
+			// The op tells where the failure happened: "dial" is absence
+			// (refused, unreachable, DNS, dial timeout all surface here);
+			// "read"/"write" mean the server accepted the connection first.
+			return e.Op == "dial"
+		case *net.DNSError:
+			return true
+		}
+		// Leaf equality, not errors.Is: Is would descend into joined
+		// subtrees below this node with any-branch semantics.
+		if err == syscall.ECONNREFUSED || err == syscall.EHOSTUNREACH || err == syscall.ENETUNREACH {
+			return true
+		}
+		err = errors.Unwrap(err)
 	}
-	if errors.Is(err, syscall.ECONNREFUSED) ||
-		errors.Is(err, syscall.EHOSTUNREACH) ||
-		errors.Is(err, syscall.ENETUNREACH) {
-		return true
-	}
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return true
-	}
-	return errors.Is(err, context.DeadlineExceeded)
+	return false
 }
 
 // Connect opens and pings a pgxpool for the resolved DSN. Connection failures

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -1,0 +1,82 @@
+// Package testdb centralizes how integration tests reach a real Postgres.
+//
+// Before #385 each venue hardcoded its own connection story: the internal
+// suite pinned postgres:postgres@localhost:5432/forma and the factory tests
+// required DATABASE_URL — so CI's provisioned service (test:test@…/forma_test,
+// exported as DB_* env) was never reached and every Postgres-backed test
+// silently skipped. This package resolves the DSN from the same env the rest
+// of the repo reads and makes an unreachable database a hard failure in CI,
+// where the service exists on purpose.
+package testdb
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lychee-technology/forma/internal/bootstrap"
+)
+
+// ResolveDSN returns the Postgres DSN for integration tests. DATABASE_URL
+// wins when set (the factory suite's historical contract); otherwise the DSN
+// is built from the DB_* variables CI's test job exports, defaulting to the
+// scripts/local_server.sh Postgres (postgres:postgres@localhost:5432/forma).
+func ResolveDSN() string {
+	if dsn := os.Getenv("DATABASE_URL"); dsn != "" {
+		return dsn
+	}
+	u := url.URL{
+		Scheme: "postgres",
+		User: url.UserPassword(
+			bootstrap.Env("DB_USER", "postgres"),
+			bootstrap.Env("DB_PASSWORD", "postgres"),
+		),
+		Host:     net.JoinHostPort(bootstrap.Env("DB_HOST", "localhost"), bootstrap.Env("DB_PORT", "5432")),
+		Path:     "/" + bootstrap.Env("DB_NAME", "forma"),
+		RawQuery: "sslmode=" + bootstrap.Env("DB_SSL_MODE", "disable"),
+	}
+	return u.String()
+}
+
+// FailOnUnreachable reports whether an unreachable database is a failure
+// rather than a skip. GitHub Actions sets CI on every hosted runner, so this
+// needs no workflow wiring and stays correct if more jobs provision Postgres
+// (#385).
+func FailOnUnreachable() bool {
+	return os.Getenv("CI") != ""
+}
+
+// Connect opens and pings a pgxpool for the resolved DSN. When the database
+// is unreachable it fails the test in CI (the service is provisioned on
+// purpose — a skip would go dark, #385) and skips on developer machines
+// without a local Postgres. The pool is closed via t.Cleanup.
+func Connect(t testing.TB, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+
+	cfg, err := pgxpool.ParseConfig(ResolveDSN())
+	if err != nil {
+		t.Fatalf("failed to parse integration test DSN (check DATABASE_URL / DB_* env): %v", err)
+	}
+	cfg.ConnConfig.ConnectTimeout = 2 * time.Second
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err == nil {
+		if err = pool.Ping(ctx); err != nil {
+			pool.Close()
+		}
+	}
+	if err != nil {
+		if FailOnUnreachable() {
+			t.Fatalf("integration database unreachable in CI — the workflow provisions Postgres on purpose, so this is a failure, not a skip (#385): %v", err)
+		}
+		t.Skipf("skipping: no local Postgres (%v)", err)
+	}
+
+	t.Cleanup(pool.Close)
+	return pool
+}

--- a/internal/testdb/testdb_test.go
+++ b/internal/testdb/testdb_test.go
@@ -1,8 +1,15 @@
 package testdb
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"net"
 	"strings"
+	"syscall"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // clearDBEnv blanks every variable ResolveDSN reads so ambient shell/CI env
@@ -56,6 +63,44 @@ func TestResolveDSNPrefersDatabaseURL(t *testing.T) {
 	t.Setenv("DATABASE_URL", "postgres://u:p@override:5/db")
 	if got := ResolveDSN(); got != "postgres://u:p@override:5/db" {
 		t.Errorf("ResolveDSN() = %q, want DATABASE_URL to win over DB_*", got)
+	}
+}
+
+// TestUnreachableClassifiesNetworkAbsenceOnly pins the local skip/fail split
+// (#486 review P2): only network-level absence — nothing listening, unknown
+// host, connect timeout — may skip; a server that answered and rejected us
+// (bad credentials, missing database, protocol/TLS failure) is
+// misconfiguration and must fail loudly even off-CI.
+func TestUnreachableClassifiesNetworkAbsenceOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"connection refused", fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED), true},
+		{"host unreachable", fmt.Errorf("dial tcp: %w", syscall.EHOSTUNREACH), true},
+		{"network unreachable", fmt.Errorf("dial tcp: %w", syscall.ENETUNREACH), true},
+		{"unknown host", fmt.Errorf("lookup: %w", &net.DNSError{Err: "no such host", IsNotFound: true}), true},
+		{"connect timeout", fmt.Errorf("ping: %w", context.DeadlineExceeded), true},
+		{"auth failure", fmt.Errorf("connect: %w", &pgconn.PgError{Code: "28P01", Message: "password authentication failed"}), false},
+		{"missing database", fmt.Errorf("connect: %w", &pgconn.PgError{Code: "3D000", Message: "database does not exist"}), false},
+		{"protocol junk from a non-postgres listener", fmt.Errorf("read: %w", io.EOF), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unreachable(tt.err); got != tt.want {
+				t.Errorf("unreachable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveDSNEscapesSSLMode(t *testing.T) {
+	clearDBEnv(t)
+	t.Setenv("DB_SSL_MODE", "verify full&x=y")
+	got := ResolveDSN()
+	if !strings.Contains(got, "sslmode=verify+full%26x%3Dy") {
+		t.Errorf("ResolveDSN() = %q, want query-escaped sslmode value", got)
 	}
 }
 

--- a/internal/testdb/testdb_test.go
+++ b/internal/testdb/testdb_test.go
@@ -1,0 +1,71 @@
+package testdb
+
+import (
+	"strings"
+	"testing"
+)
+
+// clearDBEnv blanks every variable ResolveDSN reads so ambient shell/CI env
+// cannot leak into a test case. t.Setenv also registers restoration.
+func clearDBEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"DATABASE_URL", "DB_HOST", "DB_PORT", "DB_NAME",
+		"DB_USER", "DB_PASSWORD", "DB_SSL_MODE",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestResolveDSNDefaultsMatchLocalServer(t *testing.T) {
+	clearDBEnv(t)
+	got := ResolveDSN()
+	want := "postgres://postgres:postgres@localhost:5432/forma?sslmode=disable"
+	if got != want {
+		t.Errorf("ResolveDSN() with no env = %q, want local_server.sh defaults %q", got, want)
+	}
+}
+
+func TestResolveDSNReadsDBVars(t *testing.T) {
+	clearDBEnv(t)
+	t.Setenv("DB_HOST", "db.example")
+	t.Setenv("DB_PORT", "15432")
+	t.Setenv("DB_NAME", "forma_test")
+	t.Setenv("DB_USER", "test")
+	t.Setenv("DB_PASSWORD", "test")
+	t.Setenv("DB_SSL_MODE", "require")
+	got := ResolveDSN()
+	want := "postgres://test:test@db.example:15432/forma_test?sslmode=require"
+	if got != want {
+		t.Errorf("ResolveDSN() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDSNEscapesPassword(t *testing.T) {
+	clearDBEnv(t)
+	t.Setenv("DB_PASSWORD", "p@ss/word")
+	got := ResolveDSN()
+	if !strings.Contains(got, "p%40ss%2Fword") {
+		t.Errorf("ResolveDSN() = %q, want URL-escaped password p%%40ss%%2Fword", got)
+	}
+}
+
+func TestResolveDSNPrefersDatabaseURL(t *testing.T) {
+	clearDBEnv(t)
+	t.Setenv("DB_HOST", "ignored.example")
+	t.Setenv("DATABASE_URL", "postgres://u:p@override:5/db")
+	if got := ResolveDSN(); got != "postgres://u:p@override:5/db" {
+		t.Errorf("ResolveDSN() = %q, want DATABASE_URL to win over DB_*", got)
+	}
+}
+
+func TestFailOnUnreachableFollowsCIVar(t *testing.T) {
+	t.Setenv("CI", "")
+	if FailOnUnreachable() {
+		t.Error("FailOnUnreachable() = true with CI unset, want false (developer machines skip)")
+	}
+	t.Setenv("CI", "true")
+	if !FailOnUnreachable() {
+		t.Error("FailOnUnreachable() = false with CI=true, want true (CI provisions Postgres on purpose)")
+	}
+}

--- a/internal/testdb/testdb_test.go
+++ b/internal/testdb/testdb_test.go
@@ -2,9 +2,12 @@ package testdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -72,6 +75,8 @@ func TestResolveDSNPrefersDatabaseURL(t *testing.T) {
 // (bad credentials, missing database, protocol/TLS failure) is
 // misconfiguration and must fail loudly even off-CI.
 func TestUnreachableClassifiesNetworkAbsenceOnly(t *testing.T) {
+	refused := &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}
+	authFail := &pgconn.PgError{Code: "28P01", Message: "password authentication failed"}
 	tests := []struct {
 		name string
 		err  error
@@ -81,10 +86,23 @@ func TestUnreachableClassifiesNetworkAbsenceOnly(t *testing.T) {
 		{"host unreachable", fmt.Errorf("dial tcp: %w", syscall.EHOSTUNREACH), true},
 		{"network unreachable", fmt.Errorf("dial tcp: %w", syscall.ENETUNREACH), true},
 		{"unknown host", fmt.Errorf("lookup: %w", &net.DNSError{Err: "no such host", IsNotFound: true}), true},
-		{"connect timeout", fmt.Errorf("ping: %w", context.DeadlineExceeded), true},
-		{"auth failure", fmt.Errorf("connect: %w", &pgconn.PgError{Code: "28P01", Message: "password authentication failed"}), false},
+		{"dial-level refusal in OpError", fmt.Errorf("connect: %w", refused), true},
+		{"dial timeout", fmt.Errorf("connect: %w", &net.OpError{Op: "dial", Net: "tcp", Err: os.ErrDeadlineExceeded}), true},
+		{"auth failure", fmt.Errorf("connect: %w", authFail), false},
 		{"missing database", fmt.Errorf("connect: %w", &pgconn.PgError{Code: "3D000", Message: "database does not exist"}), false},
 		{"protocol junk from a non-postgres listener", fmt.Errorf("read: %w", io.EOF), false},
+		// Handshake/startup timeouts happen after the server accepted the TCP
+		// connection: the listener exists, so this is not absence (#486
+		// review round 3, finding 2).
+		{"handshake read timeout", fmt.Errorf("receive: %w", &net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded}), false},
+		{"bare expired context", fmt.Errorf("ping: %w", context.DeadlineExceeded), false},
+		// pgx v5 joins per-address results inside pgconn.ConnectError
+		// (pgconn.go builds errors.Join(allErrors...)). A mixed outcome —
+		// one address refused, another answered and rejected us — must not
+		// skip: the server-side error is the actionable one (#486 review
+		// round 3, finding 1).
+		{"joined mixed refusal and auth failure", fmt.Errorf("connect: %w", errors.Join(refused, fmt.Errorf("server: %w", authFail))), false},
+		{"joined all-absence", fmt.Errorf("connect: %w", errors.Join(refused, &net.OpError{Op: "dial", Net: "tcp", Err: syscall.EHOSTUNREACH})), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -92,6 +110,93 @@ func TestUnreachableClassifiesNetworkAbsenceOnly(t *testing.T) {
 				t.Errorf("unreachable(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// outcomeTB records Connect's terminal action instead of ending the test.
+// Embedding testing.TB satisfies the interface's unexported method; Fatalf
+// and Skipf stop the goroutine the way the real implementations do.
+type outcomeTB struct {
+	testing.TB
+	fatal string
+	skip  string
+}
+
+func (o *outcomeTB) Helper() {}
+
+func (o *outcomeTB) Fatalf(format string, args ...any) {
+	o.fatal = fmt.Sprintf(format, args...)
+	runtime.Goexit()
+}
+
+func (o *outcomeTB) Skipf(format string, args ...any) {
+	o.skip = fmt.Sprintf(format, args...)
+	runtime.Goexit()
+}
+
+// runConnect drives Connect against the DATABASE_URL the caller staged and
+// reports which terminal action it took. Connect ends its goroutine via
+// Goexit (as real Fatalf/Skipf do), so it runs on a dedicated one.
+func runConnect(t *testing.T) *outcomeTB {
+	t.Helper()
+	rec := &outcomeTB{TB: t}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Connect(rec, context.Background())
+	}()
+	<-done
+	return rec
+}
+
+// A listener that accepts and then stays silent is a live server that never
+// completes the Postgres startup exchange: pgx times out reading, and that
+// must fail locally, not skip — the timeout happened after dial succeeded
+// (#486 review round 3, finding 2). Exercises the real pgx error chain.
+func TestConnectLocallyFailsOnSilentListener(t *testing.T) {
+	clearDBEnv(t)
+	t.Setenv("CI", "")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("start silent listener: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+		}
+	}()
+	t.Setenv("DATABASE_URL", fmt.Sprintf("postgres://u:p@%s/db?sslmode=disable", ln.Addr()))
+
+	rec := runConnect(t)
+	if rec.fatal == "" || rec.skip != "" {
+		t.Errorf("Connect on a silent listener: fatal=%q skip=%q, want a loud local failure", rec.fatal, rec.skip)
+	}
+}
+
+// A closed port is genuine absence: the local skip must survive the
+// narrowed classifier. Exercises the real pgx dial-refused chain, joined
+// per-address by pgconn (#486 review round 3, finding 1's green half).
+func TestConnectLocallySkipsOnClosedPort(t *testing.T) {
+	clearDBEnv(t)
+	t.Setenv("CI", "")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve a port: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close reserved port: %v", err)
+	}
+	t.Setenv("DATABASE_URL", fmt.Sprintf("postgres://u:p@%s/db?sslmode=disable", addr))
+
+	rec := runConnect(t)
+	if rec.skip == "" || rec.fatal != "" {
+		t.Errorf("Connect on a closed port: fatal=%q skip=%q, want a local skip", rec.fatal, rec.skip)
 	}
 }
 

--- a/internal/testdb/testdb_test.go
+++ b/internal/testdb/testdb_test.go
@@ -209,13 +209,13 @@ func TestResolveDSNEscapesSSLMode(t *testing.T) {
 	}
 }
 
-func TestFailOnUnreachableFollowsCIVar(t *testing.T) {
+func TestInCIFollowsCIVar(t *testing.T) {
 	t.Setenv("CI", "")
-	if FailOnUnreachable() {
-		t.Error("FailOnUnreachable() = true with CI unset, want false (developer machines skip)")
+	if InCI() {
+		t.Error("InCI() = true with CI unset, want false (developer machines skip)")
 	}
 	t.Setenv("CI", "true")
-	if !FailOnUnreachable() {
-		t.Error("FailOnUnreachable() = false with CI=true, want true (CI provisions Postgres on purpose)")
+	if !InCI() {
+		t.Error("InCI() = false with CI=true, want true (CI provisions Postgres on purpose)")
 	}
 }


### PR DESCRIPTION
Fixes #385.

## What

CI provisions a Postgres service and exports `DB_*` env for it, but neither Postgres-backed test venue ever read that env — both silently skipped in CI while reporting green:

- `internal`'s `connectTestPostgres` hardcoded `postgres://postgres:postgres@localhost:5432/forma`; CI's service is `test:test@localhost:5432/forma_test`, so `Ping` failed and every test built on `setupIntegrationEnv` skipped.
- `factory`'s `connectTestPostgres` skipped unless `DATABASE_URL` was set, and CI never sets `DATABASE_URL` (second dark venue, per the issue's re-verification comment).

## How

New test-support package **`internal/testdb`** is now the single owner of both decisions:

- **DSN resolution** (`ResolveDSN`): `DATABASE_URL` wins when set (preserves the factory suite's historical contract); otherwise the DSN is built from `DB_HOST`/`DB_PORT`/`DB_USER`/`DB_PASSWORD`/`DB_NAME`/`DB_SSL_MODE` via `internal/bootstrap.Env`, defaulting to the `scripts/local_server.sh` Postgres (`postgres:postgres@localhost:5432/forma?sslmode=disable`) — so local developers and CI's service both work with zero configuration.
- **Skip policy** (`FailOnUnreachable` + `Connect`): an unreachable database **fails** when `CI` is set (GitHub Actions sets it on every hosted runner — the fail-closed arm needs no workflow wiring, exactly the pattern decided in the issue's third comment) and **skips** on developer machines without a local Postgres.

Both venues' `connectTestPostgres` helpers are now thin delegations to `testdb.Connect`; no call site changed. `.github/workflows/ci.yml` is untouched.

Note: `internal/pgdsn` was not reused on purpose — it renders libpq keyword/value DSNs for DuckDB's postgres scanner, while this path needs the URL form that `DATABASE_URL` and pgxpool already speak.

## Verification (local, Postgres 16 via rootless Podman)

- `go test ./internal -run Integration -v`: **9 integration tests PASS, 0 SKIP** (previously all dark unless a `postgres:postgres/forma` instance happened to exist).
- Same with CI's exact env shape (`CI=true DB_USER=test DB_PASSWORD=test DB_NAME=forma_test` against a matching database): 9 PASS — proves the service credentials work end to end.
- `CI=true` + unreachable port: **FAIL** with `integration database unreachable in CI …` (both venues) — the issue's second acceptance criterion.
- `CI` unset + unreachable port: 9 SKIP, exit 0 — developer machines keep the quiet skip.
- `factory`: 51 test/subtest PASS with only `DB_*` defaults (previously skipped on `DATABASE_URL not set`); `DATABASE_URL` precedence re-verified.
- Full suite via `./scripts/test_with_container_runtime.sh`: green. `make fmt-check` + `make lint`: clean.

Acceptance criterion "tests report as run, not skipped, in the CI run log" to be confirmed on this PR's own Test job log once CI completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEk6FGV1nAzs3URty4djtG
