### PR TITLE
fix(compaction): retain merged sources after the manifest swap for the in-flight-reader window

### DIFF
--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -6,8 +6,12 @@ manifest 条目，双向报告差异，并可选修复。它是两条既有故�
 - **#197 flush 孤儿**：delta flush 导出成功、行已标记 `flushed_at != 0`，但 manifest
   append 失败。文件在最终 key 上、数据只存在于该文件，重跑 flush 不会补录。
 - **#188 compaction 遗留**：rewrite 崩溃留下的 `_tmp/` staging 对象与未列入 manifest 的
-  `base-{uuid}.parquet`，以及 manifest 提交后删除失败的 merged source。这些对象的数据
-  已并入 merged base，属于纯垃圾。
+  `base-{uuid}.parquet`，以及 manifest 提交后被 splice 出去的 merged source。#461 起
+  compactor **有意不再内联删除** merged source：持有 pre-swap 路径集的 in-flight 联邦
+  读还可能懒打开它们，零宽限删除会让该读以不可降级的 `ParquetSetInconsistentError`
+  失败并触发熔断计数。因此**每次** rewrite 都会留下未列入的 source（base/tmp 形态走
+  `--gc`，delta 形态走 `--repair --gc`），本工具的两阶段 grace 回收是其成文回收机制，
+  不再只是崩溃残留的兜底。这些对象的数据已并入 merged base，属于纯垃圾。
 - **#226 swallowed-delete 残留**：flush / cdc-init / compaction 经 `CopyTmpToFinal`
   提升成功后，对 `_tmp/` staging 对象的 DeleteObject 失败被有意吞掉（提升已成功，
   流程不应失败）。CopyObject 或导出失败时 #226 已在带内当场自愈（best-effort 删除
@@ -23,8 +27,8 @@ manifest 条目，双向报告差异，并可选修复。它是两条既有故�
 
 | 类别 | 形态 | 来源 | 处置 |
 |------|------|------|------|
-| delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | flush 的 manifest-append 失败（#252 起 append 先于 mark-flushed：行留 dirty、重试自愈覆盖，孤儿通常判为可 GC 残留；#252 前为 #197 丢失数据形态）或 #188 删除失败的 merged source | `--repair` 经守卫判定后补录或转残留（见下） |
-| merged base 孤儿 | `base-{uuid}.parquet` | #188 | `--gc` 两阶段删除（见下） |
+| delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | flush 的 manifest-append 失败（#252 起 append 先于 mark-flushed：行留 dirty、重试自愈覆盖，孤儿通常判为可 GC 残留；#252 前为 #197 丢失数据形态）或 #461 起每次 rewrite 保留的 merged source | `--repair` 经守卫判定后补录或转残留（见下） |
+| merged base 孤儿 | `base-{uuid}.parquet` | #188 崩溃 / #461 起每次 rewrite 保留的 merged source | `--gc` 两阶段删除（见下） |
 | init base 孤儿 | `{min}_{max}.parquet` | cdc-init 导出 | `--repair` 下先经晋升守卫（三重证明，见下）整组判定：证明通过则整组补录进 manifest base 层；证明不通过（或未开 `--repair`）保持 GC 候选，走 `--gc` 两阶段删除（见下）。#290 起 cdc-init 与 reconcile 持同一把 per-schema advisory lock，故此锁下的 init 形态孤儿必非 in-flight init——只可能是发布失败的 manifest 或被后续 init 覆盖的旧文件 |
 | `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | staging 残留（#188 崩溃 / #226 swallowed-delete） | `--gc` 两阶段删除（见下） |
 

--- a/internal/compaction/merge.go
+++ b/internal/compaction/merge.go
@@ -66,11 +66,13 @@ func (d *DuckMerger) MergeToTmp(ctx context.Context, sourceURIs []string, tmpURI
 
 	// The merge runs union_by_name (#189), which would NULL-pad the system
 	// columns of a malformed source: every such row then folds into the
-	// single NULL row_id partition and all but one are silently discarded —
-	// and the compactor deletes the merged sources afterwards, making the
-	// loss permanent. Enforce the export invariant per source BEFORE any
-	// write. An unreadable footer is inconclusive and passes through: the
-	// merge itself must read every file and will fail loudly on it.
+	// single NULL row_id partition and all but one are silently discarded. If
+	// published, that lossy output would splice the source entries out of the
+	// manifest; although the source bytes remain as unlisted GC candidates,
+	// the manifest read path would no longer consult them. Enforce the export
+	// invariant per source BEFORE any write. An unreadable footer is
+	// inconclusive and passes through: the merge itself must read every file
+	// and will fail loudly on it.
 	if err := validateMergeSourceSchemas(ctx, d.DB, sourceURIs); err != nil {
 		return MergeStats{}, fmt.Errorf("pre-merge parquet schema validation: %w", err)
 	}

--- a/internal/compaction/merge_test.go
+++ b/internal/compaction/merge_test.go
@@ -206,9 +206,11 @@ func TestDuckMerger_RequiresDB(t *testing.T) {
 // TestDuckMerger_RejectsWrongSchemaSource pins the #189-review P1: the merge
 // scan runs union_by_name, which NULL-pads a malformed source's system
 // columns — every such row folds into the single NULL row_id partition and
-// all but one are silently discarded, and runRewrite deletes the merged
-// sources afterwards, making the loss permanent. The pre-merge invariant
-// check must abort before any write instead.
+// all but one are silently discarded. A published result would splice the
+// source entries out of the manifest, leaving the lossy output as the only
+// manifest-visible data even though the source bytes are retained as
+// unlisted GC candidates. The pre-merge invariant check must abort before
+// any write instead.
 func TestDuckMerger_RejectsWrongSchemaSource(t *testing.T) {
 	db, err := sql.Open("duckdb", "")
 	require.NoError(t, err)

--- a/internal/compaction/rewrite.go
+++ b/internal/compaction/rewrite.go
@@ -128,11 +128,7 @@ func (c *Compactor) runRewrite(
 	// breaker-worthy ParquetSetInconsistentError. They stay behind as
 	// unlisted orphans for manifest-reconcile, whose gcSchema sighting-state
 	// grace exists exactly for this window (base/tmp shapes via --gc, delta
-	// shapes via --repair --gc).
-	c.Logger.Info("rewrite retired merged sources; left unlisted for manifest-reconcile gc",
-		zap.Int16("schema_id", schemaID),
-		zap.Int("retired_sources", len(sources)))
-
+	// shapes via --repair --gc). files_merged below counts them.
 	telemetry.EmitCompactionRewriteApplied(ctx, schemaID)
 	c.Logger.Info("compaction rewrite completed",
 		zap.Int16("schema_id", schemaID),

--- a/internal/compaction/rewrite.go
+++ b/internal/compaction/rewrite.go
@@ -22,7 +22,7 @@ func (c *Compactor) canRewrite() bool {
 
 // runRewrite executes the dirty-ratio rewrite (#188): merge the schema's
 // COMPLETE base+delta parquet set into one new base file, swap the manifest
-// under the loaded ETag, then best-effort delete the merged sources.
+// under the loaded ETag, and RETAIN the now-unlisted sources.
 //
 // Ordering is what makes this safe under manifest-driven reads
 // (manifest ⊆ live objects, internal/manifest/query_source.go):
@@ -37,14 +37,18 @@ func (c *Compactor) canRewrite() bool {
 //  3. commit the manifest swap — the only atomic step; a conditional-put
 //     conflict surfaces as ErrConcurrentModification and the retry recomputes
 //     everything from a fresh manifest,
-//  4. only after the commit, delete the now-unlisted sources. Deletion is
-//     best-effort: a failure leaves unlisted orphans for #203's
-//     reconciliation, never a broken read set. In-flight queries that
-//     resolved the pre-swap object list can race step 4 and fail loudly on a
-//     missing key; the residual window is one query duration (noted on #188).
+//  4. after the commit, the now-unlisted sources are deliberately NOT
+//     deleted (#461): an in-flight query that resolved the pre-swap object
+//     list may still lazily open them, and a zero-grace delete would fail it
+//     with the non-degradable ParquetSetInconsistentError. They are left as
+//     unlisted orphans for manifest-reconcile's sighting-state GC grace
+//     (base/tmp shapes via --gc, delta shapes via --repair --gc). The only
+//     inline deletion is a confirmed-412 conflict dropping its own
+//     never-listed staged base.
 //
 // A crash before step 3 leaves the manifest untouched (staged objects become
-// #203 orphans); a crash after it leaves only unlisted sources behind.
+// #203 orphans); a crash after it changes nothing — the retained sources are
+// the same unlisted orphans the happy path leaves.
 func (c *Compactor) runRewrite(
 	ctx context.Context,
 	schemaID int16,
@@ -118,11 +122,16 @@ func (c *Compactor) runRewrite(
 		return CompactionResult{}, fmt.Errorf("rewrite manifest swap for schema %d had an ambiguous outcome; staged base retained at %s: %w", schemaID, finalKey, err)
 	}
 
-	sourceKeys := make([]string, 0, len(sources))
-	for _, f := range sources {
-		sourceKeys = append(sourceKeys, f.Path)
-	}
-	c.deleteObjects(ctx, schemaID, sourceKeys)
+	// #461: the merged sources are NOT deleted here. An in-flight federated
+	// read that resolved the pre-swap manifest may still lazily open them;
+	// deleting now would fail that read with the non-degradable,
+	// breaker-worthy ParquetSetInconsistentError. They stay behind as
+	// unlisted orphans for manifest-reconcile, whose gcSchema sighting-state
+	// grace exists exactly for this window (base/tmp shapes via --gc, delta
+	// shapes via --repair --gc).
+	c.Logger.Info("rewrite retired merged sources; left unlisted for manifest-reconcile gc",
+		zap.Int16("schema_id", schemaID),
+		zap.Int("retired_sources", len(sources)))
 
 	telemetry.EmitCompactionRewriteApplied(ctx, schemaID)
 	c.Logger.Info("compaction rewrite completed",
@@ -191,6 +200,9 @@ func (c *Compactor) objectURI(path string) string {
 
 // deleteObjects best-effort deletes bucket-relative keys. Failures (and
 // absolute foreign-bucket paths) are logged and left to #203 reconciliation.
+// Since #461 the rewrite only calls it for a confirmed-412 attempt's own
+// never-listed staged base — merged sources are retained for the
+// in-flight-reader window and reclaimed by manifest-reconcile's GC grace.
 func (c *Compactor) deleteObjects(ctx context.Context, schemaID int16, paths []string) {
 	for _, path := range paths {
 		key := path

--- a/internal/compaction/rewrite.go
+++ b/internal/compaction/rewrite.go
@@ -58,8 +58,10 @@ func (c *Compactor) runRewrite(
 	analysis CompactionResult,
 ) (CompactionResult, error) {
 	// Fail closed before anything is merged: past this point the sources are
-	// folded into one object and then deleted, so a corrupt input would be
-	// laundered into the new base and lose its name (#347).
+	// folded into one object and spliced out of the manifest, so a corrupt
+	// input would be laundered into the new base and lose its listed name —
+	// the retained bytes (#461) are unlisted orphans on a GC countdown, not a
+	// named copy anyone would consult (#347).
 	if err := c.verifySourceChecksums(ctx, schemaID, sources); err != nil {
 		return CompactionResult{}, err
 	}

--- a/internal/compaction/rewrite_test.go
+++ b/internal/compaction/rewrite_test.go
@@ -236,8 +236,10 @@ func TestCompactor_Rewrite_MergesAndSplicesManifest(t *testing.T) {
 	require.Equal(t, int64(4096), newBase.SizeBytes)
 	require.Equal(t, map[string]string{"row_id": "UUID", "changed_at": "BIGINT", "deleted_at": "BIGINT"}, newBase.Columns)
 
-	// Sources deleted only AFTER the successful commit; staged key kept.
-	require.Equal(t, []string{"p/1/aaa_bbb.parquet", "p/1/ddd.parquet"}, nonTmpDeletes(s3c.deletes))
+	// #461: the committed sources are NOT deleted inline — they must survive
+	// the in-flight-reader window as unlisted orphans until manifest-reconcile
+	// --gc reclaims them past the grace period.
+	require.Empty(t, nonTmpDeletes(s3c.deletes))
 	require.Equal(t, 1, applied)
 }
 
@@ -257,10 +259,11 @@ func TestCompactor_Rewrite_ConflictRetryRecomputesFromFreshManifest(t *testing.T
 	require.Equal(t, merger.sources[0], merger.sources[1])
 
 	// Attempt 1's staged base (never listed) was cleaned up before the retry;
-	// the committed sources were deleted exactly once, after the commit.
+	// the committed sources were retained for the in-flight-reader window
+	// (#461) — manifest-reconcile --gc reclaims them past the grace period.
 	require.Len(t, s3c.copies, 2)
 	firstStaged := s3c.copies[0]
-	require.Equal(t, []string{firstStaged, "p/1/aaa_bbb.parquet", "p/1/ddd.parquet"}, nonTmpDeletes(s3c.deletes))
+	require.Equal(t, []string{firstStaged}, nonTmpDeletes(s3c.deletes))
 	require.Equal(t, s3c.copies[1], result.NewBaseKey)
 	require.NotContains(t, s3c.deletes, result.NewBaseKey)
 }

--- a/internal/compaction/verify_inputs.go
+++ b/internal/compaction/verify_inputs.go
@@ -14,10 +14,12 @@ import (
 
 // ErrSourceChecksumMismatch marks a rewrite input whose bytes no longer hash
 // to its manifest stamp. The rewrite must NOT proceed: runRewrite merges the
-// sources into the new base and then deletes them, so this gate is the last
-// moment silent corruption (#347) is both detectable and still attributable
-// to a named object. Probe failures never map to this error — a failed GET is
-// transient infrastructure, not a corruption verdict.
+// sources into the new base and splices them out of the manifest, so this
+// gate is the last moment silent corruption (#347) is both detectable and
+// attributable to a manifest-listed object. The source bytes may remain as
+// unlisted GC candidates, but the read path will no longer consult that
+// named entry after the rewrite. Probe failures never map to this error — a
+// failed GET is transient infrastructure, not a corruption verdict.
 var ErrSourceChecksumMismatch = errors.New("compaction source checksum mismatch")
 
 // verifySourceChecksums re-hashes every stamped rewrite source and compares

--- a/internal/e2e_harness/production/checksum_corruption_chain_e2e_test.go
+++ b/internal/e2e_harness/production/checksum_corruption_chain_e2e_test.go
@@ -145,9 +145,11 @@ func assertScrubReportsOnlyDivergence(ctx context.Context, t *testing.T, env *En
 // assertCompactionRefusesCorruptSource runs the default (verifying) compaction
 // pass over the corrupted delta and requires the fail-closed outcome: an
 // ErrSourceChecksumMismatch, and a store left exactly as it was. The
-// post-conditions are the point — the rewrite merges its sources and then
-// deletes them, so a gate that fired but let the pass continue would still
-// have destroyed the only named copy of the corrupt bytes.
+// post-conditions are the point — the rewrite merges its sources and splices
+// them out of the manifest (since #461 their bytes are retained but unlisted,
+// awaiting reconcile GC), so a gate that fired but let the pass continue
+// would still have laundered the corrupt bytes into the new base and cost
+// them their name.
 func assertCompactionRefusesCorruptSource(ctx context.Context, t *testing.T, env *Env,
 	schema SchemaRef, corruptKey string) {
 	t.Helper()
@@ -194,7 +196,7 @@ func assertCompactionRefusesCorruptSource(ctx context.Context, t *testing.T, env
 // disagrees with the object's bytes — while the merge can still read it.
 // That also makes this the harmful case the gate exists to prevent, run on
 // purpose: the opted-out rewrite folds an unverified source into the new base
-// and deletes it.
+// and splices it out of the manifest (#461: retained unlisted, not deleted).
 func assertChecksumOptOutRewrites(ctx context.Context, t *testing.T, env *Env,
 	schema SchemaRef, deltaKey, deltaPath string, pristine []byte) {
 	t.Helper()
@@ -213,6 +215,8 @@ func assertChecksumOptOutRewrites(ctx context.Context, t *testing.T, env *Env,
 		t.Fatalf("verifying pass over a poisoned stamp must refuse with ErrSourceChecksumMismatch, got: %v", err)
 	}
 
+	everListed := map[string]bool{}
+	recordListedKeys(ctx, t, env, schema, everListed)
 	result, err := env.RunCompactionWith(ctx, schema, CompactionOverrides{SkipInputChecksumVerify: true})
 	if err != nil {
 		t.Fatalf("compaction with the checksum gate opted out: %v", err)
@@ -229,7 +233,7 @@ func assertChecksumOptOutRewrites(ctx context.Context, t *testing.T, env *Env,
 	// Compactor's ObjectReader wiring on the production harness path.
 	assertEntryChecksumMatchesBytes(ctx, t, env, "compaction-merged base", soleTierEntry(t, m, "base"))
 	assertNoDuplicateManifestEntries(t, m)
-	assertManifestMatchesInventory(ctx, t, env, schema)
+	assertManifestMatchesInventory(ctx, t, env, schema, everListed)
 	env.AssertQueryMatches(ctx, Query{Schema: schema, Limit: 100})
 }
 

--- a/internal/e2e_harness/production/compaction_atomicity_e2e_test.go
+++ b/internal/e2e_harness/production/compaction_atomicity_e2e_test.go
@@ -32,6 +32,9 @@ func TestCompactionManifestAtomicity(t *testing.T) {
 	}
 	mustFlush(ctx, t, env) // dirty ratio 1/5 = 20% > 5%: rewrite-eligible
 
+	everListed := map[string]bool{}
+	recordListedKeys(ctx, t, env, wide, everListed)
+
 	// Pause the compactor exactly at its manifest save; the rewrite's parquet
 	// staging traffic (DuckDB httpfs + CopyObject) does not match.
 	pauser := NewPausingS3OnKey(cluster.S3, S3OpPut, "manifest/")
@@ -62,6 +65,7 @@ func TestCompactionManifestAtomicity(t *testing.T) {
 		t.Fatalf("apply concurrent update: %v", err)
 	}
 	mustFlush(ctx, t, env)
+	recordListedKeys(ctx, t, env, wide, everListed) // + the concurrent delta
 	midVersion := loadSchemaManifest(ctx, t, env, wide).Version
 
 	pauser.Resume()
@@ -95,9 +99,10 @@ func TestCompactionManifestAtomicity(t *testing.T) {
 		t.Errorf("delta entries after conflict retry = %d, want 0 (concurrent delta folded)", got)
 	}
 	assertNoDuplicateManifestEntries(t, m)
-	// Includes the failed first attempt's staged base: it must not linger as
-	// an unlisted orphan.
-	assertManifestMatchesInventory(ctx, t, env, wide)
+	// The failed first attempt's staged base was never listed, so it must not
+	// linger (the confirmed-412 cleanup); the retry's retired sources are in
+	// everListed and may (#461: must be able to) survive unlisted.
+	assertManifestMatchesInventory(ctx, t, env, wide, everListed)
 
 	// Full result equivalence: engine vs oracle, which knows both updates.
 	env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100})

--- a/internal/e2e_harness/production/compaction_evolution_e2e_test.go
+++ b/internal/e2e_harness/production/compaction_evolution_e2e_test.go
@@ -242,7 +242,8 @@ func assertMergedBaseUnion(ctx context.Context, t *testing.T, env *Env, key stri
 // assertMixedGenRewriteSurfaces pins the manifest and hot-tier surfaces after
 // the mixed-generation rewrite: exactly one base entry (the merged file),
 // zero delta entries, monotonic manifest version, no duplicate entries,
-// manifest == S3 inventory, and an untouched hot tier.
+// manifest ⊆ S3 inventory with only retired sources unlisted (#461), and an
+// untouched hot tier.
 func assertMixedGenRewriteSurfaces(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, mBefore *manifest.Manifest, hotBefore int64) {
 	t.Helper()
 	mAfter := loadSchemaManifest(ctx, t, env, schema)
@@ -256,7 +257,11 @@ func assertMixedGenRewriteSurfaces(ctx context.Context, t *testing.T, env *Env, 
 		t.Errorf("manifest version %d -> %d, want monotonic advance", mBefore.Version, mAfter.Version)
 	}
 	assertNoDuplicateManifestEntries(t, mAfter)
-	assertManifestMatchesInventory(ctx, t, env, schema)
+	everListed := make(map[string]bool, len(mBefore.Files))
+	for _, f := range mBefore.Files {
+		everListed[f.Path] = true
+	}
+	assertManifestMatchesInventory(ctx, t, env, schema, everListed)
 
 	hotAfter, err := env.countUnflushed(ctx)
 	if err != nil {

--- a/internal/e2e_harness/production/compaction_inflight_reader_e2e_test.go
+++ b/internal/e2e_harness/production/compaction_inflight_reader_e2e_test.go
@@ -1,0 +1,84 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/compaction"
+)
+
+// TestCompactionRewriteInFlightReaderRetention is #461's regression: a
+// federated reader that resolved its parquet path set from the PRE-swap
+// manifest must keep working after the compactor commits the swap. The
+// compactor therefore retains the merged sources (unlisted, reclaimed by
+// manifest-reconcile --gc past its grace); this test holds the pre-swap path
+// set across a real rewrite publish and proves the scan still answers
+// correctly. Before the fix the inline post-commit delete made this exact
+// read fail with the non-degradable, breaker-worthy
+// ParquetSetInconsistentError.
+func TestCompactionRewriteInFlightReaderRetention(t *testing.T) {
+	cluster := SharedCluster(t)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1] // e2e_wide
+	env := NewEnv(t, cluster)
+
+	creates := seedCompactionBase(ctx, t, env, wide, 5)
+	update := UpdateEvent(wide, creates[0].RowID, map[string]any{"title": "inflight-v2"})
+	if err := env.ApplyEvents(ctx, update); err != nil {
+		t.Fatalf("apply update: %v", err)
+	}
+	mustFlush(ctx, t, env) // dirty ratio 1/5 = 20% > 5%: rewrite-eligible
+
+	// The in-flight reader's snapshot: the path set resolved from the
+	// pre-swap manifest, exactly what resolveScanSources would be holding
+	// while the compactor publishes.
+	preSwap := loadSchemaManifest(ctx, t, env, wide)
+	preSwapKeys := make([]string, 0, len(preSwap.Files))
+	preSwapURIs := make([]string, 0, len(preSwap.Files))
+	for _, f := range preSwap.Files {
+		preSwapKeys = append(preSwapKeys, f.Path)
+		preSwapURIs = append(preSwapURIs, fmt.Sprintf("s3://%s/%s", env.Cluster.Bucket, strings.TrimPrefix(f.Path, "/")))
+	}
+	if len(preSwapURIs) < 2 {
+		t.Fatalf("pre-swap manifest lists %d files, want at least base+delta", len(preSwapURIs))
+	}
+
+	// The compactor publishes: the manifest swap commits and the sources are
+	// spliced out.
+	result, err := env.RunCompaction(ctx, wide)
+	if err != nil {
+		t.Fatalf("compaction: %v", err)
+	}
+	if result.Outcome != compaction.RewriteApplied {
+		t.Fatalf("outcome = %s (dirty ratio %.2f), want %s", result.Outcome, result.DirtyRatio, compaction.RewriteApplied)
+	}
+
+	// Writer-side acceptance: every pre-swap source object survives the
+	// publish — the zero-grace inline delete was the bug.
+	after := map[string]bool{}
+	for _, k := range schemaParquetKeys(ctx, t, env, wide) {
+		after[k] = true
+	}
+	for _, k := range preSwapKeys {
+		if !after[k] {
+			t.Errorf("pre-swap source %s was deleted at publish; an in-flight reader holding the old path set would fail ParquetSetInconsistent", k)
+		}
+	}
+
+	// Reader-side acceptance, verified empirically through the real engine: a
+	// query still holding the pre-swap path set (pinned via the explicit
+	// path-list hint — same read_parquet scan shape, same DuckDB open path)
+	// must succeed and answer identically to the oracle.
+	held := env.AssertQueryMatches(ctx, Query{
+		Schema:                wide,
+		S3ParquetPathTemplate: strings.Join(preSwapURIs, ","),
+		Limit:                 100,
+	})
+	if held == nil || held.Plan == nil || !held.Plan.Routing.UseDuckDB {
+		t.Fatalf("pre-swap path-set query did not route to duckdb")
+	}
+}

--- a/internal/e2e_harness/production/compaction_rewrite_e2e_test.go
+++ b/internal/e2e_harness/production/compaction_rewrite_e2e_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -83,31 +81,54 @@ func assertRewrittenBase(ctx context.Context, t *testing.T, env *Env, key string
 	}
 }
 
-// assertManifestMatchesInventory pins the #188 success criteria "manifest
-// correctly reflects object inventory" and "no orphan objects": the schema's
-// live parquet keys (tmp excluded: swallowed-delete residue is reclaimed by
-// manifest-reconcile --gc, #226) and the manifest's file
-// paths must be exactly the same set.
-func assertManifestMatchesInventory(ctx context.Context, t *testing.T, env *Env, schema SchemaRef) {
+// assertManifestMatchesInventory pins the #188 success criteria under the
+// #461 retention contract: every manifest entry must exist in S3 (manifest ⊆
+// live objects — the read-safety invariant), and every live parquet key NOT
+// in the manifest (tmp excluded: swallowed-delete residue is reclaimed by
+// manifest-reconcile --gc, #226) must be a retired source — a key that was
+// manifest-listed earlier in the test (everListed) and is deliberately
+// retained for the in-flight-reader window until manifest-reconcile's GC
+// grace reclaims it. A never-listed leftover is still the staged-orphan bug.
+func assertManifestMatchesInventory(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, everListed map[string]bool) {
 	t.Helper()
 	inventory := schemaParquetKeys(ctx, t, env, schema)
-	m := loadSchemaManifest(ctx, t, env, schema)
-	listed := make([]string, 0, len(m.Files))
-	for _, f := range m.Files {
-		listed = append(listed, f.Path)
+	live := make(map[string]bool, len(inventory))
+	for _, k := range inventory {
+		live[k] = true
 	}
-	sort.Strings(listed)
-	if !reflect.DeepEqual(inventory, listed) {
-		t.Errorf("manifest and S3 inventory diverge:\n s3 objects: %v\n manifest:   %v", inventory, listed)
+	m := loadSchemaManifest(ctx, t, env, schema)
+	listed := make(map[string]bool, len(m.Files))
+	for _, f := range m.Files {
+		listed[f.Path] = true
+		if !live[f.Path] {
+			t.Errorf("manifest entry %s is missing from S3 (dangling)", f.Path)
+		}
+	}
+	for _, k := range inventory {
+		if !listed[k] && !everListed[k] {
+			t.Errorf("unlisted object %s in S3 was never manifest-listed; a staged orphan must not linger (#188/#203)", k)
+		}
+	}
+}
+
+// recordListedKeys folds the schema's currently listed manifest paths into
+// everListed, so a later assertManifestMatchesInventory can tell a #461
+// retired source (was listed, then spliced out) from a staged orphan. Call it
+// right before every operation that swaps the manifest.
+func recordListedKeys(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, everListed map[string]bool) {
+	t.Helper()
+	for _, f := range loadSchemaManifest(ctx, t, env, schema).Files {
+		everListed[f.Path] = true
 	}
 }
 
 // TestCompactionRewriteEquivalence covers #188 scenario 2 with hot rows
 // present: a dirty-ratio-eligible schema (2 updates + 1 delete over 5 base
 // rows) must be rewritten into a single new base parquet holding exactly the
-// LWW winners, with the merged source objects removed from S3 and the
-// manifest, bit-for-bit identical federated results, an untouched hot tier,
-// and a Noop second pass (idempotency).
+// LWW winners, with the merged source objects spliced out of the manifest but
+// retained in S3 for the in-flight-reader window (#461), bit-for-bit
+// identical federated results, an untouched hot tier, and a Noop second pass
+// (idempotency).
 func TestCompactionRewriteEquivalence(t *testing.T) {
 	cluster := SharedCluster(t)
 	ctx := context.Background()
@@ -142,6 +163,8 @@ func TestCompactionRewriteEquivalence(t *testing.T) {
 
 	mBefore := loadSchemaManifest(ctx, t, env, wide)
 	mergedFiles := len(mBefore.Files)
+	everListed := map[string]bool{}
+	recordListedKeys(ctx, t, env, wide, everListed)
 
 	result := assertCompactionEquivalence(ctx, t, env, wide,
 		compactionEquivalenceQueries(wide), CompactionOverrides{}, "rewrite")
@@ -172,7 +195,7 @@ func TestCompactionRewriteEquivalence(t *testing.T) {
 		t.Errorf("manifest version %d -> %d, want monotonic advance", mBefore.Version, mAfter.Version)
 	}
 	assertNoDuplicateManifestEntries(t, mAfter)
-	assertManifestMatchesInventory(ctx, t, env, wide)
+	assertManifestMatchesInventory(ctx, t, env, wide, everListed)
 
 	winners := map[uuid.UUID]*Event{
 		creates[0].RowID: updates[0],
@@ -236,6 +259,8 @@ func TestCompactionRewriteMultiVersionLWW(t *testing.T) {
 	}
 	mustFlush(ctx, t, env) // delta #2: v2 of row 0
 
+	everListed := map[string]bool{}
+	recordListedKeys(ctx, t, env, wide, everListed)
 	result := assertCompactionEquivalence(ctx, t, env, wide,
 		compactionEquivalenceQueries(wide), CompactionOverrides{}, "multi-version")
 	if result.Outcome != compaction.RewriteApplied {
@@ -253,7 +278,7 @@ func TestCompactionRewriteMultiVersionLWW(t *testing.T) {
 		creates[1].RowID: creates[1],
 	}
 	assertRewrittenBase(ctx, t, env, result.NewBaseKey, winners, nil)
-	assertManifestMatchesInventory(ctx, t, env, wide)
+	assertManifestMatchesInventory(ctx, t, env, wide, everListed)
 	// #256: the merge writer stamps the new base entry from a DESCRIBE of the
 	// tmp object it merged into; tmp→final is a byte-identical copy, so the
 	// stamp must equal a DESCRIBE of the published object.
@@ -282,6 +307,8 @@ func TestCompactionRewriteAllTombstones(t *testing.T) {
 	}
 	mustFlush(ctx, t, env)
 
+	everListed := map[string]bool{}
+	recordListedKeys(ctx, t, env, wide, everListed)
 	result := assertCompactionEquivalence(ctx, t, env, wide,
 		compactionEquivalenceQueries(wide), CompactionOverrides{}, "all-tombstones")
 	if result.Outcome != compaction.RewriteApplied {
@@ -299,7 +326,7 @@ func TestCompactionRewriteAllTombstones(t *testing.T) {
 		t.Errorf("delta entries = %d, want 0", got)
 	}
 	assertRewrittenBase(ctx, t, env, result.NewBaseKey, nil, []uuid.UUID{creates[0].RowID, creates[1].RowID})
-	assertManifestMatchesInventory(ctx, t, env, wide)
+	assertManifestMatchesInventory(ctx, t, env, wide, everListed)
 	// #256 edge: a zero-row merged base still describes to a full column set,
 	// so it must still carry a byte-truth stamp rather than fall back to nil.
 	assertEntriesStampedToByteTruth(ctx, t, env, "compaction rewrite (zero-row merged base)",
@@ -335,6 +362,8 @@ func TestCompactionFullLifecycleEquivalence(t *testing.T) {
 	flush := mustFlush(ctx, t, env)
 	assertTombstoneParquet(ctx, t, env, soleParquetKey(t, flush), del)
 
+	everListed := map[string]bool{}
+	recordListedKeys(ctx, t, env, wide, everListed)
 	result := assertCompactionEquivalence(ctx, t, env, wide,
 		compactionEquivalenceQueries(wide), CompactionOverrides{}, "full-lifecycle")
 	if result.Outcome != compaction.RewriteApplied {
@@ -343,7 +372,7 @@ func TestCompactionFullLifecycleEquivalence(t *testing.T) {
 
 	winners := map[uuid.UUID]*Event{creates[0].RowID: update}
 	assertRewrittenBase(ctx, t, env, result.NewBaseKey, winners, []uuid.UUID{del.RowID})
-	assertManifestMatchesInventory(ctx, t, env, wide)
+	assertManifestMatchesInventory(ctx, t, env, wide, everListed)
 
 	// Deletion stays invisible under every tier preference; parquet-serving
 	// hints must still route through DuckDB (mirrors lifecycle's #175 loop).


### PR DESCRIPTION
Fixes #461.

## Problem

`runRewrite` deleted the merged source objects immediately after the CAS manifest swap, with zero retention grace. A federated read that resolved its path set from the pre-swap manifest and was still lazily opening objects failed with `ParquetSetInconsistentError` — non-degradable, breaker-worthy, never retried — so routine compaction on a healthy system produced hard read failures and could open the DuckDB circuit breaker.

## Fix (writer-side, acceptance criterion 1)

The compactor no longer deletes the freshly-spliced-out sources. They stay behind as unlisted orphans for `manifest-reconcile`, whose `gcSchema` sighting-state grace (default `--gc-grace` 15m, requiring both "unlisted longer than grace" and "object older than grace") was built exactly for the in-flight-reader window. Base/tmp shapes are reclaimed by `--gc`, delta shapes by `--repair --gc`. The only inline deletion left is a confirmed-412 conflict dropping its own never-listed staged base — no reader can hold that key.

Safety of the handoff, verified against the reconcile guards:

- **Delta orphans are not re-appended by `--repair`:** `classifyDeltaOrphan` probes uncovered rows against the listed inventory; a compacted-away delta is fully covered by the new merged base → `deltaLeftover` → GC path.
- **Init-shaped base orphans are not re-promoted:** `checkEvictionDates` refuses a promotion when any listed base entry postdates the init export — after a rewrite the freshly merged base always does.

The read-side alternative in the issue (re-resolve the manifest once before classifying) is deliberately **not** implemented: `ParquetSource.MissingIn`'s godoc records the #249 adjudication that classification must probe the exact path set the failed scan used, and the acceptance criteria are joined by "or".

## Test changes

- `internal/compaction/rewrite_test.go`: success and conflict-retry paths now pin retention (no source deletes; the confirmed-412 staged-base delete stays).
- `assertManifestMatchesInventory` (production e2e) now pins the two invariants the retention contract actually guarantees: every manifest entry exists in S3 (manifest ⊆ live objects), and every unlisted live object was manifest-listed earlier in the test — a never-listed leftover still fails as a staged orphan (the atomicity test's 412 staged-base check keeps its teeth).
- **New regression (required coverage):** `TestCompactionRewriteInFlightReaderRetention` holds the path set resolved from the pre-swap manifest across a real rewrite publish, asserts every pre-swap object survives, and executes a query pinned to that path set through the real engine — it must succeed with oracle-identical results.
- `docs/manifest-reconcile.md`: #188 leftovers are now the routine product of every rewrite, not just crash residue; reconcile's two-phase grace GC is their documented reclamation path.

## Verification (all executed)

- `make test` (full unit suite incl. e2e smoke, rootless Podman): PASS
- `make fmt-check`, `make lint` (root + infra): PASS
- `go test -tags=e2e ./internal/e2e_harness/production -run TestCompactionRewriteInFlightReaderRetention`: PASS
- `go test -tags=e2e ./internal/e2e_harness/production -run 'TestCompaction|TestChecksumCorruptionChain|TestManifestConsistency'`: PASS (132s)

## Operational note

Deployments that never run `manifest-reconcile --gc` (and `--repair --gc` for delta shapes) will accumulate retired sources; the objects are unlisted, so they are invisible to reads (the production glob does not cross `/`, and manifest-driven reads scan only listed objects) — this matches the already-documented recovery contract for failed deletions.




## Release note

> Compaction no longer deletes merged source objects inline; reclamation now requires periodically scheduled `manifest-reconcile --gc` (plus `--repair --gc` for delta shapes). Deployments without a reconcile schedule will accumulate unlisted retired sources (invisible to reads, unbounded storage growth).
