### PR TITLE
Fix DuckDB conn-init CI flake: per-step deadline, visible init warnings, extension cache (#487)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,23 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # DuckDB extension INSTALLs hit the network on a cold runner; a slow
+      # download can eat a connection-init step's 5s deadline, and the
+      # fail-open init then logs-and-skips that extension (#487). Restoring
+      # the local extension repository makes INSTALL a no-op on the hot path.
+      # go.sum pins the duckdb-go driver and thereby the DuckDB core version
+      # that names the extension directory; restore-keys lets a stale cache
+      # still serve, since INSTALL only re-downloads what the current version
+      # lacks. Every job that opens DuckDB connections carries this step
+      # (TestDuckDBExtensionCacheCoversExposedJobs guards that).
+      - name: Cache DuckDB extensions
+        uses: actions/cache@v4
+        with:
+          path: ~/.duckdb/extensions
+          key: duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Download dependencies
         run: go mod download
 
@@ -103,6 +120,15 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # See the test job's cache-step note (#487).
+      - name: Cache DuckDB extensions
+        uses: actions/cache@v4
+        with:
+          path: ~/.duckdb/extensions
+          key: duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Run E2E harness tests
         run: go test -v ./internal/e2e_harness/... -timeout=5m
 
@@ -124,6 +150,15 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      # See the test job's cache-step note (#487).
+      - name: Cache DuckDB extensions
+        uses: actions/cache@v4
+        with:
+          path: ~/.duckdb/extensions
+          key: duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -50,6 +50,15 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      # See ci.yml's test-job cache-step note (#487).
+      - name: Cache DuckDB extensions
+        uses: actions/cache@v4
+        with:
+          path: ~/.duckdb/extensions
+          key: duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Run full federated e2e suite (no -short)
         run: go test -v ./internal/e2e_harness/federated/... -tags=e2e -timeout=75m
 
@@ -81,6 +90,15 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      # See ci.yml's test-job cache-step note (#487).
+      - name: Cache DuckDB extensions
+        uses: actions/cache@v4
+        with:
+          path: ~/.duckdb/extensions
+          key: duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            duckdb-extensions-${{ runner.os }}-${{ runner.arch }}-
 
       # TestNightlyRacesProductionSuite guards this line. The 30m timeout is
       # the gate run's 10m (make test-e2e-production) times the ~2-3x race

--- a/duckdb_ext_cache_guard_test.go
+++ b/duckdb_ext_cache_guard_test.go
@@ -1,0 +1,86 @@
+package forma
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDuckDBExtensionCacheCoversExposedJobs pins the CI half of the #487 fix:
+// DuckDB extension INSTALLs download from the network, and on a cold runner a
+// slow download can eat a connection-init step's deadline — the fail-open
+// init then logs-and-skips that extension. Every workflow job that opens
+// DuckDB connections must therefore restore the local extension repository
+// (~/.duckdb/extensions) from the actions cache, keeping INSTALL a local
+// no-op on the hot path. Comment lines are skipped so prose never satisfies a
+// positive guard (#482/#485 hardening, same as the sibling ci.yml guards).
+func TestDuckDBExtensionCacheCoversExposedJobs(t *testing.T) {
+	for _, tc := range []struct {
+		workflow string
+		jobs     []string
+	}{
+		{".github/workflows/ci.yml", []string{"test", "e2e", "k6-smoke"}},
+		{".github/workflows/nightly-e2e.yml", []string{"federated-full", "production-race"}},
+	} {
+		wf, err := os.ReadFile(tc.workflow)
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.workflow, err)
+		}
+		for _, job := range tc.jobs {
+			block := workflowJobBlock(t, string(wf), job)
+			var hasCache, hasPath bool
+			for _, line := range strings.Split(block, "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "#") {
+					continue
+				}
+				if strings.HasPrefix(trimmed, "uses: actions/cache@") {
+					hasCache = true
+				}
+				if strings.Contains(trimmed, "~/.duckdb") {
+					hasPath = true
+				}
+			}
+			if !hasCache || !hasPath {
+				t.Errorf("%s job %q has no actions/cache step covering ~/.duckdb: a cold runner re-downloads DuckDB extensions inside the connection-init deadline again (#487)", tc.workflow, job)
+			}
+		}
+	}
+}
+
+// workflowJobBlock cuts one job's body out of a workflow file by indentation:
+// the block starts after the two-space `<job>:` key under the top-level
+// `jobs:` key and ends at the next non-blank line indented two spaces or less
+// (the next job, or a later top-level key). Deliberately not a YAML parser —
+// same rationale as ciLintJobBlock (#482), which delegates here. If the
+// workflow's job indentation ever changes shape, this fails loudly via
+// t.Fatal rather than passing on an empty block.
+func workflowJobBlock(t *testing.T, text, job string) string {
+	t.Helper()
+	lines := strings.Split(text, "\n")
+	inJobs := false
+	start := -1
+	for i, line := range lines {
+		if line == "jobs:" {
+			inJobs = true
+			continue
+		}
+		if !inJobs {
+			continue
+		}
+		if start == -1 {
+			if line == "  "+job+":" {
+				start = i + 1
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(line, "    ") {
+			return strings.Join(lines[start:i], "\n")
+		}
+	}
+	if start == -1 {
+		t.Fatalf("workflow has no `%s:` job under `jobs:`: this guard scopes its check to that job and has lost its target", job)
+	}
+	return strings.Join(lines[start:], "\n")
+}

--- a/internal/cdc/duckdb_exporter_init_test.go
+++ b/internal/cdc/duckdb_exporter_init_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lychee-technology/forma/internal/duckdbinit"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func newExporterInitTestConfig() CDCConfig {
@@ -28,7 +29,11 @@ func newExporterInitTestConfig() CDCConfig {
 func TestNewDuckExporter_FreshConnectionsConfigured(t *testing.T) {
 	t.Setenv("AWS_SESSION_TOKEN", "")
 	ctx := context.Background()
-	exp, err := NewDuckExporter(ctx, newExporterInitTestConfig(), "AKIDEXAMPLE", "testsecretvalue", "", zap.NewNop())
+	// zaptest, not zap.NewNop(): connection init is fail-open, so a degraded
+	// init (e.g. an INSTALL timing out) surfaces only as a logged warning —
+	// with a nop logger the failure output shows just the downstream NULL
+	// scan with zero trace of the real cause (#487).
+	exp, err := NewDuckExporter(ctx, newExporterInitTestConfig(), "AKIDEXAMPLE", "testsecretvalue", "", zaptest.NewLogger(t))
 	require.NoError(t, err)
 	defer exp.DB.Close()
 
@@ -48,7 +53,7 @@ func TestNewDuckExporter_FreshConnectionsConfigured(t *testing.T) {
 // The exporter pool must be bounded (#285: sql.Open default is unlimited).
 func TestNewDuckExporter_PoolBoundedToSingleConnection(t *testing.T) {
 	t.Setenv("AWS_SESSION_TOKEN", "")
-	exp, err := NewDuckExporter(context.Background(), newExporterInitTestConfig(), "AKIDEXAMPLE", "testsecretvalue", "", zap.NewNop())
+	exp, err := NewDuckExporter(context.Background(), newExporterInitTestConfig(), "AKIDEXAMPLE", "testsecretvalue", "", zaptest.NewLogger(t))
 	require.NoError(t, err)
 	defer exp.DB.Close()
 	require.Equal(t, 1, exp.DB.Stats().MaxOpenConnections)

--- a/internal/duckdbinit/duckdbinit.go
+++ b/internal/duckdbinit/duckdbinit.go
@@ -15,9 +15,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// DefaultInitTimeout bounds one hook run (all init statements of a single new
-// physical connection). It matches the 5s ping bound both constructors use,
-// and the pre-#285 exporter's construction-time init deadline.
+// DefaultInitTimeout bounds each init step of a new physical connection.
+// It matches the 5s ping bound both constructors use, and the pre-#285
+// exporter's construction-time init deadline. The bound is per step, not per
+// hook run: under one shared deadline a single slow INSTALL (a network
+// download on a cold cache) starved every later step, so the network-free
+// SET s3_* statements were skipped and connections opened with half their
+// session config silently missing (#487).
 const DefaultInitTimeout = 5 * time.Second
 
 // Stmt is a single statement executed on every new physical DuckDB connection.
@@ -67,28 +71,37 @@ func ValidateS3Credential(name, value string) error {
 // init never blocks the connection; construction-time errors are limited to
 // the credential validation done by the statement builders.
 //
-// Each hook run executes its statements under one shared initTimeout deadline:
-// driver cancellation rides on the context passed to ExecContext, so an
-// unbounded context would let a stalled INSTALL/LOAD block connection
-// establishment (and thereby constructors) indefinitely. A non-positive
-// initTimeout disables the bound.
-func MakeConnInit(steps []Step, log *zap.SugaredLogger, initTimeout time.Duration) func(driver.ExecerContext) error {
+// Each step runs under its own stepTimeout deadline: driver cancellation
+// rides on the context passed to ExecContext, so an unbounded context would
+// let a stalled INSTALL/LOAD block connection establishment (and thereby
+// constructors) indefinitely. The deadline is deliberately not shared across
+// steps — one slow INSTALL must degrade only its own step, never starve the
+// later, network-free SET statements into being skipped (#487). The hook run
+// stays bounded at len(steps) * stepTimeout. A non-positive stepTimeout
+// disables the bound.
+func MakeConnInit(steps []Step, log *zap.SugaredLogger, stepTimeout time.Duration) func(driver.ExecerContext) error {
 	return func(execer driver.ExecerContext) error {
-		ctx := context.Background()
-		if initTimeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, initTimeout)
-			defer cancel()
-		}
 		for _, step := range steps {
-			for _, s := range step.Stmts {
-				// Statements are literal SQL, no NamedValue args.
-				if _, err := execer.ExecContext(ctx, s.SQL, nil); err != nil {
-					log.Warnw("duckdb: connection init step failed", "step", s.Label, "err", err)
-					break
-				}
-			}
+			runStep(execer, step, log, stepTimeout)
 		}
 		return nil
+	}
+}
+
+// runStep executes one step's statements under a fresh stepTimeout deadline,
+// logging and skipping the step's remainder on the first failure.
+func runStep(execer driver.ExecerContext, step Step, log *zap.SugaredLogger, stepTimeout time.Duration) {
+	ctx := context.Background()
+	if stepTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, stepTimeout)
+		defer cancel()
+	}
+	for _, s := range step.Stmts {
+		// Statements are literal SQL, no NamedValue args.
+		if _, err := execer.ExecContext(ctx, s.SQL, nil); err != nil {
+			log.Warnw("duckdb: connection init step failed", "step", s.Label, "err", err)
+			return
+		}
 	}
 }

--- a/internal/duckdbinit/duckdbinit_test.go
+++ b/internal/duckdbinit/duckdbinit_test.go
@@ -92,9 +92,6 @@ type stepBudgetExecer struct {
 }
 
 func (e *stepBudgetExecer) ExecContext(ctx context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
-	if e.ctxErrs == nil {
-		e.ctxErrs = make(map[string]error)
-	}
 	e.ctxErrs[query] = ctx.Err()
 	if query == e.blockOn {
 		<-ctx.Done()
@@ -113,7 +110,7 @@ func TestMakeConnInit_SlowStepDoesNotStarveLaterSteps(t *testing.T) {
 		duckdbinit.ExtensionStep("httpfs"),
 		duckdbinit.SingleStmtStep("SET s3_region='us-test-1';", "set s3_region"),
 	}
-	execer := &stepBudgetExecer{blockOn: "INSTALL httpfs;"}
+	execer := &stepBudgetExecer{blockOn: "INSTALL httpfs;", ctxErrs: make(map[string]error)}
 	require.NoError(t, duckdbinit.MakeConnInit(steps, zap.NewNop().Sugar(), 50*time.Millisecond)(execer))
 
 	require.Contains(t, execer.ctxErrs, "SET s3_region='us-test-1';", "later steps must still run after a timed-out step")

--- a/internal/duckdbinit/duckdbinit_test.go
+++ b/internal/duckdbinit/duckdbinit_test.go
@@ -84,6 +84,44 @@ func TestMakeConnInit_BlockedStmtObservesCancellation(t *testing.T) {
 	require.Contains(t, execer.executed, "SET s3_region='us-test-1';", "later steps must still be attempted after a timed-out step")
 }
 
+// stepBudgetExecer blocks the statement matching blockOn until its context
+// expires and records the context error every statement observes on entry.
+type stepBudgetExecer struct {
+	blockOn string
+	ctxErrs map[string]error
+}
+
+func (e *stepBudgetExecer) ExecContext(ctx context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	if e.ctxErrs == nil {
+		e.ctxErrs = make(map[string]error)
+	}
+	e.ctxErrs[query] = ctx.Err()
+	if query == e.blockOn {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return driver.RowsAffected(0), nil
+}
+
+// Issue #487: a single slow INSTALL must not starve the steps after it. Under
+// one shared deadline, an INSTALL that eats the whole budget hands an
+// already-expired context to every later step — including the network-free
+// SET s3_* statements — so a slow extension download silently zeroes the S3
+// session config. Each step must get its own deadline instead.
+func TestMakeConnInit_SlowStepDoesNotStarveLaterSteps(t *testing.T) {
+	steps := []duckdbinit.Step{
+		duckdbinit.ExtensionStep("httpfs"),
+		duckdbinit.SingleStmtStep("SET s3_region='us-test-1';", "set s3_region"),
+	}
+	execer := &stepBudgetExecer{blockOn: "INSTALL httpfs;"}
+	require.NoError(t, duckdbinit.MakeConnInit(steps, zap.NewNop().Sugar(), 50*time.Millisecond)(execer))
+
+	require.Contains(t, execer.ctxErrs, "SET s3_region='us-test-1';", "later steps must still run after a timed-out step")
+	require.NoError(t, execer.ctxErrs["SET s3_region='us-test-1';"],
+		"a step after a timed-out step must run under its own live deadline, not the expired remnant of a shared one (#487)")
+	require.NotContains(t, execer.ctxErrs, "LOAD httpfs;", "a timed-out INSTALL must still skip its own LOAD")
+}
+
 func TestValidateS3Credential(t *testing.T) {
 	for _, bad := range []string{"a'b", `a"b`, "a;b", `a\b`, "a b"} {
 		require.Error(t, duckdbinit.ValidateS3Credential("s3_region", bad), "value %q must be rejected", bad)

--- a/internal/federated/duckdb_conn_init_test.go
+++ b/internal/federated/duckdb_conn_init_test.go
@@ -18,12 +18,23 @@ import (
 	"github.com/lychee-technology/forma/internal/duckdbinit"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
+
+// useTestGlobalLogger routes zap's globals into the test log for the test's
+// duration: NewDuckDBClientContext's connection init logs through zap.S(), and
+// init is fail-open — a degraded init (e.g. an INSTALL timing out) surfaces
+// only as a logged warning. Without this, a failure shows just the downstream
+// NULL-scan error with zero trace of the real cause (#487).
+func useTestGlobalLogger(t *testing.T) {
+	t.Cleanup(zap.ReplaceGlobals(zaptest.NewLogger(t)))
+}
 
 // The ping issued during construction opens (and thereby initializes) the first
 // pooled connection, so a freshly constructed client must already expose the S3
 // session settings and extensions on that connection.
 func TestNewDuckDBClientContext_FirstConnectionConfigured(t *testing.T) {
+	useTestGlobalLogger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -76,6 +87,7 @@ func newS3ConfiguredDuckDBConfig() forma.DuckDBConfig {
 // Issue #245: session-scoped SET statements (s3_region etc.) must reach every pooled
 // connection, not just the one that happened to serve the configuration calls.
 func TestNewDuckDBClientContext_AllConnectionsConfigured(t *testing.T) {
+	useTestGlobalLogger(t)
 	duck, err := NewDuckDBClient(newS3ConfiguredDuckDBConfig())
 	require.NoError(t, err)
 	defer duck.Close()
@@ -108,6 +120,7 @@ func TestNewDuckDBClientContext_AllConnectionsConfigured(t *testing.T) {
 // Issue #245: mirrors the real failure shape — concurrent federated queries spread
 // across the pool must all see the configured S3 session settings.
 func TestNewDuckDBClientContext_ConcurrentConnectionsConfigured(t *testing.T) {
+	useTestGlobalLogger(t)
 	duck, err := NewDuckDBClient(newS3ConfiguredDuckDBConfig())
 	require.NoError(t, err)
 	defer duck.Close()

--- a/toolchain_guard_test.go
+++ b/toolchain_guard_test.go
@@ -148,40 +148,12 @@ func TestCILintJobRunsMakeLint(t *testing.T) {
 	}
 }
 
-// ciLintJobBlock cuts the `lint:` job's body out of ci.yml by indentation: it
-// starts after the two-space `lint:` key under the top-level `jobs:` key and
-// ends at the next non-blank line indented two spaces or less (the next job,
-// or a later top-level key). Deliberately not a YAML parser — a yaml
-// dependency buys nothing here (#482 review round 1), and the sibling guards
-// in this file are plain text scans for the same reason. If the workflow's
-// job indentation ever changes shape, this fails loudly via t.Fatal rather
-// than passing on an empty block.
+// ciLintJobBlock cuts the `lint:` job's body out of ci.yml. The indentation
+// cut lives in workflowJobBlock (duckdb_ext_cache_guard_test.go), which is
+// deliberately not a YAML parser — a yaml dependency buys nothing here (#482
+// review round 1), and the sibling guards in this file are plain text scans
+// for the same reason.
 func ciLintJobBlock(t *testing.T, text string) string {
 	t.Helper()
-	lines := strings.Split(text, "\n")
-	inJobs := false
-	start := -1
-	for i, line := range lines {
-		if line == "jobs:" {
-			inJobs = true
-			continue
-		}
-		if !inJobs {
-			continue
-		}
-		if start == -1 {
-			if line == "  lint:" {
-				start = i + 1
-			}
-			continue
-		}
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" && !strings.HasPrefix(line, "    ") {
-			return strings.Join(lines[start:i], "\n")
-		}
-	}
-	if start == -1 {
-		t.Fatal("ci.yml has no `lint:` job under `jobs:`: this guard scopes its run-directive check to that job and has lost its target (#454)")
-	}
-	return strings.Join(lines[start:], "\n")
+	return workflowJobBlock(t, text, "lint")
 }


### PR DESCRIPTION
Closes #487.

Implements all three directions from the issue (decision record: [plan comment](https://github.com/Lychee-Technology/forma/issues/487#issuecomment-5422282324)).

## D1 — Per-step init deadline (`internal/duckdbinit`)

The mechanism fix. `MakeConnInit` previously ran every step of a hook run under one shared 5s context, so an INSTALL that ate the budget handed an already-expired context to every later step — including the network-free `SET s3_*` statements — and connections opened with half their session config silently missing. Each `Step` now gets its own `stepTimeout`-bounded context:

- Fail-open contract (#245/#285) unchanged: failed/timed-out statements are still logged and skipped; a failed INSTALL still skips its own LOAD; the connection still opens.
- Still bounded: worst case is `len(steps) × 5s` instead of 5s; only first-time INSTALLs ever approach the deadline, and D3 takes those off the network in CI.

TDD: `TestMakeConnInit_SlowStepDoesNotStarveLaterSteps` blocks an INSTALL until its deadline expires and asserts the later SET arrives with a live context — red under the shared deadline (fails with `context deadline exceeded` on the SET), green after.

## D2 — Degraded init is now visible in test output

The failing tests logged through `zap.NewNop()` (cdc) / an untouched `zap.S()` global (federated), so the `"duckdb: connection init step failed"` warning — the only trace of the real cause — was discarded. The connection-opening propagation tests now use `zaptest.NewLogger(t)` (cdc) and `zap.ReplaceGlobals` with `t.Cleanup` restore (federated, whose constructor logs via the global).

Rejected sub-direction from the issue: a strict fail-fast init mode — it would fork the fail-open contract into a second, test-only mode; with D1 a degraded step can no longer zero out later steps, and with D2 any residual degradation names itself.

## D3 — Cache DuckDB extensions on CI runners

`actions/cache` on `~/.duckdb/extensions` for every job that opens DuckDB connections: ci.yml `test`/`e2e`/`k6-smoke` and nightly-e2e.yml `federated-full`/`production-race`. Key: `duckdb-extensions-{os}-{arch}-{hashFiles(go.sum)}` (go.sum pins the duckdb-go driver and thereby the DuckDB core version that names the extension directory; the test job is arm64, the rest amd64), with a `restore-keys` prefix fallback — a stale cache still serves since INSTALL only re-downloads what the current version lacks.

New guard `TestDuckDBExtensionCacheCoversExposedJobs` pins that coverage in the established plain-text-scan style (comment lines skipped, #482/#485); `ciLintJobBlock` now delegates to the generalized `workflowJobBlock`.

## Verification

- `go test ./internal/duckdbinit ./internal/cdc ./internal/federated` and the root guard tests: pass (new test observed red first).
- `make fmt-check`, `make lint`: clean.
- Full `make test` via `scripts/test_with_container_runtime.sh`: all packages ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsmokCNqVJ9sYH5AtbqaXB
