### PR TITLE
fix(reconcile): refuse gc against a non-empty but foreign manifest (#481)

### DIFF
--- a/cmd/tools/manifest_reconcile.go
+++ b/cmd/tools/manifest_reconcile.go
@@ -130,7 +130,7 @@ func parseReconcileFlags(args []string) (*reconcileOptions, error) {
 	gc := fs.Bool("gc", false, "Delete base-shaped and _tmp orphans older than the grace period")
 	var allowEmptyManifest schemaIDList
 	fs.Var(&allowEmptyManifest, "allow-empty-manifest-schema",
-		"Schema ID whose EMPTY manifest is operator-confirmed legitimate: --gc then accepts zero manifest entries for that schema instead of refusing (#463). Repeatable / comma-separable; deliberately schema-explicit — there is no global override")
+		"Schema ID whose EMPTY manifest is operator-confirmed legitimate: --gc then accepts zero manifest entries for that schema instead of refusing (#463). Repeatable / comma-separable; deliberately schema-explicit — there is no global override. Does NOT waive a non-empty manifest with zero entries in the schema's data prefix (#481 foreign manifest): that signature always refuses")
 	verifyStamps := fs.Bool("verify-stamps", false, "Compare every listed entry's column stamp against the parquet footer (byte-truth check for the #256 stamp trust)")
 	verifyChecksums := fs.Bool("verify-checksums", false, "Re-hash every checksum-stamped object and compare with the manifest stamp (#347 byte-integrity scrub; one full GET per stamped entry)")
 	gcGrace := fs.Duration("gc-grace", 15*time.Minute, "Minimum object age before --gc may delete it")

--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -261,7 +261,7 @@ grace，后续运行就会删除它们）。
 P 调度时上界 ≈ grace + 2P。
 混用"带 --gc 与不带 --gc"的运行方式时，早先运行留下的目击记录可能在文件短暂重新列入清单期间未被清理，建议保持一致的 --repair --gc 运行方式以让目击清理正常工作。
 
-## `--gc` 的空 manifest 防护（#463）
+## `--gc` 的空/外来 manifest 防护（#463 / #481）
 
 `ResolverManifestStore.Load` 对解析不到的 manifest 采用 LoadOrCreate 语义（解析为空
 manifest）。因此当 `--manifest-prefix`/`--manifest-template` 指错位置而 `--data-prefix`
@@ -280,9 +280,24 @@ manifest，证明解析路径有效）；被**拒绝**的 init 晋升集合自 #
 刻意不提供全局开关：一次模板指错会同时清空所有 schema 的 manifest，全局放行恰好放过
 防护要拦的事故。
 
+#481 将防护从「manifest 条目数为 0」收紧为真正的不变量：**本轮加载的 manifest 没有任何
+条目落在该 schema 的数据前缀内**（in-prefix = 0）。因此固定文件模板（`--manifest-template`
+漏掉 `{{.SchemaID}}`）、跨 schema/跨环境指错、或条目全部指向另一个 bucket 的「非空但外来」
+manifest 同样被拒绝。拒绝信息同时引用原始条目数与 in-prefix 条目数（与报告的
+`M manifest entries resolved (K in schema prefix)` 一致），便于区分「manifest 为空」与
+「manifest 外来」。**外来签名不可用 `--allow-empty-manifest-schema` 放行**——它意味着模板
+或 bucket 配置错误，而非合法的空 manifest；修复方式是校正 `--manifest-prefix`/
+`--manifest-template`/`--s3-bucket` 使之与写入端一致。
+
+另外，`ResolverManifestStore.Load` 自 #481 起校验加载到的 manifest 的 `schema_id`：与请求
+schema 不一致时按工具故障失败（计入 schema Err，退出码 1，先于任何分类），固定文件模板
+在加载阶段即被拦截。`schema_id` 为 0（旧版 manifest 未落此字段）保持兼容、照常加载，
+仍由 in-prefix 防护兜底。
+
 排查手段：不带 `--repair`/`--gc` 的只读巡检即为 dry-run——报告对每个 schema 打印
-`inventory: N objects in storage, M manifest entries resolved; orphan candidates: ...`，
-「N 个对象、0 条 manifest 条目」即模板指错的典型签名。
+`inventory: N objects in storage, M manifest entries resolved (K in schema prefix); orphan candidates: ...`，
+「N 个对象、0 条 manifest 条目」即模板指错的典型签名；「M > 0 而 in-prefix 为 0」则是
+#481 的外来 manifest 签名。
 
 ## `--verify-stamps`：#256 戳记的离线字节真值核查
 
@@ -432,6 +447,7 @@ forma-tools manifest-reconcile ... --verify-stamps
 forma-tools manifest-reconcile ... --verify-checksums
 
 # 确认某 schema 的 manifest 确实为空后，逐 schema 放行 #463 空 manifest 防护
+# （只放行「条目为 0」的空签名；#481 非空外来 manifest 不可放行，需修正模板/bucket 配置）
 forma-tools manifest-reconcile ... --gc --allow-empty-manifest-schema 7
 # 多个 schema：重复旗标或逗号分隔（等价写法）
 forma-tools manifest-reconcile ... --gc --allow-empty-manifest-schema 7,9 --allow-empty-manifest-schema 11

--- a/internal/reconcile/classify.go
+++ b/internal/reconcile/classify.go
@@ -115,11 +115,14 @@ type diffResult struct {
 	dangling          []string
 	unverifiable      []string
 	// objectsSeen counts the classified parquet objects under the schema
-	// prefix; manifestEntries counts the manifest's file entries as loaded.
-	// Both feed the per-schema inventory report and the #463 empty-manifest
-	// GC guard, which must quote the same numbers the report prints.
-	objectsSeen     int
-	manifestEntries int
+	// prefix; manifestEntries counts the manifest's file entries as loaded,
+	// and manifestEntriesInPrefix the subset that normalizes into this
+	// schema's data prefix — the entries this run can actually verify
+	// against the listing. All feed the per-schema inventory report and the
+	// #463/#481 GC guard, which must quote the numbers the report prints.
+	objectsSeen             int
+	manifestEntries         int
+	manifestEntriesInPrefix int
 }
 
 // diffSchema computes the two-way diff for one schema: objects absent from
@@ -176,6 +179,7 @@ func diffSchema(bucket, dataPrefix string, schemaID int16, objects []ObjectInfo,
 			d.unverifiable = append(d.unverifiable, f.Path)
 			continue
 		}
+		d.manifestEntriesInPrefix++
 		if _, live := listedKeys[key]; !live {
 			d.dangling = append(d.dangling, key)
 		}

--- a/internal/reconcile/classify_test.go
+++ b/internal/reconcile/classify_test.go
@@ -168,6 +168,23 @@ func TestClassifyObjectKey_RequiresUUIDShapes(t *testing.T) {
 	}
 }
 
+func TestDiffSchema_CountsInPrefixManifestEntries(t *testing.T) {
+	m := &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: "data/7/" + uuidA + ".parquet"},              // in prefix, relative
+		{Tier: "base", Path: "s3://bkt/data/7/base-" + uuidB + ".parquet"}, // in prefix, same-bucket URI
+		{Tier: "delta", Path: "data/8/" + uuidC + ".parquet"},              // out of prefix (another schema)
+		{Tier: "delta", Path: "s3://other/data/7/" + uuidA + ".parquet"},   // foreign bucket: unverifiable
+		{Tier: "delta", Path: "data/7/*.parquet"},                          // glob: unverifiable
+	}}
+	d := diffSchema("bkt", "data", 7, nil, m)
+	if d.manifestEntries != 5 {
+		t.Fatalf("manifestEntries = %d, want 5", d.manifestEntries)
+	}
+	if d.manifestEntriesInPrefix != 2 {
+		t.Fatalf("manifestEntriesInPrefix = %d, want 2", d.manifestEntriesInPrefix)
+	}
+}
+
 func objectKeys(objs []ObjectInfo) []string {
 	keys := make([]string, 0, len(objs))
 	for _, o := range objs {

--- a/internal/reconcile/empty_manifest_guard_test.go
+++ b/internal/reconcile/empty_manifest_guard_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/lychee-technology/forma/internal/manifest"
 )
@@ -183,6 +184,50 @@ func TestGC_ManifestWithInPrefixEntries_GuardDoesNotFire(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, report.Schemas[0].Err)
 	require.Equal(t, []string{merged}, deleter.deleted)
+}
+
+func TestGC_FixedFileTemplate_ForeignManifest_FailsInsteadOfDeleting(t *testing.T) {
+	// #481 acceptance regression: a fixed-file --manifest-template (no
+	// {{.SchemaID}}) resolving to an EXISTING foreign manifest, with
+	// --data-prefix still matching the writers', must fail --gc — through
+	// the real resolver store, not a fake.
+	ctx := context.Background()
+	mem := newMemManifestStore()
+	resolver := &ResolverManifestStore{
+		Store:    mem,
+		Resolver: manifest.PathResolver{PathTemplate: "manifest/data.json"},
+	}
+	m7, etag, err := resolver.Load(ctx, 7)
+	require.NoError(t, err)
+	m7.Files = append(m7.Files, manifest.FileEntry{Tier: "delta", Path: "data/7/" + uuidC + ".parquet"})
+	_, err = resolver.Save(ctx, 7, m7, etag)
+	require.NoError(t, err)
+
+	old := testClock().Add(-24 * time.Hour)
+	merged9 := "data/9/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/9/": {{Key: merged9, LastModified: old}},
+	}}
+	deleter := &fakeDeleter{}
+	r := &Reconciler{
+		Lister:     lister,
+		Deleter:    deleter,
+		Manifests:  resolver,
+		Locker:     &fakeLocker{},
+		Schemas:    &fakeEnum{ids: []int16{9}},
+		GCStates:   newFakeGCState(),
+		Now:        testClock,
+		Bucket:     "bkt",
+		DataPrefix: "data",
+		Logger:     zap.NewNop(),
+		Opts:       Options{GC: true, GCGrace: 15 * time.Minute},
+	}
+	seedGCSighting(t, r, 9, old, merged9)
+
+	report, err := r.Run(ctx)
+	require.NoError(t, err)
+	require.Error(t, report.Schemas[0].Err, "schema 9 must fail, not delete its base tier")
+	require.Empty(t, deleter.deleted)
 }
 
 func TestGC_NonEmptyManifest_GuardDoesNotFire(t *testing.T) {

--- a/internal/reconcile/empty_manifest_guard_test.go
+++ b/internal/reconcile/empty_manifest_guard_test.go
@@ -132,7 +132,7 @@ func TestGC_ForeignManifestWithBaseObjects_RefusesInsteadOfDeleting(t *testing.T
 	require.Error(t, s.Err, "live base objects against a foreign manifest must fail the schema")
 	require.Contains(t, s.Err.Error(), "2 manifest entries", "refusal must quote the raw count")
 	require.Contains(t, s.Err.Error(), "0 in-prefix", "refusal must quote the in-prefix count")
-	require.NotContains(t, s.Err.Error(), "--allow-empty-manifest-schema 7",
+	require.NotContains(t, s.Err.Error(), "re-run with --allow-empty-manifest-schema",
 		"a foreign manifest must not advertise the empty-manifest waiver")
 	require.Empty(t, deleter.deleted)
 	require.Empty(t, s.Deleted)

--- a/internal/reconcile/empty_manifest_guard_test.go
+++ b/internal/reconcile/empty_manifest_guard_test.go
@@ -97,6 +97,94 @@ func TestGC_EmptyManifestTmpOnly_GuardDoesNotFire(t *testing.T) {
 	require.Equal(t, []string{tmpKey}, deleter.deleted)
 }
 
+// #481: a NON-EMPTY manifest that accounts for none of this schema's data —
+// a fixed-file --manifest-template, a cross-schema/cross-tier mispointing,
+// or entries all in a foreign bucket — reaches the same irreversible outcome
+// #463 closed off, because the raw entry count waived the guard. The guard
+// must key on the in-prefix count, and the foreign signature is never
+// waivable: it indicates a wrong template, not a legitimately empty manifest.
+
+func TestGC_ForeignManifestWithBaseObjects_RefusesInsteadOfDeleting(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour)
+	initShaped := "data/7/" + uuidA + "_" + uuidB + ".parquet"
+	merged := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: initShaped, LastModified: old},
+			{Key: merged, LastModified: old},
+		},
+	}}
+	deleter := &fakeDeleter{}
+	// Fixed-file template resolved schema 7 to another schema's manifest:
+	// non-empty, but every entry lies outside data/7/.
+	foreign := &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: "data/9/" + uuidC + ".parquet"},
+		{Tier: "base", Path: "s3://other/data/7/base-" + uuidB + ".parquet"},
+	}}
+	r := newTestReconciler(lister, newFakeManifests(foreign), deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Opts = Options{GC: true, GCGrace: 15 * time.Minute}
+	seedGCSighting(t, r, 7, old, initShaped, merged)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	s := report.Schemas[0]
+	require.Error(t, s.Err, "live base objects against a foreign manifest must fail the schema")
+	require.Contains(t, s.Err.Error(), "2 manifest entries", "refusal must quote the raw count")
+	require.Contains(t, s.Err.Error(), "0 in-prefix", "refusal must quote the in-prefix count")
+	require.NotContains(t, s.Err.Error(), "--allow-empty-manifest-schema 7",
+		"a foreign manifest must not advertise the empty-manifest waiver")
+	require.Empty(t, deleter.deleted)
+	require.Empty(t, s.Deleted)
+}
+
+func TestGC_ForeignManifest_EmptyWaiverDoesNotApply(t *testing.T) {
+	old := testClock().Add(-24 * time.Hour)
+	merged := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {{Key: merged, LastModified: old}},
+	}}
+	deleter := &fakeDeleter{}
+	foreign := &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: "data/9/" + uuidC + ".parquet"},
+	}}
+	r := newTestReconciler(lister, newFakeManifests(foreign), deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Opts = Options{GC: true, GCGrace: 15 * time.Minute, AllowEmptyManifestSchemas: []int16{7}}
+	seedGCSighting(t, r, 7, old, merged)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.Error(t, report.Schemas[0].Err,
+		"--allow-empty-manifest-schema waives EMPTY manifests only, never a non-empty foreign one")
+	require.Empty(t, deleter.deleted)
+}
+
+func TestGC_ManifestWithInPrefixEntries_GuardDoesNotFire(t *testing.T) {
+	// One in-prefix entry proves resolution reached this schema's manifest;
+	// leftover GC proceeds even if other entries are foreign.
+	old := testClock().Add(-24 * time.Hour)
+	listedDelta := "data/7/" + uuidC + ".parquet"
+	merged := "data/7/base-" + uuidA + ".parquet"
+	lister := &fakeLister{objects: map[string][]ObjectInfo{
+		"data/7/": {
+			{Key: listedDelta, LastModified: old},
+			{Key: merged, LastModified: old},
+		},
+	}}
+	deleter := &fakeDeleter{}
+	m := &manifest.Manifest{SchemaID: 7, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: listedDelta},
+		{Tier: "delta", Path: "s3://other/data/7/" + uuidB + ".parquet"},
+	}}
+	r := newTestReconciler(lister, newFakeManifests(m), deleter, &fakeLocker{}, &fakeEnum{ids: []int16{7}})
+	r.Opts = Options{GC: true, GCGrace: 15 * time.Minute}
+	seedGCSighting(t, r, 7, old, merged)
+
+	report, err := r.Run(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, report.Schemas[0].Err)
+	require.Equal(t, []string{merged}, deleter.deleted)
+}
+
 func TestGC_NonEmptyManifest_GuardDoesNotFire(t *testing.T) {
 	old := testClock().Add(-24 * time.Hour)
 	listedDelta := "data/7/" + uuidC + ".parquet"

--- a/internal/reconcile/gc.go
+++ b/internal/reconcile/gc.go
@@ -36,7 +36,7 @@ func (r *Reconciler) refuseEmptyManifestGC(schemaID int16, d diffResult, promote
 		return nil
 	}
 	if d.manifestEntries > 0 {
-		return fmt.Errorf("gc refused for schema %d: %d base object(s) live in storage (init=%d merged=%d, %d objects seen) but none of the %d manifest entries resolved lie inside this schema's data prefix (0 in-prefix) — the loaded manifest is foreign to this schema (fixed-file or cross-schema --manifest-template, or entries pointing at another bucket), not a record of its data; verify --manifest-prefix/--manifest-template and --s3-bucket against the writers' configuration (--allow-empty-manifest-schema only waives genuinely EMPTY manifests, never a foreign one)",
+		return fmt.Errorf("gc refused for schema %d: %d base object(s) live in storage (init=%d merged=%d, %d objects seen) but none of the %d manifest entries resolved lie inside this schema's data prefix (0 in-prefix) — the loaded manifest is foreign to this schema (fixed-file or cross-schema --manifest-template, entries pointing at another bucket, or unverifiable glob entries), not a verifiable record of its data; verify --manifest-prefix/--manifest-template and --s3-bucket against the writers' configuration (--allow-empty-manifest-schema only waives genuinely EMPTY manifests, never a foreign one)",
 			schemaID, baseObjects, len(d.baseInitOrphans), len(d.baseMergedOrphans), d.objectsSeen, d.manifestEntries)
 	}
 	for _, id := range r.Opts.AllowEmptyManifestSchemas {

--- a/internal/reconcile/gc.go
+++ b/internal/reconcile/gc.go
@@ -9,21 +9,35 @@ import (
 	"go.uber.org/zap"
 )
 
-// refuseEmptyManifestGC is the #463 guard: a schema with at least one live
-// base-tier object and ZERO manifest entries is far more likely a
-// manifest-resolution failure (a mis-pointed --manifest-prefix/
-// --manifest-template while --data-prefix still matches; the resolver's
-// LoadOrCreate semantics turn that into an empty manifest) than genuine
-// mass orphaning — proceeding would classify the whole base tier as
-// orphaned and, past the grace, delete it irreversibly. GC therefore fails
-// the schema instead. A successful init promotion this run clears the
-// guard (it just published this schema's manifest, proving resolution
-// works), and an operator who has confirmed a schema's manifest is
-// genuinely empty can waive it per schema via --allow-empty-manifest-schema.
+// refuseEmptyManifestGC is the #463/#481 guard: a schema with at least one
+// live base-tier object whose loaded manifest accounts for NONE of this
+// schema's data — zero entries normalize into its data prefix — is far more
+// likely a manifest-resolution failure than genuine mass orphaning;
+// proceeding would classify the whole base tier as orphaned and, past the
+// grace, delete it irreversibly. GC therefore fails the schema instead.
+// Two signatures share that invariant:
+//
+//   - #463: the manifest resolved EMPTY (a mis-pointed --manifest-prefix/
+//     --manifest-template turned into an empty manifest by the resolver's
+//     LoadOrCreate semantics). An operator who has confirmed the schema's
+//     manifest is genuinely empty can waive this per schema via
+//     --allow-empty-manifest-schema.
+//   - #481: the manifest is NON-EMPTY but foreign — a fixed-file template
+//     (no {{.SchemaID}}), a cross-schema/cross-tier mispointing, or entries
+//     all in a foreign bucket. Never waivable: entries exist but none
+//     describe this schema's data, which indicates a wrong template or
+//     bucket, not a legitimately empty manifest.
+//
+// A successful init promotion this run clears the guard (it just published
+// this schema's manifest, proving resolution works).
 func (r *Reconciler) refuseEmptyManifestGC(schemaID int16, d diffResult, promotedInit bool) error {
 	baseObjects := len(d.baseInitOrphans) + len(d.baseMergedOrphans)
-	if d.manifestEntries > 0 || baseObjects == 0 || promotedInit {
+	if d.manifestEntriesInPrefix > 0 || baseObjects == 0 || promotedInit {
 		return nil
+	}
+	if d.manifestEntries > 0 {
+		return fmt.Errorf("gc refused for schema %d: %d base object(s) live in storage (init=%d merged=%d, %d objects seen) but none of the %d manifest entries resolved lie inside this schema's data prefix (0 in-prefix) — the loaded manifest is foreign to this schema (fixed-file or cross-schema --manifest-template, or entries pointing at another bucket), not a record of its data; verify --manifest-prefix/--manifest-template and --s3-bucket against the writers' configuration (--allow-empty-manifest-schema only waives genuinely EMPTY manifests, never a foreign one)",
+			schemaID, baseObjects, len(d.baseInitOrphans), len(d.baseMergedOrphans), d.objectsSeen, d.manifestEntries)
 	}
 	for _, id := range r.Opts.AllowEmptyManifestSchemas {
 		if id == schemaID {

--- a/internal/reconcile/manifests.go
+++ b/internal/reconcile/manifests.go
@@ -12,7 +12,8 @@ import (
 // does not exist yet reconciles as empty instead of erroring (the
 // compaction ManifestProvider errors on a missing manifest, which is wrong
 // for reconciliation: an empty manifest with live objects is exactly the
-// all-orphans case the tool must report).
+// all-orphans case the tool must report). Load also rejects a manifest
+// whose stored SchemaID names a different schema (#481).
 type ResolverManifestStore struct {
 	Store    manifest.Store
 	Resolver manifest.PathResolver
@@ -26,6 +27,15 @@ func (s *ResolverManifestStore) Load(ctx context.Context, schemaID int16) (*mani
 	m, etag, err := manifest.LoadOrCreate(ctx, s.Store, path, schemaID)
 	if err != nil {
 		return nil, "", fmt.Errorf("load manifest %s: %w", path, err)
+	}
+	// #481: a loaded manifest claiming a different schema is a mis-pointed
+	// template (e.g. a fixed-file --manifest-template without
+	// {{.SchemaID}}) — fail the schema before any classification rather
+	// than diff its data against a foreign manifest. SchemaID 0 is
+	// tolerated: manifests written before the field was stamped unmarshal
+	// to 0, and the #481 in-prefix GC guard still covers them.
+	if m.SchemaID != 0 && m.SchemaID != schemaID {
+		return nil, "", fmt.Errorf("manifest %s claims schema %d, not requested schema %d — mis-pointed --manifest-prefix/--manifest-template (fixed-file or cross-schema)", path, m.SchemaID, schemaID)
 	}
 	return m, etag, nil
 }

--- a/internal/reconcile/manifests_test.go
+++ b/internal/reconcile/manifests_test.go
@@ -50,6 +50,44 @@ func TestResolverManifestStore_MissingManifestLoadsEmpty(t *testing.T) {
 	require.Empty(t, etag)
 }
 
+func TestResolverManifestStore_SchemaIDMismatchFails(t *testing.T) {
+	// #481: a fixed-file --manifest-template (no {{.SchemaID}}) resolves
+	// every schema to the same manifest. Loading it for the wrong schema
+	// must fail the schema as a tool error before any classification.
+	mem := newMemManifestStore()
+	store := &ResolverManifestStore{
+		Store:    mem,
+		Resolver: manifest.PathResolver{PathTemplate: "manifest/data.json"},
+	}
+	ctx := context.Background()
+
+	m, etag, err := store.Load(ctx, 7)
+	require.NoError(t, err)
+	m.Files = append(m.Files, manifest.FileEntry{Tier: "delta", Path: "data/7/a.parquet"})
+	_, err = store.Save(ctx, 7, m, etag)
+	require.NoError(t, err)
+
+	_, _, err = store.Load(ctx, 9)
+	require.Error(t, err, "schema 9 must not load schema 7's manifest")
+	require.Contains(t, err.Error(), "schema 7")
+	require.Contains(t, err.Error(), "schema 9")
+}
+
+func TestResolverManifestStore_LegacyZeroSchemaIDLoads(t *testing.T) {
+	// Manifests written before schema_id was stamped unmarshal to 0; they
+	// must keep loading (the in-prefix guard still covers them for --gc).
+	mem := newMemManifestStore()
+	mem.data["manifest/7.json"] = []byte(`{"files":[{"tier":"delta","path":"data/7/a.parquet"}]}`)
+	mem.etags["manifest/7.json"] = "v0"
+	store := &ResolverManifestStore{
+		Store:    mem,
+		Resolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
+	}
+	m, _, err := store.Load(context.Background(), 7)
+	require.NoError(t, err)
+	require.Len(t, m.Files, 1)
+}
+
 func TestResolverManifestStore_SaveRoundTrip(t *testing.T) {
 	store := &ResolverManifestStore{
 		Store:    newMemManifestStore(),

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -87,7 +87,9 @@ type Options struct {
 	// exactly these schemas. Schema-explicit by design: one mis-pointed
 	// manifest template resolves EVERY schema's manifest empty, so a global
 	// override would wave the whole fleet through the very failure the
-	// guard exists to stop.
+	// guard exists to stop. It waives only the truly-empty signature: a
+	// NON-EMPTY manifest with zero in-prefix entries (#481 foreign
+	// manifest) is never waivable.
 	AllowEmptyManifestSchemas []int16
 }
 

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -160,7 +160,7 @@ func (r *Reconciler) reconcileSchema(ctx context.Context, schemaID int16) Schema
 	}
 
 	d := diffSchema(r.Bucket, r.DataPrefix, schemaID, objects, m)
-	s.ObjectsSeen, s.ManifestEntries = d.objectsSeen, d.manifestEntries
+	s.ObjectsSeen, s.ManifestEntries, s.ManifestEntriesInPrefix = d.objectsSeen, d.manifestEntries, d.manifestEntriesInPrefix
 	s.DeltaOrphans = objectKeyList(d.deltaOrphans)
 	s.BaseOrphans = append(objectKeyList(d.baseInitOrphans), objectKeyList(d.baseMergedOrphans)...)
 	s.TmpOrphans = objectKeyList(d.tmpOrphans)

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -30,7 +30,7 @@ type SchemaReport struct {
 	// against raw>0/in-prefix=0 is the foreign-manifest signature --gc
 	// refuses.
 	ManifestEntriesInPrefix int
-	Repaired        []string // delta orphans appended to the manifest (--repair)
+	Repaired                []string // delta orphans appended to the manifest (--repair)
 	// DeltaLeftovers are delta orphans the repair guard classified as
 	// compaction leftovers (no uncovered rows, or every uncovered row
 	// deleted in Postgres): never appended, GC-eligible under --gc.

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -24,6 +24,12 @@ type SchemaReport struct {
 	// against 0 entries is the mis-pointed-template signature --gc refuses.
 	ObjectsSeen     int
 	ManifestEntries int
+	// ManifestEntriesInPrefix counts the loaded entries that normalize into
+	// this schema's data prefix (#481) — the raw/in-prefix pair
+	// distinguishes "manifest empty" from "manifest foreign": N objects
+	// against raw>0/in-prefix=0 is the foreign-manifest signature --gc
+	// refuses.
+	ManifestEntriesInPrefix int
 	Repaired        []string // delta orphans appended to the manifest (--repair)
 	// DeltaLeftovers are delta orphans the repair guard classified as
 	// compaction leftovers (no uncovered rows, or every uncovered row
@@ -128,8 +134,8 @@ func (r Report) Render(w io.Writer) {
 			continue
 		}
 		fmt.Fprintf(w, "schema %d:\n", s.SchemaID)
-		fmt.Fprintf(w, "  inventory: %d objects in storage, %d manifest entries resolved; orphan candidates: delta=%d base=%d tmp=%d unknown=%d\n",
-			s.ObjectsSeen, s.ManifestEntries, len(s.DeltaOrphans), len(s.BaseOrphans), len(s.TmpOrphans), len(s.Unknown))
+		fmt.Fprintf(w, "  inventory: %d objects in storage, %d manifest entries resolved (%d in schema prefix); orphan candidates: delta=%d base=%d tmp=%d unknown=%d\n",
+			s.ObjectsSeen, s.ManifestEntries, s.ManifestEntriesInPrefix, len(s.DeltaOrphans), len(s.BaseOrphans), len(s.TmpOrphans), len(s.Unknown))
 		renderKeys(w, "delta orphan", s.DeltaOrphans)
 		renderKeys(w, "delta leftover (gc-eligible)", s.DeltaLeftovers)
 		renderKeys(w, "base orphan", s.BaseOrphans)

--- a/internal/reconcile/report_test.go
+++ b/internal/reconcile/report_test.go
@@ -87,21 +87,23 @@ func TestReport_RenderNamesExactKeys(t *testing.T) {
 }
 
 func TestRender_InventoryCounts(t *testing.T) {
-	// #463: the report quotes per-schema inventory — objects seen in
-	// storage, manifest entries resolved, candidates by class — so an
-	// operator can spot the "N objects, 0 entries" resolution-failure
-	// signature before any --gc, and the guard's refusal quotes the same
-	// numbers.
+	// #463/#481: the report quotes per-schema inventory — objects seen in
+	// storage, manifest entries resolved (raw and in-prefix), candidates by
+	// class — so an operator can spot both the "N objects, 0 entries"
+	// resolution-failure signature and the "raw>0, in-prefix 0" foreign-
+	// manifest signature before any --gc, and the guard's refusal quotes
+	// the same numbers.
 	var buf bytes.Buffer
 	Report{Schemas: []SchemaReport{{
-		SchemaID:        7,
-		ObjectsSeen:     5,
-		ManifestEntries: 0,
-		BaseOrphans:     []string{"data/7/base-b.parquet"},
-		TmpOrphans:      []string{"data/7/_tmp/c.parquet"},
+		SchemaID:                7,
+		ObjectsSeen:             5,
+		ManifestEntries:         3,
+		ManifestEntriesInPrefix: 0,
+		BaseOrphans:             []string{"data/7/base-b.parquet"},
+		TmpOrphans:              []string{"data/7/_tmp/c.parquet"},
 	}}}.Render(&buf)
 	out := buf.String()
-	if !strings.Contains(out, "inventory: 5 objects in storage, 0 manifest entries resolved") {
+	if !strings.Contains(out, "inventory: 5 objects in storage, 3 manifest entries resolved (0 in schema prefix)") {
 		t.Fatalf("missing inventory line in:\n%s", out)
 	}
 	if !strings.Contains(out, "orphan candidates: delta=0 base=1 tmp=1 unknown=0") {


### PR DESCRIPTION
Closes #481.

The #463 guard (PR #480) keyed on the **raw** loaded manifest entry count, so a non-empty but **foreign** manifest — a fixed-file `--manifest-template` without `{{.SchemaID}}`, a cross-schema/cross-tier mispointing, or entries all in another bucket — waived the guard and let a cron `--gc` irreversibly delete a schema's entire base tier. This implements **both** complementary options from the issue.

## Changes

1. **In-prefix guard (option 1).** `diffSchema` now counts the manifest entries that normalize into the schema's data prefix (`manifestEntriesInPrefix` — exactly the complement of the existing `unverifiable` classification). `refuseEmptyManifestGC` keys on that count instead of `len(m.Files)`:
   - raw = 0 → the #463 empty signature, message and `--allow-empty-manifest-schema` waiver unchanged;
   - raw > 0, in-prefix = 0 → the #481 foreign signature: refused with a message quoting **both** counts, and **never waivable** — the flag only waives genuinely empty manifests (a foreign manifest indicates a wrong template/bucket, not a legitimately empty manifest).
2. **Schema-ID validation at load (option 2).** `ResolverManifestStore.Load` fails when the loaded manifest's `SchemaID` names a different schema (→ `SchemaReport.Err`, exit 1, before any classification), catching the fixed-file template directly at load. `SchemaID == 0` is tolerated as legacy/unset (mirrors `query_source.go`), with the in-prefix guard as backstop.
3. **Report.** The inventory line becomes `… M manifest entries resolved (K in schema prefix) …`, so the refusal quotes exactly what the report prints (preserving the #463 property); dry-run signature for the foreign case is "M > 0, in-prefix 0".
4. Flag help text and `docs/manifest-reconcile.md` updated (section retitled 空/外来 manifest 防护 #463/#481).

## Ruling on the issue's open points

- `--allow-empty-manifest-schema` does **not** waive the foreign signature — enforced structurally (the foreign branch returns before the waiver loop).
- The issue's caveat case (healthy manifest whose entries are all foreign-bucket `s3://` URIs) now refuses under `--gc`: the run cannot verify anything it is about to delete against that manifest; the fix is running reconcile with the writers' `--s3-bucket`.

## Acceptance criteria

- [x] `--gc` refuses on ≥1 live base/merged object with zero in-prefix entries regardless of raw count; refusal quotes raw + in-prefix counts (`TestGC_ForeignManifestWithBaseObjects_RefusesInsteadOfDeleting`).
- [x] SchemaID mismatch fails the schema as a tool error before classification (`TestResolverManifestStore_SchemaIDMismatchFails`, legacy-0 tolerance covered by `TestResolverManifestStore_LegacyZeroSchemaIDLoads`).
- [x] Regression: fixed-file `--manifest-template` resolving to an existing foreign manifest with matching `--data-prefix` fails `--gc` through the real resolver store (`TestGC_FixedFileTemplate_ForeignManifest_FailsInsteadOfDeleting`).
- [x] Waiver semantics ruled and tested (`TestGC_ForeignManifest_EmptyWaiverDoesNotApply`); one in-prefix entry keeps normal GC (`TestGC_ManifestWithInPrefixEntries_GuardDoesNotFire`); all four pre-existing #463 guard tests unchanged and passing.

Full suite green via `scripts/test_with_container_runtime.sh`; `go vet` + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsmokCNqVJ9sYH5AtbqaXB
