### PR TITLE
fix(cdc-init): paginate the base backfill by keyset, not LIMIT/OFFSET

### DIFF
--- a/internal/cdc/config.go
+++ b/internal/cdc/config.go
@@ -63,7 +63,8 @@ type CDCConfig struct {
 	// (the snapshot is already captured) and before the DuckDB export. Test
 	// seam for driving mutations inside the selection->export race window
 	// (#182); always nil in production. A hook error aborts the batch before
-	// any side effect.
+	// any side effect. The init backfill fires the same hook per batch
+	// (#462); it has no snapshot clock, so there the hook receives 0.
 	BeforeExportHook func(ctx context.Context, schemaID int16, batchIDs []uuid.UUID, snapshot int64) error
 }
 

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -299,9 +299,9 @@ func iterateSchemaBatches(
 	state *schemaInitState,
 	onBatch func(rowIDs []uuid.UUID) error,
 ) error {
-	offset := 0
+	var after *uuid.UUID
 	for {
-		rowIDs, err := selectEntityMainBatch(ctx, runCtx.db, runCtx.cfg.EntityMainTable, state.schemaID, offset, state.batchSize)
+		rowIDs, err := selectEntityMainBatch(ctx, runCtx.db, runCtx.cfg.EntityMainTable, state.schemaID, after, state.batchSize)
 		if err != nil {
 			return fmt.Errorf("select batch: %w", err)
 		}
@@ -309,10 +309,19 @@ func iterateSchemaBatches(
 			return nil
 		}
 
+		// Selection->export test seam, mirroring the flusher's (#182). Init
+		// has no snapshot clock, so the hook receives 0.
+		if hook := runCtx.cfg.BeforeExportHook; hook != nil {
+			if err := hook(ctx, state.schemaID, rowIDs, 0); err != nil {
+				return fmt.Errorf("before-export hook: %w", err)
+			}
+		}
+
 		if err := onBatch(rowIDs); err != nil {
 			return err
 		}
-		offset += state.batchSize
+		last := rowIDs[len(rowIDs)-1]
+		after = &last
 	}
 }
 
@@ -451,20 +460,26 @@ func getEntityMainCount(ctx context.Context, db *sql.DB, tableName string, schem
 	return cnt, nil
 }
 
-// selectEntityMainBatch returns a batch of row IDs ordered by ltbase_row_id.
-func selectEntityMainBatch(ctx context.Context, db *sql.DB, tableName string, schemaID int16, offset, limit int) ([]uuid.UUID, error) {
+// selectEntityMainBatch returns a batch of row IDs ordered by ltbase_row_id,
+// strictly after the `after` cursor (nil starts from the beginning). Keyset
+// pagination, not LIMIT/OFFSET: init runs against a live table (TrySchemaLock
+// excludes only flusher/init/reconcile, not CRUD), and with OFFSET a row
+// deleted below the cursor shifts the window left and silently drops one live
+// row from the wholesale-replaced base tier (#462). The row-id cursor is
+// immune — membership changes below it cannot move the window.
+func selectEntityMainBatch(ctx context.Context, db *sql.DB, tableName string, schemaID int16, after *uuid.UUID, limit int) ([]uuid.UUID, error) {
 	if tableName == "" {
 		tableName = "entity_main"
 	}
 	query := fmt.Sprintf(`
 		SELECT ltbase_row_id
 		FROM %s
-		WHERE ltbase_schema_id = $1 AND ltbase_deleted_at IS NULL
+		WHERE ltbase_schema_id = $1 AND ltbase_deleted_at IS NULL AND ($3::uuid IS NULL OR ltbase_row_id > $3)
 		ORDER BY ltbase_row_id
-		LIMIT $2 OFFSET $3`,
+		LIMIT $2`,
 		sanitizeIdentifier(tableName))
 
-	rows, err := db.QueryContext(ctx, query, schemaID, limit, offset)
+	rows, err := db.QueryContext(ctx, query, schemaID, limit, after)
 	if err != nil {
 		return nil, fmt.Errorf("select batch: %w", err)
 	}

--- a/internal/e2e_harness/production/cdc.go
+++ b/internal/e2e_harness/production/cdc.go
@@ -111,6 +111,7 @@ func (e *Env) RunInit(ctx context.Context, schema SchemaRef) (*InitReport, error
 // InitOverrides customizes a single init pass (#180). Zero-value fields fall
 // back to the defaults RunInit uses.
 type InitOverrides struct {
+	Config *cdc.CDCConfig // nil: e.CDC
 	DryRun bool
 }
 
@@ -124,8 +125,12 @@ func (e *Env) RunInitWith(ctx context.Context, schema SchemaRef, ov InitOverride
 		return nil, fmt.Errorf("capture pre-init s3 listing: %w", err)
 	}
 
+	cfg := e.CDC
+	if ov.Config != nil {
+		cfg = *ov.Config
+	}
 	summary, err := cdc.RunInit(ctx, cdc.InitOptions{
-		Config:               e.CDC,
+		Config:               cfg,
 		S3Client:             e.Cluster.S3,
 		SchemaRegistryTable:  e.Tables.SchemaRegistry,
 		SchemaIDFilter:       int(schema.ID),

--- a/internal/e2e_harness/production/init_concurrent_delete_e2e_test.go
+++ b/internal/e2e_harness/production/init_concurrent_delete_e2e_test.go
@@ -1,0 +1,87 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestInitConcurrentDelete pins issue #462: cdc-init's base backfill must not
+// lose a live row when a concurrent delete lands below its batch cursor.
+//
+// The init batch loop paginates entity_main while ordinary CRUD keeps
+// running (TrySchemaLock excludes only flusher/init/reconcile). With
+// LIMIT/OFFSET pagination a row soft-deleted below the cursor shrinks the
+// filtered set, shifts the window left, and silently drops exactly one live
+// row from the wholesale-replaced base tier. The mutation is driven through
+// cdc.CDCConfig.BeforeExportHook — the same selection->export seam #182 uses
+// for the flusher — firing inside the second batch, i.e. after the cursor
+// has moved past the victim's batch.
+func TestInitConcurrentDelete(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	env := NewEnv(t, SharedCluster(t))
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+
+	creates := buildOpenCreates(wide, 6)
+	mustApplyEvents(ctx, t, env, "seed creates", creates...)
+
+	// Order rows by ltbase_row_id — the init batch ordering — so "lowest
+	// row id" (the already-paginated-past victim) is deterministic even if
+	// UUIDv7 assignment ever ties within a millisecond.
+	sorted := append([]*Event(nil), creates...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].RowID.String() < sorted[j].RowID.String()
+	})
+	victim := sorted[0]
+
+	// BatchSize 2 over 6 rows gives three batches. The hook soft-deletes the
+	// victim while batch 2 is in flight: batch 1 (the victim's) is already
+	// selected and exported, so the delete lands strictly below the cursor
+	// before batch 3 is selected — the issue's reproduction verbatim.
+	// RunInitWith is synchronous, so the hook runs inline and
+	// deterministically; it reports failures through the init error.
+	var hookBatches int
+	cfg := env.CDC
+	cfg.BatchSize = 2
+	cfg.BeforeExportHook = func(hctx context.Context, _ int16, _ []uuid.UUID, _ int64) error {
+		hookBatches++
+		if hookBatches == 2 {
+			return env.ApplyEvents(hctx, DeleteEvent(wide, victim.RowID))
+		}
+		return nil
+	}
+	report, err := env.RunInitWith(ctx, wide, InitOverrides{Config: &cfg})
+	if err != nil {
+		t.Fatalf("init with concurrent delete: %v", err)
+	}
+
+	// Positive control: the run really was batched and the delete really
+	// fired mid-run (before the last batch selection).
+	if hookBatches < 3 {
+		t.Fatalf("init ran %d batches, want >= 3 (delete must land mid-run)", hookBatches)
+	}
+
+	// The acceptance criterion: every surviving row is present in the base
+	// tier the manifest now points at. (The victim may legitimately appear
+	// too — it was exported before the delete and LWW/tombstones hide it.)
+	var basePaths []string
+	for _, f := range report.Manifest.Files {
+		if f.Tier == "base" {
+			basePaths = append(basePaths, f.Path)
+		}
+	}
+	if len(basePaths) == 0 {
+		t.Fatalf("manifest has no base entries after init: %+v", report.Manifest.Files)
+	}
+	got := fetchParquetRowIDs(ctx, t, env, basePaths)
+	for _, ev := range sorted[1:] {
+		if !got[ev.RowID.String()] {
+			t.Errorf("surviving row %s missing from the new base tier (silent cold-tier row loss)", ev.RowID)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #462.

## Problem

`cdc-init` batched its base backfill with `LIMIT/OFFSET` over the live, filtered `entity_main` table. `TrySchemaLock` excludes only flusher/init/reconcile, so ordinary CRUD keeps running during a backfill: a row soft-/hard-deleted below the offset cursor shrinks the filtered set, shifts the window left, and silently drops exactly one live row from the wholesale-replaced base tier. Once `manifest-reconcile --gc` deletes the old base objects, the row is gone from federated reads with no error anywhere.

## Fix

`selectEntityMainBatch` now takes a strict `ltbase_row_id > cursor` keyset bound, with the cursor (last row id of the previous batch) carried by `iterateSchemaBatches`. Membership changes below the cursor can no longer move the window; concurrent inserts above it are picked up or skipped harmlessly, same as before. The flusher was already immune (it selects by `flushed_at = 0`).

## Regression coverage

`TestInitConcurrentDelete` (e2e, real Postgres + S3): seeds 6 rows, runs init with `BatchSize=2`, and soft-deletes the lowest-row-id row while batch 2 is in flight — i.e. strictly below the cursor, the issue's reproduction verbatim. It then asserts every surviving row is present in the base tier referenced by the new manifest. The delete is driven through the flusher's existing selection→export seam (`CDCConfig.BeforeExportHook`, #182), now also fired per init batch, riding a new `InitOverrides.Config` injection in the harness. Red before the fix (exactly one surviving row missing), green after.

## Verification

- `TestInitConcurrentDelete`: fails on `main`'s pagination, passes with the fix
- Full `-tags=e2e` production suite: pass (471s)
- `make test` (unit suites): pass
- `make lint`, `gofmt`: clean