### PR TITLE
ci: nightly production e2e suite under -race — the #410 ruling

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -53,24 +53,21 @@ jobs:
       - name: Run full federated e2e suite (no -short)
         run: go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=75m
 
+      # The two nightly jobs share one reporting script but MUST NOT share a
+      # label: the label keys the open-issue lookup, so a shared one appends
+      # this suite's failures to the other suite's thread (#410 review).
       - name: File or update failure issue
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh label create nightly-e2e --repo "$GITHUB_REPOSITORY" \
-            --color D93F0B --description "Nightly full e2e suite failure" --force
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
-            --state open --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
-              --body "Nightly full federated e2e suite failed again: $run_url"
-          else
-            gh issue create --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
-              --title "nightly: full federated e2e suite failed" \
-              --body "The scheduled full federated suite (\`-tags=e2e\`, no \`-short\`) failed: $run_url (refs #434)"
-          fi
+        run: >
+          bash scripts/nightly_failure_issue.sh
+          nightly-e2e
+          "Nightly full e2e suite failure"
+          "nightly: full federated e2e suite failed"
+          "Nightly full federated e2e suite failed again"
+          "The scheduled full federated suite (\`-tags=e2e\`, no \`-short\`) failed"
+          "#434"
 
   production-race:
     name: Production Suite (-race)
@@ -91,21 +88,16 @@ jobs:
       - name: Run production e2e suite under -race
         run: go test -v ./internal/e2e_harness/production/ -tags=e2e -race -timeout=30m
 
+      # Same script, own label — see the label note on the federated job.
       - name: File or update failure issue
         if: failure()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh label create nightly-e2e --repo "$GITHUB_REPOSITORY" \
-            --color D93F0B --description "Nightly full e2e suite failure" --force
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
-            --state open --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
-              --body "Nightly production e2e suite failed under -race: $run_url"
-          else
-            gh issue create --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
-              --title "nightly: production e2e suite failed under -race" \
-              --body "The scheduled production suite run (\`-tags=e2e -race\`) failed: $run_url (refs #410)"
-          fi
+        run: >
+          bash scripts/nightly_failure_issue.sh
+          nightly-e2e-race
+          "Nightly production e2e -race failure"
+          "nightly: production e2e suite failed under -race"
+          "Nightly production e2e suite failed under -race again"
+          "The scheduled production suite run (\`-tags=e2e -race\`) failed"
+          "#410"

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -4,6 +4,15 @@
 # signal, and the measurable baseline for the suite's flake rate. It gates
 # nothing: value is signal, so failures file/update a labeled issue instead
 # of blocking PRs.
+#
+# The production-race job is the #410 ruling: CI races only the unit suite,
+# so the production e2e harness — the one venue driving real concurrent
+# flush/compaction/read against real containers — had no recurring -race
+# signal after passing once during #345. It lives here, not in the PR gate:
+# the race detector's slowdown would invalidate the wall-clock regression
+# tripwires #434 calibrated for race-free runs, and this workflow already
+# has the budget and the failure-issue reporting. Jobs run on separate
+# hosted runners, so the two suites' containers never contend.
 name: Nightly Full E2E
 
 on:
@@ -61,4 +70,42 @@ jobs:
             gh issue create --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
               --title "nightly: full federated e2e suite failed" \
               --body "The scheduled full federated suite (\`-tags=e2e\`, no \`-short\`) failed: $run_url (refs #434)"
+          fi
+
+  production-race:
+    name: Production Suite (-race)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # TestNightlyRacesProductionSuite guards this line. The 30m timeout is
+      # the gate run's 10m (make test-e2e-production) times the ~2-3x race
+      # instrumentation cost, rounded up.
+      - name: Run production e2e suite under -race
+        run: go test -v ./internal/e2e_harness/production/ -tags=e2e -race -timeout=30m
+
+      - name: File or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create nightly-e2e --repo "$GITHUB_REPOSITORY" \
+            --color D93F0B --description "Nightly full e2e suite failure" --force
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
+            --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Nightly production e2e suite failed under -race: $run_url"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --label nightly-e2e \
+              --title "nightly: production e2e suite failed under -race" \
+              --body "The scheduled production suite run (\`-tags=e2e -race\`) failed: $run_url (refs #410)"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Bun black-box E2E and k6 load tests live in `tests/e2e/` (see its README). Bench
 
 Local server: `./scripts/local_server.sh` (Docker Compose Postgres + init-db + server on :8080).
 
-CI (`.github/workflows/ci.yml`) runs lint, unit tests with `-race`, the e2e smoke + `-tags=e2e -short` federated suite, the production harness, and `benchmark-smoke`. Note `-short` skips 37 of the 124 federated e2e tests (deduplication, merge-on-read, data-tier, soft-delete, performance); their CI signal is the nightly full-suite run (`.github/workflows/nightly-e2e.yml`), which files a `nightly-e2e`-labeled issue on failure (#434).
+CI (`.github/workflows/ci.yml`) runs lint, unit tests with `-race`, the e2e smoke + `-tags=e2e -short` federated suite, the production harness, and `benchmark-smoke`. Note `-short` skips 37 of the 124 federated e2e tests (deduplication, merge-on-read, data-tier, soft-delete, performance); their CI signal is the nightly workflow (`.github/workflows/nightly-e2e.yml`), which runs the full federated suite (#434) and the production suite under `-race` (#410), filing a `nightly-e2e`- / `nightly-e2e-race`-labeled issue respectively on failure.
 
 ## Architecture
 

--- a/internal/e2e_harness/production/monotonic_version_e2e_test.go
+++ b/internal/e2e_harness/production/monotonic_version_e2e_test.go
@@ -64,17 +64,23 @@ func TestMonotonicVersionsCloseSameMillisecondTies(t *testing.T) {
 const clockAheadLeadMs = 20_000
 
 // requireExactStamp asserts got == want and, on mismatch, separates the two
-// possible causes: if the wall clock has overtaken the restamp, the lead
-// budget was eaten by scheduling — the GREATEST branch was never reachable
-// and the exact-version pin is meaningless — so the failure must read as a
-// blown budget, not as a monotonicity regression (#410 review).
-func requireExactStamp(t *testing.T, what string, got, want, ahead int64) {
+// possible causes: if the wall clock had overtaken the restamp by the time
+// the write completed, the lead budget was eaten by scheduling — the
+// GREATEST branch was never reachable and the exact-version pin is
+// meaningless — so the failure must read as a blown budget, not as a
+// monotonicity regression (#410 review). wroteByMs is a clock reading taken
+// right after the asserted write returned, not at assert time: for the
+// recreate race the assertion runs only after the paused flush resumes and
+// finishes, and reading the clock there could report a genuine regression
+// as a blown budget (review round 2). Conversely wroteByMs <= ahead is
+// conclusive: the stamping GREATEST saw a clock no later than this reading.
+func requireExactStamp(t *testing.T, what string, got, want, ahead, wroteByMs int64) {
 	t.Helper()
 	if got == want {
 		return
 	}
-	if now := time.Now().UnixMilli(); now > ahead {
-		t.Fatalf("%s stamped %d, want %d — but the wall clock (%d) has passed the restamp (%d): the %dms clock-ahead lead was exhausted by scheduling; raise clockAheadLeadMs, this is not a GREATEST regression", what, got, want, now, ahead, int64(clockAheadLeadMs))
+	if wroteByMs > ahead {
+		t.Fatalf("%s stamped %d, want %d — but the wall clock (%d) had passed the restamp (%d) when the write completed: the %dms clock-ahead lead was exhausted by scheduling; raise clockAheadLeadMs, this is not a GREATEST regression", what, got, want, wroteByMs, ahead, clockAheadLeadMs)
 	}
 	t.Fatalf("%s stamped %d, want %d (strictly above the row's previous version)", what, got, want)
 }
@@ -118,10 +124,11 @@ func testUpdateAdvancesPastClockAheadVersion(ctx context.Context, t *testing.T, 
 
 	upd := UpdateEvent(wide, target.RowID, map[string]any{"title": "fresh-b", "count": float64(200)})
 	mustApplyEvents(ctx, t, env, "monotonic update", upd)
+	wroteBy := time.Now().UnixMilli()
 
 	// The effective version must be ahead+1 — strictly past the clock-ahead
 	// previous version, not the (smaller) wall-clock read.
-	requireExactStamp(t, "update change_log", upd.ChangedAt, ahead+1, ahead)
+	requireExactStamp(t, "update change_log", upd.ChangedAt, ahead+1, ahead, wroteBy)
 	var mainVer int64
 	if err := env.Pool.QueryRow(ctx,
 		"SELECT ltbase_updated_at FROM entity_main WHERE ltbase_schema_id = $1 AND ltbase_row_id = $2",
@@ -181,8 +188,9 @@ func testDeleteOutranksClockAheadLiveVersion(ctx context.Context, t *testing.T, 
 
 	del := DeleteEvent(wide, victim.RowID)
 	mustApplyEvents(ctx, t, env, "delete-guard delete", del)
-	requireExactStamp(t, "tombstone changed_at", del.ChangedAt, ahead+1, ahead)
-	requireExactStamp(t, "tombstone deleted_at", del.DeletedAt, ahead+1, ahead)
+	wroteBy := time.Now().UnixMilli()
+	requireExactStamp(t, "tombstone changed_at", del.ChangedAt, ahead+1, ahead, wroteBy)
+	requireExactStamp(t, "tombstone deleted_at", del.DeletedAt, ahead+1, ahead, wroteBy)
 
 	// Flush IMMEDIATELY: the clock-ahead tombstone must be exported and
 	// marked in this run (round-2 P1).
@@ -238,7 +246,7 @@ func TestRecreateBetweenExportAndMark(t *testing.T) {
 	ahead := restampMainVersionAhead(ctx, t, env, wide, victim, clockAheadLeadMs)
 	del := DeleteEvent(wide, victim.RowID)
 	mustApplyEvents(ctx, t, env, "recreate-race delete", del)
-	requireExactStamp(t, "recreate-race tombstone", del.ChangedAt, ahead+1, ahead)
+	requireExactStamp(t, "recreate-race tombstone", del.ChangedAt, ahead+1, ahead, time.Now().UnixMilli())
 
 	// The paused flush lists and exports the tombstone @ ahead+1, then hangs
 	// before mark; the recreate lands while it hangs. title/count are the
@@ -251,15 +259,20 @@ func TestRecreateBetweenExportAndMark(t *testing.T) {
 		TextItems:  map[string]string{"text_01": "reborn"},
 		Int32Items: map[string]int32{"integer_01": 30},
 	}
+	// recreatedBy is read inside the pause, right after the insert returns:
+	// the assertion below only runs once the flush has resumed and finished,
+	// and a clock read that late would blame the budget for that whole leg.
+	var recreatedBy int64
 	report, err := runPausedFlush(ctx, t, env, func() {
 		if err := repo.InsertPersistentRecord(ctx, tables, rec); err != nil {
 			t.Errorf("recreate during paused flush: %v", err)
 		}
+		recreatedBy = time.Now().UnixMilli()
 	})
 	if err != nil {
 		t.Fatalf("paused flush: %v", err)
 	}
-	requireExactStamp(t, "recreate", rec.UpdatedAt, ahead+2, ahead)
+	requireExactStamp(t, "recreate", rec.UpdatedAt, ahead+2, ahead, recreatedBy)
 	// Mirror the recreate into the oracle event log (the restamp-mirroring
 	// pattern) so oracle-checked probes stay meaningful.
 	env.eventSeq++

--- a/internal/e2e_harness/production/monotonic_version_e2e_test.go
+++ b/internal/e2e_harness/production/monotonic_version_e2e_test.go
@@ -63,6 +63,22 @@ func TestMonotonicVersionsCloseSameMillisecondTies(t *testing.T) {
 // costs no wall time.
 const clockAheadLeadMs = 20_000
 
+// requireExactStamp asserts got == want and, on mismatch, separates the two
+// possible causes: if the wall clock has overtaken the restamp, the lead
+// budget was eaten by scheduling — the GREATEST branch was never reachable
+// and the exact-version pin is meaningless — so the failure must read as a
+// blown budget, not as a monotonicity regression (#410 review).
+func requireExactStamp(t *testing.T, what string, got, want, ahead int64) {
+	t.Helper()
+	if got == want {
+		return
+	}
+	if now := time.Now().UnixMilli(); now > ahead {
+		t.Fatalf("%s stamped %d, want %d — but the wall clock (%d) has passed the restamp (%d): the %dms clock-ahead lead was exhausted by scheduling; raise clockAheadLeadMs, this is not a GREATEST regression", what, got, want, now, ahead, int64(clockAheadLeadMs))
+	}
+	t.Fatalf("%s stamped %d, want %d (strictly above the row's previous version)", what, got, want)
+}
+
 // restampMainVersionAhead moves the row's stored version aheadMillis past the
 // current wall clock and returns the restamped version. The guard count
 // proves the restamp took — a silent no-op would leave the scenario probing
@@ -105,9 +121,7 @@ func testUpdateAdvancesPastClockAheadVersion(ctx context.Context, t *testing.T, 
 
 	// The effective version must be ahead+1 — strictly past the clock-ahead
 	// previous version, not the (smaller) wall-clock read.
-	if upd.ChangedAt != ahead+1 {
-		t.Fatalf("update stamped change_log at %d, want %d (GREATEST over the row's previous version)", upd.ChangedAt, ahead+1)
-	}
+	requireExactStamp(t, "update change_log", upd.ChangedAt, ahead+1, ahead)
 	var mainVer int64
 	if err := env.Pool.QueryRow(ctx,
 		"SELECT ltbase_updated_at FROM entity_main WHERE ltbase_schema_id = $1 AND ltbase_row_id = $2",
@@ -167,10 +181,8 @@ func testDeleteOutranksClockAheadLiveVersion(ctx context.Context, t *testing.T, 
 
 	del := DeleteEvent(wide, victim.RowID)
 	mustApplyEvents(ctx, t, env, "delete-guard delete", del)
-	if del.ChangedAt != ahead+1 || del.DeletedAt != ahead+1 {
-		t.Fatalf("tombstone stamped (changed_at=%d, deleted_at=%d), want both %d (strictly past the clock-ahead live version)",
-			del.ChangedAt, del.DeletedAt, ahead+1)
-	}
+	requireExactStamp(t, "tombstone changed_at", del.ChangedAt, ahead+1, ahead)
+	requireExactStamp(t, "tombstone deleted_at", del.DeletedAt, ahead+1, ahead)
 
 	// Flush IMMEDIATELY: the clock-ahead tombstone must be exported and
 	// marked in this run (round-2 P1).
@@ -226,9 +238,7 @@ func TestRecreateBetweenExportAndMark(t *testing.T) {
 	ahead := restampMainVersionAhead(ctx, t, env, wide, victim, clockAheadLeadMs)
 	del := DeleteEvent(wide, victim.RowID)
 	mustApplyEvents(ctx, t, env, "recreate-race delete", del)
-	if del.ChangedAt != ahead+1 {
-		t.Fatalf("tombstone stamped %d, want %d", del.ChangedAt, ahead+1)
-	}
+	requireExactStamp(t, "recreate-race tombstone", del.ChangedAt, ahead+1, ahead)
 
 	// The paused flush lists and exports the tombstone @ ahead+1, then hangs
 	// before mark; the recreate lands while it hangs. title/count are the
@@ -249,9 +259,7 @@ func TestRecreateBetweenExportAndMark(t *testing.T) {
 	if err != nil {
 		t.Fatalf("paused flush: %v", err)
 	}
-	if rec.UpdatedAt != ahead+2 {
-		t.Fatalf("recreate stamped %d, want %d (strictly above the retained tombstone)", rec.UpdatedAt, ahead+2)
-	}
+	requireExactStamp(t, "recreate", rec.UpdatedAt, ahead+2, ahead)
 	// Mirror the recreate into the oracle event log (the restamp-mirroring
 	// pattern) so oracle-checked probes stay meaningful.
 	env.eventSeq++

--- a/internal/e2e_harness/production/monotonic_version_e2e_test.go
+++ b/internal/e2e_harness/production/monotonic_version_e2e_test.go
@@ -52,6 +52,17 @@ func TestMonotonicVersionsCloseSameMillisecondTies(t *testing.T) {
 	}
 }
 
+// clockAheadLeadMs is how far past the wall clock the restamps below move a
+// row's version. The exact-version assertions (ahead+1 / ahead+2) hold only
+// while the wall clock is still behind the restamp, so this is a budget for
+// everything between the restamp and the asserted write — which for the
+// recreate race includes a full flush list+export leg. Under -race that leg
+// alone took ~2.1s (nightly production-race run, #410), blowing the original
+// 2s lead; 20s keeps the GREATEST branch deterministically exercised on
+// 2-core CI runners. Nothing waits for the clock to catch up, so the size
+// costs no wall time.
+const clockAheadLeadMs = 20_000
+
 // restampMainVersionAhead moves the row's stored version aheadMillis past the
 // current wall clock and returns the restamped version. The guard count
 // proves the restamp took — a silent no-op would leave the scenario probing
@@ -87,7 +98,7 @@ func testUpdateAdvancesPastClockAheadVersion(ctx context.Context, t *testing.T, 
 	mustApplyEvents(ctx, t, env, "monotonic creates", target, bystander)
 	mustFlush(ctx, t, env) // delta A: live "stale-a" @ its create ts
 
-	ahead := restampMainVersionAhead(ctx, t, env, wide, target, 2000)
+	ahead := restampMainVersionAhead(ctx, t, env, wide, target, clockAheadLeadMs)
 
 	upd := UpdateEvent(wide, target.RowID, map[string]any{"title": "fresh-b", "count": float64(200)})
 	mustApplyEvents(ctx, t, env, "monotonic update", upd)
@@ -152,7 +163,7 @@ func testDeleteOutranksClockAheadLiveVersion(ctx context.Context, t *testing.T, 
 	mustApplyEvents(ctx, t, env, "delete-guard creates", victim, control)
 	mustFlush(ctx, t, env) // delta: both live @ create ts
 
-	ahead := restampMainVersionAhead(ctx, t, env, wide, victim, 2000)
+	ahead := restampMainVersionAhead(ctx, t, env, wide, victim, clockAheadLeadMs)
 
 	del := DeleteEvent(wide, victim.RowID)
 	mustApplyEvents(ctx, t, env, "delete-guard delete", del)
@@ -212,7 +223,7 @@ func TestRecreateBetweenExportAndMark(t *testing.T) {
 	mustApplyEvents(ctx, t, env, "recreate-race creates", victim, control)
 	mustFlush(ctx, t, env) // delta #1: both live
 
-	ahead := restampMainVersionAhead(ctx, t, env, wide, victim, 2000)
+	ahead := restampMainVersionAhead(ctx, t, env, wide, victim, clockAheadLeadMs)
 	del := DeleteEvent(wide, victim.RowID)
 	mustApplyEvents(ctx, t, env, "recreate-race delete", del)
 	if del.ChangedAt != ahead+1 {

--- a/nightly_guard_test.go
+++ b/nightly_guard_test.go
@@ -1,0 +1,41 @@
+package forma
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestNightlyRacesProductionSuite pins the #410 ruling: the nightly workflow
+// must run the production e2e harness under -race. CI's PR gate races only
+// the unit suite, and the gate's e2e jobs cannot carry -race — the detector's
+// slowdown would invalidate the wall-clock regression tripwires #434
+// calibrated for race-free runs — so this scheduled run is the only recurring
+// -race signal over the harness's real concurrent flush/compaction/read
+// paths. A plain text scan, like the sibling guards in
+// toolchain_guard_test.go: a yaml dependency buys nothing here.
+func TestNightlyRacesProductionSuite(t *testing.T) {
+	wf, err := os.ReadFile(".github/workflows/nightly-e2e.yml")
+	if err != nil {
+		t.Fatalf("read .github/workflows/nightly-e2e.yml: %v", err)
+	}
+	found := false
+	for _, line := range strings.Split(string(wf), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") || !strings.HasPrefix(trimmed, "run:") {
+			continue
+		}
+		if !strings.Contains(trimmed, "./internal/e2e_harness/production/") {
+			continue
+		}
+		found = true
+		for _, flag := range []string{"-tags=e2e", "-race"} {
+			if !strings.Contains(trimmed, flag) {
+				t.Errorf("nightly production run line %q lacks %s: the production suite would silently lose its only recurring -race signal (#410)", trimmed, flag)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no run directive for ./internal/e2e_harness/production/ found in nightly-e2e.yml: the -race guard has lost its target (#410)")
+	}
+}

--- a/scripts/nightly_failure_issue.sh
+++ b/scripts/nightly_failure_issue.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Files or updates the labeled failure issue for a nightly e2e job (#434,
+# #410). One definition shared by both nightly jobs so the mechanics — label
+# idempotency, first-open-issue selection, run URL construction — cannot
+# diverge. The label keys the update lookup, so each job MUST pass its own
+# label: with a shared label one suite's failures get appended to the other
+# suite's open issue and the per-suite signal is buried (#410 review).
+#
+# Inputs (env): GH_TOKEN, GITHUB_REPOSITORY, GITHUB_SERVER_URL, GITHUB_RUN_ID
+# Arguments: <label> <label-description> <issue-title> <comment-prefix> <body-prefix> <ref>
+# The run URL and "(refs <ref>)" are appended to the comment/body here.
+set -Eeuo pipefail
+
+label="$1"
+label_desc="$2"
+title="$3"
+comment_prefix="$4"
+body_prefix="$5"
+ref="$6"
+
+gh label create "$label" --repo "$GITHUB_REPOSITORY" \
+	--color D93F0B --description "$label_desc" --force
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "$label" \
+	--state open --json number --jq '.[0].number // empty')
+if [ -n "$existing" ]; then
+	gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+		--body "$comment_prefix: $run_url"
+else
+	gh issue create --repo "$GITHUB_REPOSITORY" --label "$label" \
+		--title "$title" \
+		--body "$body_prefix: $run_url (refs $ref)"
+fi

--- a/scripts/nightly_failure_issue.sh
+++ b/scripts/nightly_failure_issue.sh
@@ -11,6 +11,11 @@
 # The run URL and "(refs <ref>)" are appended to the comment/body here.
 set -Eeuo pipefail
 
+if [ "$#" -ne 6 ]; then
+	echo "usage: $0 <label> <label-description> <issue-title> <comment-prefix> <body-prefix> <ref>" >&2
+	exit 2
+fi
+
 label="$1"
 label_desc="$2"
 title="$3"


### PR DESCRIPTION
Closes #410.

## What this is

#410's two primary decisions were already settled by #436 / PR #483 (the two issues are the same finding from different sweeps): `make lint` carries `--build-tags e2e` fail-closed, CI runs the recipe via `make lint`, and `TestLintRecipeCoversE2ETag` guards the flag. Verified at current main: `make lint` exits 0.

What remained — per epic #452's Phase 1 carry-out — was recording the ruling #410 asked for: nothing keeps the production e2e suite green under `-race` after its one-off pass during #345.

## The ruling

Run the production suite under `-race` **nightly, not in the PR gate**:

- The race detector's 2–10x slowdown would invalidate the wall-clock regression tripwires #434 just calibrated for race-free runs; the nightly workflow already has the budget and the failure-issue reporting, and its value-is-signal design (gates nothing, files labeled issues) fits a race probe exactly.
- New `production-race` job in `nightly-e2e.yml` (separate hosted runner, so no container contention with the federated job; 30m test timeout ≈ local race-instrumented runtime 8m × headroom).
- `TestNightlyRacesProductionSuite` guards the `-race` flag the same way `TestLintRecipeCoversE2ETag` guards the lint tag (negative-checked: removing `-race` fails the guard).
- The failure-issue mechanics are now one script (`scripts/nightly_failure_issue.sh`) with per-suite labels — a shared label would have appended `-race` failures onto the federated flake thread and buried the signal. Federated messages stay byte-identical.

## Deflake found by the ruling's own verification

The first full `-race` run failed `TestRecreateBetweenExportAndMark`: its 2s clock-ahead restamp is a budget for everything between restamp and the asserted write — including a flush list+export leg that took ~2.08s under `-race` — so the wall clock overtook the restamp and `GREATEST` stamped wall time (`recreate stamped 1787725421723, want 1787725421646`). Not a data race, not a correctness bug: the write-path invariant (strictly above the tombstone) held; only the deterministic exact-version pin lost its precondition.

- `clockAheadLeadMs = 20s` keeps the GREATEST branch deterministically exercised on 2-core runners (nothing waits for the clock to catch up, so size costs no wall time).
- `requireExactStamp` distinguishes a real GREATEST regression from an exhausted lead budget in the failure message, so a nightly-filed issue reads correctly.

## Verification

- Full production suite `-tags=e2e -race`: **PASS, no data races**, 487s locally (podman) after the deflake; the pre-fix run reproduced the failure.
- Monotonic scenarios `-race -count=3`: PASS, twice (before and after the review round).
- `make lint`, `make fmt-check`, root-package guard tests, actionlint on the workflow: clean.
- Failure-issue script dry-run against a stub `gh`: federated create/comment bodies byte-identical to the previous inline step.

Refs #452 (Phase 1 carry-out), #434, #436, #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsmokCNqVJ9sYH5AtbqaXB