### PR TITLE
test(e2e): de-flake full federated suite + nightly full-suite CI (#434)

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -11,6 +11,14 @@ on:
     - cron: '30 19 * * *' # 03:30 Asia/Shanghai
   workflow_dispatch:
 
+# A manual dispatch overlapping the scheduled run (or a hung run meeting the
+# next day's schedule) must queue, not double-run: two suites sharing one
+# runner-class would contend exactly like the local churn this suite is being
+# de-flaked against (#490 review).
+concurrency:
+  group: nightly-e2e
+  cancel-in-progress: false
+
 env:
   GO_VERSION: '1.26.0'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,56 @@
+# Nightly full federated e2e suite (#434). CI's per-PR run uses -short, which
+# skips 37 of the 124 federated e2e tests (deduplication, merge-on-read,
+# data-tier, soft-delete, performance). This scheduled run is their only CI
+# signal, and the measurable baseline for the suite's flake rate. It gates
+# nothing: value is signal, so failures file/update a labeled issue instead
+# of blocking PRs.
+name: Nightly Full E2E
+
+on:
+  schedule:
+    - cron: '30 19 * * *' # 03:30 Asia/Shanghai
+  workflow_dispatch:
+
+env:
+  GO_VERSION: '1.26.0'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  federated-full:
+    name: Full Federated Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run full federated e2e suite (no -short)
+        run: go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=75m
+
+      - name: File or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create nightly-e2e --repo "$GITHUB_REPOSITORY" \
+            --color D93F0B --description "Nightly full e2e suite failure" --force
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
+            --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Nightly full federated e2e suite failed again: $run_url"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
+              --title "nightly: full federated e2e suite failed" \
+              --body "The scheduled full federated suite (\`-tags=e2e\`, no \`-short\`) failed: $run_url (refs #434)"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Bun black-box E2E and k6 load tests live in `tests/e2e/` (see its README). Bench
 
 Local server: `./scripts/local_server.sh` (Docker Compose Postgres + init-db + server on :8080).
 
-CI (`.github/workflows/ci.yml`) runs lint, unit tests with `-race`, the e2e smoke + `-tags=e2e -short` federated suite, the production harness, and `benchmark-smoke`.
+CI (`.github/workflows/ci.yml`) runs lint, unit tests with `-race`, the e2e smoke + `-tags=e2e -short` federated suite, the production harness, and `benchmark-smoke`. Note `-short` skips 37 of the 124 federated e2e tests (deduplication, merge-on-read, data-tier, soft-delete, performance); their CI signal is the nightly full-suite run (`.github/workflows/nightly-e2e.yml`), which files a `nightly-e2e`-labeled issue on failure (#434).
 
 ## Architecture
 

--- a/internal/e2e_harness/federated/deduplication_test.go
+++ b/internal/e2e_harness/federated/deduplication_test.go
@@ -157,8 +157,12 @@ func TestDeduplication_BulkPerformance(t *testing.T) {
 	// Verify deduplication occurred
 	AssertNoDuplicates(t, result.Records)
 
-	// Verify performance (should be < 5s for 10K records with 30% duplicates)
-	require.Less(t, duration, 5*time.Second, "deduplication took too long: %v", duration)
+	// Regression tripwire, not a performance target: in isolation this query
+	// runs in ~220ms, but the full suite's container churn has pushed it past
+	// a 5s ceiling on a loaded host (#434). The ceiling only needs to catch a
+	// broken dedup (30s-class); real latency baselining belongs to the
+	// benchmark harness.
+	require.Less(t, duration, 30*time.Second, "deduplication took too long: %v", duration)
 
 	// Calculate actual dedup ratio
 	uniqueCount := len(result.Records)

--- a/internal/e2e_harness/federated/soft_delete_test.go
+++ b/internal/e2e_harness/federated/soft_delete_test.go
@@ -355,8 +355,11 @@ func TestSoftDelete_BulkDeletedExclusion(t *testing.T) {
 	AssertRecordCount(t, result.Records, expectedLive)
 	AssertNoDeleted(t, result.Records)
 
-	// Should complete in reasonable time
-	require.Less(t, duration, 3*time.Second, "soft delete filtering too slow: %v", duration)
+	// Regression tripwire, not a performance target: an absolute wall-clock
+	// ceiling in a containerised e2e run measures the host as much as the
+	// code (#434). 15s only catches an order-of-magnitude regression on this
+	// 1000-record query.
+	require.Less(t, duration, 15*time.Second, "soft delete filtering too slow: %v", duration)
 
 	t.Logf("TC-04-06 PASSED: Bulk delete exclusion - %d total, %d deleted -> %d returned in %v",
 		totalRecords, totalRecords-expectedLive, expectedLive, duration)

--- a/internal/e2e_harness/harness.go
+++ b/internal/e2e_harness/harness.go
@@ -35,7 +35,10 @@ func (h *TestHarness) StartPostgres(ctx context.Context) (string, error) {
 			"POSTGRES_USER":     "postgres",
 			"POSTGRES_DB":       "postgres",
 		},
-		WaitingFor: wait.ForListeningPort("5432/tcp").WithStartupTimeout(30 * time.Second),
+		// 120s, not 30s: the per-container startup budget must absorb the
+		// docker-socket contention of back-to-back container churn in a full
+		// suite run (#434); a healthy start still returns in seconds.
+		WaitingFor: wait.ForListeningPort("5432/tcp").WithStartupTimeout(120 * time.Second),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
@@ -217,7 +220,18 @@ func (h *TestHarness) StartS3(ctx context.Context) (string, error) {
 			"RUSTFS_ACCESS_KEY": RustFSAccessKey,
 			"RUSTFS_SECRET_KEY": RustFSSecretKey,
 		},
-		WaitingFor: wait.ForListeningPort("9000/tcp").WithStartupTimeout(60 * time.Second),
+		// Readiness means the server answered HTTP, not merely that a port
+		// mapping exists: under back-to-back container churn the mapped-port
+		// probe has timed out against a slow docker socket while RustFS was
+		// still booting (#434). Any status code counts — unauthenticated
+		// GET / gets an S3 error response, and a response at all proves the
+		// HTTP stack is serving. The budget is deliberately wide: it bounds
+		// the worst case on a loaded host, and a healthy start still returns
+		// in seconds.
+		WaitingFor: wait.ForHTTP("/").
+			WithPort("9000/tcp").
+			WithStatusCodeMatcher(func(int) bool { return true }).
+			WithStartupTimeout(120 * time.Second),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/internal/e2e_harness/harness.go
+++ b/internal/e2e_harness/harness.go
@@ -225,9 +225,9 @@ func (h *TestHarness) StartS3(ctx context.Context) (string, error) {
 		// probe has timed out against a slow docker socket while RustFS was
 		// still booting (#434). Any status code counts — unauthenticated
 		// GET / gets an S3 error response, and a response at all proves the
-		// HTTP stack is serving. The budget is deliberately wide: it bounds
-		// the worst case on a loaded host, and a healthy start still returns
-		// in seconds.
+		// HTTP stack is serving. The budget (60s → 120s) is deliberately
+		// wide: it bounds the worst case on a loaded host, and a healthy
+		// start still returns in seconds.
 		WaitingFor: wait.ForHTTP("/").
 			WithPort("9000/tcp").
 			WithStatusCodeMatcher(func(int) bool { return true }).


### PR DESCRIPTION
De-flakes the full federated e2e suite's two environment-sensitive failure modes and gives the 37 `-short`-skipped tests a CI signal. Plan and rationale: https://github.com/Lychee-Technology/forma/issues/434#issuecomment-5420183177

## Changes

**1. Wall-clock ceilings become regression tripwires** (`deduplication_test.go`, `soft_delete_test.go`)
The 5s ceiling that failed at 5.22s on a loaded host measures the host, not the code (the same query runs in ~220ms in isolation — a 23× margin). Raised to 30s (dedup, 10K records) and 15s (soft-delete, 1K records): still catches an order-of-magnitude regression, no longer fails on docker contention. Real latency baselining stays in the benchmark harness.

**2. RustFS readiness waits on an HTTP response, wider startup budgets** (`internal/e2e_harness/harness.go`)
The observed `wait until ready: mapped port … context deadline exceeded` failure sat in `wait.ForListeningPort`'s 60s budget while the docker socket was slow under churn. Readiness now means the server *answered HTTP* (any status — unauthenticated `GET /` gets an S3 error response, which proves the HTTP stack is serving), with a 120s budget. Postgres startup budget widened 30s→120s for the same back-to-back-churn reason. Shared by the federated harness and the production cluster (both call `StartS3`/`StartPostgres`).

**3. Nightly full-suite workflow** (`.github/workflows/nightly-e2e.yml`)
Scheduled (03:30 Asia/Shanghai) + `workflow_dispatch`; runs `go test ./internal/e2e_harness/federated/... -tags=e2e` with **no `-short`** — the only CI signal for the 37 skipped tests, and the measurable baseline for the flake rate. Gates nothing: on failure it files (or comments on) one open `nightly-e2e`-labeled issue. Takes effect once merged to main (scheduled workflows run from the default branch).

**4. AGENTS.md** now states the `-short` gap and points at the nightly signal.

## Invariant coverage (acceptance criterion from the issue)

- Covered by the production harness (no `Short()` gates, per-PR CI): `three_tier_merge`, `tiebreak_lww`, `filter_lww_matrix`, `cdc_fault_*`.
- Covered **only** by `-short`-skipped federated tests (nightly is their signal): dedup QUALIFY ordering (6), merge-on-read (7), data-tier routing (7), soft-delete visibility, performance envelopes (8).

## Verification

- `make fmt-check` ✅, `make lint` exit 0 ✅ (root + infra)
- Full unit suite via `./scripts/test_with_container_runtime.sh` exit 0 ✅
- `go vet` and `go vet -tags=e2e` over `./internal/e2e_harness/...` ✅
- Live e2e through the new RustFS HTTP wait (rootless Podman): `TestDeduplication_SameTier` PASS (5.27s incl. Postgres+RustFS+DuckDB startup); `TestDeduplication_BulkPerformance` PASS — 13,000 records deduped in **776ms**, comfortably inside the new 30s tripwire
- Workflow YAML parses (1 job); ci.yml guards (`TestCILintJob*`, `TestGatesRunUnderPinnedToolchain`) PASS — the new workflow file is outside their scope

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsmokCNqVJ9sYH5AtbqaXB
