### PR TITLE
fix(schemavalidate): own the invalid-number-literal published message (#453)

### DIFF
--- a/internal/schemavalidate/nonfinite_paths.go
+++ b/internal/schemavalidate/nonfinite_paths.go
@@ -78,7 +78,7 @@ func moreSuffix(n int) string {
 	return ""
 }
 
-// maxNonFiniteWalkDepth bounds the recursion below. Nothing upstream enforces a
+// maxMarshalRefusalWalkDepth bounds the recursion below. Nothing upstream enforces a
 // shallower limit: encoding/json's decoder refuses nesting past 10000, ten times
 // this cap, so a decoded document can sit well beyond it.
 //
@@ -89,10 +89,11 @@ func moreSuffix(n int) string {
 // are pinned.
 //
 // What limits the cost of that degradation is the payload's provenance, not its
-// depth: JSON has no syntax for a non-finite, so an HTTP request can never
-// produce the refusal this walk exists to explain. Only a Go embedder can, which
-// makes a message degraded by this cap an embedder-only outcome.
-const maxNonFiniteWalkDepth = 1000
+// depth: JSON has no syntax for a non-finite, and a decoded json.Number is
+// grammar-valid by construction, so an HTTP request can never produce either
+// refusal this walk exists to explain. Only a Go embedder can, which makes a
+// message degraded by this cap an embedder-only outcome.
+const maxMarshalRefusalWalkDepth = 1000
 
 // marshalRefusalPaths walks a document and returns every finding the walk can
 // name — non-finite floats and invalid json.Number literals (#453) — each
@@ -104,7 +105,7 @@ const maxNonFiniteWalkDepth = 1000
 // is what makes a cyclic payload safe here — json.Marshal detects a cycle and
 // refuses, so this walk runs precisely when a cycle is possible, and following
 // one has no natural end, so the cap is the end. A merely deep acyclic payload
-// hits the same cap and gets the same treatment (see maxNonFiniteWalkDepth).
+// hits the same cap and gets the same treatment (see maxMarshalRefusalWalkDepth).
 //
 // Abandoning rather than truncating is deliberate: a partial walk cannot tell
 // "nothing wrong in this payload" from "stopped looking", and only the first
@@ -126,33 +127,34 @@ const maxNonFiniteWalkDepth = 1000
 // Structs, custom Marshalers and channels land here too. A fault at the
 // document root is likewise left to the library: there is no attribute to name.
 func marshalRefusalPaths(doc any) ([]nonFinitePath, []invalidNumberLiteral) {
-	var walker nonFiniteWalker
+	var walker marshalRefusalWalker
 	walker.walk("", doc, 0)
 	if walker.aborted {
 		return nil, nil
 	}
-	slices.SortFunc(walker.found, func(a, b nonFinitePath) int {
+	slices.SortFunc(walker.nonFinite, func(a, b nonFinitePath) int {
 		return strings.Compare(a.path, b.path)
 	})
 	slices.SortFunc(walker.invalid, func(a, b invalidNumberLiteral) int {
 		return strings.Compare(a.path, b.path)
 	})
-	return walker.found, walker.invalid
+	return walker.nonFinite, walker.invalid
 }
 
-// nonFiniteWalker carries the walk's accumulated findings and its abort flag.
-// Once aborted, every pending frame returns without doing further work.
-type nonFiniteWalker struct {
-	found   []nonFinitePath
-	invalid []invalidNumberLiteral
-	aborted bool
+// marshalRefusalWalker carries the walk's accumulated findings — one slice per
+// finding kind — and its abort flag. Once aborted, every pending frame returns
+// without doing further work.
+type marshalRefusalWalker struct {
+	nonFinite []nonFinitePath
+	invalid   []invalidNumberLiteral
+	aborted   bool
 }
 
-func (w *nonFiniteWalker) walk(path string, node any, depth int) {
+func (w *marshalRefusalWalker) walk(path string, node any, depth int) {
 	if w.aborted {
 		return
 	}
-	if depth > maxNonFiniteWalkDepth {
+	if depth > maxMarshalRefusalWalkDepth {
 		w.aborted = true
 		return
 	}
@@ -202,18 +204,18 @@ func (w *nonFiniteWalker) walk(path string, node any, depth int) {
 	}
 }
 
-func (w *nonFiniteWalker) appendIfNonFinite(path string, value float64) {
+func (w *marshalRefusalWalker) appendIfNonFinite(path string, value float64) {
 	if path == "" {
 		return
 	}
 	if math.IsNaN(value) || math.IsInf(value, 0) {
-		w.found = append(w.found, nonFinitePath{path: path, value: value})
+		w.nonFinite = append(w.nonFinite, nonFinitePath{path: path, value: value})
 	}
 }
 
 // appendInvalidLiteral mirrors appendIfNonFinite's root rule: a fault at the
 // document root has no attribute to name and falls back to the library text.
-func (w *nonFiniteWalker) appendInvalidLiteral(path, literal string) {
+func (w *marshalRefusalWalker) appendInvalidLiteral(path, literal string) {
 	if path == "" {
 		return
 	}

--- a/internal/schemavalidate/nonfinite_paths.go
+++ b/internal/schemavalidate/nonfinite_paths.go
@@ -34,28 +34,48 @@ type invalidNumberLiteral struct {
 // in their payload is barely actionable. So the payload is walked here to
 // derive the path. Only the first offender is named — alphabetically first, so
 // the same payload always produces the same message — with a count of the
-// rest, matching the precedent in transform's missing-required error.
+// rest, matching the precedent in transform's missing-required error. When
+// both finding kinds are present the non-finite message wins: either is
+// truthful (each would refuse on its own), and a fixed priority keeps the
+// published message deterministic.
+//
+// The invalid-literal message is owned rather than forwarded (#453):
+// forwarding stdlib text made the published 4xx body a function of the build
+// toolchain — Go 1.27 rewords it — which is a silent API-contract change
+// triggered by nothing but a go.mod bump. The raw library error rides along
+// as operator detail, so the log keeps it while the body never sees it.
 //
 // If the walk comes back empty, the library's text is published unchanged: it
 // is then the only description of the fault that exists. That covers a failing
 // json.Marshaler and an unsupported type such as a channel or func — and a
 // cycle, which reaches this branch because the walk is depth-capped and gives
-// up on one rather than following it (see nonFinitePaths). There the library's
-// text begins "json: unsupported value: encountered a cycle" and goes on to
-// name the type it was found via; publishing it is the honest answer, because
-// no single attribute is at fault.
+// up on one rather than following it (see marshalRefusalPaths). There the
+// library's text begins "json: unsupported value: encountered a cycle" and
+// goes on to name the type it was found via; publishing it is the honest
+// answer, because no single attribute is at fault.
 func marshalRefusalError(doc any, marshalErr error) error {
-	found, _ := marshalRefusalPaths(doc)
-	if len(found) == 0 {
-		return forma.InvalidInputf("payload cannot be encoded as JSON: %v", marshalErr)
+	nonFinite, invalidLiterals := marshalRefusalPaths(doc)
+	if len(nonFinite) > 0 {
+		return forma.InvalidInputf(
+			"payload cannot be encoded as JSON: attribute %q holds non-finite number %v; a finite value is required%s",
+			nonFinite[0].path, nonFinite[0].value, moreSuffix(len(nonFinite)))
 	}
-	more := ""
-	if len(found) > 1 {
-		more = fmt.Sprintf(" (and %d more)", len(found)-1)
+	if len(invalidLiterals) > 0 {
+		return forma.WithOperatorDetail(forma.InvalidInputf(
+			"payload cannot be encoded as JSON: attribute %q holds invalid number literal %q; a valid JSON number is required%s",
+			invalidLiterals[0].path, invalidLiterals[0].literal, moreSuffix(len(invalidLiterals))),
+			marshalErr)
 	}
-	return forma.InvalidInputf(
-		"payload cannot be encoded as JSON: attribute %q holds non-finite number %v; a finite value is required%s",
-		found[0].path, found[0].value, more)
+	return forma.InvalidInputf("payload cannot be encoded as JSON: %v", marshalErr)
+}
+
+// moreSuffix renders the " (and N more)" tail shared by both owned messages:
+// only the alphabetically first offender is named, the rest are counted.
+func moreSuffix(n int) string {
+	if n > 1 {
+		return fmt.Sprintf(" (and %d more)", n-1)
+	}
+	return ""
 }
 
 // maxNonFiniteWalkDepth bounds the recursion below. Nothing upstream enforces a

--- a/internal/schemavalidate/nonfinite_paths.go
+++ b/internal/schemavalidate/nonfinite_paths.go
@@ -18,6 +18,13 @@ type nonFinitePath struct {
 	value float64
 }
 
+// invalidNumberLiteral is one json.Number found in a payload whose text
+// json.Marshal refuses as JSON number grammar, with the dotted path it sits at.
+type invalidNumberLiteral struct {
+	path    string
+	literal string
+}
+
 // marshalRefusalError classifies a json.Marshal refusal of the caller's own
 // payload (#322): caller input, so it carries forma.ErrInvalidInput and
 // publishes.
@@ -38,7 +45,7 @@ type nonFinitePath struct {
 // name the type it was found via; publishing it is the honest answer, because
 // no single attribute is at fault.
 func marshalRefusalError(doc any, marshalErr error) error {
-	found := nonFinitePaths(doc)
+	found, _ := marshalRefusalPaths(doc)
 	if len(found) == 0 {
 		return forma.InvalidInputf("payload cannot be encoded as JSON: %v", marshalErr)
 	}
@@ -67,59 +74,57 @@ func marshalRefusalError(doc any, marshalErr error) error {
 // makes a message degraded by this cap an embedder-only outcome.
 const maxNonFiniteWalkDepth = 1000
 
-// nonFinitePaths walks a document and returns every non-finite float in it,
+// marshalRefusalPaths walks a document and returns every finding the walk can
+// name — non-finite floats and invalid json.Number literals (#453) — each
 // sorted by path. It exists for one error path — json.Marshal has just refused
 // the payload — and is never on a successful write.
 //
 // The walk is depth-capped, and exceeding the cap abandons it entirely: nil
-// comes back, and the caller publishes the library's text. That is what makes
-// a cyclic payload safe here — json.Marshal detects a cycle and refuses, so
-// this walk runs precisely when a cycle is possible, and following one has no
-// natural end, so the cap is the end. A merely deep acyclic payload hits the
-// same cap and gets the same treatment (see maxNonFiniteWalkDepth).
+// comes back for both kinds, and the caller publishes the library's text. That
+// is what makes a cyclic payload safe here — json.Marshal detects a cycle and
+// refuses, so this walk runs precisely when a cycle is possible, and following
+// one has no natural end, so the cap is the end. A merely deep acyclic payload
+// hits the same cap and gets the same treatment (see maxNonFiniteWalkDepth).
 //
 // Abandoning rather than truncating is deliberate: a partial walk cannot tell
-// "no non-finite in this payload" from "stopped looking", and only the first
-// answer may be published. A payload with a shallow non-finite and a too-deep
+// "nothing wrong in this payload" from "stopped looking", and only the first
+// answer may be published. A payload with a shallow finding and a too-deep
 // branch is what distinguishes them, and is pinned.
 //
 // Only the shapes a payload is made of are walked: map[string]any, []any,
 // float64, float32, *float64, *float32 and json.Number. Every one of them can
 // be what Marshal refused — a pointer at a non-finite gives "unsupported
-// value: NaN", and a json.Number spelled "NaN"/"Inf"/"Infinity" gives "invalid
-// number literal". A nil pointer is skipped: it marshals as null, so it is
-// never the cause.
+// value: NaN", and a json.Number refuses either as a non-finite spelling
+// ("NaN"/"Inf"/"Infinity") or as garbage that is not JSON number grammar; the
+// two gates on that case are documented at the case itself.
 //
-// The json.Number case counts a literal only when it parses cleanly to a
-// non-finite. That gate excludes exactly the two kinds that must not be named:
-// "1e400", which ParseFloat reports out of range but which is valid JSON
-// grammar and marshals fine (so it never causes a refusal at all), and garbage
-// such as "abc", which does cause one but is already named by the library's
-// own "invalid number literal" text.
-//
-// Everything else yields nothing and falls back to that library text. That
+// Everything else yields nothing and falls back to the library text. That
 // includes shapes which do refuse and which an embedder could plausibly hand
 // in — a []float64 or map[string]float64 holding a non-finite refuses exactly
 // like []any would, but is not walked, because type-switching every concrete
 // numeric container is a losing game against a caller who can name any type.
-// Structs, custom Marshalers and channels land here too. A non-finite at the
+// Structs, custom Marshalers and channels land here too. A fault at the
 // document root is likewise left to the library: there is no attribute to name.
-func nonFinitePaths(doc any) []nonFinitePath {
+func marshalRefusalPaths(doc any) ([]nonFinitePath, []invalidNumberLiteral) {
 	var walker nonFiniteWalker
 	walker.walk("", doc, 0)
 	if walker.aborted {
-		return nil
+		return nil, nil
 	}
 	slices.SortFunc(walker.found, func(a, b nonFinitePath) int {
 		return strings.Compare(a.path, b.path)
 	})
-	return walker.found
+	slices.SortFunc(walker.invalid, func(a, b invalidNumberLiteral) int {
+		return strings.Compare(a.path, b.path)
+	})
+	return walker.found, walker.invalid
 }
 
 // nonFiniteWalker carries the walk's accumulated findings and its abort flag.
 // Once aborted, every pending frame returns without doing further work.
 type nonFiniteWalker struct {
 	found   []nonFinitePath
+	invalid []invalidNumberLiteral
 	aborted bool
 }
 
@@ -159,11 +164,20 @@ func (w *nonFiniteWalker) walk(path string, node any, depth int) {
 			w.appendIfNonFinite(path, float64(*v))
 		}
 	case json.Number:
-		// A non-nil err covers both literals that must not be named: 1e400,
-		// which is out of range but valid JSON that marshals fine, and garbage
-		// such as "abc", which the library's own text already names.
-		if parsed, err := strconv.ParseFloat(string(v), 64); err == nil {
+		// Two gates (#453). A literal that parses cleanly to a non-finite
+		// ("NaN", "Infinity") is a non-finite finding. Anything else is probed
+		// against json.Marshal itself: the literal is invalid exactly when the
+		// library refuses it, which keeps this classification immune to grammar
+		// drift between toolchains. The probe is also what excludes 1e400 —
+		// ParseFloat reports it out of range, but it is valid JSON grammar and
+		// marshals fine, so it never causes a refusal and must not be named.
+		if parsed, err := strconv.ParseFloat(string(v), 64); err == nil &&
+			(math.IsNaN(parsed) || math.IsInf(parsed, 0)) {
 			w.appendIfNonFinite(path, parsed)
+			return
+		}
+		if _, err := json.Marshal(v); err != nil {
+			w.appendInvalidLiteral(path, string(v))
 		}
 	}
 }
@@ -175,6 +189,15 @@ func (w *nonFiniteWalker) appendIfNonFinite(path string, value float64) {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
 		w.found = append(w.found, nonFinitePath{path: path, value: value})
 	}
+}
+
+// appendInvalidLiteral mirrors appendIfNonFinite's root rule: a fault at the
+// document root has no attribute to name and falls back to the library text.
+func (w *nonFiniteWalker) appendInvalidLiteral(path, literal string) {
+	if path == "" {
+		return
+	}
+	w.invalid = append(w.invalid, invalidNumberLiteral{path: path, literal: literal})
 }
 
 func joinAttributePath(prefix, key string) string {

--- a/internal/schemavalidate/nonfinite_paths_test.go
+++ b/internal/schemavalidate/nonfinite_paths_test.go
@@ -27,6 +27,13 @@ func cyclicMap() map[string]any {
 	return m
 }
 
+// nonFinitePaths keeps the pre-#453 unit tests reading naturally: prod code
+// walks once via marshalRefusalPaths and gets both finding kinds.
+func nonFinitePaths(doc any) []nonFinitePath {
+	found, _ := marshalRefusalPaths(doc)
+	return found
+}
+
 func TestNonFinitePaths(t *testing.T) {
 	t.Run("flat map", func(t *testing.T) {
 		found := nonFinitePaths(map[string]any{"name": "x", "score": math.NaN()})
@@ -244,17 +251,65 @@ func TestNonFinitePathsCoversPointerAndNumberSpellings(t *testing.T) {
 	})
 }
 
-// TestNonFinitePathsIgnoresNonRefusingNumberLiterals guards the gate on the
-// json.Number case. 1e400 is the one that matters: ParseFloat reports it out of
-// range (and hands back +Inf), but it is valid JSON grammar and marshals fine,
-// so it is never the cause of a refusal and naming it would be a lie. "abc"
-// does cause a refusal, but the library's own text already names it.
-func TestNonFinitePathsIgnoresNonRefusingNumberLiterals(t *testing.T) {
-	for _, literal := range []string{"1e400", "-1e400", "abc", "", "1.5"} {
-		t.Run(literal, func(t *testing.T) {
-			require.Empty(t, nonFinitePaths(map[string]any{"score": json.Number(literal)}))
+// TestMarshalRefusalPathsClassifiesNumberLiterals guards the two gates on the
+// json.Number case (#453). A literal parsing cleanly to a non-finite is a
+// non-finite finding; a literal json.Marshal itself refuses is an invalid
+// literal finding — probed against Marshal, not re-derived from grammar, so
+// the classification cannot drift from the refusal it explains. 1e400 is the
+// literal that must land in neither: ParseFloat reports it out of range, but
+// it is valid JSON grammar and marshals fine, so it never causes a refusal.
+func TestMarshalRefusalPathsClassifiesNumberLiterals(t *testing.T) {
+	for literal, want := range map[string]struct{ nonFinite, invalid bool }{
+		"NaN":      {nonFinite: true},
+		"Infinity": {nonFinite: true},
+		"abc":      {invalid: true},
+		"":         {},              // encoding/json marshals an empty Number as 0 — never a refusal
+		"1_0":      {invalid: true}, // ParseFloat accepts it; JSON grammar does not
+		"1e400":    {},
+		"-1e400":   {},
+		"1.5":      {},
+	} {
+		t.Run("literal "+literal, func(t *testing.T) {
+			nonFinite, invalid := marshalRefusalPaths(map[string]any{"score": json.Number(literal)})
+			require.Equal(t, want.nonFinite, len(nonFinite) == 1, "non-finite findings: %v", nonFinite)
+			require.Equal(t, want.invalid, len(invalid) == 1, "invalid-literal findings: %v", invalid)
+			if want.invalid {
+				require.Equal(t, "score", invalid[0].path)
+				require.Equal(t, literal, invalid[0].literal)
+			}
 		})
 	}
+}
+
+// TestInvalidNumberLiteralPathsShareWalkSemantics pins that the second finding
+// kind inherits the walk's contract: dotted/indexed paths, sorted output, a
+// skipped root (no attribute to name), and the depth-cap abort discarding a
+// partial answer rather than publishing it.
+func TestInvalidNumberLiteralPathsShareWalkSemantics(t *testing.T) {
+	t.Run("nested and indexed paths, sorted", func(t *testing.T) {
+		_, invalid := marshalRefusalPaths(map[string]any{
+			"z": json.Number("abc"),
+			"a": map[string]any{"b": []any{json.Number("def")}},
+		})
+		require.Len(t, invalid, 2)
+		require.Equal(t, "a.b[0]", invalid[0].path)
+		require.Equal(t, "z", invalid[1].path)
+	})
+
+	t.Run("document root is not named", func(t *testing.T) {
+		nonFinite, invalid := marshalRefusalPaths(json.Number("abc"))
+		require.Empty(t, nonFinite)
+		require.Empty(t, invalid)
+	})
+
+	t.Run("a partial result is discarded on abort", func(t *testing.T) {
+		nonFinite, invalid := marshalRefusalPaths(map[string]any{
+			"a": json.Number("abc"),
+			"z": nestMaps(maxNonFiniteWalkDepth+1, map[string]any{"deep": json.Number("def")}),
+		})
+		require.Nil(t, nonFinite)
+		require.Nil(t, invalid)
+	})
 }
 
 // TestValidateNamesNonFinitePointerAndNumber is the same coverage at the seam.

--- a/internal/schemavalidate/nonfinite_paths_test.go
+++ b/internal/schemavalidate/nonfinite_paths_test.go
@@ -334,18 +334,46 @@ func TestValidateNamesNonFinitePointerAndNumber(t *testing.T) {
 	}
 }
 
-// TestValidateFallsBackOnInvalidNumberLiteral pins the boundary the json.Number
-// gate creates: a literal that is garbage rather than non-finite still refuses,
-// and must publish the library text, which already names it.
-func TestValidateFallsBackOnInvalidNumberLiteral(t *testing.T) {
+// TestValidateNamesInvalidNumberLiteral pins #453: a garbage json.Number
+// refuses marshal, and the published message is owned — naming the attribute,
+// the literal, and the expected state — never forwarded stdlib text, whose
+// wording is a function of the build toolchain (Go 1.27 rewords it). The raw
+// library error stays reachable for operators via WithOperatorDetail.
+func TestValidateNamesInvalidNumberLiteral(t *testing.T) {
 	const schema = `{"type":"object","properties":{"score":{"type":"number"}}}`
 	v, err := New(registryWith(t, "ev", schema, 3), t.TempDir())
 	require.NoError(t, err)
 
-	err = v.Validate(3, map[string]any{"score": json.Number("abc")})
-	require.ErrorIs(t, err, forma.ErrInvalidInput)
-	msg, ok := forma.ResolvePublicMessage(err)
-	require.True(t, ok)
-	require.Contains(t, msg, "invalid number literal")
-	require.NotContains(t, msg, "non-finite", "nothing may be named when the walk found nothing")
+	t.Run("single literal", func(t *testing.T) {
+		err := v.Validate(3, map[string]any{"score": json.Number("abc")})
+		require.ErrorIs(t, err, forma.ErrInvalidInput)
+		msg, ok := forma.ResolvePublicMessage(err)
+		require.True(t, ok, "the carrier must publish, not earn a redacted body (#313)")
+		require.Contains(t, msg, "payload cannot be encoded as JSON")
+		require.Contains(t, msg, `attribute "score" holds invalid number literal "abc"`)
+		require.Contains(t, msg, "a valid JSON number is required")
+		require.NotContains(t, msg, "json:", "stdlib text must not reach the published body")
+		require.NotContains(t, msg, "more)")
+		require.True(t, forma.HasOperatorDetail(err), "the raw library error belongs to the log, not the body")
+	})
+
+	t.Run("multiple literals count the rest", func(t *testing.T) {
+		err := v.Validate(3, map[string]any{"b": json.Number("abc"), "a": json.Number("def")})
+		require.ErrorIs(t, err, forma.ErrInvalidInput)
+		msg, ok := forma.ResolvePublicMessage(err)
+		require.True(t, ok)
+		require.Contains(t, msg, `attribute "a" holds invalid number literal "def"`)
+		require.Contains(t, msg, "(and 1 more)")
+	})
+
+	// Priority is deterministic when both kinds are present: the non-finite
+	// message wins, matching the walk's original purpose.
+	t.Run("non-finite outranks invalid literal", func(t *testing.T) {
+		err := v.Validate(3, map[string]any{"bad": json.Number("abc"), "score": math.NaN()})
+		require.ErrorIs(t, err, forma.ErrInvalidInput)
+		msg, ok := forma.ResolvePublicMessage(err)
+		require.True(t, ok)
+		require.Contains(t, msg, `attribute "score" holds non-finite number NaN`)
+		require.NotContains(t, msg, "invalid number literal")
+	})
 }

--- a/internal/schemavalidate/nonfinite_paths_test.go
+++ b/internal/schemavalidate/nonfinite_paths_test.go
@@ -154,7 +154,7 @@ func TestNonFinitePathsAbortsOnCycle(t *testing.T) {
 // walk cannot tell "no non-finite here" from "stopped looking".
 func TestNonFinitePathsAbortsBeyondDepthCap(t *testing.T) {
 	t.Run("beyond the cap the walk yields nothing", func(t *testing.T) {
-		doc := nestMaps(maxNonFiniteWalkDepth+1, map[string]any{"score": math.NaN()})
+		doc := nestMaps(maxMarshalRefusalWalkDepth+1, map[string]any{"score": math.NaN()})
 		require.Nil(t, nonFinitePaths(doc))
 	})
 
@@ -168,7 +168,7 @@ func TestNonFinitePathsAbortsBeyondDepthCap(t *testing.T) {
 	t.Run("a partial result is discarded, not published", func(t *testing.T) {
 		doc := map[string]any{
 			"a": math.NaN(),
-			"z": nestMaps(maxNonFiniteWalkDepth+1, map[string]any{"deep": math.NaN()}),
+			"z": nestMaps(maxMarshalRefusalWalkDepth+1, map[string]any{"deep": math.NaN()}),
 		}
 		require.Nil(t, nonFinitePaths(doc))
 	})
@@ -206,7 +206,7 @@ func TestValidateFallsBackBeyondDepthCap(t *testing.T) {
 	v, err := New(registryWith(t, "ev", schema, 3), t.TempDir())
 	require.NoError(t, err)
 
-	doc := nestMaps(maxNonFiniteWalkDepth+1, map[string]any{"score": math.NaN()})
+	doc := nestMaps(maxMarshalRefusalWalkDepth+1, map[string]any{"score": math.NaN()})
 	err = v.Validate(3, doc)
 	require.ErrorIs(t, err, forma.ErrInvalidInput)
 	msg, ok := forma.ResolvePublicMessage(err)
@@ -265,6 +265,9 @@ func TestMarshalRefusalPathsClassifiesNumberLiterals(t *testing.T) {
 		"abc":      {invalid: true},
 		"":         {},              // encoding/json marshals an empty Number as 0 — never a refusal
 		"1_0":      {invalid: true}, // ParseFloat accepts it; JSON grammar does not
+		"0x1p4":    {invalid: true}, // hex float: same ParseFloat-accepts/JSON-refuses band
+		"+1":       {invalid: true}, // JSON numbers take no leading +
+		"01":       {invalid: true}, // JSON numbers take no leading zero
 		"1e400":    {},
 		"-1e400":   {},
 		"1.5":      {},
@@ -305,7 +308,7 @@ func TestInvalidNumberLiteralPathsShareWalkSemantics(t *testing.T) {
 	t.Run("a partial result is discarded on abort", func(t *testing.T) {
 		nonFinite, invalid := marshalRefusalPaths(map[string]any{
 			"a": json.Number("abc"),
-			"z": nestMaps(maxNonFiniteWalkDepth+1, map[string]any{"deep": json.Number("def")}),
+			"z": nestMaps(maxMarshalRefusalWalkDepth+1, map[string]any{"deep": json.Number("def")}),
 		})
 		require.Nil(t, nonFinite)
 		require.Nil(t, invalid)


### PR DESCRIPTION
Closes #453.

## What changed

The published 4xx body for a garbage `json.Number` literal (e.g. `json.Number("abc")`) is now an owned message instead of forwarded `encoding/json` text:

```
payload cannot be encoded as JSON: attribute "score" holds invalid number literal "abc"; a valid JSON number is required
```

The raw stdlib error stays reachable for operators via `forma.WithOperatorDetail` — it reaches `Error()` and the log, never the published body. `TestValidateFallsBackOnInvalidNumberLiteral` (which asserted Go 1.26's stdlib wording and FAILed deterministically under Go 1.27) is replaced by `TestValidateNamesInvalidNumberLiteral`, which asserts only owned text.

## Decision table (`marshalRefusalError`)

| Walk finding | Published body | Operator detail |
|---|---|---|
| Non-finite float(s) | owned: `attribute "x" holds non-finite number NaN; a finite value is required` (unchanged) | — |
| Invalid `json.Number` literal(s) | owned: `attribute "x" holds invalid number literal "abc"; a valid JSON number is required` (**new**, #453) | raw stdlib error |
| Neither (channel/func, failing Marshaler, cycle, depth-cap abandon, root-level fault) | library text unchanged — the only description that exists | — |

When both kinds are present, non-finite wins — fixed priority keeps the message deterministic. Both owned messages name the alphabetically first offender plus an `(and N more)` count, matching the existing precedent.

## Why probe `json.Marshal` as the gate

The walker classifies a `json.Number` as an invalid literal only when `json.Marshal` itself refuses it, rather than re-deriving JSON number grammar. This keeps the classification exactly aligned with the refusal it explains, on any toolchain. Probing caught a real edge during TDD: `json.Number("")` marshals as `0` in encoding/json — never a refusal — so a grammar re-implementation would have named a literal that can't be the fault. `1e400` (valid JSON, `ParseFloat` range error) is likewise excluded by construction; `"1_0"` (accepted by `ParseFloat`, rejected by JSON grammar) is correctly flagged.

## Effect on the Go 1.27 migration (#453 / #448)

- The deterministic FAIL mode of `TestValidateFallsBackOnInvalidNumberLiteral` under Go 1.27 disappears: no test in this package asserts stdlib wording for the garbage-literal case any more.
- A toolchain bump can no longer silently change this user-visible 4xx body.
- The future Go 1.27 migration's critical path shrinks to the golangci-lint v1.64.8 pin (#448). Out of scope, deliberately: the remaining walk-empty fallbacks (unsupported type, cycle, depth-cap) still publish library text — there no attribute/literal exists to name and the library text is the only description of the fault. Their tests (`unsupported type`, `cycle`, `unsupported value: NaN` assertions) remain toolchain-sensitive; if Go 1.27's jsonv2 rewords those too, that belongs to the migration issue.

## Verification

- `go test ./internal/schemavalidate` — all green (new unit tests for classification, walk-semantics inheritance incl. depth-cap abort discarding invalid-literal findings, and the three-branch seam behavior).
- `make fmt-check`, `make lint` — green.
- `./scripts/test_with_container_runtime.sh` (full `make test`) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrozwMGpNtcCzHtV6pPjfY
