### PR TITLE
security(compaction): route operator-configured read_parquet paths through sqlutil.EscapeLiteral (#478)

### DIFF
--- a/internal/compaction/merge_sql.go
+++ b/internal/compaction/merge_sql.go
@@ -3,6 +3,8 @@ package compaction
 import (
 	"fmt"
 	"strings"
+
+	"github.com/lychee-technology/forma/internal/sqlutil"
 )
 
 // mergeLWWOrderBy mirrors the federated read path's version fold EXACTLY
@@ -28,7 +30,10 @@ const defaultMergeCopyOptions = "FORMAT PARQUET, PARQUET_VERSION V2, COMPRESSION
 
 // validateMergeURI rejects URIs that cannot be embedded in a single-quoted
 // DuckDB literal. Production keys are prefix/schemaID/uuid-ish and never
-// carry quotes; this guards against SQL breakage, not hostile input.
+// carry quotes; this guards against SQL breakage, not hostile input. The
+// render sites additionally wrap every URI in sqlutil.EscapeLiteral (#478)
+// as defense-in-depth, so escaping is an identity transform on anything
+// this validator admits; the validator stays as the operator-facing error.
 func validateMergeURI(uri string) error {
 	if uri == "" {
 		return fmt.Errorf("empty parquet URI")
@@ -59,7 +64,7 @@ func buildMergeSQL(sourceURIs []string, tmpURI, copyOptions string) (string, err
 		if err := validateMergeURI(uri); err != nil {
 			return "", fmt.Errorf("merge source: %w", err)
 		}
-		quoted = append(quoted, "'"+uri+"'")
+		quoted = append(quoted, fmt.Sprintf("'%s'", sqlutil.EscapeLiteral(uri)))
 	}
 	if copyOptions == "" {
 		copyOptions = defaultMergeCopyOptions
@@ -75,7 +80,7 @@ func buildMergeSQL(sourceURIs []string, tmpURI, copyOptions string) (string, err
     FROM read_parquet([%s], union_by_name=true)
   )
   WHERE _rn = 1 AND (deleted_at IS NULL OR deleted_at = 0)
-) TO '%s' (%s)`, mergeLWWOrderBy, strings.Join(quoted, ", "), tmpURI, copyOptions), nil
+) TO '%s' (%s)`, mergeLWWOrderBy, strings.Join(quoted, ", "), sqlutil.EscapeLiteral(tmpURI), copyOptions), nil
 }
 
 // buildMergeRowsInSQL counts the raw version rows across the source files
@@ -89,7 +94,7 @@ func buildMergeRowsInSQL(sourceURIs []string) (string, error) {
 		if err := validateMergeURI(uri); err != nil {
 			return "", fmt.Errorf("rows-in source: %w", err)
 		}
-		quoted = append(quoted, "'"+uri+"'")
+		quoted = append(quoted, fmt.Sprintf("'%s'", sqlutil.EscapeLiteral(uri)))
 	}
 	return fmt.Sprintf("SELECT COUNT(*) FROM read_parquet([%s], union_by_name=true)", strings.Join(quoted, ", ")), nil
 }
@@ -109,5 +114,5 @@ func buildMergeStatsSQL(tmpURI string) (string, error) {
        COALESCE(MAX(CAST(row_id AS VARCHAR)), ''),
        COALESCE(MIN(changed_at), 0),
        COALESCE(MAX(changed_at), 0)
-FROM read_parquet('%s')`, tmpURI), nil
+FROM read_parquet('%s')`, sqlutil.EscapeLiteral(tmpURI)), nil
 }

--- a/internal/compaction/uncovered_rows.go
+++ b/internal/compaction/uncovered_rows.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/lychee-technology/forma/internal/sqlutil"
 )
 
 // UncoveredRow is one row_id in an orphan parquet whose newest uncovered
@@ -38,7 +40,7 @@ func UncoveredRows(ctx context.Context, db *sql.DB, orphanURI string, listedURIs
 			if err := validateMergeURI(uri); err != nil {
 				return nil, fmt.Errorf("uncovered-rows listed file: %w", err)
 			}
-			quoted = append(quoted, "'"+uri+"'")
+			quoted = append(quoted, fmt.Sprintf("'%s'", sqlutil.EscapeLiteral(uri)))
 		}
 		notSuperseded = fmt.Sprintf(`
 WHERE NOT EXISTS (
@@ -53,7 +55,7 @@ SELECT CAST(row_id AS VARCHAR) AS rid,
        (arg_max(COALESCE(deleted_at, 0), changed_at) > 0) AS tomb
 FROM read_parquet('%s') o%s
 GROUP BY row_id
-ORDER BY rid`, orphanURI, notSuperseded)
+ORDER BY rid`, sqlutil.EscapeLiteral(orphanURI), notSuperseded)
 
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {

--- a/internal/e2e_harness/federated/query_build.go
+++ b/internal/e2e_harness/federated/query_build.go
@@ -112,14 +112,14 @@ func buildParquetPushdownSemijoin(basePath, deltaPath string, hasBase, hasDelta 
 func benchmarkParquetProjection(schemaID int16, tier, path string, tradeTimeOnlyProjection bool) string {
 	switch schemaID {
 	case benchmarkSchemaIDCustomer:
-		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, '' as symbol, '' as exchange, region, 0 as tradeType, 0 as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
+		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, '' as symbol, '' as exchange, region, 0 as tradeType, 0 as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, sqlutil.EscapeLiteral(path))
 	case benchmarkSchemaIDSecurity:
-		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, '' as exchange, '' as region, 0 as tradeType, 0 as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
+		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, '' as exchange, '' as region, 0 as tradeType, 0 as tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, sqlutil.EscapeLiteral(path))
 	default:
 		if tradeTimeOnlyProjection {
-			return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, '' as name, version, '' as symbol, '' as exchange, '' as region, 0 as tradeType, tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
+			return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, '' as name, version, '' as symbol, '' as exchange, '' as region, 0 as tradeType, tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, sqlutil.EscapeLiteral(path))
 		}
-		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, path)
+		return fmt.Sprintf(`SELECT row_id, schema_id, changed_at, deleted_at, name, version, symbol, exchange, region, tradeType, tradeTime, '%s' as tier FROM read_parquet('%s')`, tier, sqlutil.EscapeLiteral(path))
 	}
 }
 

--- a/internal/e2e_harness/production/artifacts.go
+++ b/internal/e2e_harness/production/artifacts.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/lychee-technology/forma/internal/sqlutil"
 )
 
 // maxParquetArtifacts caps how many parquet files get schema+sample dumps.
@@ -277,7 +279,7 @@ func (e *Env) dumpOneParquet(ctx context.Context, dir, key string) error {
 	path := fmt.Sprintf("s3://%s/%s", e.Cluster.Bucket, key)
 	base := filepath.Join(dir, "parquet", sanitizeName(strings.TrimPrefix(key, e.S3Prefix+"/")))
 
-	schema, err := e.duckRowsToMaps(ctx, fmt.Sprintf("DESCRIBE SELECT * FROM read_parquet('%s')", path), 0)
+	schema, err := e.duckRowsToMaps(ctx, fmt.Sprintf("DESCRIBE SELECT * FROM read_parquet('%s')", sqlutil.EscapeLiteral(path)), 0)
 	if err != nil {
 		return fmt.Errorf("describe: %w", err)
 	}
@@ -285,7 +287,7 @@ func (e *Env) dumpOneParquet(ctx context.Context, dir, key string) error {
 		return err
 	}
 
-	sample, err := e.duckRowsToMaps(ctx, fmt.Sprintf("SELECT * FROM read_parquet('%s') LIMIT %d", path, maxSampleRows), maxSampleRows)
+	sample, err := e.duckRowsToMaps(ctx, fmt.Sprintf("SELECT * FROM read_parquet('%s') LIMIT %d", sqlutil.EscapeLiteral(path), maxSampleRows), maxSampleRows)
 	if err != nil {
 		return fmt.Errorf("sample: %w", err)
 	}

--- a/parquet_literal_guard_test.go
+++ b/parquet_literal_guard_test.go
@@ -19,12 +19,12 @@ import (
 // site is covered the moment it is added.
 //
 // Scanned shapes (fmt.Sprintf format string literals) in internal/federated,
-// internal/sqlgen, and internal/parquetcheck:
+// internal/sqlgen, internal/parquetcheck, and internal/compaction (#478):
 //   - contains `read_parquet('%s'`  (drainParquet, describeParquetColumns,
-//     parquetcheck.Describe)
+//     parquetcheck.Describe, compaction.UncoveredRows, buildMergeStatsSQL)
 //   - contains `glob('%s'`          (globParquetPaths)
 //   - equals   `'%s'`               (formatDuckDBPathList, drainGuardedParquet
-//     via BuildParquetScanSource)
+//     via BuildParquetScanSource, compaction's per-URI list quoting)
 //
 // For each, the argument feeding that %s must be a call to
 // sqlutil.EscapeLiteral(...).
@@ -35,7 +35,7 @@ import (
 // some other construction is invisible here and is covered by the behavioral
 // escape tests instead. Test files are excluded.
 func TestParquetPathRendersAreEscaped(t *testing.T) {
-	dirs := []string{"internal/federated", "internal/sqlgen", "internal/parquetcheck"}
+	dirs := []string{"internal/federated", "internal/sqlgen", "internal/parquetcheck", "internal/compaction"}
 
 	isEscapeLiteralCall := func(e ast.Expr) bool {
 		call, ok := e.(*ast.CallExpr)


### PR DESCRIPTION
Closes #478.

## What

Follow-up from the PR #476 review (Observation 6 + the issue-comment addendum): the same escaping rule #456 established for the federated read path now covers `internal/compaction` and the two harness sites the issue comment lists.

### `internal/compaction` (issue acceptance)

- **Both named render sites escape their path argument**: `UncoveredRows`' orphan render (`uncovered_rows.go`) and `buildMergeStatsSQL` (`merge_sql.go`) now wrap the URI in `sqlutil.EscapeLiteral` inside `read_parquet('%s')`.
- **Same-class sites in the same functions were folded in**: the three per-URI list quotings (previously `"'"+uri+"'"` string concatenation, in `UncoveredRows`, `buildMergeSQL`, `buildMergeRowsInSQL`) are rewritten as `fmt.Sprintf("'%s'", sqlutil.EscapeLiteral(uri))` — deliberately, so they leave the guard's documented concatenation blind spot and fall under its exact-`'%s'` shape. `buildMergeSQL`'s `TO '%s'` target is escaped too (its COPY format is outside the guard's shapes; same class of render).
- **Guard extended**: `TestParquetPathRendersAreEscaped` now scans `internal/compaction`; its doc comment lists the new package and sites.
- `validateMergeURI` stays as the operator-facing rejection; its comment now states the division of labor: escaping is an identity transform on anything the validator admits (pure defense-in-depth, zero behavior change — the package's exact-SQL assertions pass unchanged).

### Harness sites from the issue comment

`benchmarkParquetProjection` (`internal/e2e_harness/federated/query_build.go:115` plus its three identical sibling branches) and `dumpOneParquet` (`internal/e2e_harness/production/artifacts.go:280` plus the sibling sample query at `:288`) escape their path argument.

**Scope ruling** (recorded here per repo convention): the guard's scanned dirs are NOT widened to the e2e harness. The issue comment itself frames that as conditional future work ("if the guard's scanned dirs are ever widened beyond production packages"), and the guard's first-vararg-is-the-path assumption is false for the harness's `'%s' as tier … read_parquet('%s')` formats — widening would need a guard rework disproportionate to fixture-only renders. The remaining harness renders not listed in the issue (`federated/cdc.go:174`, `federated/query_build.go:76,97,100,254`, `federated/s3_operations.go:199`) are likewise fixed-fixture strings and stay untouched.

## Verification

- Guard TDD cycle: adding `internal/compaction` to the scanned dirs first made `TestParquetPathRendersAreEscaped` fail naming exactly `uncovered_rows.go:51` and `merge_sql.go:106`; after the escapes it is green.
- Mutation check: temporarily reverting `buildMergeStatsSQL`'s escape made the guard fail naming that exact site; escape restored, green again (the guard bites, it is not vacuous).
- `make fmt-check` clean; `make lint` clean (pinned golangci-lint v1.64.8, root + infra modules).
- Full unit suite green via `./scripts/test_with_container_runtime.sh` (`make test`).
- `go vet ./internal/e2e_harness/...` clean.

Acceptance criteria of #478: both boxes met.
