### PR TITLE
fix(federated): enforce declared-type fit at write, project EAV narrow ints by storage width (#384)

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -605,7 +605,9 @@ stamp existing.
 ### **6.3 Smart Type Casting**
 
 * PostgreSQL numeric $\rightarrow$ DuckDB DOUBLE (Precision loss acceptable for search, not for finance).
-* PostgreSQL smallint $\rightarrow$ DuckDB INTEGER or BIGINT (Safe).
+* PostgreSQL smallint/integer $\rightarrow$ **binding-dependent**: column-bound
+  attributes keep the physical SMALLINT/INTEGER width, EAV-only attributes
+  carry storage width DOUBLE — the precise per-surface contract is §6.4 (#384).
 * PostgreSQL text (containing UUID) $\rightarrow$ DuckDB UUID (Explicit cast required).
 
 ### **6.4 Numeric Width Contract (#384)**

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -631,9 +631,15 @@ applied on both sides:
   width: their storage is physically int4/int2.
 * **Predicate operands**: DuckDB operand casts follow column storage width —
   `integer`/`smallint`/`numeric` operands cast to `DOUBLE` (an operand of any
-  magnitude compares, like Postgres, instead of raising a Conversion Error;
-  the former `DECIMAL(38,10)` numeric cast also truncated operand scale at 10
-  fractional digits and overflowed past ~1e28). Float64 operands bind in
+  magnitude compares instead of raising a Conversion Error; the former
+  `DECIMAL(38,10)` numeric cast also truncated operand scale at 10 fractional
+  digits and overflowed past ~1e28). To keep the Postgres route on the same
+  verdict, integral operands for these DOUBLE-width classes **narrow through
+  the same float64 funnel the stored data took**
+  (`sqlgen.NarrowEAVNumericOperand`, applied by the EAV predicate binder and
+  the batch attr-value anchor alike): above 2^53 both engines compare the
+  operand's float64 image, rather than Postgres comparing the exact integer
+  while DuckDB matches its rounded neighbor. Float64 operands bind in
   shortest round-trip form (`strconv.FormatFloat(v, 'g', -1, 64)`), so the
   DuckDB side recovers the identical float64 the PG side binds — `%.15g`
   dropped the 16th-17th significant digits. `bigint` stays `BIGINT` with

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -610,36 +610,47 @@ stamp existing.
 
 ### **6.4 Numeric Width Contract (#384)**
 
-`eav_data.value_numeric` is an unconstrained PG `NUMERIC`, so declared attribute
-width and physical storage width can disagree. The ruling, applied on both
-sides:
+`eav_data.value_numeric` is an unconstrained PG `NUMERIC`, but every value the
+write funnel puts there is a **float64 image** (`transform.populateTypedValue`
+narrows the whole numeric family through `numutil.Float64`), so the effective
+EAV storage width is DOUBLE regardless of the declared type. The ruling,
+applied on both sides:
 
-* **Write side**: the EAV write funnel (`transform.populateTypedValue`) rejects
-  numeric-family values that do not fit the declared integer type — out of
-  range or non-integral for `smallint`/`integer`/`bigint` — as user-facing
-  invalid input. `numeric` stays unconstrained (its float64 ceiling is #205).
-  Main-column-bound write fidelity is tracked separately (#459).
+* **Write side**: the EAV write funnel rejects numeric-family values that do
+  not fit the declared integer type — out of range or non-integral for
+  `smallint`/`integer`/`bigint` — as user-facing invalid input. `numeric`
+  stays unconstrained (its float64 ceiling is #205). Main-column-bound write
+  fidelity is tracked separately (#459).
 * **Projection**: EAV-only `integer`/`smallint` project by **storage width** —
-  `TRY_CAST(value_numeric AS BIGINT)` — on every DuckDB surface (hot EAV pivot,
-  list elements, CDC parquet export, cold NULL augmentation), so historical
-  out-of-declared-range rows answer identically on all tiers instead of being
-  NULL only on DuckDB. Column-bound attributes keep declared width: their
-  storage is physically int4/int2.
+  `TRY_CAST(value_numeric AS DOUBLE)`, exactly like the `numeric` class — on
+  every DuckDB surface (hot EAV pivot, list elements, CDC parquet export, cold
+  NULL augmentation). DOUBLE reproduces every float64 image faithfully, so
+  historical out-of-declared-range *and* non-integral rows answer identically
+  on all tiers (an integer-width cast NULLed the former and rounded the
+  latter, only on the DuckDB legs). Column-bound attributes keep declared
+  width: their storage is physically int4/int2.
 * **Predicate operands**: DuckDB operand casts follow column storage width —
-  `integer`/`smallint` operands cast to `BIGINT` (an out-of-range operand
-  matches nothing, like Postgres, instead of raising a Conversion Error) and
-  `numeric` operands cast to `DOUBLE` (matching the DOUBLE columns; the former
-  `DECIMAL(38,10)` cast truncated operand scale at 10 fractional digits and
-  overflowed past ~1e28).
-* **Bool truthiness**: both engines compare `value_numeric <> 0`. The PG EAV
-  EXISTS predicate renders `(x.value_numeric <> 0) =/!= <bool>` rather than
-  `x.value_numeric = 1.0/0.0`, matching every DuckDB leg's column derivation.
+  `integer`/`smallint`/`numeric` operands cast to `DOUBLE` (an operand of any
+  magnitude compares, like Postgres, instead of raising a Conversion Error;
+  the former `DECIMAL(38,10)` numeric cast also truncated operand scale at 10
+  fractional digits and overflowed past ~1e28). Float64 operands bind in
+  shortest round-trip form (`strconv.FormatFloat(v, 'g', -1, 64)`), so the
+  DuckDB side recovers the identical float64 the PG side binds — `%.15g`
+  dropped the 16th-17th significant digits. `bigint` stays `BIGINT` with
+  exact int64/decimal-string binds (#281/#357).
+* **Bool**: both engines compare the `value_numeric <> 0` truthiness — the PG
+  EAV EXISTS predicate renders `(x.value_numeric <> 0) =/!= <bool>` — and
+  parse operands under one shared rule (`ParseBool` spellings, else any
+  integer with `>0` truthiness), so no spelling errors on exactly one route.
   (The write-side bool truth table is #404.)
 
 Parquet files written before this contract carry INT32/INT16 attribute columns
 and NULLs where a value exceeded the declared width; `union_by_name=true` scans
 promote the mixed widths losslessly, and the NULLs are unrecoverable from
-parquet alone (re-flush from PG restores them).
+parquet alone (re-flush from PG restores them; #501 tracks detection/repair).
+The remaining asymmetry class is #205's float64 ceiling: values only a full
+NUMERIC can hold (planted by direct SQL, never by the funnel) still read
+exactly on Postgres and as their float64 image on DuckDB.
 
 ## **7. Resilience and Error Handling**
 

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -608,6 +608,39 @@ stamp existing.
 * PostgreSQL smallint $\rightarrow$ DuckDB INTEGER or BIGINT (Safe).
 * PostgreSQL text (containing UUID) $\rightarrow$ DuckDB UUID (Explicit cast required).
 
+### **6.4 Numeric Width Contract (#384)**
+
+`eav_data.value_numeric` is an unconstrained PG `NUMERIC`, so declared attribute
+width and physical storage width can disagree. The ruling, applied on both
+sides:
+
+* **Write side**: the EAV write funnel (`transform.populateTypedValue`) rejects
+  numeric-family values that do not fit the declared integer type — out of
+  range or non-integral for `smallint`/`integer`/`bigint` — as user-facing
+  invalid input. `numeric` stays unconstrained (its float64 ceiling is #205).
+  Main-column-bound write fidelity is tracked separately (#459).
+* **Projection**: EAV-only `integer`/`smallint` project by **storage width** —
+  `TRY_CAST(value_numeric AS BIGINT)` — on every DuckDB surface (hot EAV pivot,
+  list elements, CDC parquet export, cold NULL augmentation), so historical
+  out-of-declared-range rows answer identically on all tiers instead of being
+  NULL only on DuckDB. Column-bound attributes keep declared width: their
+  storage is physically int4/int2.
+* **Predicate operands**: DuckDB operand casts follow column storage width —
+  `integer`/`smallint` operands cast to `BIGINT` (an out-of-range operand
+  matches nothing, like Postgres, instead of raising a Conversion Error) and
+  `numeric` operands cast to `DOUBLE` (matching the DOUBLE columns; the former
+  `DECIMAL(38,10)` cast truncated operand scale at 10 fractional digits and
+  overflowed past ~1e28).
+* **Bool truthiness**: both engines compare `value_numeric <> 0`. The PG EAV
+  EXISTS predicate renders `(x.value_numeric <> 0) =/!= <bool>` rather than
+  `x.value_numeric = 1.0/0.0`, matching every DuckDB leg's column derivation.
+  (The write-side bool truth table is #404.)
+
+Parquet files written before this contract carry INT32/INT16 attribute columns
+and NULLs where a value exceeded the declared width; `union_by_name=true` scans
+promote the mixed widths losslessly, and the NULLs are unrecoverable from
+parquet alone (re-flush from PG restores them).
+
 ## **7. Resilience and Error Handling**
 
 ### **7.1 Circuit Breaker**

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -342,10 +342,12 @@ func castEAVValue(meta forma.AttributeMetadata) string {
 		return "TRY_CAST(value_numeric AS BIGINT)"
 	case forma.ValueTypeSmallInt, forma.ValueTypeInteger:
 		// castEAVValue only ever serves EAV-only attributes (bound attrs
-		// export through castMainValue), whose storage is unconstrained
-		// NUMERIC: export by storage width so the parquet tiers keep values
-		// the declared width cannot hold, matching the hot pivot (#384).
-		return "TRY_CAST(value_numeric AS BIGINT)"
+		// export through castMainValue), whose value_numeric holds float64
+		// images (the write funnel narrows through numutil.Float64): export
+		// by storage width DOUBLE so the parquet tiers keep values the
+		// declared width cannot hold — over-range and non-integral history
+		// alike — matching the hot pivot (#384).
+		return "TRY_CAST(value_numeric AS DOUBLE)"
 	case forma.ValueTypeBigInt, forma.ValueTypeNumeric:
 		return fmt.Sprintf("TRY_CAST(value_numeric AS %s)", duckTypeForValue(meta.ValueType))
 	case forma.ValueTypeUUID:

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -340,7 +340,13 @@ func castEAVValue(meta forma.AttributeMetadata) string {
 		return "(value_numeric <> 0)"
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
 		return "TRY_CAST(value_numeric AS BIGINT)"
-	case forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeNumeric:
+	case forma.ValueTypeSmallInt, forma.ValueTypeInteger:
+		// castEAVValue only ever serves EAV-only attributes (bound attrs
+		// export through castMainValue), whose storage is unconstrained
+		// NUMERIC: export by storage width so the parquet tiers keep values
+		// the declared width cannot hold, matching the hot pivot (#384).
+		return "TRY_CAST(value_numeric AS BIGINT)"
+	case forma.ValueTypeBigInt, forma.ValueTypeNumeric:
 		return fmt.Sprintf("TRY_CAST(value_numeric AS %s)", duckTypeForValue(meta.ValueType))
 	case forma.ValueTypeUUID:
 		return "CAST(value_text AS VARCHAR)"

--- a/internal/cdc/duckdb_exporter_type_lockstep_test.go
+++ b/internal/cdc/duckdb_exporter_type_lockstep_test.go
@@ -47,7 +47,7 @@ func TestCastEAVValueMatchesNullScanTypeof(t *testing.T) {
 
 			var scan string
 			require.NoError(t,
-				db.QueryRow("SELECT typeof(NULL::"+sqlgen.DuckDBNullScanType(vt, "")+")").Scan(&scan))
+				db.QueryRow("SELECT typeof(NULL::"+sqlgen.DuckDBNullScanType(forma.AttributeMetadata{ValueType: vt})+")").Scan(&scan))
 
 			require.Equal(t, exported, scan,
 				"cold NULL scan type must equal the exported parquet column type for %s (#205 no-widening)", vt)

--- a/internal/cdc/export_sql_shared_test.go
+++ b/internal/cdc/export_sql_shared_test.go
@@ -212,7 +212,8 @@ func TestBuildSchemaDrivenProjection_MixedBoundAndUnboundAttributesKeepCastsAlia
 	require.Contains(t, projection.mainProjections[0], "AS display_name")
 	require.Len(t, projection.eavAgg, 2)
 	require.Contains(t, projection.eavAgg[0], "attr_id = 21")
-	require.Contains(t, projection.eavAgg[0], "TRY_CAST(value_numeric AS INTEGER)")
+	// #384: EAV-only integer exports by storage width (BIGINT).
+	require.Contains(t, projection.eavAgg[0], "TRY_CAST(value_numeric AS BIGINT)")
 	require.Contains(t, projection.eavAgg[0], "AS employee_count")
 	require.Contains(t, projection.eavAgg[1], "attr_id = 22")
 	require.Contains(t, projection.eavAgg[1], "(value_numeric <> 0)")
@@ -281,7 +282,7 @@ func TestBuildSchemaDrivenProjection_ListAttrAggregatesElementsOrderedByIndex(t 
 	// aggregate but detected by the presence count, so an explicit empty
 	// list exports as [] while an absent attribute exports as NULL (#204).
 	require.Equal(t,
-		"CASE WHEN count(*) FILTER (WHERE attr_id = 19) > 0 THEN coalesce(list(TRY_CAST(value_numeric AS INTEGER) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 19 AND array_indices <> ''), []) END AS nums",
+		"CASE WHEN count(*) FILTER (WHERE attr_id = 19) > 0 THEN coalesce(list(TRY_CAST(value_numeric AS BIGINT) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 19 AND array_indices <> ''), []) END AS nums",
 		projection.eavAgg[1])
 	require.Equal(t,
 		"CASE WHEN count(*) FILTER (WHERE attr_id = 18) > 0 THEN coalesce(list(CAST(value_text AS VARCHAR) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 18 AND array_indices <> ''), []) END AS tags",

--- a/internal/cdc/export_sql_shared_test.go
+++ b/internal/cdc/export_sql_shared_test.go
@@ -212,8 +212,9 @@ func TestBuildSchemaDrivenProjection_MixedBoundAndUnboundAttributesKeepCastsAlia
 	require.Contains(t, projection.mainProjections[0], "AS display_name")
 	require.Len(t, projection.eavAgg, 2)
 	require.Contains(t, projection.eavAgg[0], "attr_id = 21")
-	// #384: EAV-only integer exports by storage width (BIGINT).
-	require.Contains(t, projection.eavAgg[0], "TRY_CAST(value_numeric AS BIGINT)")
+	// #384: EAV-only integer exports by storage width (DOUBLE — the write
+	// funnel narrows everything through float64).
+	require.Contains(t, projection.eavAgg[0], "TRY_CAST(value_numeric AS DOUBLE)")
 	require.Contains(t, projection.eavAgg[0], "AS employee_count")
 	require.Contains(t, projection.eavAgg[1], "attr_id = 22")
 	require.Contains(t, projection.eavAgg[1], "(value_numeric <> 0)")
@@ -282,7 +283,7 @@ func TestBuildSchemaDrivenProjection_ListAttrAggregatesElementsOrderedByIndex(t 
 	// aggregate but detected by the presence count, so an explicit empty
 	// list exports as [] while an absent attribute exports as NULL (#204).
 	require.Equal(t,
-		"CASE WHEN count(*) FILTER (WHERE attr_id = 19) > 0 THEN coalesce(list(TRY_CAST(value_numeric AS BIGINT) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 19 AND array_indices <> ''), []) END AS nums",
+		"CASE WHEN count(*) FILTER (WHERE attr_id = 19) > 0 THEN coalesce(list(TRY_CAST(value_numeric AS DOUBLE) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 19 AND array_indices <> ''), []) END AS nums",
 		projection.eavAgg[1])
 	require.Equal(t,
 		"CASE WHEN count(*) FILTER (WHERE attr_id = 18) > 0 THEN coalesce(list(CAST(value_text AS VARCHAR) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 18 AND array_indices <> ''), []) END AS tags",

--- a/internal/e2e_harness/production/compaction_evolution_e2e_test.go
+++ b/internal/e2e_harness/production/compaction_evolution_e2e_test.go
@@ -66,7 +66,7 @@ func buildEvoV1Profile() AttrProfile {
 }
 
 // buildEvoV2Profile seeds v2 rows: new_col + fractional score, so any silent
-// DOUBLE→INTEGER coercion in the merge corrupts a visible value.
+// DOUBLE→BIGINT coercion in the merge corrupts a visible value.
 func buildEvoV2Profile() AttrProfile {
 	return buildEvolutionProfile(func(ordinal int) map[string]any {
 		return map[string]any{
@@ -78,7 +78,7 @@ func buildEvoV2Profile() AttrProfile {
 
 // buildEvolutionEquivalenceQueries is the before/after snapshot set: an
 // unsorted page, a sort on a generation-stable attribute, a score filter
-// spanning both generations (v1 INTEGER rows and v2 DOUBLE rows in one
+// spanning both generations (v1 BIGINT rows and v2 DOUBLE rows in one
 // numeric domain, with the boundary row score=20 included), and a new_col
 // filter that only v2-generation rows can match (v1 rows are NULL).
 func buildEvolutionEquivalenceQueries(schema SchemaRef) []Query {
@@ -179,8 +179,8 @@ func assertMergedBaseUnion(ctx context.Context, t *testing.T, env *Env, key stri
 		"name":    "VARCHAR",
 		"value":   "DOUBLE",
 		"old_col": "VARCHAR", // v1 legacy column survives the union
-		"new_col": "INTEGER", // v2 addition present
-		"score":   "DOUBLE",  // INTEGER widened to the delta's DOUBLE
+		"new_col": "BIGINT",  // v2 addition present
+		"score":   "DOUBLE",  // BIGINT widened to the delta's DOUBLE
 	})
 
 	path := buildParquetS3Path(env, key)
@@ -291,11 +291,11 @@ func TestCompactionMixedGenerationEquivalence(t *testing.T) {
 	// shapes the equivalence pass proves nothing about cross-generation merge.
 	baseCols := describeParquetCols(ctx, t, env, seed.baseKey)
 	requireParquetCols(t, "base (v1)", baseCols, map[string]string{
-		"name": "VARCHAR", "value": "DOUBLE", "old_col": "VARCHAR", "score": "INTEGER"})
+		"name": "VARCHAR", "value": "DOUBLE", "old_col": "VARCHAR", "score": "BIGINT"})
 	forbidParquetCols(t, "base (v1)", baseCols, "new_col")
 	deltaCols := describeParquetCols(ctx, t, env, seed.deltaKey)
 	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{
-		"score": "DOUBLE", "new_col": "INTEGER"})
+		"score": "DOUBLE", "new_col": "BIGINT"})
 	forbidParquetCols(t, "delta (v2)", deltaCols, "old_col")
 
 	// Positive control for the row-level LWW assertion: the update targets'
@@ -395,7 +395,7 @@ func verifyPostCompactionEvolution(ctx context.Context, t *testing.T, env *Env, 
 
 	// Monotonic healing: the second merge output keeps the union shape.
 	requireParquetCols(t, "second merged base", describeParquetCols(ctx, t, env, second.NewBaseKey),
-		map[string]string{"old_col": "VARCHAR", "new_col": "INTEGER", "score": "DOUBLE"})
+		map[string]string{"old_col": "VARCHAR", "new_col": "BIGINT", "score": "DOUBLE"})
 	path := buildParquetS3Path(env, second.NewBaseKey)
 	var oldColSurvivors int
 	if err := env.Duck.DB.QueryRowContext(ctx, fmt.Sprintf(

--- a/internal/e2e_harness/production/compaction_evolution_e2e_test.go
+++ b/internal/e2e_harness/production/compaction_evolution_e2e_test.go
@@ -66,7 +66,7 @@ func buildEvoV1Profile() AttrProfile {
 }
 
 // buildEvoV2Profile seeds v2 rows: new_col + fractional score, so any silent
-// DOUBLE→BIGINT coercion in the merge corrupts a visible value.
+// DOUBLE→integer coercion in the merge corrupts a visible value.
 func buildEvoV2Profile() AttrProfile {
 	return buildEvolutionProfile(func(ordinal int) map[string]any {
 		return map[string]any{
@@ -78,7 +78,7 @@ func buildEvoV2Profile() AttrProfile {
 
 // buildEvolutionEquivalenceQueries is the before/after snapshot set: an
 // unsorted page, a sort on a generation-stable attribute, a score filter
-// spanning both generations (v1 BIGINT rows and v2 DOUBLE rows in one
+// spanning both generations (v1 integer-generation rows and v2 DOUBLE rows in one
 // numeric domain, with the boundary row score=20 included), and a new_col
 // filter that only v2-generation rows can match (v1 rows are NULL).
 func buildEvolutionEquivalenceQueries(schema SchemaRef) []Query {
@@ -179,8 +179,8 @@ func assertMergedBaseUnion(ctx context.Context, t *testing.T, env *Env, key stri
 		"name":    "VARCHAR",
 		"value":   "DOUBLE",
 		"old_col": "VARCHAR", // v1 legacy column survives the union
-		"new_col": "BIGINT",  // v2 addition present
-		"score":   "DOUBLE",  // BIGINT widened to the delta's DOUBLE
+		"new_col": "DOUBLE",  // v2 addition present
+		"score":   "DOUBLE",  // both generations export DOUBLE since #384; was BIGINT widened to the delta's DOUBLE
 	})
 
 	path := buildParquetS3Path(env, key)
@@ -291,11 +291,11 @@ func TestCompactionMixedGenerationEquivalence(t *testing.T) {
 	// shapes the equivalence pass proves nothing about cross-generation merge.
 	baseCols := describeParquetCols(ctx, t, env, seed.baseKey)
 	requireParquetCols(t, "base (v1)", baseCols, map[string]string{
-		"name": "VARCHAR", "value": "DOUBLE", "old_col": "VARCHAR", "score": "BIGINT"})
+		"name": "VARCHAR", "value": "DOUBLE", "old_col": "VARCHAR", "score": "DOUBLE"})
 	forbidParquetCols(t, "base (v1)", baseCols, "new_col")
 	deltaCols := describeParquetCols(ctx, t, env, seed.deltaKey)
 	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{
-		"score": "DOUBLE", "new_col": "BIGINT"})
+		"score": "DOUBLE", "new_col": "DOUBLE"})
 	forbidParquetCols(t, "delta (v2)", deltaCols, "old_col")
 
 	// Positive control for the row-level LWW assertion: the update targets'
@@ -395,7 +395,7 @@ func verifyPostCompactionEvolution(ctx context.Context, t *testing.T, env *Env, 
 
 	// Monotonic healing: the second merge output keeps the union shape.
 	requireParquetCols(t, "second merged base", describeParquetCols(ctx, t, env, second.NewBaseKey),
-		map[string]string{"old_col": "VARCHAR", "new_col": "BIGINT", "score": "DOUBLE"})
+		map[string]string{"old_col": "VARCHAR", "new_col": "DOUBLE", "score": "DOUBLE"})
 	path := buildParquetS3Path(env, second.NewBaseKey)
 	var oldColSurvivors int
 	if err := env.Duck.DB.QueryRowContext(ctx, fmt.Sprintf(

--- a/internal/e2e_harness/production/full_type_parquet_e2e_test.go
+++ b/internal/e2e_harness/production/full_type_parquet_e2e_test.go
@@ -294,8 +294,10 @@ func assertWideParquetValues(ctx context.Context, t *testing.T, env *Env, key, t
 	for rows.Next() {
 		var rowIDStr string
 		var title, ref, note, token sql.NullString
-		var rank, level sql.NullInt16
-		var count, qty sql.NullInt32
+		var rank sql.NullInt16
+		var count sql.NullInt32
+		// EAV-only level/qty are physically DOUBLE since #384.
+		var level, qty sql.NullFloat64
 		var amount, joined, touched, born, seen, total sql.NullInt64
 		var score, ratio sql.NullFloat64
 		var active sql.NullBool
@@ -320,9 +322,9 @@ func assertWideParquetValues(ctx context.Context, t *testing.T, env *Env, key, t
 		checkStr(t, tier, rowID, "ref", ref, want.ref)
 		checkStr(t, tier, rowID, "token", token, want.token)
 		checkI16(t, tier, rowID, "rank", rank, want.rank)
-		checkI16(t, tier, rowID, "level", level, want.level)
+		checkNarrowFromDouble(t, tier, rowID, "level", level, want.level)
 		checkI32(t, tier, rowID, "count", count, want.count)
-		checkI32(t, tier, rowID, "qty", qty, want.qty)
+		checkNarrowFromDouble(t, tier, rowID, "qty", qty, want.qty)
 		checkI64(t, tier, rowID, "amount", amount, want.amount)
 		checkI64(t, tier, rowID, "joined", joined, want.joined)
 		checkI64(t, tier, rowID, "touched", touched, want.touched)
@@ -416,6 +418,21 @@ func checkI32(t *testing.T, tier string, rowID uuid.UUID, col string, got sql.Nu
 		t.Errorf("%s %s.%s = NULL, want %d", tier, rowID, col, *want)
 	case want != nil && got.Int32 != *want:
 		t.Errorf("%s %s.%s = %d, want %d", tier, rowID, col, got.Int32, *want)
+	}
+}
+
+// checkNarrowFromDouble compares a DOUBLE parquet column (EAV-only narrow
+// ints export at storage width DOUBLE, #384) against the declared-width
+// truth; every in-range integer value is exact in DOUBLE.
+func checkNarrowFromDouble[T int16 | int32](t *testing.T, tier string, rowID uuid.UUID, col string, got sql.NullFloat64, want *T) {
+	t.Helper()
+	switch {
+	case want == nil && got.Valid:
+		t.Errorf("%s %s.%s = %v, want NULL", tier, rowID, col, got.Float64)
+	case want != nil && !got.Valid:
+		t.Errorf("%s %s.%s = NULL, want %d", tier, rowID, col, *want)
+	case want != nil && got.Float64 != float64(*want):
+		t.Errorf("%s %s.%s = %v, want %d", tier, rowID, col, got.Float64, *want)
 	}
 }
 

--- a/internal/e2e_harness/production/full_type_parquet_e2e_test.go
+++ b/internal/e2e_harness/production/full_type_parquet_e2e_test.go
@@ -18,8 +18,9 @@ import (
 // castEAVValue (internal/cdc/duckdb_exporter.go); note the deliberate
 // asymmetries: bound uuid (ref) is physical UUID while EAV uuid (token) is
 // VARCHAR, and bound smallint/integer (rank/count) keep declared width while
-// EAV-only level/qty export at storage width BIGINT (#384 — value_numeric is
-// unconstrained NUMERIC, so declared width manufactured NULLs).
+// EAV-only level/qty export at storage width DOUBLE (#384 — value_numeric
+// holds float64 images from the write funnel, so declared width manufactured
+// NULLs for over-range history and rounded non-integral history).
 var wideParquetTypes = map[string]string{
 	"schema_id": "SMALLINT", "row_id": "UUID",
 	"changed_at": "BIGINT", "deleted_at": "BIGINT",
@@ -27,7 +28,7 @@ var wideParquetTypes = map[string]string{
 	"title": "VARCHAR", "rank": "SMALLINT", "count": "INTEGER", "amount": "BIGINT",
 	"score": "DOUBLE", "ref": "UUID", "joined": "BIGINT", "touched": "BIGINT",
 	"note": "VARCHAR", "active": "BOOLEAN", "born": "BIGINT", "seen": "BIGINT",
-	"level": "BIGINT", "qty": "BIGINT", "total": "BIGINT", "ratio": "DOUBLE", "token": "VARCHAR",
+	"level": "DOUBLE", "qty": "DOUBLE", "total": "BIGINT", "ratio": "DOUBLE", "token": "VARCHAR",
 	// #204: list attrs export as a DuckDB LIST of the items type.
 	"tags": "VARCHAR[]",
 }

--- a/internal/e2e_harness/production/full_type_parquet_e2e_test.go
+++ b/internal/e2e_harness/production/full_type_parquet_e2e_test.go
@@ -16,7 +16,10 @@ import (
 // wideParquetTypes pins the physical parquet schema of e2e_wide exports.
 // Attribute types come from cdc.duckTypeForValue / castMainValue /
 // castEAVValue (internal/cdc/duckdb_exporter.go); note the deliberate
-// asymmetry: bound uuid (ref) is physical UUID, EAV uuid (token) is VARCHAR.
+// asymmetries: bound uuid (ref) is physical UUID while EAV uuid (token) is
+// VARCHAR, and bound smallint/integer (rank/count) keep declared width while
+// EAV-only level/qty export at storage width BIGINT (#384 — value_numeric is
+// unconstrained NUMERIC, so declared width manufactured NULLs).
 var wideParquetTypes = map[string]string{
 	"schema_id": "SMALLINT", "row_id": "UUID",
 	"changed_at": "BIGINT", "deleted_at": "BIGINT",
@@ -24,7 +27,7 @@ var wideParquetTypes = map[string]string{
 	"title": "VARCHAR", "rank": "SMALLINT", "count": "INTEGER", "amount": "BIGINT",
 	"score": "DOUBLE", "ref": "UUID", "joined": "BIGINT", "touched": "BIGINT",
 	"note": "VARCHAR", "active": "BOOLEAN", "born": "BIGINT", "seen": "BIGINT",
-	"level": "SMALLINT", "qty": "INTEGER", "total": "BIGINT", "ratio": "DOUBLE", "token": "VARCHAR",
+	"level": "BIGINT", "qty": "BIGINT", "total": "BIGINT", "ratio": "DOUBLE", "token": "VARCHAR",
 	// #204: list attrs export as a DuckDB LIST of the items type.
 	"tags": "VARCHAR[]",
 }

--- a/internal/e2e_harness/production/manifest_stamp_rerun_e2e_test.go
+++ b/internal/e2e_harness/production/manifest_stamp_rerun_e2e_test.go
@@ -54,7 +54,7 @@ func TestManifestStamp_InPlaceRewriteInvalidatesValidatorCache(t *testing.T) {
 		func(ordinal int) map[string]any { return map[string]any{"score": float64(50 + ordinal*10)} })))
 	baseKey := runInitBase(ctx, t, env, simple)
 	requireParquetCols(t, "base (with score)", describeParquetCols(ctx, t, env, baseKey),
-		map[string]string{"score": "INTEGER"})
+		map[string]string{"score": "BIGINT"})
 
 	// Warm-up: builds the engine that must survive both rewrites and leaves
 	// the validator holding a column set that CLAIMS score.

--- a/internal/e2e_harness/production/manifest_stamp_rerun_e2e_test.go
+++ b/internal/e2e_harness/production/manifest_stamp_rerun_e2e_test.go
@@ -54,7 +54,7 @@ func TestManifestStamp_InPlaceRewriteInvalidatesValidatorCache(t *testing.T) {
 		func(ordinal int) map[string]any { return map[string]any{"score": float64(50 + ordinal*10)} })))
 	baseKey := runInitBase(ctx, t, env, simple)
 	requireParquetCols(t, "base (with score)", describeParquetCols(ctx, t, env, baseKey),
-		map[string]string{"score": "BIGINT"})
+		map[string]string{"score": "DOUBLE"})
 
 	// Warm-up: builds the engine that must survive both rewrites and leaves
 	// the validator holding a column set that CLAIMS score.

--- a/internal/e2e_harness/production/numeric_width_parity_e2e_test.go
+++ b/internal/e2e_harness/production/numeric_width_parity_e2e_test.go
@@ -109,9 +109,10 @@ func TestEAVIntegerWidthParityBothDialects(t *testing.T) {
 	// smallint. In-range placeholders first; the illegal state is planted.
 	rowOver := CreateEvent(wide, map[string]any{"title": "w-qty-over", "qty": 42})
 	rowFrac := CreateEvent(wide, map[string]any{"title": "w-qty-frac", "qty": 43})
+	rowP53 := CreateEvent(wide, map[string]any{"title": "w-qty-p53", "qty": 44})
 	rowSmall := CreateEvent(wide, map[string]any{"title": "w-qty-small", "qty": 7})
 	rowLevel := CreateEvent(wide, map[string]any{"title": "w-level-over", "level": 5})
-	seeded := []*Event{rowOver, rowFrac, rowSmall, rowLevel}
+	seeded := []*Event{rowOver, rowFrac, rowP53, rowSmall, rowLevel}
 	mustApplyEvents(ctx, t, env, "width parity creates", seeded...)
 
 	env.ExecSQL(ctx,
@@ -121,6 +122,9 @@ func TestEAVIntegerWidthParityBothDialects(t *testing.T) {
 		"UPDATE eav_data SET value_numeric = 1.5 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 14",
 		wide.ID, rowFrac.RowID)
 	env.ExecSQL(ctx,
+		"UPDATE eav_data SET value_numeric = 9007199254740992 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 14",
+		wide.ID, rowP53.RowID)
+	env.ExecSQL(ctx,
 		"UPDATE eav_data SET value_numeric = 40000 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 13",
 		wide.ID, rowLevel.RowID)
 
@@ -128,16 +132,27 @@ func TestEAVIntegerWidthParityBothDialects(t *testing.T) {
 		// 2^32: past INT32. Equality must address the stored value on both
 		// dialects, and the DuckDB leg must not error on the operand.
 		{"qty_equals_2p32", Filter{Attr: "qty", Op: "equals", Value: "4294967296"}, []*Event{rowOver}},
-		// Range operator with an in-range literal still sees the row.
-		{"qty_gt_maxint32", Filter{Attr: "qty", Op: "gt", Value: "2147483647"}, []*Event{rowOver}},
+		// Range operator with an in-range literal sees both planted rows
+		// above INT32 (2^32 and 2^53).
+		{"qty_gt_maxint32", Filter{Attr: "qty", Op: "gt", Value: "2147483647"}, []*Event{rowOver, rowP53}},
 		// Non-integral history (P1a): DOUBLE projection keeps 1.5 as 1.5 on
 		// every DuckDB tier — an integer-width cast rounded it to 2, matching
 		// equals:2 only on the DuckDB legs while Postgres compared 1.5.
 		{"qty_equals_frac", Filter{Attr: "qty", Op: "equals", Value: "1.5"}, []*Event{rowFrac}},
 		{"qty_equals_2_not_frac", Filter{Attr: "qty", Op: "equals", Value: "2"}, nil},
+		// 2^53 boundary (fourth-review P1): the stored value is the float64
+		// image 2^53; the operand 2^53+1 narrows to that same image on BOTH
+		// engines (PG via NarrowEAVNumericOperand, DuckDB via CAST AS
+		// DOUBLE), so both match — pre-fix PG bound the exact int64 and
+		// missed while the DuckDB tiers matched. A representable neighbor
+		// (…990) still misses on both.
+		{"qty_equals_2p53", Filter{Attr: "qty", Op: "equals", Value: "9007199254740992"}, []*Event{rowP53}},
+		{"qty_equals_2p53_plus_1_same_image", Filter{Attr: "qty", Op: "equals", Value: "9007199254740993"}, []*Event{rowP53}},
+		{"qty_equals_2p53_minus_2_empty", Filter{Attr: "qty", Op: "equals", Value: "9007199254740990"}, nil},
 		// The placeholder values must be gone — guards that the UPDATEs took.
 		{"qty_equals_placeholder_gone", Filter{Attr: "qty", Op: "equals", Value: "42"}, nil},
 		{"qty_equals_frac_placeholder_gone", Filter{Attr: "qty", Op: "equals", Value: "43"}, nil},
+		{"qty_equals_p53_placeholder_gone", Filter{Attr: "qty", Op: "equals", Value: "44"}, nil},
 		// In-range values keep working.
 		{"qty_equals_in_range", Filter{Attr: "qty", Op: "equals", Value: "7"}, []*Event{rowSmall}},
 		// smallint twin at 40000 (past INT16).

--- a/internal/e2e_harness/production/numeric_width_parity_e2e_test.go
+++ b/internal/e2e_harness/production/numeric_width_parity_e2e_test.go
@@ -1,0 +1,236 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lychee-technology/forma"
+)
+
+// This file is the #384 acceptance suite: for EAV-only attributes whose
+// stored value_numeric falls outside (or beside) the declared width, hot
+// Postgres and cold DuckDB must answer the same filter identically —
+// projection by storage width (BIGINT/DOUBLE), operand casts by storage
+// width, and one bool truth rule (value_numeric <> 0) on both routes.
+//
+// Out-of-range values are planted by direct eav_data UPDATEs: the write
+// funnel rejects them since #384 (TestEAVIntegerWidthWriteRejection), so the
+// planted rows stand in for history written before the rejection existed.
+
+// widthProbe is one filter probe plus the exact row set it must return, on
+// both dialects. Expectations are row-identity sets, never oracle
+// comparisons (the oracle normalizes numerics to float64).
+type widthProbe struct {
+	name   string
+	filter Filter
+	want   []*Event
+}
+
+// runWidthProbes executes every probe and asserts the routing dialect plus
+// the exact row-ID set. wantDuck pins which binder actually ran.
+func runWidthProbes(ctx context.Context, t *testing.T, env *Env, label string,
+	base Query, wantDuck bool, probes []widthProbe) {
+	t.Helper()
+	for _, p := range probes {
+		q := base
+		q.Filters = []Filter{p.filter}
+		res := mustQuery(ctx, t, env, q)
+		if got := res.Plan.Routing.UseDuckDB; got != wantDuck {
+			t.Errorf("%s/%s: UseDuckDB = %t, want %t (routing %+v)",
+				label, p.name, got, wantDuck, res.Plan.Routing)
+		}
+		assertWidthRowSet(t, label+"/"+p.name, res, p.want)
+	}
+}
+
+// assertWidthRowSet fails unless res.Records is exactly the given events as an
+// unordered row-ID set. Both directions matter: a width mismatch can drop a
+// row that should match (NULL projection) and/or fail the query outright.
+func assertWidthRowSet(t *testing.T, label string, res *QueryResult, want []*Event) {
+	t.Helper()
+	got := map[uuid.UUID]bool{}
+	for _, r := range res.Records {
+		got[r.RowID] = true
+	}
+	if len(got) != len(want) {
+		t.Errorf("%s: %d rows, want %d (got %v)", label, len(got), len(want), got)
+	}
+	for _, ev := range want {
+		if !got[ev.RowID] {
+			t.Errorf("%s: missing row %s (%v)", label, ev.RowID, ev.Attrs["title"])
+		}
+	}
+}
+
+// serveFromCold exports every seeded row to base parquet and clears their
+// change_log entries so the rows leave the dirty set and are served from the
+// cold tier (the RunInit-plus-DELETE idiom of the boundary suites).
+func serveFromCold(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, seeded []*Event) {
+	t.Helper()
+	if _, err := env.RunInit(ctx, schema); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+	env.ExecSQL(ctx,
+		"DELETE FROM change_log WHERE schema_id = $1 AND row_id = ANY($2)",
+		schema.ID, rowIDs(seeded))
+}
+
+// TestEAVIntegerWidthParityBothDialects is the #384 headline: an EAV-only
+// integer/smallint value past the declared width (planted directly, standing
+// in for pre-rejection history) must be matched by the same filter on the hot
+// Postgres route and every DuckDB tier. Pre-#384 the DuckDB legs projected it
+// to NULL via TRY_CAST at declared width (no match) and the strict
+// CAST(? AS INTEGER) operand raised a Conversion Error for the out-of-range
+// literal, while hot Postgres compared the stored NUMERIC and matched.
+func TestEAVIntegerWidthParityBothDialects(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	// `qty` (attr 14) is the EAV-only integer, `level` (attr 13) the EAV-only
+	// smallint. In-range placeholders first; the over-range state is planted.
+	rowOver := CreateEvent(wide, map[string]any{"title": "w-qty-over", "qty": 42})
+	rowSmall := CreateEvent(wide, map[string]any{"title": "w-qty-small", "qty": 7})
+	rowLevel := CreateEvent(wide, map[string]any{"title": "w-level-over", "level": 5})
+	seeded := []*Event{rowOver, rowSmall, rowLevel}
+	mustApplyEvents(ctx, t, env, "width parity creates", seeded...)
+
+	env.ExecSQL(ctx,
+		"UPDATE eav_data SET value_numeric = 4294967296 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 14",
+		wide.ID, rowOver.RowID)
+	env.ExecSQL(ctx,
+		"UPDATE eav_data SET value_numeric = 40000 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 13",
+		wide.ID, rowLevel.RowID)
+
+	probes := []widthProbe{
+		// 2^32: past INT32. Equality must address the stored value on both
+		// dialects, and the DuckDB leg must not error on the operand.
+		{"qty_equals_2p32", Filter{Attr: "qty", Op: "equals", Value: "4294967296"}, []*Event{rowOver}},
+		// Range operator with an in-range literal still sees the row.
+		{"qty_gt_maxint32", Filter{Attr: "qty", Op: "gt", Value: "2147483647"}, []*Event{rowOver}},
+		// The placeholder value must be gone — guards that the UPDATE took.
+		{"qty_equals_placeholder_gone", Filter{Attr: "qty", Op: "equals", Value: "42"}, nil},
+		// In-range values keep working.
+		{"qty_equals_in_range", Filter{Attr: "qty", Op: "equals", Value: "7"}, []*Event{rowSmall}},
+		// smallint twin at 40000 (past INT16).
+		{"level_equals_40000", Filter{Attr: "level", Op: "equals", Value: "40000"}, []*Event{rowLevel}},
+		{"level_gt_maxint16", Filter{Attr: "level", Op: "gt", Value: "32767"}, []*Event{rowLevel}},
+	}
+
+	hotBase := Query{Schema: wide, PreferHot: true, Limit: 100}
+	runWidthProbes(ctx, t, env, "int/hot-pg", hotBase, false, probes)
+
+	serveFromCold(ctx, t, env, wide, seeded)
+	coldBase := Query{Schema: wide, Limit: 100}
+	runWidthProbes(ctx, t, env, "int/cold-duck", coldBase, true, probes)
+}
+
+// TestEAVIntegerWidthWriteRejection pins the write half of the #384 ruling:
+// the production write path answers invalid input for numeric-family values
+// that do not fit the declared integer type, instead of storing state the
+// tiers used to disagree on.
+func TestEAVIntegerWidthWriteRejection(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	rejected := []struct {
+		name  string
+		attrs map[string]any
+	}{
+		{"integer_past_2p31", map[string]any{"title": "rej-int", "qty": int64(4294967296)}},
+		{"smallint_past_2p15", map[string]any{"title": "rej-small", "level": 40000}},
+		{"integer_non_integral", map[string]any{"title": "rej-frac", "qty": 1.5}},
+	}
+	for _, tc := range rejected {
+		err := env.ApplyEvents(ctx, CreateEvent(wide, tc.attrs))
+		if err == nil {
+			t.Errorf("%s: out-of-width write must be rejected", tc.name)
+			continue
+		}
+		if !errors.Is(err, forma.ErrInvalidInput) {
+			t.Errorf("%s: rejection must be user-facing invalid input, got %v", tc.name, err)
+		}
+	}
+
+	// Control: boundary values stay writable.
+	ok := CreateEvent(wide, map[string]any{"title": "ok-bounds", "qty": 2147483647, "level": -32768})
+	mustApplyEvents(ctx, t, env, "in-range boundary write", ok)
+}
+
+// TestEAVBoolTruthinessParityBothDialects pins the #384 bool ruling: both
+// routes compare the value_numeric <> 0 truthiness. Pre-#384 the OLTP route
+// bound equality against exactly 1.0/0.0, so a stored 2 (planted; the write
+// funnels store only 1/0, #404) matched equals:1 on the DuckDB tiers and not
+// on the hot route.
+func TestEAVBoolTruthinessParityBothDialects(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	// `active` is attr 8, EAV-only bool.
+	rowTrue := CreateEvent(wide, map[string]any{"title": "b-true", "active": true})
+	rowStored2 := CreateEvent(wide, map[string]any{"title": "b-two", "active": true})
+	rowFalse := CreateEvent(wide, map[string]any{"title": "b-false", "active": false})
+	seeded := []*Event{rowTrue, rowStored2, rowFalse}
+	mustApplyEvents(ctx, t, env, "bool truthiness creates", seeded...)
+
+	env.ExecSQL(ctx,
+		"UPDATE eav_data SET value_numeric = 2 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 8",
+		wide.ID, rowStored2.RowID)
+
+	probes := []widthProbe{
+		{"active_equals_1", Filter{Attr: "active", Op: "equals", Value: "1"}, []*Event{rowTrue, rowStored2}},
+		{"active_equals_0", Filter{Attr: "active", Op: "equals", Value: "0"}, []*Event{rowFalse}},
+		{"active_not_equals_1", Filter{Attr: "active", Op: "not_equals", Value: "1"}, []*Event{rowFalse}},
+	}
+
+	hotBase := Query{Schema: wide, PreferHot: true, Limit: 100}
+	runWidthProbes(ctx, t, env, "bool/hot-pg", hotBase, false, probes)
+
+	serveFromCold(ctx, t, env, wide, seeded)
+	coldBase := Query{Schema: wide, Limit: 100}
+	runWidthProbes(ctx, t, env, "bool/cold-duck", coldBase, true, probes)
+}
+
+// TestEAVNumericOperandWidthParityBothDialects pins the #384 numeric ruling:
+// operands cast to DOUBLE, the width every tier column actually carries.
+// Pre-#384 the CAST(? AS DECIMAL(38,10)) operand silently truncated literals
+// beyond 10 fractional digits (mismatching a stored DOUBLE the hot route
+// matched) and overflowed outright past ~1e28 (one-sided query failure —
+// the gt_1e28 probes could not even run on the DuckDB leg).
+func TestEAVNumericOperandWidthParityBothDialects(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	// `ratio` is attr 16, EAV-only numeric. All values are float64-clean.
+	rowFine := CreateEvent(wide, map[string]any{"title": "n-fine", "ratio": 0.12345678905})
+	rowCoarse := CreateEvent(wide, map[string]any{"title": "n-coarse", "ratio": 0.1234567890})
+	rowHuge := CreateEvent(wide, map[string]any{"title": "n-huge", "ratio": 1e30})
+	seeded := []*Event{rowFine, rowCoarse, rowHuge}
+	mustApplyEvents(ctx, t, env, "numeric width creates", seeded...)
+
+	probes := []widthProbe{
+		// 11 fractional digits: DECIMAL(38,10) truncated this operand.
+		{"ratio_equals_11_digits", Filter{Attr: "ratio", Op: "equals", Value: "0.12345678905"}, []*Event{rowFine}},
+		// Past DECIMAL(38,10)'s integer range: must answer, not error.
+		{"ratio_gt_1e28", Filter{Attr: "ratio", Op: "gt", Value: "1e28"}, []*Event{rowHuge}},
+		{"ratio_lt_1", Filter{Attr: "ratio", Op: "lt", Value: "1"}, []*Event{rowFine, rowCoarse}},
+	}
+
+	hotBase := Query{Schema: wide, PreferHot: true, Limit: 100}
+	runWidthProbes(ctx, t, env, "num/hot-pg", hotBase, false, probes)
+
+	serveFromCold(ctx, t, env, wide, seeded)
+	coldBase := Query{Schema: wide, Limit: 100}
+	runWidthProbes(ctx, t, env, "num/cold-duck", coldBase, true, probes)
+}

--- a/internal/e2e_harness/production/numeric_width_parity_e2e_test.go
+++ b/internal/e2e_harness/production/numeric_width_parity_e2e_test.go
@@ -13,9 +13,10 @@ import (
 
 // This file is the #384 acceptance suite: for EAV-only attributes whose
 // stored value_numeric falls outside (or beside) the declared width, hot
-// Postgres and cold DuckDB must answer the same filter identically —
-// projection by storage width (BIGINT/DOUBLE), operand casts by storage
-// width, and one bool truth rule (value_numeric <> 0) on both routes.
+// Postgres and every DuckDB tier must answer the same filter identically —
+// projection and operand casts by storage width (DOUBLE: the write funnel
+// narrows everything through float64), and one bool truth rule
+// (value_numeric <> 0) with one operand parse rule on both routes.
 //
 // Out-of-range values are planted by direct eav_data UPDATEs: the write
 // funnel rejects them since #384 (TestEAVIntegerWidthWriteRejection), so the
@@ -66,26 +67,38 @@ func assertWidthRowSet(t *testing.T, label string, res *QueryResult, want []*Eve
 	}
 }
 
-// serveFromCold exports every seeded row to base parquet and clears their
-// change_log entries so the rows leave the dirty set and are served from the
-// cold tier (the RunInit-plus-DELETE idiom of the boundary suites).
-func serveFromCold(ctx context.Context, t *testing.T, env *Env, schema SchemaRef, seeded []*Event) {
+// runWidthProbesAllTiers drives the same probe set through all three tiers
+// via the real pipeline: hot (unflushed, PreferHot → Postgres), warm (after a
+// real CDC flush the rows are served from delta parquet), and cold (after a
+// real compaction the delta is merged into base). The warm stage is what pins
+// that the CDC export — not just the init export — carries the storage-width
+// contract.
+func runWidthProbesAllTiers(ctx context.Context, t *testing.T, env *Env, schema SchemaRef,
+	label string, probes []widthProbe) {
 	t.Helper()
-	if _, err := env.RunInit(ctx, schema); err != nil {
-		t.Fatalf("run init: %v", err)
+	hotBase := Query{Schema: schema, PreferHot: true, Limit: 100}
+	runWidthProbes(ctx, t, env, label+"/hot-pg", hotBase, false, probes)
+
+	if _, err := env.RunFlush(ctx); err != nil {
+		t.Fatalf("%s: flush: %v", label, err)
 	}
-	env.ExecSQL(ctx,
-		"DELETE FROM change_log WHERE schema_id = $1 AND row_id = ANY($2)",
-		schema.ID, rowIDs(seeded))
+	duckBase := Query{Schema: schema, Limit: 100}
+	runWidthProbes(ctx, t, env, label+"/warm-duck", duckBase, true, probes)
+
+	if _, err := env.RunCompaction(ctx, schema); err != nil {
+		t.Fatalf("%s: compaction: %v", label, err)
+	}
+	runWidthProbes(ctx, t, env, label+"/cold-duck", duckBase, true, probes)
 }
 
 // TestEAVIntegerWidthParityBothDialects is the #384 headline: an EAV-only
 // integer/smallint value past the declared width (planted directly, standing
 // in for pre-rejection history) must be matched by the same filter on the hot
-// Postgres route and every DuckDB tier. Pre-#384 the DuckDB legs projected it
-// to NULL via TRY_CAST at declared width (no match) and the strict
-// CAST(? AS INTEGER) operand raised a Conversion Error for the out-of-range
-// literal, while hot Postgres compared the stored NUMERIC and matched.
+// Postgres route and every DuckDB tier. Pre-#384 the DuckDB legs projected an
+// over-range value to NULL via TRY_CAST at declared width (no match), rounded
+// a non-integral value, and the strict CAST(? AS INTEGER) operand raised a
+// Conversion Error for the out-of-range literal — while hot Postgres compared
+// the stored NUMERIC and matched throughout.
 func TestEAVIntegerWidthParityBothDialects(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
@@ -93,16 +106,20 @@ func TestEAVIntegerWidthParityBothDialects(t *testing.T) {
 	wide := DefaultSchemaFixtures()[1]
 
 	// `qty` (attr 14) is the EAV-only integer, `level` (attr 13) the EAV-only
-	// smallint. In-range placeholders first; the over-range state is planted.
+	// smallint. In-range placeholders first; the illegal state is planted.
 	rowOver := CreateEvent(wide, map[string]any{"title": "w-qty-over", "qty": 42})
+	rowFrac := CreateEvent(wide, map[string]any{"title": "w-qty-frac", "qty": 43})
 	rowSmall := CreateEvent(wide, map[string]any{"title": "w-qty-small", "qty": 7})
 	rowLevel := CreateEvent(wide, map[string]any{"title": "w-level-over", "level": 5})
-	seeded := []*Event{rowOver, rowSmall, rowLevel}
+	seeded := []*Event{rowOver, rowFrac, rowSmall, rowLevel}
 	mustApplyEvents(ctx, t, env, "width parity creates", seeded...)
 
 	env.ExecSQL(ctx,
 		"UPDATE eav_data SET value_numeric = 4294967296 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 14",
 		wide.ID, rowOver.RowID)
+	env.ExecSQL(ctx,
+		"UPDATE eav_data SET value_numeric = 1.5 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 14",
+		wide.ID, rowFrac.RowID)
 	env.ExecSQL(ctx,
 		"UPDATE eav_data SET value_numeric = 40000 WHERE schema_id = $1 AND row_id = $2 AND attr_id = 13",
 		wide.ID, rowLevel.RowID)
@@ -113,21 +130,25 @@ func TestEAVIntegerWidthParityBothDialects(t *testing.T) {
 		{"qty_equals_2p32", Filter{Attr: "qty", Op: "equals", Value: "4294967296"}, []*Event{rowOver}},
 		// Range operator with an in-range literal still sees the row.
 		{"qty_gt_maxint32", Filter{Attr: "qty", Op: "gt", Value: "2147483647"}, []*Event{rowOver}},
-		// The placeholder value must be gone — guards that the UPDATE took.
+		// Non-integral history (P1a): DOUBLE projection keeps 1.5 as 1.5 on
+		// every DuckDB tier — an integer-width cast rounded it to 2, matching
+		// equals:2 only on the DuckDB legs while Postgres compared 1.5.
+		{"qty_equals_frac", Filter{Attr: "qty", Op: "equals", Value: "1.5"}, []*Event{rowFrac}},
+		{"qty_equals_2_not_frac", Filter{Attr: "qty", Op: "equals", Value: "2"}, nil},
+		// The placeholder values must be gone — guards that the UPDATEs took.
 		{"qty_equals_placeholder_gone", Filter{Attr: "qty", Op: "equals", Value: "42"}, nil},
+		{"qty_equals_frac_placeholder_gone", Filter{Attr: "qty", Op: "equals", Value: "43"}, nil},
 		// In-range values keep working.
 		{"qty_equals_in_range", Filter{Attr: "qty", Op: "equals", Value: "7"}, []*Event{rowSmall}},
 		// smallint twin at 40000 (past INT16).
 		{"level_equals_40000", Filter{Attr: "level", Op: "equals", Value: "40000"}, []*Event{rowLevel}},
 		{"level_gt_maxint16", Filter{Attr: "level", Op: "gt", Value: "32767"}, []*Event{rowLevel}},
+		// Operand past BIGINT (P2a): compares as DOUBLE instead of erroring
+		// only on the DuckDB route.
+		{"qty_gt_1e30_empty", Filter{Attr: "qty", Op: "gt", Value: "1e30"}, nil},
 	}
 
-	hotBase := Query{Schema: wide, PreferHot: true, Limit: 100}
-	runWidthProbes(ctx, t, env, "int/hot-pg", hotBase, false, probes)
-
-	serveFromCold(ctx, t, env, wide, seeded)
-	coldBase := Query{Schema: wide, Limit: 100}
-	runWidthProbes(ctx, t, env, "int/cold-duck", coldBase, true, probes)
+	runWidthProbesAllTiers(ctx, t, env, wide, "int", probes)
 }
 
 // TestEAVIntegerWidthWriteRejection pins the write half of the #384 ruling:
@@ -190,14 +211,14 @@ func TestEAVBoolTruthinessParityBothDialects(t *testing.T) {
 		{"active_equals_1", Filter{Attr: "active", Op: "equals", Value: "1"}, []*Event{rowTrue, rowStored2}},
 		{"active_equals_0", Filter{Attr: "active", Op: "equals", Value: "0"}, []*Event{rowFalse}},
 		{"active_not_equals_1", Filter{Attr: "active", Op: "not_equals", Value: "1"}, []*Event{rowFalse}},
+		// Operand spellings under the engine-shared parse rule (P2b): "true"
+		// used to 400 only on the PG route, "2" used to error only on the
+		// DuckDB route.
+		{"active_equals_true", Filter{Attr: "active", Op: "equals", Value: "true"}, []*Event{rowTrue, rowStored2}},
+		{"active_equals_2_truthy", Filter{Attr: "active", Op: "equals", Value: "2"}, []*Event{rowTrue, rowStored2}},
 	}
 
-	hotBase := Query{Schema: wide, PreferHot: true, Limit: 100}
-	runWidthProbes(ctx, t, env, "bool/hot-pg", hotBase, false, probes)
-
-	serveFromCold(ctx, t, env, wide, seeded)
-	coldBase := Query{Schema: wide, Limit: 100}
-	runWidthProbes(ctx, t, env, "bool/cold-duck", coldBase, true, probes)
+	runWidthProbesAllTiers(ctx, t, env, wide, "bool", probes)
 }
 
 // TestEAVNumericOperandWidthParityBothDialects pins the #384 numeric ruling:
@@ -216,21 +237,21 @@ func TestEAVNumericOperandWidthParityBothDialects(t *testing.T) {
 	rowFine := CreateEvent(wide, map[string]any{"title": "n-fine", "ratio": 0.12345678905})
 	rowCoarse := CreateEvent(wide, map[string]any{"title": "n-coarse", "ratio": 0.1234567890})
 	rowHuge := CreateEvent(wide, map[string]any{"title": "n-huge", "ratio": 1e30})
-	seeded := []*Event{rowFine, rowCoarse, rowHuge}
+	rowP16 := CreateEvent(wide, map[string]any{"title": "n-p16", "ratio": 0.1234567890123456})
+	seeded := []*Event{rowFine, rowCoarse, rowHuge, rowP16}
 	mustApplyEvents(ctx, t, env, "numeric width creates", seeded...)
 
 	probes := []widthProbe{
 		// 11 fractional digits: DECIMAL(38,10) truncated this operand.
 		{"ratio_equals_11_digits", Filter{Attr: "ratio", Op: "equals", Value: "0.12345678905"}, []*Event{rowFine}},
+		// 16 significant digits (P1b): the %.15g operand render dropped the
+		// last digit, so the DuckDB route bound an adjacent float64 and
+		// equality missed the row only there.
+		{"ratio_equals_16_digits", Filter{Attr: "ratio", Op: "equals", Value: "0.1234567890123456"}, []*Event{rowP16}},
 		// Past DECIMAL(38,10)'s integer range: must answer, not error.
 		{"ratio_gt_1e28", Filter{Attr: "ratio", Op: "gt", Value: "1e28"}, []*Event{rowHuge}},
-		{"ratio_lt_1", Filter{Attr: "ratio", Op: "lt", Value: "1"}, []*Event{rowFine, rowCoarse}},
+		{"ratio_lt_1", Filter{Attr: "ratio", Op: "lt", Value: "1"}, []*Event{rowFine, rowCoarse, rowP16}},
 	}
 
-	hotBase := Query{Schema: wide, PreferHot: true, Limit: 100}
-	runWidthProbes(ctx, t, env, "num/hot-pg", hotBase, false, probes)
-
-	serveFromCold(ctx, t, env, wide, seeded)
-	coldBase := Query{Schema: wide, Limit: 100}
-	runWidthProbes(ctx, t, env, "num/cold-duck", coldBase, true, probes)
+	runWidthProbesAllTiers(ctx, t, env, wide, "num", probes)
 }

--- a/internal/e2e_harness/production/schema_evolution_e2e_test.go
+++ b/internal/e2e_harness/production/schema_evolution_e2e_test.go
@@ -234,7 +234,7 @@ func TestSchemaEvolutionAddedColumn(t *testing.T) {
 		map[string]string{"name": "VARCHAR", "value": "DOUBLE", "label": "VARCHAR"})
 	forbidParquetCols(t, "base (v1)", baseCols, "score")
 	requireParquetCols(t, "delta (v2)", describeParquetCols(ctx, t, env, deltaKey),
-		map[string]string{"score": "INTEGER", "label": "VARCHAR"})
+		map[string]string{"score": "BIGINT", "label": "VARCHAR"})
 
 	full := env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 20})
 	assertUsesDuckDB(t, full)
@@ -283,7 +283,7 @@ func TestSchemaEvolutionRemovedColumn(t *testing.T) {
 	seedGeneration(ctx, t, env, simple, 5, scoreProfile)
 	baseKey := runInitBase(ctx, t, env, simple)
 	requireParquetCols(t, "base (v1)", describeParquetCols(ctx, t, env, baseKey),
-		map[string]string{"score": "INTEGER", "label": "VARCHAR"})
+		map[string]string{"score": "BIGINT", "label": "VARCHAR"})
 
 	if err := env.EvolveSchema(ctx, v2); err != nil {
 		t.Fatalf("evolve schema to v2: %v", err)
@@ -327,14 +327,14 @@ func TestSchemaEvolutionRemovedColumn(t *testing.T) {
 
 // TestSchemaEvolutionChangedType covers #189 scenario 3: `score` keeps its
 // attributeID but its valueType changes integer→numeric, so the v1 base
-// parquet stores INTEGER where the v2 delta stores DOUBLE. Contract:
+// parquet stores BIGINT where the v2 delta stores DOUBLE. Contract:
 // predictable widening — the union resolves to DOUBLE, matching the oracle's
 // numeric-family float64 normalization; filters and sorts see one coherent
 // numeric domain across generations.
 //
 // Red on current main with SILENTLY WRONG DATA, not a loud failure: without
 // union_by_name DuckDB coerces every file to the first file's schema, so the
-// delta's DOUBLE values are cast to the base's INTEGER — fractional scores
+// delta's DOUBLE values are cast to the base's BIGINT — fractional scores
 // are corrupted in place and only the oracle catches it (attr mismatches,
 // totals identical). That failure mode is the strongest reason the fix must
 // widen the union rather than pin first-file-wins.
@@ -355,7 +355,7 @@ func TestSchemaEvolutionChangedType(t *testing.T) {
 		})))
 
 	requireParquetCols(t, "base (v1 integer)", describeParquetCols(ctx, t, env, baseKey),
-		map[string]string{"score": "INTEGER"})
+		map[string]string{"score": "BIGINT"})
 	requireParquetCols(t, "delta (v2 numeric)", describeParquetCols(ctx, t, env, deltaKey),
 		map[string]string{"score": "DOUBLE"})
 
@@ -366,7 +366,7 @@ func TestSchemaEvolutionChangedType(t *testing.T) {
 	}
 
 	// One numeric domain across generations: the threshold catches v1
-	// INTEGER rows (20,30,40) and every v2 DOUBLE row (50.5..110.5).
+	// BIGINT rows (20,30,40) and every v2 DOUBLE row (50.5..110.5).
 	filtered := env.AssertQueryMatches(ctx, Query{
 		Schema:  simple,
 		Filters: []Filter{{Attr: "score", Op: "gte", Value: "20"}},
@@ -408,7 +408,7 @@ func TestSchemaEvolutionMixedGenerations(t *testing.T) {
 	requireParquetCols(t, "base (v1)", baseCols, map[string]string{"old_col": "VARCHAR"})
 	forbidParquetCols(t, "base (v1)", baseCols, "new_col")
 	deltaCols := describeParquetCols(ctx, t, env, deltaKey)
-	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{"new_col": "INTEGER"})
+	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{"new_col": "BIGINT"})
 	forbidParquetCols(t, "delta (v2)", deltaCols, "old_col")
 
 	full := env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 20})
@@ -461,10 +461,10 @@ func TestSchemaEvolutionRenamedColumn(t *testing.T) {
 		})))
 
 	baseCols := describeParquetCols(ctx, t, env, baseKey)
-	requireParquetCols(t, "base (v1)", baseCols, map[string]string{"score": "INTEGER"})
+	requireParquetCols(t, "base (v1)", baseCols, map[string]string{"score": "BIGINT"})
 	forbidParquetCols(t, "base (v1)", baseCols, "points")
 	deltaCols := describeParquetCols(ctx, t, env, deltaKey)
-	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{"points": "INTEGER"})
+	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{"points": "BIGINT"})
 	forbidParquetCols(t, "delta (v2)", deltaCols, "score")
 
 	full := env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 20})

--- a/internal/e2e_harness/production/schema_evolution_e2e_test.go
+++ b/internal/e2e_harness/production/schema_evolution_e2e_test.go
@@ -234,7 +234,7 @@ func TestSchemaEvolutionAddedColumn(t *testing.T) {
 		map[string]string{"name": "VARCHAR", "value": "DOUBLE", "label": "VARCHAR"})
 	forbidParquetCols(t, "base (v1)", baseCols, "score")
 	requireParquetCols(t, "delta (v2)", describeParquetCols(ctx, t, env, deltaKey),
-		map[string]string{"score": "BIGINT", "label": "VARCHAR"})
+		map[string]string{"score": "DOUBLE", "label": "VARCHAR"})
 
 	full := env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 20})
 	assertUsesDuckDB(t, full)
@@ -283,7 +283,7 @@ func TestSchemaEvolutionRemovedColumn(t *testing.T) {
 	seedGeneration(ctx, t, env, simple, 5, scoreProfile)
 	baseKey := runInitBase(ctx, t, env, simple)
 	requireParquetCols(t, "base (v1)", describeParquetCols(ctx, t, env, baseKey),
-		map[string]string{"score": "BIGINT", "label": "VARCHAR"})
+		map[string]string{"score": "DOUBLE", "label": "VARCHAR"})
 
 	if err := env.EvolveSchema(ctx, v2); err != nil {
 		t.Fatalf("evolve schema to v2: %v", err)
@@ -326,15 +326,16 @@ func TestSchemaEvolutionRemovedColumn(t *testing.T) {
 }
 
 // TestSchemaEvolutionChangedType covers #189 scenario 3: `score` keeps its
-// attributeID but its valueType changes integer→numeric, so the v1 base
-// parquet stores BIGINT where the v2 delta stores DOUBLE. Contract:
-// predictable widening — the union resolves to DOUBLE, matching the oracle's
-// numeric-family float64 normalization; filters and sorts see one coherent
-// numeric domain across generations.
+// attributeID but its valueType changes integer→numeric. Since #384 both
+// generations export at EAV storage width DOUBLE (pre-#384 the v1 base
+// stored the declared integer width), so the union is trivially DOUBLE —
+// matching the oracle's numeric-family float64 normalization; filters and
+// sorts see one coherent numeric domain across generations.
 //
 // Red on current main with SILENTLY WRONG DATA, not a loud failure: without
 // union_by_name DuckDB coerces every file to the first file's schema, so the
-// delta's DOUBLE values are cast to the base's BIGINT — fractional scores
+// delta's DOUBLE values are cast to the base's narrower integer width —
+// fractional scores
 // are corrupted in place and only the oracle catches it (attr mismatches,
 // totals identical). That failure mode is the strongest reason the fix must
 // widen the union rather than pin first-file-wins.
@@ -355,7 +356,7 @@ func TestSchemaEvolutionChangedType(t *testing.T) {
 		})))
 
 	requireParquetCols(t, "base (v1 integer)", describeParquetCols(ctx, t, env, baseKey),
-		map[string]string{"score": "BIGINT"})
+		map[string]string{"score": "DOUBLE"})
 	requireParquetCols(t, "delta (v2 numeric)", describeParquetCols(ctx, t, env, deltaKey),
 		map[string]string{"score": "DOUBLE"})
 
@@ -366,7 +367,7 @@ func TestSchemaEvolutionChangedType(t *testing.T) {
 	}
 
 	// One numeric domain across generations: the threshold catches v1
-	// BIGINT rows (20,30,40) and every v2 DOUBLE row (50.5..110.5).
+	// integer-generation rows (20,30,40) and every v2 DOUBLE row (50.5..110.5).
 	filtered := env.AssertQueryMatches(ctx, Query{
 		Schema:  simple,
 		Filters: []Filter{{Attr: "score", Op: "gte", Value: "20"}},
@@ -408,7 +409,7 @@ func TestSchemaEvolutionMixedGenerations(t *testing.T) {
 	requireParquetCols(t, "base (v1)", baseCols, map[string]string{"old_col": "VARCHAR"})
 	forbidParquetCols(t, "base (v1)", baseCols, "new_col")
 	deltaCols := describeParquetCols(ctx, t, env, deltaKey)
-	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{"new_col": "BIGINT"})
+	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{"new_col": "DOUBLE"})
 	forbidParquetCols(t, "delta (v2)", deltaCols, "old_col")
 
 	full := env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 20})
@@ -461,10 +462,10 @@ func TestSchemaEvolutionRenamedColumn(t *testing.T) {
 		})))
 
 	baseCols := describeParquetCols(ctx, t, env, baseKey)
-	requireParquetCols(t, "base (v1)", baseCols, map[string]string{"score": "BIGINT"})
+	requireParquetCols(t, "base (v1)", baseCols, map[string]string{"score": "DOUBLE"})
 	forbidParquetCols(t, "base (v1)", baseCols, "points")
 	deltaCols := describeParquetCols(ctx, t, env, deltaKey)
-	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{"points": "BIGINT"})
+	requireParquetCols(t, "delta (v2)", deltaCols, map[string]string{"points": "DOUBLE"})
 	forbidParquetCols(t, "delta (v2)", deltaCols, "score")
 
 	full := env.AssertQueryMatches(ctx, Query{Schema: simple, Limit: 20})

--- a/internal/federated/cold_columns.go
+++ b/internal/federated/cold_columns.go
@@ -31,7 +31,7 @@ func coldMissingColumns(cache forma.SchemaAttributeCache, unionCols map[string]s
 		}
 		missing = append(missing, sqlgen.NullScanColumn{
 			Name:       col,
-			DuckDBType: sqlgen.DuckDBNullScanType(meta.ValueType, meta.EffectiveItemsType()),
+			DuckDBType: sqlgen.DuckDBNullScanType(meta),
 		})
 	}
 	sort.Slice(missing, func(i, j int) bool { return missing[i].Name < missing[j].Name })

--- a/internal/federated/cold_columns_plan_cache_test.go
+++ b/internal/federated/cold_columns_plan_cache_test.go
@@ -110,14 +110,14 @@ func TestEngineColdMissingSetRekeysPlanCache(t *testing.T) {
 	e.schemaValidator.markValidated(coldPlanCachePath, coldPlanCacheFooter(false), nil)
 
 	sql1, notes1 := runColdPlanCacheQuery(t, e, duck)
-	require.Contains(t, sql1, "NULL::BIGINT AS score",
+	require.Contains(t, sql1, "NULL::DOUBLE AS score",
 		"cold-absent attribute must render as a typed NULL in the scan source")
 	require.Contains(t, notes1, "plan_cache=miss", "first request compiles")
 
 	sql2, notes2 := runColdPlanCacheQuery(t, e, duck)
 	require.Contains(t, notes2, "plan_cache=hit",
 		"same shape, same paths, same missing set: the skeleton must be reused — this is the reuse that could poison")
-	require.Contains(t, sql2, "NULL::BIGINT AS score")
+	require.Contains(t, sql2, "NULL::DOUBLE AS score")
 
 	// The first flush lands `score`. Overwriting the cached footer is a TEST
 	// STAND-IN for "a new file's columns joined the union": flush and
@@ -134,7 +134,7 @@ func TestEngineColdMissingSetRekeysPlanCache(t *testing.T) {
 	sql3, notes3 := runColdPlanCacheQuery(t, e, duck)
 	require.Contains(t, notes3, "plan_cache=miss",
 		"the missing set alone must re-key the plan cache (#255 poisoning guard)")
-	require.NotContains(t, sql3, "NULL::BIGINT AS score",
+	require.NotContains(t, sql3, "NULL::DOUBLE AS score",
 		"post-flush the real column must be scanned, not a cached NULL projection")
 	require.NotContains(t, sql3, ", NULL::",
 		"no missing columns: the scan source carries no typed-NULL augmentation at all")
@@ -192,7 +192,7 @@ func TestEngineColdMissingSetRekeysPlanCacheViaGlobExpansion(t *testing.T) {
 	// Run 1 — pre-flush: the glob expands to the single v1 base object, whose
 	// footer has no `score`.
 	sql1, notes1 := runColdPlanCacheQueryWithHint(t, e, duck, coldPlanCacheGlob)
-	require.Contains(t, sql1, "NULL::BIGINT AS score",
+	require.Contains(t, sql1, "NULL::DOUBLE AS score",
 		"cold-absent attribute must render as a typed NULL in the scan source")
 	require.Contains(t, notes1, "plan_cache=miss", "first request compiles")
 
@@ -205,7 +205,7 @@ func TestEngineColdMissingSetRekeysPlanCacheViaGlobExpansion(t *testing.T) {
 	sql2, notes2 := runColdPlanCacheQueryWithHint(t, e, duck, coldPlanCacheGlob)
 	require.Contains(t, notes2, "plan_cache=miss",
 		"the missing set ALONE must re-key the plan cache: the glob path string never changed (#255)")
-	require.NotContains(t, sql2, "NULL::BIGINT AS score",
+	require.NotContains(t, sql2, "NULL::DOUBLE AS score",
 		"post-flush the real column must be scanned, not a cached NULL projection")
 	require.NotContains(t, sql2, ", NULL::",
 		"no missing columns: the scan source carries no typed-NULL augmentation at all")

--- a/internal/federated/cold_columns_plan_cache_test.go
+++ b/internal/federated/cold_columns_plan_cache_test.go
@@ -110,14 +110,14 @@ func TestEngineColdMissingSetRekeysPlanCache(t *testing.T) {
 	e.schemaValidator.markValidated(coldPlanCachePath, coldPlanCacheFooter(false), nil)
 
 	sql1, notes1 := runColdPlanCacheQuery(t, e, duck)
-	require.Contains(t, sql1, "NULL::INTEGER AS score",
+	require.Contains(t, sql1, "NULL::BIGINT AS score",
 		"cold-absent attribute must render as a typed NULL in the scan source")
 	require.Contains(t, notes1, "plan_cache=miss", "first request compiles")
 
 	sql2, notes2 := runColdPlanCacheQuery(t, e, duck)
 	require.Contains(t, notes2, "plan_cache=hit",
 		"same shape, same paths, same missing set: the skeleton must be reused — this is the reuse that could poison")
-	require.Contains(t, sql2, "NULL::INTEGER AS score")
+	require.Contains(t, sql2, "NULL::BIGINT AS score")
 
 	// The first flush lands `score`. Overwriting the cached footer is a TEST
 	// STAND-IN for "a new file's columns joined the union": flush and
@@ -134,7 +134,7 @@ func TestEngineColdMissingSetRekeysPlanCache(t *testing.T) {
 	sql3, notes3 := runColdPlanCacheQuery(t, e, duck)
 	require.Contains(t, notes3, "plan_cache=miss",
 		"the missing set alone must re-key the plan cache (#255 poisoning guard)")
-	require.NotContains(t, sql3, "NULL::INTEGER AS score",
+	require.NotContains(t, sql3, "NULL::BIGINT AS score",
 		"post-flush the real column must be scanned, not a cached NULL projection")
 	require.NotContains(t, sql3, ", NULL::",
 		"no missing columns: the scan source carries no typed-NULL augmentation at all")
@@ -192,7 +192,7 @@ func TestEngineColdMissingSetRekeysPlanCacheViaGlobExpansion(t *testing.T) {
 	// Run 1 — pre-flush: the glob expands to the single v1 base object, whose
 	// footer has no `score`.
 	sql1, notes1 := runColdPlanCacheQueryWithHint(t, e, duck, coldPlanCacheGlob)
-	require.Contains(t, sql1, "NULL::INTEGER AS score",
+	require.Contains(t, sql1, "NULL::BIGINT AS score",
 		"cold-absent attribute must render as a typed NULL in the scan source")
 	require.Contains(t, notes1, "plan_cache=miss", "first request compiles")
 
@@ -205,7 +205,7 @@ func TestEngineColdMissingSetRekeysPlanCacheViaGlobExpansion(t *testing.T) {
 	sql2, notes2 := runColdPlanCacheQueryWithHint(t, e, duck, coldPlanCacheGlob)
 	require.Contains(t, notes2, "plan_cache=miss",
 		"the missing set ALONE must re-key the plan cache: the glob path string never changed (#255)")
-	require.NotContains(t, sql2, "NULL::INTEGER AS score",
+	require.NotContains(t, sql2, "NULL::BIGINT AS score",
 		"post-flush the real column must be scanned, not a cached NULL projection")
 	require.NotContains(t, sql2, ", NULL::",
 		"no missing columns: the scan source carries no typed-NULL augmentation at all")

--- a/internal/federated/cold_columns_test.go
+++ b/internal/federated/cold_columns_test.go
@@ -22,8 +22,8 @@ func TestColdMissingColumnsDetectsAbsentAttributes(t *testing.T) {
 	}
 	got := coldMissingColumns(cache, union)
 	require.Equal(t, []sqlgen.NullScanColumn{
-		// EAV-only integer augments at storage width BIGINT (#384).
-		{Name: "score", DuckDBType: "BIGINT"},
+		// EAV-only integer augments at storage width DOUBLE (#384).
+		{Name: "score", DuckDBType: "DOUBLE"},
 		{Name: "tags", DuckDBType: "BIGINT[]"},
 	}, got, "absent attrs detected, present ones skipped, sorted by name")
 }

--- a/internal/federated/cold_columns_test.go
+++ b/internal/federated/cold_columns_test.go
@@ -22,7 +22,8 @@ func TestColdMissingColumnsDetectsAbsentAttributes(t *testing.T) {
 	}
 	got := coldMissingColumns(cache, union)
 	require.Equal(t, []sqlgen.NullScanColumn{
-		{Name: "score", DuckDBType: "INTEGER"},
+		// EAV-only integer augments at storage width BIGINT (#384).
+		{Name: "score", DuckDBType: "BIGINT"},
 		{Name: "tags", DuckDBType: "BIGINT[]"},
 	}, got, "absent attrs detected, present ones skipped, sorted by name")
 }

--- a/internal/postgres_persistent_repository_by_attr_values.go
+++ b/internal/postgres_persistent_repository_by_attr_values.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/numutil"
+	"github.com/lychee-technology/forma/internal/sqlgen"
 )
 
 // QueryPersistentRecordsByAttrValues fetches full records whose attribute
@@ -85,20 +86,22 @@ func buildAttrValuesAnchor(attr string, meta forma.AttributeMetadata, values []s
 
 	switch meta.ValueType {
 	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
-		// Per-element typing, mirroring ConvertPgMainValue and
-		// parseDuckDBRawParam (#281, #357): one literal must mean one Go value
-		// on every binder, or the same operand can match under a filter and
-		// miss under relation enrichment (#355). Integral literals in any
-		// accepted spelling bind as exact int64; genuinely fractional ones stay
-		// float64, which is what the write path's own float64 hop stored.
-		// Collapsing the slice to a single element type is not equivalent:
-		// []float64 loses exactness above 2^53, and rendering exact decimals
-		// into a ::numeric[] cast would stop matching stored fractional values.
+		// Per-element typing, mirroring the EAV predicate normalizer (#281,
+		// #357): one literal must mean one Go value on every binder, or the
+		// same operand can match under a filter and miss under relation
+		// enrichment (#355). Integral literals bind as exact int64 for
+		// bigint and narrow through the write funnel's float64 for the
+		// DOUBLE-width classes (sqlgen.NarrowEAVNumericOperand, #384);
+		// genuinely fractional ones stay float64, which is what the write
+		// path's own float64 hop stored. Collapsing the slice to a single
+		// element type is not equivalent: []float64 loses bigint exactness
+		// above 2^53, and rendering exact decimals into a ::numeric[] cast
+		// would stop matching stored fractional values.
 		operands := make([]any, 0, len(values))
 		for _, v := range values {
 			switch parsed := numutil.TryParseNumber(v).(type) {
 			case int64:
-				operands = append(operands, parsed)
+				operands = append(operands, sqlgen.NarrowEAVNumericOperand(meta.ValueType, parsed))
 			case float64:
 				operands = append(operands, parsed)
 			default:

--- a/internal/postgres_persistent_repository_by_attr_values_test.go
+++ b/internal/postgres_persistent_repository_by_attr_values_test.go
@@ -134,7 +134,7 @@ func TestQueryPersistentRecordsByAttrValuesNumericValues(t *testing.T) {
 	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(1))
 
 	mock.ExpectQuery(`t\.attr_id = \$2 AND t\.value_numeric = ANY\(\$3\)`).
-		WithArgs(int16(1), int16(31), []any{int64(7), int64(9)}, 2, 0).
+		WithArgs(int16(1), int16(31), []any{float64(7), float64(9)}, 2, 0).
 		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
 
 	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "rank", []string{"7", "9"}, 2)
@@ -211,7 +211,7 @@ func TestQueryPersistentRecordsByAttrValuesKeepsFractionalOperandsFloat64(t *tes
 	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(1))
 
 	mock.ExpectQuery(`t\.attr_id = \$2 AND t\.value_numeric = ANY\(\$3\)`).
-		WithArgs(int16(1), int16(33), []any{9.5, int64(8)}, 2, 0).
+		WithArgs(int16(1), int16(33), []any{9.5, float64(8)}, 2, 0).
 		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
 
 	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "ratio",
@@ -240,6 +240,37 @@ func TestQueryPersistentRecordsByAttrValuesRejectsNonNumericOperand(t *testing.T
 	require.Contains(t, err.Error(), `invalid value "not-a-number"`)
 	require.Contains(t, err.Error(), "bigint")
 	require.NotContains(t, err.Error(), "float64")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestQueryPersistentRecordsByAttrValuesNarrowsDoubleWidthOperands is the
+// #384 companion to the exact-bigint pin above: an integer attribute's EAV
+// storage holds float64 images (the write funnel narrows through float64), so
+// its integral operands take the same narrowing — above 2^53 the bind is the
+// float64 image, keeping the batch anchor on the same verdict as the EAV
+// predicate binder and the DuckDB route (whose CAST(? AS DOUBLE) rounds the
+// operand to the same image).
+func TestQueryPersistentRecordsByAttrValuesNarrowsDoubleWidthOperands(t *testing.T) {
+	ctx := context.Background()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDBPersistentRecordRepository(mock, newByAttrValuesTestCache(t))
+	tables := model.StorageTables{EntityMain: "main_table", EAVData: "eav_table"}
+
+	rowID := uuid.MustParse("77777777-7777-7777-7777-777777777777")
+	columns, values := optimizedQueryFixtureColumnsAndValues(rowID, int64(1))
+
+	mock.ExpectQuery(`t\.attr_id = \$2 AND t\.value_numeric = ANY\(\$3\)`).
+		WithArgs(int16(1), int16(31), []any{float64(9007199254740992)}, 2, 0).
+		WillReturnRows(pgxmock.NewRows(columns).AddRow(values...))
+
+	page, err := repo.QueryPersistentRecordsByAttrValues(ctx, tables, 1, "rank",
+		[]string{"9007199254740993"}, 2)
+	require.NoError(t, err)
+	require.Len(t, page.Records, 1)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/postgres_persistent_repository_query.go
+++ b/internal/postgres_persistent_repository_query.go
@@ -366,8 +366,8 @@ func (b *hybridConditionBuilder) emitEAVLeaf(p sqlgen.HybridLeafPayload) (string
 	valuePlaceholder := fmt.Sprintf("$%d", b.argCounter)
 
 	clause := fmt.Sprintf(
-		"EXISTS (SELECT 1 FROM %s x WHERE x.schema_id = %s AND x.row_id = %s AND x.attr_id = %s AND x.%s %s %s)",
-		b.eavTable, schemaAlias, rowAlias, attrPlaceholder, eav.ValueColumn, eav.SQLOp, valuePlaceholder,
+		"EXISTS (SELECT 1 FROM %s x WHERE x.schema_id = %s AND x.row_id = %s AND x.attr_id = %s AND %s %s %s)",
+		b.eavTable, schemaAlias, rowAlias, attrPlaceholder, eav.ComparisonLHS("x"), eav.SQLOp, valuePlaceholder,
 	)
 	return clause, []any{eav.AttrID, eav.Value}, nil
 }

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -134,15 +134,11 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		// it miss on every tier alike — tier parity preserved.
 		//
 		// integer/smallint joined this arm in #355 purely to end the binder
-		// divergence: it changes no query result. Below the bound of the arm's
-		// own cast — 2^31 for CAST(? AS INTEGER), 2^15 for CAST(? AS SMALLINT) —
-		// int64 and float64 denote the same number, so comparisons are identical.
-		// Above it, both parameter types raise the same class of conversion error
-		// from that cast (DuckDB words the int64 and the float64 case
-		// differently), so queries fail either way. On the column side
-		// (independent of the parameter), an EAV-only integer attribute's stored
-		// value outside the 32-bit range is projected to NULL on every DuckDB tier
-		// via TRY_CAST; that is a separate defect tracked in #384.
+		// divergence: it changes no query result. Since #384 their operand
+		// cast is CAST(? AS BIGINT) (storage width, matching the BIGINT
+		// EAV columns), so an operand beyond the declared 2^31/2^15 range
+		// compares normally and matches nothing on both engines instead of
+		// raising a DuckDB Conversion Error while Postgres answered.
 		switch v := numutil.TryParseNumber(valStr).(type) {
 		case int64:
 			return v, nil

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -105,6 +105,22 @@ func detectValueType(valStr string) forma.ValueType {
 	return forma.ValueTypeText
 }
 
+// parseBoolOperand parses a bool predicate operand under ONE rule for both
+// engines (#384 P2b): the standard bool spellings via ParseBool, else any
+// integer literal with the >0 truthiness the PG EAV path has always applied.
+// Before this, PG accepted "2" (truthy) but rejected "true", while the DuckDB
+// path accepted "true" but failed "2" — the same filter erred on exactly one
+// route depending on spelling.
+func parseBoolOperand(valStr string) (parsed, ok bool) {
+	if b, err := strconv.ParseBool(strings.ToLower(valStr)); err == nil {
+		return b, true
+	}
+	if i, err := strconv.Atoi(valStr); err == nil {
+		return i > 0, true
+	}
+	return false, false
+}
+
 // parseDuckDBRawParam parses a string value into a typed Go value for DuckDB parameters.
 func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) (any, error) {
 	switch valueType {
@@ -112,14 +128,10 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		return valStr, nil
 
 	case forma.ValueTypeBool:
-		if b, e := strconv.ParseBool(strings.ToLower(valStr)); e == nil {
+		if b, ok := parseBoolOperand(valStr); ok {
 			return b, nil
-		} else if valStr == "1" {
-			return true, nil
-		} else if valStr == "0" {
-			return false, nil
 		}
-		return valStr, nil
+		return nil, forma.InvalidInputf("invalid boolean value for '%s': %s", attr, valStr)
 
 	case forma.ValueTypeNumeric, forma.ValueTypeBigInt,
 		forma.ValueTypeSmallInt, forma.ValueTypeInteger:
@@ -128,17 +140,17 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		// TryParseNumber the two Postgres predicate paths and the batch
 		// attr-value anchor use (#355), so every emitter agrees on the value.
 		// A bigint predicate above 2^53 — legal column state since #205 —
-		// compares exactly instead of riding float64 + %.15g. Fractional
+		// compares exactly instead of riding a rounded float64. Fractional
 		// literals keep float64, the numeric family's storage contract.
 		// EAV-only bigints round at write (2^53 ceiling), so exact binds above
 		// it miss on every tier alike — tier parity preserved.
 		//
 		// integer/smallint joined this arm in #355 purely to end the binder
 		// divergence: it changes no query result. Since #384 their operand
-		// cast is CAST(? AS BIGINT) (storage width, matching the BIGINT
-		// EAV columns), so an operand beyond the declared 2^31/2^15 range
-		// compares normally and matches nothing on both engines instead of
-		// raising a DuckDB Conversion Error while Postgres answered.
+		// cast is CAST(? AS DOUBLE) (storage width — EAV columns are DOUBLE
+		// like the numeric class), so an operand of any magnitude compares
+		// normally on both engines instead of raising a DuckDB Conversion
+		// Error while Postgres answered.
 		switch v := numutil.TryParseNumber(valStr).(type) {
 		case int64:
 			return v, nil

--- a/internal/sqlgen/duckdb_bigint_pivot_test.go
+++ b/internal/sqlgen/duckdb_bigint_pivot_test.go
@@ -35,8 +35,9 @@ func TestBuildEAVPivotEmitsTypedCasts(t *testing.T) {
 	require.NoError(t, err)
 
 	// bigint / date pivot 出 BIGINT;EAV-only integer/smallint 按存储宽度出
-	// BIGINT(#384):value_numeric 是无约束 NUMERIC,按声明宽度 cast 会把超出
-	// 声明范围的历史值只在 DuckDB 腿上 TRY_CAST 成 NULL。
+	// DOUBLE(#384):写漏斗经 float64 收窄,value_numeric 全是 float64 镜像,
+	// 按声明宽度 cast 会把越界历史值 TRY_CAST 成 NULL、把非整数历史值取整,
+	// 且都只发生在 DuckDB 腿上。
 	require.Contains(t, sp.EAVPivotSelect,
 		"TRY_CAST(MAX(CASE WHEN attr_id = 5 THEN value_numeric END) AS BIGINT) AS amount")
 	require.Contains(t, sp.EAVPivotSelect,
@@ -44,9 +45,9 @@ func TestBuildEAVPivotEmitsTypedCasts(t *testing.T) {
 	require.Contains(t, sp.EAVPivotSelect,
 		"TRY_CAST(MAX(CASE WHEN attr_id = 15 THEN value_numeric END) AS BIGINT) AS total")
 	require.Contains(t, sp.EAVPivotSelect,
-		"TRY_CAST(MAX(CASE WHEN attr_id = 16 THEN value_numeric END) AS BIGINT) AS qty")
+		"TRY_CAST(MAX(CASE WHEN attr_id = 16 THEN value_numeric END) AS DOUBLE) AS qty")
 	require.Contains(t, sp.EAVPivotSelect,
-		"TRY_CAST(MAX(CASE WHEN attr_id = 17 THEN value_numeric END) AS BIGINT) AS level")
+		"TRY_CAST(MAX(CASE WHEN attr_id = 17 THEN value_numeric END) AS DOUBLE) AS level")
 	// column-bound integer/smallint 保持声明宽度:物理列本身就是 int4/int2,
 	// COALESCE 伙伴 m.<col> 同宽,外层 CAST 也按描述符宽度扫描。
 	require.Contains(t, sp.EAVPivotSelect,

--- a/internal/sqlgen/duckdb_bigint_pivot_test.go
+++ b/internal/sqlgen/duckdb_bigint_pivot_test.go
@@ -26,11 +26,17 @@ func TestBuildEAVPivotEmitsTypedCasts(t *testing.T) {
 		"qty":   {AttributeID: 16, ValueType: forma.ValueTypeInteger},
 		"level": {AttributeID: 17, ValueType: forma.ValueTypeSmallInt},
 		"ratio": {AttributeID: 18, ValueType: forma.ValueTypeNumeric},
+		"score": {AttributeID: 19, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnInteger01}},
+		"grade": {AttributeID: 20, ValueType: forma.ValueTypeSmallInt,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnSmallint01}},
 	}
 	sp, err := BuildSchemaProjection(7, cache)
 	require.NoError(t, err)
 
-	// bigint / date pivot 出 BIGINT;integer/smallint 出各自原生类型
+	// bigint / date pivot 出 BIGINT;EAV-only integer/smallint 按存储宽度出
+	// BIGINT(#384):value_numeric 是无约束 NUMERIC,按声明宽度 cast 会把超出
+	// 声明范围的历史值只在 DuckDB 腿上 TRY_CAST 成 NULL。
 	require.Contains(t, sp.EAVPivotSelect,
 		"TRY_CAST(MAX(CASE WHEN attr_id = 5 THEN value_numeric END) AS BIGINT) AS amount")
 	require.Contains(t, sp.EAVPivotSelect,
@@ -38,9 +44,15 @@ func TestBuildEAVPivotEmitsTypedCasts(t *testing.T) {
 	require.Contains(t, sp.EAVPivotSelect,
 		"TRY_CAST(MAX(CASE WHEN attr_id = 15 THEN value_numeric END) AS BIGINT) AS total")
 	require.Contains(t, sp.EAVPivotSelect,
-		"TRY_CAST(MAX(CASE WHEN attr_id = 16 THEN value_numeric END) AS INTEGER) AS qty")
+		"TRY_CAST(MAX(CASE WHEN attr_id = 16 THEN value_numeric END) AS BIGINT) AS qty")
 	require.Contains(t, sp.EAVPivotSelect,
-		"TRY_CAST(MAX(CASE WHEN attr_id = 17 THEN value_numeric END) AS SMALLINT) AS level")
+		"TRY_CAST(MAX(CASE WHEN attr_id = 17 THEN value_numeric END) AS BIGINT) AS level")
+	// column-bound integer/smallint 保持声明宽度:物理列本身就是 int4/int2,
+	// COALESCE 伙伴 m.<col> 同宽,外层 CAST 也按描述符宽度扫描。
+	require.Contains(t, sp.EAVPivotSelect,
+		"TRY_CAST(MAX(CASE WHEN attr_id = 19 THEN value_numeric END) AS INTEGER) AS score")
+	require.Contains(t, sp.EAVPivotSelect,
+		"TRY_CAST(MAX(CASE WHEN attr_id = 20 THEN value_numeric END) AS SMALLINT) AS grade")
 	// numeric 保持 DOUBLE 语义:不 cast
 	require.Contains(t, sp.EAVPivotSelect,
 		"MAX(CASE WHEN attr_id = 18 THEN value_numeric END) AS ratio")

--- a/internal/sqlgen/duckdb_cold_scan.go
+++ b/internal/sqlgen/duckdb_cold_scan.go
@@ -124,28 +124,37 @@ func BuildParquetScanSource(pathsSQL string, missing []NullScanColumn) string {
 	return fmt.Sprintf("(SELECT %s FROM %s) AS cold_scan", strings.Join(parts, ", "), base)
 }
 
-// DuckDBNullScanType maps an attribute's value type to the DuckDB type its
+// DuckDBNullScanType maps an attribute's metadata to the DuckDB type its
 // parquet column would carry, for NULL::<type> augmentation. Kept in
 // lockstep with buildEAVPivotExpr / eavElementCastExpr (hot leg) and
-// cdc.castEAVValue (export leg): a mismatch would widen the UNION ALL and
-// re-open #205.
-func DuckDBNullScanType(vt forma.ValueType, itemsType forma.ValueType) string {
-	if vt == forma.ValueTypeList {
-		return duckDBNullScalarType(itemsType) + "[]"
+// cdc.castEAVValue / castMainValue (export leg): a mismatch would widen the
+// UNION ALL and re-open #205. The binding matters since #384: EAV-only
+// integer/smallint carry storage width (BIGINT) on every DuckDB surface,
+// while column-bound ones keep the physical int4/int2 width.
+func DuckDBNullScanType(meta forma.AttributeMetadata) string {
+	if meta.ValueType == forma.ValueTypeList {
+		// Lists are always EAV-only; elements carry EAV storage width.
+		return duckDBNullScalarType(meta.EffectiveItemsType(), false) + "[]"
 	}
-	return duckDBNullScalarType(vt)
+	return duckDBNullScalarType(meta.ValueType, meta.ColumnBinding != nil)
 }
 
-func duckDBNullScalarType(vt forma.ValueType) string {
+func duckDBNullScalarType(vt forma.ValueType, isColumn bool) string {
 	switch vt {
 	case forma.ValueTypeBool:
 		return "BOOLEAN"
 	case forma.ValueTypeBigInt, forma.ValueTypeDate, forma.ValueTypeDateTime:
 		return "BIGINT"
 	case forma.ValueTypeInteger:
-		return "INTEGER"
+		if isColumn {
+			return "INTEGER"
+		}
+		return "BIGINT"
 	case forma.ValueTypeSmallInt:
-		return "SMALLINT"
+		if isColumn {
+			return "SMALLINT"
+		}
+		return "BIGINT"
 	case forma.ValueTypeNumeric:
 		return "DOUBLE"
 	default: // text / uuid — VARCHAR on every tier

--- a/internal/sqlgen/duckdb_cold_scan.go
+++ b/internal/sqlgen/duckdb_cold_scan.go
@@ -129,8 +129,9 @@ func BuildParquetScanSource(pathsSQL string, missing []NullScanColumn) string {
 // lockstep with buildEAVPivotExpr / eavElementCastExpr (hot leg) and
 // cdc.castEAVValue / castMainValue (export leg): a mismatch would widen the
 // UNION ALL and re-open #205. The binding matters since #384: EAV-only
-// integer/smallint carry storage width (BIGINT) on every DuckDB surface,
-// while column-bound ones keep the physical int4/int2 width.
+// integer/smallint carry storage width (DOUBLE — value_numeric holds float64
+// images) on every DuckDB surface, while column-bound ones keep the physical
+// int4/int2 width.
 func DuckDBNullScanType(meta forma.AttributeMetadata) string {
 	if meta.ValueType == forma.ValueTypeList {
 		// Lists are always EAV-only; elements carry EAV storage width.
@@ -149,12 +150,12 @@ func duckDBNullScalarType(vt forma.ValueType, isColumn bool) string {
 		if isColumn {
 			return "INTEGER"
 		}
-		return "BIGINT"
+		return "DOUBLE"
 	case forma.ValueTypeSmallInt:
 		if isColumn {
 			return "SMALLINT"
 		}
-		return "BIGINT"
+		return "DOUBLE"
 	case forma.ValueTypeNumeric:
 		return "DOUBLE"
 	default: // text / uuid — VARCHAR on every tier

--- a/internal/sqlgen/duckdb_cold_scan_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_test.go
@@ -61,18 +61,18 @@ func TestDuckDBNullScanTypeMirrorsTierTypes(t *testing.T) {
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeBigInt}, "BIGINT"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeDate}, "BIGINT"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime}, "BIGINT"},
-		// #384: EAV-only integer/smallint carry storage width (the NUMERIC
-		// column round-trips values the declared width cannot hold), while
+		// #384: EAV-only integer/smallint carry storage width DOUBLE (the
+		// write funnel narrows everything through float64), while
 		// column-bound ones keep the physical int4/int2 width.
-		{forma.AttributeMetadata{ValueType: forma.ValueTypeInteger}, "BIGINT"},
-		{forma.AttributeMetadata{ValueType: forma.ValueTypeSmallInt}, "BIGINT"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeInteger}, "DOUBLE"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeSmallInt}, "DOUBLE"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeInteger, ColumnBinding: bound}, "INTEGER"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeSmallInt, ColumnBinding: bound}, "SMALLINT"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeNumeric}, "DOUBLE"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeText}, "VARCHAR"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeUUID}, "VARCHAR"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: forma.ValueTypeBigInt}, "BIGINT[]"},
-		{forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: forma.ValueTypeInteger}, "BIGINT[]"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: forma.ValueTypeInteger}, "DOUBLE[]"},
 		{forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: forma.ValueTypeText}, "VARCHAR[]"},
 	}
 	for _, c := range cases {

--- a/internal/sqlgen/duckdb_cold_scan_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_test.go
@@ -52,24 +52,32 @@ func TestBuildParquetScanSourceWrapsMissingColumnsAsTypedNulls(t *testing.T) {
 // TestDuckDBNullScanTypeMatchesHotLegTypeof below (hot pivot) and
 // cdc.TestCastEAVValueMatchesNullScanTypeof (export leg).
 func TestDuckDBNullScanTypeMirrorsTierTypes(t *testing.T) {
+	bound := &forma.MainColumnBinding{ColumnName: forma.MainColumnInteger01}
 	cases := []struct {
-		vt, items forma.ValueType
-		want      string
+		meta forma.AttributeMetadata
+		want string
 	}{
-		{forma.ValueTypeBool, "", "BOOLEAN"},
-		{forma.ValueTypeBigInt, "", "BIGINT"},
-		{forma.ValueTypeDate, "", "BIGINT"},
-		{forma.ValueTypeDateTime, "", "BIGINT"},
-		{forma.ValueTypeInteger, "", "INTEGER"},
-		{forma.ValueTypeSmallInt, "", "SMALLINT"},
-		{forma.ValueTypeNumeric, "", "DOUBLE"},
-		{forma.ValueTypeText, "", "VARCHAR"},
-		{forma.ValueTypeUUID, "", "VARCHAR"},
-		{forma.ValueTypeList, forma.ValueTypeBigInt, "BIGINT[]"},
-		{forma.ValueTypeList, forma.ValueTypeText, "VARCHAR[]"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeBool}, "BOOLEAN"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeBigInt}, "BIGINT"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeDate}, "BIGINT"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeDateTime}, "BIGINT"},
+		// #384: EAV-only integer/smallint carry storage width (the NUMERIC
+		// column round-trips values the declared width cannot hold), while
+		// column-bound ones keep the physical int4/int2 width.
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeInteger}, "BIGINT"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeSmallInt}, "BIGINT"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeInteger, ColumnBinding: bound}, "INTEGER"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeSmallInt, ColumnBinding: bound}, "SMALLINT"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeNumeric}, "DOUBLE"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeText}, "VARCHAR"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeUUID}, "VARCHAR"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: forma.ValueTypeBigInt}, "BIGINT[]"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: forma.ValueTypeInteger}, "BIGINT[]"},
+		{forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: forma.ValueTypeText}, "VARCHAR[]"},
 	}
 	for _, c := range cases {
-		require.Equal(t, c.want, DuckDBNullScanType(c.vt, c.items), "vt=%s items=%s", c.vt, c.items)
+		require.Equal(t, c.want, DuckDBNullScanType(c.meta), "vt=%s items=%s bound=%v",
+			c.meta.ValueType, c.meta.ItemsType, c.meta.ColumnBinding != nil)
 	}
 }
 
@@ -174,7 +182,7 @@ func TestDuckDBNullScanTypeMatchesHotLegTypeof(t *testing.T) {
 			require.NoError(t, db.QueryRow("SELECT "+hotExpr).Scan(&hot),
 				"hot-leg cast %q must evaluate", eavElementCastExpr(vt))
 
-			cold := typeOf(t, "NULL::"+DuckDBNullScanType(vt, ""))
+			cold := typeOf(t, "NULL::"+DuckDBNullScanType(forma.AttributeMetadata{ValueType: vt}))
 			require.Equal(t, hot, cold,
 				"cold NULL scan type must equal the hot-leg EAV cast type for %s (#205 no-widening)", vt)
 		})
@@ -189,7 +197,7 @@ func TestDuckDBNullScanTypeMatchesHotLegTypeof(t *testing.T) {
 			require.NoError(t, db.QueryRow(
 				"SELECT typeof(list(x)) FROM (SELECT "+eavElementCastExpr(items)+
 					" AS x FROM "+eavFixtureSubquery+")").Scan(&hot))
-			cold := typeOf(t, "NULL::"+DuckDBNullScanType(forma.ValueTypeList, items))
+			cold := typeOf(t, "NULL::"+DuckDBNullScanType(forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: items}))
 			require.Equal(t, hot, cold, "LIST element type must round-trip through the []-suffix construction for items=%s", items)
 		})
 	}
@@ -239,7 +247,7 @@ func TestDuckDBNullScanTypeMatchesPivotLegTypeof(t *testing.T) {
 	for _, vt := range scalars {
 		t.Run(string(vt), func(t *testing.T) {
 			hot := pivotTypeof(t, forma.AttributeMetadata{ValueType: vt})
-			cold := nullTypeof(t, DuckDBNullScanType(vt, ""))
+			cold := nullTypeof(t, DuckDBNullScanType(forma.AttributeMetadata{ValueType: vt}))
 			require.Equal(t, hot, cold,
 				"cold NULL scan type must equal the hot-leg PIVOT type for %s (#205 no-widening)", vt)
 		})
@@ -247,7 +255,7 @@ func TestDuckDBNullScanTypeMatchesPivotLegTypeof(t *testing.T) {
 	for _, items := range scalars {
 		t.Run("list_"+string(items), func(t *testing.T) {
 			hot := pivotTypeof(t, forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: items})
-			cold := nullTypeof(t, DuckDBNullScanType(forma.ValueTypeList, items))
+			cold := nullTypeof(t, DuckDBNullScanType(forma.AttributeMetadata{ValueType: forma.ValueTypeList, ItemsType: items}))
 			require.Equal(t, hot, cold,
 				"cold NULL scan type must equal the hot-leg LIST pivot type for items=%s", items)
 		})

--- a/internal/sqlgen/duckdb_list_pivot_test.go
+++ b/internal/sqlgen/duckdb_list_pivot_test.go
@@ -26,7 +26,7 @@ func TestBuildEAVPivotListAttrAggregatesElements(t *testing.T) {
 	require.Contains(t, sp.EAVPivotSelect,
 		"CASE WHEN count(*) FILTER (WHERE attr_id = 18) > 0 THEN coalesce(list(value_text ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 18 AND array_indices <> ''), []) END AS tags")
 	require.Contains(t, sp.EAVPivotSelect,
-		"CASE WHEN count(*) FILTER (WHERE attr_id = 19) > 0 THEN coalesce(list(TRY_CAST(value_numeric AS INTEGER) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 19 AND array_indices <> ''), []) END AS nums")
+		"CASE WHEN count(*) FILTER (WHERE attr_id = 19) > 0 THEN coalesce(list(TRY_CAST(value_numeric AS BIGINT) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 19 AND array_indices <> ''), []) END AS nums")
 	// Scalar attrs keep the MAX(CASE ...) pivot untouched.
 	require.Contains(t, sp.EAVPivotSelect,
 		"MAX(CASE WHEN attr_id = 7 THEN value_text END) AS note")

--- a/internal/sqlgen/duckdb_list_pivot_test.go
+++ b/internal/sqlgen/duckdb_list_pivot_test.go
@@ -26,7 +26,7 @@ func TestBuildEAVPivotListAttrAggregatesElements(t *testing.T) {
 	require.Contains(t, sp.EAVPivotSelect,
 		"CASE WHEN count(*) FILTER (WHERE attr_id = 18) > 0 THEN coalesce(list(value_text ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 18 AND array_indices <> ''), []) END AS tags")
 	require.Contains(t, sp.EAVPivotSelect,
-		"CASE WHEN count(*) FILTER (WHERE attr_id = 19) > 0 THEN coalesce(list(TRY_CAST(value_numeric AS BIGINT) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 19 AND array_indices <> ''), []) END AS nums")
+		"CASE WHEN count(*) FILTER (WHERE attr_id = 19) > 0 THEN coalesce(list(TRY_CAST(value_numeric AS DOUBLE) ORDER BY TRY_CAST(array_indices AS BIGINT)) FILTER (WHERE attr_id = 19 AND array_indices <> ''), []) END AS nums")
 	// Scalar attrs keep the MAX(CASE ...) pivot untouched.
 	require.Contains(t, sp.EAVPivotSelect,
 		"MAX(CASE WHEN attr_id = 7 THEN value_text END) AS note")

--- a/internal/sqlgen/duckdb_namespace_render_test.go
+++ b/internal/sqlgen/duckdb_namespace_render_test.go
@@ -55,7 +55,7 @@ func TestDuckDBNamespace_RenderPaths_AttributeAliasedClause(t *testing.T) {
 
 	// The clause references attribute names (matching the CTE aliases), not the
 	// physical column the attribute is bound to.
-	require.Equal(t, "(age > CAST(? AS INTEGER)) AND (tag = ?)", dc.DuckClause)
+	require.Equal(t, "(age > CAST(? AS BIGINT)) AND (tag = ?)", dc.DuckClause)
 	require.NotContains(t, dc.DuckClause, "integer_01")
 
 	dirty := []uuid.UUID{uuid.New()}

--- a/internal/sqlgen/duckdb_namespace_render_test.go
+++ b/internal/sqlgen/duckdb_namespace_render_test.go
@@ -55,7 +55,7 @@ func TestDuckDBNamespace_RenderPaths_AttributeAliasedClause(t *testing.T) {
 
 	// The clause references attribute names (matching the CTE aliases), not the
 	// physical column the attribute is bound to.
-	require.Equal(t, "(age > CAST(? AS BIGINT)) AND (tag = ?)", dc.DuckClause)
+	require.Equal(t, "(age > CAST(? AS DOUBLE)) AND (tag = ?)", dc.DuckClause)
 	require.NotContains(t, dc.DuckClause, "integer_01")
 
 	dirty := []uuid.UUID{uuid.New()}

--- a/internal/sqlgen/duckdb_schema_projection.go
+++ b/internal/sqlgen/duckdb_schema_projection.go
@@ -234,6 +234,10 @@ func (sp *SchemaProjection) buildEAVPivot(attrs []attrProjectionInfo) {
 // bigint values above 2^53 and crashed CAST-back at a stored MaxInt64 (#205).
 // TRY_CAST (not CAST) matches export semantics: an out-of-range NUMERIC in
 // eav_data becomes NULL on every tier alike instead of a read-path crash.
+// EAV-only integer/smallint cast by storage width (BIGINT), not declared
+// width, so a stored value the declared type cannot hold answers the same on
+// hot Postgres and every DuckDB tier (#384); the write funnel now rejects new
+// ones (transform.checkDeclaredIntegerFit).
 func buildEAVPivotExpr(a attrProjectionInfo) string {
 	if a.meta.ValueType == forma.ValueTypeList {
 		// One eav_data row per element: aggregate into a LIST in element-index
@@ -256,10 +260,21 @@ func buildEAVPivotExpr(a attrProjectionInfo) string {
 	switch a.meta.ValueType {
 	case forma.ValueTypeBigInt, forma.ValueTypeDate, forma.ValueTypeDateTime:
 		return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", base)
-	case forma.ValueTypeInteger:
-		return fmt.Sprintf("TRY_CAST(%s AS INTEGER)", base)
-	case forma.ValueTypeSmallInt:
-		return fmt.Sprintf("TRY_CAST(%s AS SMALLINT)", base)
+	case forma.ValueTypeInteger, forma.ValueTypeSmallInt:
+		if a.isColumn {
+			// Bound storage is physically int4/int2: declared width IS the
+			// storage width, and the COALESCE partner m.<col> is just as
+			// narrow, so nothing wider can ever round-trip.
+			if a.meta.ValueType == forma.ValueTypeInteger {
+				return fmt.Sprintf("TRY_CAST(%s AS INTEGER)", base)
+			}
+			return fmt.Sprintf("TRY_CAST(%s AS SMALLINT)", base)
+		}
+		// EAV-only storage is unconstrained NUMERIC: project by storage width
+		// so a stored value the declared type cannot hold answers identically
+		// on every tier instead of TRY_CASTing to NULL only on the DuckDB
+		// legs while hot Postgres matches it (#384).
+		return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", base)
 	default:
 		// numeric 保持 DOUBLE;text/uuid 走 value_text,无 cast
 		return base
@@ -275,10 +290,11 @@ func eavElementCastExpr(vt forma.ValueType) string {
 		return "(value_numeric <> 0)"
 	case forma.ValueTypeBigInt, forma.ValueTypeDate, forma.ValueTypeDateTime:
 		return "TRY_CAST(value_numeric AS BIGINT)"
-	case forma.ValueTypeInteger:
-		return "TRY_CAST(value_numeric AS INTEGER)"
-	case forma.ValueTypeSmallInt:
-		return "TRY_CAST(value_numeric AS SMALLINT)"
+	case forma.ValueTypeInteger, forma.ValueTypeSmallInt:
+		// List storage is one unconstrained-NUMERIC eav row per element and
+		// lists are always EAV-only: storage width, as in the scalar EAV-only
+		// arm of buildEAVPivotExpr (#384).
+		return "TRY_CAST(value_numeric AS BIGINT)"
 	case forma.ValueTypeNumeric:
 		return "TRY_CAST(value_numeric AS DOUBLE)"
 	default: // text / uuid

--- a/internal/sqlgen/duckdb_schema_projection.go
+++ b/internal/sqlgen/duckdb_schema_projection.go
@@ -234,10 +234,11 @@ func (sp *SchemaProjection) buildEAVPivot(attrs []attrProjectionInfo) {
 // bigint values above 2^53 and crashed CAST-back at a stored MaxInt64 (#205).
 // TRY_CAST (not CAST) matches export semantics: an out-of-range NUMERIC in
 // eav_data becomes NULL on every tier alike instead of a read-path crash.
-// EAV-only integer/smallint cast by storage width (BIGINT), not declared
-// width, so a stored value the declared type cannot hold answers the same on
-// hot Postgres and every DuckDB tier (#384); the write funnel now rejects new
-// ones (transform.checkDeclaredIntegerFit).
+// EAV-only integer/smallint cast by storage width (DOUBLE — the write funnel
+// narrows everything through float64), not declared width, so a stored value
+// the declared type cannot hold answers the same on hot Postgres and every
+// DuckDB tier (#384); the write funnel now rejects new ones
+// (transform.checkDeclaredIntegerFit).
 func buildEAVPivotExpr(a attrProjectionInfo) string {
 	if a.meta.ValueType == forma.ValueTypeList {
 		// One eav_data row per element: aggregate into a LIST in element-index
@@ -270,11 +271,14 @@ func buildEAVPivotExpr(a attrProjectionInfo) string {
 			}
 			return fmt.Sprintf("TRY_CAST(%s AS SMALLINT)", base)
 		}
-		// EAV-only storage is unconstrained NUMERIC: project by storage width
-		// so a stored value the declared type cannot hold answers identically
-		// on every tier instead of TRY_CASTing to NULL only on the DuckDB
-		// legs while hot Postgres matches it (#384).
-		return fmt.Sprintf("TRY_CAST(%s AS BIGINT)", base)
+		// EAV-only storage width is DOUBLE, like the numeric class: the write
+		// funnel narrows everything through float64 (numutil.Float64), so
+		// whatever value_numeric holds — including out-of-declared-range and
+		// non-integral history — is a float64 image, and DOUBLE reproduces it
+		// exactly on every tier. A narrower integer cast either NULLed the
+		// value (BIGINT-overflow) or rounded it (1.5 → 2) only on the DuckDB
+		// legs while hot Postgres compared the raw NUMERIC (#384).
+		return fmt.Sprintf("TRY_CAST(%s AS DOUBLE)", base)
 	default:
 		// numeric 保持 DOUBLE;text/uuid 走 value_text,无 cast
 		return base
@@ -291,10 +295,10 @@ func eavElementCastExpr(vt forma.ValueType) string {
 	case forma.ValueTypeBigInt, forma.ValueTypeDate, forma.ValueTypeDateTime:
 		return "TRY_CAST(value_numeric AS BIGINT)"
 	case forma.ValueTypeInteger, forma.ValueTypeSmallInt:
-		// List storage is one unconstrained-NUMERIC eav row per element and
-		// lists are always EAV-only: storage width, as in the scalar EAV-only
-		// arm of buildEAVPivotExpr (#384).
-		return "TRY_CAST(value_numeric AS BIGINT)"
+		// List storage is one float64-funneled NUMERIC eav row per element
+		// and lists are always EAV-only: storage width DOUBLE, as in the
+		// scalar EAV-only arm of buildEAVPivotExpr (#384).
+		return "TRY_CAST(value_numeric AS DOUBLE)"
 	case forma.ValueTypeNumeric:
 		return "TRY_CAST(value_numeric AS DOUBLE)"
 	default: // text / uuid

--- a/internal/sqlgen/duckdb_sql_generator_test.go
+++ b/internal/sqlgen/duckdb_sql_generator_test.go
@@ -119,7 +119,7 @@ func TestBuildListPredicate_Equals(t *testing.T) {
 func TestBuildListPredicate_EqualsNumeric(t *testing.T) {
 	sql, param, err := BuildListPredicate("scores", "equals", "42", forma.ValueTypeInteger)
 	require.NoError(t, err)
-	require.Equal(t, "list_contains(scores, CAST(? AS BIGINT))", sql)
+	require.Equal(t, "list_contains(scores, CAST(? AS DOUBLE))", sql)
 	require.Equal(t, "42", param)
 }
 
@@ -154,7 +154,7 @@ func TestBuildListPredicate_Gt(t *testing.T) {
 func TestBuildListPredicate_Gte(t *testing.T) {
 	sql, param, err := BuildListPredicate("values", "gte", "5", forma.ValueTypeInteger)
 	require.NoError(t, err)
-	require.Equal(t, "list_any_match(values, x -> x >= CAST(? AS BIGINT))", sql)
+	require.Equal(t, "list_any_match(values, x -> x >= CAST(? AS DOUBLE))", sql)
 	require.Equal(t, "5", param)
 }
 
@@ -168,7 +168,7 @@ func TestBuildListPredicate_Lt(t *testing.T) {
 func TestBuildListPredicate_Lte(t *testing.T) {
 	sql, param, err := BuildListPredicate("values", "lte", "50", forma.ValueTypeSmallInt)
 	require.NoError(t, err)
-	require.Equal(t, "list_any_match(values, x -> x <= CAST(? AS BIGINT))", sql)
+	require.Equal(t, "list_any_match(values, x -> x <= CAST(? AS DOUBLE))", sql)
 	require.Equal(t, "50", param)
 }
 

--- a/internal/sqlgen/duckdb_sql_generator_test.go
+++ b/internal/sqlgen/duckdb_sql_generator_test.go
@@ -119,7 +119,7 @@ func TestBuildListPredicate_Equals(t *testing.T) {
 func TestBuildListPredicate_EqualsNumeric(t *testing.T) {
 	sql, param, err := BuildListPredicate("scores", "equals", "42", forma.ValueTypeInteger)
 	require.NoError(t, err)
-	require.Equal(t, "list_contains(scores, CAST(? AS INTEGER))", sql)
+	require.Equal(t, "list_contains(scores, CAST(? AS BIGINT))", sql)
 	require.Equal(t, "42", param)
 }
 
@@ -147,14 +147,14 @@ func TestBuildListPredicate_StartsWith(t *testing.T) {
 func TestBuildListPredicate_Gt(t *testing.T) {
 	sql, param, err := BuildListPredicate("values", "gt", "10", forma.ValueTypeNumeric)
 	require.NoError(t, err)
-	require.Equal(t, "list_any_match(values, x -> x > CAST(? AS DECIMAL(38,10)))", sql)
+	require.Equal(t, "list_any_match(values, x -> x > CAST(? AS DOUBLE))", sql)
 	require.Equal(t, "10", param)
 }
 
 func TestBuildListPredicate_Gte(t *testing.T) {
 	sql, param, err := BuildListPredicate("values", "gte", "5", forma.ValueTypeInteger)
 	require.NoError(t, err)
-	require.Equal(t, "list_any_match(values, x -> x >= CAST(? AS INTEGER))", sql)
+	require.Equal(t, "list_any_match(values, x -> x >= CAST(? AS BIGINT))", sql)
 	require.Equal(t, "5", param)
 }
 
@@ -168,7 +168,7 @@ func TestBuildListPredicate_Lt(t *testing.T) {
 func TestBuildListPredicate_Lte(t *testing.T) {
 	sql, param, err := BuildListPredicate("values", "lte", "50", forma.ValueTypeSmallInt)
 	require.NoError(t, err)
-	require.Equal(t, "list_any_match(values, x -> x <= CAST(? AS SMALLINT))", sql)
+	require.Equal(t, "list_any_match(values, x -> x <= CAST(? AS BIGINT))", sql)
 	require.Equal(t, "50", param)
 }
 
@@ -398,7 +398,7 @@ func TestBuildDuckClause_GivenNestedAndOrConditions_WhenClauseBuilt_ThenGrouping
 
 	clause, args, err := buildDuckClause(cond, nil)
 	require.NoError(t, err)
-	require.Equal(t, "(status = ?) AND ((score > CAST(? AS DECIMAL(38,10))) OR (email LIKE ?))", clause)
+	require.Equal(t, "(status = ?) AND ((score > CAST(? AS DOUBLE)) OR (email LIKE ?))", clause)
 	require.Equal(t, []any{"active", "10", "ops%"}, args)
 }
 

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -2,6 +2,7 @@ package sqlgen
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/lychee-technology/forma/internal/numutil"
@@ -19,14 +20,16 @@ func MapValueTypeToDuckDBType(v forma.ValueType) string {
 	case forma.ValueTypeUUID:
 		return "VARCHAR"
 	case forma.ValueTypeSmallInt, forma.ValueTypeInteger:
-		// #384: predicate operands cast by column storage width. Every
-		// integer/smallint EAV column is BIGINT across the tiers (see
-		// buildEAVPivotExpr), and a bound int4/int2 column compares against a
-		// BIGINT operand by lossless promotion. The declared-width cast was
-		// strict (CAST, not TRY_CAST), so an out-of-range operand raised a
-		// Conversion Error on the DuckDB route while Postgres answered
-		// normally; at BIGINT it simply matches nothing, like Postgres.
-		return "BIGINT"
+		// #384: predicate operands cast by column storage width. The EAV
+		// write funnel narrows every numeric-family value through float64
+		// (numutil.Float64), so an EAV integer/smallint column's true storage
+		// width is DOUBLE — which is also what every DuckDB tier projects for
+		// it (buildEAVPivotExpr) — and a bound int4/int2 column compares
+		// against a DOUBLE operand by lossless promotion (INT32 ≪ 2^53). The
+		// old declared-width cast was strict, so an out-of-range operand
+		// raised a Conversion Error on the DuckDB route while Postgres
+		// answered normally; at DOUBLE any magnitude simply compares.
+		return "DOUBLE"
 	case forma.ValueTypeBigInt:
 		return "BIGINT"
 	case forma.ValueTypeNumeric:
@@ -56,7 +59,7 @@ func MapValueTypeToDuckDBType(v forma.ValueType) string {
 }
 
 // MapValueTypeToListDuckDBType returns the DuckDB LIST type for an array of the given element type.
-// e.g., ValueTypeText -> "LIST(VARCHAR)", ValueTypeInteger -> "LIST(BIGINT)".
+// e.g., ValueTypeText -> "LIST(VARCHAR)", ValueTypeInteger -> "LIST(DOUBLE)".
 // Element types ride MapValueTypeToDuckDBType and therefore EAV storage width
 // (#384), which is always right today because list attributes cannot bind a
 // main column (their storage is one eav_data row per element, mirrored by
@@ -87,7 +90,10 @@ func CastExpression(columnOrExpr string, v forma.ValueType) string {
 //     accepted input widens to float64
 //   - bigint/numeric -> a decimal string, never a number (see
 //     toDuckDBDecimalParam): exact for int/int64/string inputs, while a float64
-//     input is rendered by decimalString's %.15g
+//     input is rendered by decimalString's shortest round-trip form, so the
+//     DuckDB side recovers the identical float64 the PG side binds (#384 P1b:
+//     the former %.15g dropped the 16th-17th significant digits and made
+//     equality miss rows only on the DuckDB route)
 func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 	if value == nil {
 		return nil, nil
@@ -230,8 +236,12 @@ func toDuckDBDecimalParam(value any) (any, error) {
 	}
 }
 
+// decimalString renders a float64 operand in its shortest round-trip decimal
+// form: CAST(<it> AS DOUBLE) recovers the identical float64, matching the
+// value pgx binds to the Postgres NUMERIC comparison (#384 P1b). %.15g is not
+// enough — float64 needs up to 17 significant digits to round-trip.
 func decimalString(v float64) string {
-	return fmt.Sprintf("%.15g", v)
+	return strconv.FormatFloat(v, 'g', -1, 64)
 }
 
 func toOptionalFloat64Param(value any) (float64, bool, error) {

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -18,17 +18,24 @@ func MapValueTypeToDuckDBType(v forma.ValueType) string {
 		return "VARCHAR"
 	case forma.ValueTypeUUID:
 		return "VARCHAR"
-	case forma.ValueTypeSmallInt:
-		return "SMALLINT"
-	case forma.ValueTypeInteger:
-		return "INTEGER"
+	case forma.ValueTypeSmallInt, forma.ValueTypeInteger:
+		// #384: predicate operands cast by column storage width. Every
+		// integer/smallint EAV column is BIGINT across the tiers (see
+		// buildEAVPivotExpr), and a bound int4/int2 column compares against a
+		// BIGINT operand by lossless promotion. The declared-width cast was
+		// strict (CAST, not TRY_CAST), so an out-of-range operand raised a
+		// Conversion Error on the DuckDB route while Postgres answered
+		// normally; at BIGINT it simply matches nothing, like Postgres.
+		return "BIGINT"
 	case forma.ValueTypeBigInt:
 		return "BIGINT"
 	case forma.ValueTypeNumeric:
-		// Use explicit-precision DECIMAL to preserve numeric precision instead of DOUBLE.
-		// DECIMAL(38,10) supports 38 digits total, 10 fractional — enough for financial
-		// and scientific use-cases without default truncation.
-		return "DECIMAL(38,10)"
+		// #384: every numeric column on every tier is DOUBLE (EAV pivot,
+		// parquet export, main double columns). The former DECIMAL(38,10)
+		// operand cast silently truncated operands beyond 10 fractional
+		// digits (false mismatch against the DOUBLE column) and overflowed
+		// past ~1e28 (one-sided query failure).
+		return "DOUBLE"
 	case forma.ValueTypeDate, forma.ValueTypeDateTime:
 		// Date/datetime attribute columns in the federated CTEs are epoch-ms
 		// BIGINT on all three sides — EAV pivot TRY_CAST(value_numeric AS

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -56,7 +56,12 @@ func MapValueTypeToDuckDBType(v forma.ValueType) string {
 }
 
 // MapValueTypeToListDuckDBType returns the DuckDB LIST type for an array of the given element type.
-// e.g., ValueTypeText -> "LIST(VARCHAR)", ValueTypeInteger -> "LIST(INTEGER)"
+// e.g., ValueTypeText -> "LIST(VARCHAR)", ValueTypeInteger -> "LIST(BIGINT)".
+// Element types ride MapValueTypeToDuckDBType and therefore EAV storage width
+// (#384), which is always right today because list attributes cannot bind a
+// main column (their storage is one eav_data row per element, mirrored by
+// eavElementCastExpr). If list column bindings ever appear, the
+// storage-vs-declared width choice needs an explicit decision here.
 func MapValueTypeToListDuckDBType(elementType forma.ValueType) string {
 	elemDuckType := MapValueTypeToDuckDBType(elementType)
 	return "LIST(" + elemDuckType + ")"

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -149,6 +149,10 @@ func ToDuckDBParam(value any, v forma.ValueType) (any, error) {
 		// int64-first parse one call later, at predicate_normalizer.go's
 		// ToDuckDBParam hop. Everything else keeps the funnel: INTEGER and
 		// SMALLINT ranges end at 2^31/2^15 and float64 is exact well past both.
+		// The DuckDB side deliberately keeps the exact int64 and lets
+		// CAST(? AS DOUBLE) round in-engine — above 2^53 it lands on the same
+		// float64 image the PG binders reach via NarrowEAVNumericOperand
+		// (#384), so both engines still compare one value.
 		if exact, ok := value.(int64); ok {
 			return exact, nil
 		}

--- a/internal/sqlgen/duckdb_type_mapper_test.go
+++ b/internal/sqlgen/duckdb_type_mapper_test.go
@@ -31,14 +31,18 @@ func TestMapValueTypeToDuckDBType_AllSupportedTypes(t *testing.T) {
 			expected: "VARCHAR",
 		},
 		{
+			// #384: integer/smallint operands cast at storage width — every
+			// EAV tier column is BIGINT and bound int4/int2 columns promote
+			// losslessly, while the old strict narrow CAST errored on
+			// out-of-range operands that Postgres answered normally.
 			name:     "ValueTypeSmallInt",
 			vt:       forma.ValueTypeSmallInt,
-			expected: "SMALLINT",
+			expected: "BIGINT",
 		},
 		{
 			name:     "ValueTypeInteger",
 			vt:       forma.ValueTypeInteger,
-			expected: "INTEGER",
+			expected: "BIGINT",
 		},
 		{
 			name:     "ValueTypeBigInt",
@@ -46,9 +50,11 @@ func TestMapValueTypeToDuckDBType_AllSupportedTypes(t *testing.T) {
 			expected: "BIGINT",
 		},
 		{
+			// #384: numeric columns are DOUBLE on every tier; DECIMAL(38,10)
+			// truncated operand scale at 10 digits and overflowed past ~1e28.
 			name:     "ValueTypeNumeric",
 			vt:       forma.ValueTypeNumeric,
-			expected: "DECIMAL(38,10)",
+			expected: "DOUBLE",
 		},
 		{
 			name:     "ValueTypeDate",
@@ -97,7 +103,7 @@ func TestCastExpression_SimpleColumn(t *testing.T) {
 			name:     "CastColumnToInteger",
 			column:   "age",
 			vt:       forma.ValueTypeInteger,
-			expected: "CAST(age AS INTEGER)",
+			expected: "CAST(age AS BIGINT)",
 		},
 		{
 			name:     "CastColumnToBoolean",
@@ -380,7 +386,7 @@ func TestMapValueTypeToListDuckDBType_TextElement(t *testing.T) {
 
 func TestMapValueTypeToListDuckDBType_IntegerElement(t *testing.T) {
 	result := MapValueTypeToListDuckDBType(forma.ValueTypeInteger)
-	require.Equal(t, "LIST(INTEGER)", result)
+	require.Equal(t, "LIST(BIGINT)", result)
 }
 
 func TestMapValueTypeToListDuckDBType_BigIntElement(t *testing.T) {
@@ -390,7 +396,7 @@ func TestMapValueTypeToListDuckDBType_BigIntElement(t *testing.T) {
 
 func TestMapValueTypeToListDuckDBType_NumericElement(t *testing.T) {
 	result := MapValueTypeToListDuckDBType(forma.ValueTypeNumeric)
-	require.Equal(t, "LIST(DECIMAL(38,10))", result)
+	require.Equal(t, "LIST(DOUBLE)", result)
 }
 
 func TestMapValueTypeToListDuckDBType_BoolElement(t *testing.T) {

--- a/internal/sqlgen/duckdb_type_mapper_test.go
+++ b/internal/sqlgen/duckdb_type_mapper_test.go
@@ -31,18 +31,19 @@ func TestMapValueTypeToDuckDBType_AllSupportedTypes(t *testing.T) {
 			expected: "VARCHAR",
 		},
 		{
-			// #384: integer/smallint operands cast at storage width — every
-			// EAV tier column is BIGINT and bound int4/int2 columns promote
-			// losslessly, while the old strict narrow CAST errored on
+			// #384: integer/smallint operands cast at storage width DOUBLE —
+			// the EAV write funnel narrows through float64, every EAV tier
+			// column is DOUBLE, and bound int4/int2 columns promote
+			// losslessly; the old strict narrow CAST errored on
 			// out-of-range operands that Postgres answered normally.
 			name:     "ValueTypeSmallInt",
 			vt:       forma.ValueTypeSmallInt,
-			expected: "BIGINT",
+			expected: "DOUBLE",
 		},
 		{
 			name:     "ValueTypeInteger",
 			vt:       forma.ValueTypeInteger,
-			expected: "BIGINT",
+			expected: "DOUBLE",
 		},
 		{
 			name:     "ValueTypeBigInt",
@@ -103,7 +104,7 @@ func TestCastExpression_SimpleColumn(t *testing.T) {
 			name:     "CastColumnToInteger",
 			column:   "age",
 			vt:       forma.ValueTypeInteger,
-			expected: "CAST(age AS BIGINT)",
+			expected: "CAST(age AS DOUBLE)",
 		},
 		{
 			name:     "CastColumnToBoolean",
@@ -386,7 +387,7 @@ func TestMapValueTypeToListDuckDBType_TextElement(t *testing.T) {
 
 func TestMapValueTypeToListDuckDBType_IntegerElement(t *testing.T) {
 	result := MapValueTypeToListDuckDBType(forma.ValueTypeInteger)
-	require.Equal(t, "LIST(BIGINT)", result)
+	require.Equal(t, "LIST(DOUBLE)", result)
 }
 
 func TestMapValueTypeToListDuckDBType_BigIntElement(t *testing.T) {

--- a/internal/sqlgen/numeric_bind_parity_test.go
+++ b/internal/sqlgen/numeric_bind_parity_test.go
@@ -20,12 +20,10 @@ import (
 // while ConvertPgMainValue went int64-first, so the two Postgres/DuckDB legs of
 // the same predicate carried different values for the same input string.
 //
-// This changes no query result. Below the bound of the arm's own cast — 2^31
-// for CAST(? AS INTEGER), 2^15 for CAST(? AS SMALLINT) — int64 and float64
-// denote the same number so comparisons are identical. Above it, both parameter
-// types raise the same class of conversion error from that cast (DuckDB words
-// the int64 and the float64 case differently), so queries fail either way. What
-// is fixed here is the divergence itself.
+// This changes no query result. Since #384 the integer/smallint operand cast
+// is CAST(? AS BIGINT) (storage width), well past any value these arms parse
+// exactly, so int64 and float64 denote the same number wherever comparisons
+// run. What is fixed here is the divergence itself.
 func TestNumericBinderTypeParity(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/sqlgen/numeric_bind_parity_test.go
+++ b/internal/sqlgen/numeric_bind_parity_test.go
@@ -20,10 +20,11 @@ import (
 // while ConvertPgMainValue went int64-first, so the two Postgres/DuckDB legs of
 // the same predicate carried different values for the same input string.
 //
-// This changes no query result. Since #384 the integer/smallint operand cast
-// is CAST(? AS BIGINT) (storage width), well past any value these arms parse
-// exactly, so int64 and float64 denote the same number wherever comparisons
-// run. What is fixed here is the divergence itself.
+// This changes no query result: the parse rule is shared, and where a bind
+// then diverges by design — the DOUBLE-width classes narrow integral operands
+// through the write funnel's float64 (#384, NarrowEAVNumericOperand) after
+// this parse — it diverges identically on both engines. What is fixed here is
+// the parse divergence itself.
 func TestNumericBinderTypeParity(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/sqlgen/operand_roundtrip_test.go
+++ b/internal/sqlgen/operand_roundtrip_test.go
@@ -1,0 +1,67 @@
+package sqlgen
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma"
+)
+
+// #384 P1b: a float64 numeric operand must render in a form CAST(... AS
+// DOUBLE) recovers bit-identically, or DuckDB equality misses rows the PG
+// NUMERIC comparison (which receives the true float64) matches. %.15g dropped
+// the 16th-17th significant digits.
+func TestDecimalStringRoundTripsFloat64(t *testing.T) {
+	cases := []float64{
+		0.1234567890123456,   // 16 sig digits — %.15g mangled this
+		0.12345678901234567,  // 17 sig digits
+		9007199254740993.5,   // beyond 2^53, parses to ...994
+		1e-300, 1.5, 3, 1e28, // assorted magnitudes
+	}
+	for _, v := range cases {
+		t.Run(strconv.FormatFloat(v, 'g', -1, 64), func(t *testing.T) {
+			s := decimalString(v)
+			back, err := strconv.ParseFloat(s, 64)
+			require.NoError(t, err)
+			require.Equal(t, v, back, "rendered operand %q must recover the identical float64", s)
+		})
+	}
+}
+
+// #384 P2b: both engines parse bool operands under one rule — ParseBool
+// spellings plus any integer with the >0 truthiness the PG path always had.
+// Before this, "2" bound only on PG and "true" bound only on DuckDB, so the
+// same filter erred on exactly one route depending on spelling.
+func TestBoolOperandParityAcrossEngines(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"flag": {AttributeID: 7, ValueType: forma.ValueTypeBool},
+	}
+	cases := []struct {
+		literal string
+		want    bool
+	}{
+		{"1", true}, {"0", false},
+		{"true", true}, {"false", false},
+		{"TRUE", true}, {"t", true},
+		{"2", true}, {"-1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.literal, func(t *testing.T) {
+			cond := &forma.KvCondition{Attr: "flag", Value: "equals:" + tc.literal}
+			paramIndex := 1
+			dual, err := ToDualClauses(cond, "eav_table", 1, cache, &paramIndex)
+			require.NoError(t, err)
+			require.Equal(t, []any{int16(7), tc.want}, dual.PgArgs, "pg bind")
+			require.Equal(t, []any{tc.want}, dual.DuckArgs, "duck bind")
+		})
+	}
+
+	// Garbage rejects identically on both routes, as invalid input.
+	cond := &forma.KvCondition{Attr: "flag", Value: "equals:maybe"}
+	paramIndex := 1
+	_, err := ToDualClauses(cond, "eav_table", 1, cache, &paramIndex)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}

--- a/internal/sqlgen/operand_roundtrip_test.go
+++ b/internal/sqlgen/operand_roundtrip_test.go
@@ -65,3 +65,18 @@ func TestBoolOperandParityAcrossEngines(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, forma.ErrInvalidInput)
 }
+
+// #384 (fourth-review P1): integral operands for the DOUBLE-width classes
+// narrow through the same float64 funnel the stored data took, so above 2^53
+// the PG bind is the float64 image DuckDB's CAST(? AS DOUBLE) also lands on —
+// one verdict on both engines instead of PG-exact-miss vs DuckDB-rounded-hit.
+// bigint keeps the exact int64: its storage is BIGINT-backed on every tier.
+func TestNarrowEAVNumericOperand(t *testing.T) {
+	const above = int64(9007199254740993) // 2^53 + 1
+	image := float64(9007199254740992)    // its float64 image
+	require.Equal(t, image, NarrowEAVNumericOperand(forma.ValueTypeInteger, above))
+	require.Equal(t, image, NarrowEAVNumericOperand(forma.ValueTypeSmallInt, above))
+	require.Equal(t, image, NarrowEAVNumericOperand(forma.ValueTypeNumeric, above))
+	require.Equal(t, above, NarrowEAVNumericOperand(forma.ValueTypeBigInt, above))
+	require.Equal(t, float64(42), NarrowEAVNumericOperand(forma.ValueTypeInteger, 42))
+}

--- a/internal/sqlgen/predicate_characterization_bigint_test.go
+++ b/internal/sqlgen/predicate_characterization_bigint_test.go
@@ -83,9 +83,11 @@ func buildCharBigIntCases() []charCase {
 			want: DualClauses{
 				PgMainClause: "m.bigint_02 < ?", PgMainArgs: []any{float64(9007199254740993.5)},
 				PgClause: charEavClause("$2", "value_numeric", "<", "$3"), PgArgs: []any{int16(12), float64(9007199254740993.5)},
-				// float64 + %.15g, unchanged by #357: fractional literals have
-				// no exact integral form to refine to.
-				DuckClause: "amount < CAST(? AS BIGINT)", DuckArgs: []any{"9.00719925474099e+15"},
+				// float64 in shortest round-trip form (#384 P1b): fractional
+				// literals have no exact integral form to refine to, and the
+				// rendered string must recover the identical float64
+				// (9007199254740993.5 rounds to ...994 at parse time).
+				DuckClause: "amount < CAST(? AS BIGINT)", DuckArgs: []any{"9.007199254740994e+15"},
 			},
 			span: 3,
 		},

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -118,18 +118,17 @@ func buildCharTextCases() []charCase {
 	}
 }
 
-// buildCharNumericBoolCases covers the numeric and boolean storage classes, including
-// the >2^31 range limit test where all three emitters now bind integer/smallint as int64
-// (#355), and the bool-int / bool-text / unbound-bool encodings. The bigint storage class
-// lives in predicate_characterization_bigint_test.go.
+// buildCharNumericBoolCases covers the numeric and boolean storage classes
+// (bigint lives in predicate_characterization_bigint_test.go): the DOUBLE-width
+// operand narrowing (#384), and the bool-int / bool-text / unbound encodings.
 func buildCharNumericBoolCases() []charCase {
 	return []charCase{
 		{
-			name: "integer gt: main/eav/duck all int64",
+			name: "integer gt: main int64, eav narrowed float64, duck int64",
 			cond: charKv("age", "gt:30"),
 			want: DualClauses{
 				PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(30)},
-				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), int64(30)},
+				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), float64(30)},
 				DuckClause: "age > CAST(? AS DOUBLE)", DuckArgs: []any{int64(30)},
 			},
 			span: 3,
@@ -145,11 +144,15 @@ func buildCharNumericBoolCases() []charCase {
 			span: 2,
 		},
 		{
-			name: "integer above 2^31: main/eav/duck all int64, duck compares at DOUBLE (#384)",
+			// #384: above 2^53 the EAV leg binds the float64 image (…992),
+			// the same value DuckDB's CAST(? AS DOUBLE) rounds to — one
+			// verdict. The bound int4 column keeps exact int64 (it can hold
+			// neither value; parity is trivial there).
+			name: "integer above 2^31: eav narrows to the float64 image (#384)",
 			cond: charKv("age", "equals:9007199254740993"),
 			want: DualClauses{
 				PgMainClause: "m.integer_01 = ?", PgMainArgs: []any{int64(9007199254740993)},
-				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), int64(9007199254740993)},
+				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), float64(9007199254740992)},
 				DuckClause: "age = CAST(? AS DOUBLE)", DuckArgs: []any{int64(9007199254740993)},
 			},
 			span: 3,
@@ -248,7 +251,7 @@ func buildCharCompositeCases() []charCase {
 				PgClause: "((" + charEavClause("$2", "value_text", "=", "$3") + ") AND (((" +
 					charEavClause("$4", "value_numeric", ">", "$5") + ") OR (" +
 					charEavClause("$6", "value_text", "=", "$7") + "))))",
-				PgArgs:     []any{int16(1), "Alice", int16(2), int64(18), int16(4), "x"},
+				PgArgs:     []any{int16(1), "Alice", int16(2), float64(18), int16(4), "x"},
 				DuckClause: "(username = ?) AND ((age > CAST(? AS DOUBLE)) OR (tag = ?))",
 				DuckArgs:   []any{"Alice", int64(18), "x"},
 			},
@@ -261,7 +264,7 @@ func buildCharCompositeCases() []charCase {
 				PgMainClause: "((m.text_01 = ?) OR (m.integer_01 > ?))", PgMainArgs: []any{"A", int64(5)},
 				PgClause: "((" + charEavClause("$3", "value_text", "=", "$4") + ") OR (" +
 					charEavClause("$5", "value_numeric", ">", "$6") + "))",
-				PgArgs:     []any{int16(1), "A", int16(2), int64(5)},
+				PgArgs:     []any{int16(1), "A", int16(2), float64(5)},
 				DuckClause: "(username = ?) OR (age > CAST(? AS DOUBLE))",
 				DuckArgs:   []any{"A", int64(5)},
 			},
@@ -274,7 +277,7 @@ func buildCharCompositeCases() []charCase {
 				PgMainClause: "((m.integer_01 > ?) AND (m.integer_01 < ?))", PgMainArgs: []any{int64(10), int64(90)},
 				PgClause: "((" + charEavClause("$3", "value_numeric", ">", "$4") + ") AND (" +
 					charEavClause("$5", "value_numeric", "<", "$6") + "))",
-				PgArgs:     []any{int16(2), int64(10), int16(2), int64(90)},
+				PgArgs:     []any{int16(2), float64(10), int16(2), float64(90)},
 				DuckClause: "(age > CAST(? AS DOUBLE)) AND (age < CAST(? AS DOUBLE))",
 				DuckArgs:   []any{int64(10), int64(90)},
 			},

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -130,7 +130,7 @@ func buildCharNumericBoolCases() []charCase {
 			want: DualClauses{
 				PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(30)},
 				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), int64(30)},
-				DuckClause: "age > CAST(? AS BIGINT)", DuckArgs: []any{int64(30)},
+				DuckClause: "age > CAST(? AS DOUBLE)", DuckArgs: []any{int64(30)},
 			},
 			span: 3,
 		},
@@ -145,12 +145,12 @@ func buildCharNumericBoolCases() []charCase {
 			span: 2,
 		},
 		{
-			name: "integer above 2^31: main/eav/duck all int64, duck compares at BIGINT (#384)",
+			name: "integer above 2^31: main/eav/duck all int64, duck compares at DOUBLE (#384)",
 			cond: charKv("age", "equals:9007199254740993"),
 			want: DualClauses{
 				PgMainClause: "m.integer_01 = ?", PgMainArgs: []any{int64(9007199254740993)},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), int64(9007199254740993)},
-				DuckClause: "age = CAST(? AS BIGINT)", DuckArgs: []any{int64(9007199254740993)},
+				DuckClause: "age = CAST(? AS DOUBLE)", DuckArgs: []any{int64(9007199254740993)},
 			},
 			span: 3,
 		},
@@ -249,7 +249,7 @@ func buildCharCompositeCases() []charCase {
 					charEavClause("$4", "value_numeric", ">", "$5") + ") OR (" +
 					charEavClause("$6", "value_text", "=", "$7") + "))))",
 				PgArgs:     []any{int16(1), "Alice", int16(2), int64(18), int16(4), "x"},
-				DuckClause: "(username = ?) AND ((age > CAST(? AS BIGINT)) OR (tag = ?))",
+				DuckClause: "(username = ?) AND ((age > CAST(? AS DOUBLE)) OR (tag = ?))",
 				DuckArgs:   []any{"Alice", int64(18), "x"},
 			},
 			span: 7,
@@ -262,7 +262,7 @@ func buildCharCompositeCases() []charCase {
 				PgClause: "((" + charEavClause("$3", "value_text", "=", "$4") + ") OR (" +
 					charEavClause("$5", "value_numeric", ">", "$6") + "))",
 				PgArgs:     []any{int16(1), "A", int16(2), int64(5)},
-				DuckClause: "(username = ?) OR (age > CAST(? AS BIGINT))",
+				DuckClause: "(username = ?) OR (age > CAST(? AS DOUBLE))",
 				DuckArgs:   []any{"A", int64(5)},
 			},
 			span: 6,
@@ -275,7 +275,7 @@ func buildCharCompositeCases() []charCase {
 				PgClause: "((" + charEavClause("$3", "value_numeric", ">", "$4") + ") AND (" +
 					charEavClause("$5", "value_numeric", "<", "$6") + "))",
 				PgArgs:     []any{int16(2), int64(10), int16(2), int64(90)},
-				DuckClause: "(age > CAST(? AS BIGINT)) AND (age < CAST(? AS BIGINT))",
+				DuckClause: "(age > CAST(? AS DOUBLE)) AND (age < CAST(? AS DOUBLE))",
 				DuckArgs:   []any{int64(10), int64(90)},
 			},
 			span: 6,

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -159,7 +159,7 @@ func buildCharNumericBoolCases() []charCase {
 			cond: charKv("active", "equals:1"),
 			want: DualClauses{
 				PgMainClause: "m.bool_01 = ?", PgMainArgs: []any{int64(1)},
-				PgClause: charEXISTS+"$2 AND (x.value_numeric <> 0) = $3)", PgArgs: []any{int16(5), true},
+				PgClause: charEXISTS + "$2 AND (x.value_numeric <> 0) = $3)", PgArgs: []any{int16(5), true},
 				DuckClause: "active = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
 			},
 			span: 3,
@@ -169,7 +169,7 @@ func buildCharNumericBoolCases() []charCase {
 			cond: charKv("verified", "equals:0"),
 			want: DualClauses{
 				PgMainClause: "m.text_02 = ?", PgMainArgs: []any{"0"},
-				PgClause: charEXISTS+"$2 AND (x.value_numeric <> 0) = $3)", PgArgs: []any{int16(6), false},
+				PgClause: charEXISTS + "$2 AND (x.value_numeric <> 0) = $3)", PgArgs: []any{int16(6), false},
 				DuckClause: "verified = CAST(? AS BOOLEAN)", DuckArgs: []any{false},
 			},
 			span: 3,
@@ -179,7 +179,7 @@ func buildCharNumericBoolCases() []charCase {
 			cond: charKv("flag", "equals:1"),
 			want: DualClauses{
 				PgMainClause: "", PgMainArgs: nil,
-				PgClause: charEXISTS+"$1 AND (x.value_numeric <> 0) = $2)", PgArgs: []any{int16(7), true},
+				PgClause: charEXISTS + "$1 AND (x.value_numeric <> 0) = $2)", PgArgs: []any{int16(7), true},
 				DuckClause: "flag = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
 			},
 			span: 2,

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -130,7 +130,7 @@ func buildCharNumericBoolCases() []charCase {
 			want: DualClauses{
 				PgMainClause: "m.integer_01 > ?", PgMainArgs: []any{int64(30)},
 				PgClause: charEavClause("$2", "value_numeric", ">", "$3"), PgArgs: []any{int16(2), int64(30)},
-				DuckClause: "age > CAST(? AS INTEGER)", DuckArgs: []any{int64(30)},
+				DuckClause: "age > CAST(? AS BIGINT)", DuckArgs: []any{int64(30)},
 			},
 			span: 3,
 		},
@@ -140,7 +140,7 @@ func buildCharNumericBoolCases() []charCase {
 			want: DualClauses{
 				PgMainClause: "", PgMainArgs: nil,
 				PgClause: charEavClause("$1", "value_numeric", "<", "$2"), PgArgs: []any{int16(3), 3.5},
-				DuckClause: "score < CAST(? AS DECIMAL(38,10))", DuckArgs: []any{"3.5"},
+				DuckClause: "score < CAST(? AS DOUBLE)", DuckArgs: []any{"3.5"},
 			},
 			span: 2,
 		},
@@ -150,7 +150,7 @@ func buildCharNumericBoolCases() []charCase {
 			want: DualClauses{
 				PgMainClause: "m.integer_01 = ?", PgMainArgs: []any{int64(9007199254740993)},
 				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(2), int64(9007199254740993)},
-				DuckClause: "age = CAST(? AS INTEGER)", DuckArgs: []any{int64(9007199254740993)},
+				DuckClause: "age = CAST(? AS BIGINT)", DuckArgs: []any{int64(9007199254740993)},
 			},
 			span: 3,
 		},
@@ -249,7 +249,7 @@ func buildCharCompositeCases() []charCase {
 					charEavClause("$4", "value_numeric", ">", "$5") + ") OR (" +
 					charEavClause("$6", "value_text", "=", "$7") + "))))",
 				PgArgs:     []any{int16(1), "Alice", int16(2), int64(18), int16(4), "x"},
-				DuckClause: "(username = ?) AND ((age > CAST(? AS INTEGER)) OR (tag = ?))",
+				DuckClause: "(username = ?) AND ((age > CAST(? AS BIGINT)) OR (tag = ?))",
 				DuckArgs:   []any{"Alice", int64(18), "x"},
 			},
 			span: 7,
@@ -262,7 +262,7 @@ func buildCharCompositeCases() []charCase {
 				PgClause: "((" + charEavClause("$3", "value_text", "=", "$4") + ") OR (" +
 					charEavClause("$5", "value_numeric", ">", "$6") + "))",
 				PgArgs:     []any{int16(1), "A", int16(2), int64(5)},
-				DuckClause: "(username = ?) OR (age > CAST(? AS INTEGER))",
+				DuckClause: "(username = ?) OR (age > CAST(? AS BIGINT))",
 				DuckArgs:   []any{"A", int64(5)},
 			},
 			span: 6,
@@ -275,7 +275,7 @@ func buildCharCompositeCases() []charCase {
 				PgClause: "((" + charEavClause("$3", "value_numeric", ">", "$4") + ") AND (" +
 					charEavClause("$5", "value_numeric", "<", "$6") + "))",
 				PgArgs:     []any{int16(2), int64(10), int16(2), int64(90)},
-				DuckClause: "(age > CAST(? AS INTEGER)) AND (age < CAST(? AS INTEGER))",
+				DuckClause: "(age > CAST(? AS BIGINT)) AND (age < CAST(? AS BIGINT))",
 				DuckArgs:   []any{int64(10), int64(90)},
 			},
 			span: 6,
@@ -442,7 +442,7 @@ func TestStandaloneBuilders_Characterization(t *testing.T) {
 			wantClause string
 			wantArgs   []any
 		}{
-			{"numeric literal", "equals:42", "ghost = CAST(? AS DECIMAL(38,10))", []any{"42"}},
+			{"numeric literal", "equals:42", "ghost = CAST(? AS DOUBLE)", []any{"42"}},
 			{"bool literal", "equals:true", "ghost = CAST(? AS BOOLEAN)", []any{true}},
 			{"uuid literal", "equals:0b210f52-1f4d-4f47-9799-1e2f2c0efc07", "ghost = CAST(? AS VARCHAR)", []any{"0b210f52-1f4d-4f47-9799-1e2f2c0efc07"}},
 			{"iso literal", "gte:2024-01-02T03:04:05Z", "ghost >= CAST(? AS BIGINT)", []any{int64(1704164645000)}},

--- a/internal/sqlgen/predicate_characterization_test.go
+++ b/internal/sqlgen/predicate_characterization_test.go
@@ -145,7 +145,7 @@ func buildCharNumericBoolCases() []charCase {
 			span: 2,
 		},
 		{
-			name: "integer above 2^31: main/eav/duck all int64 (CAST raises conversion error identically on both types)",
+			name: "integer above 2^31: main/eav/duck all int64, duck compares at BIGINT (#384)",
 			cond: charKv("age", "equals:9007199254740993"),
 			want: DualClauses{
 				PgMainClause: "m.integer_01 = ?", PgMainArgs: []any{int64(9007199254740993)},
@@ -155,31 +155,31 @@ func buildCharNumericBoolCases() []charCase {
 			span: 3,
 		},
 		{
-			name: "bool bool-int encoding: main int64(1), eav float64(1), duck true",
+			name: "bool bool-int encoding: main int64(1), eav truthy bool, duck true",
 			cond: charKv("active", "equals:1"),
 			want: DualClauses{
 				PgMainClause: "m.bool_01 = ?", PgMainArgs: []any{int64(1)},
-				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(5), float64(1)},
+				PgClause: charEXISTS+"$2 AND (x.value_numeric <> 0) = $3)", PgArgs: []any{int16(5), true},
 				DuckClause: "active = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
 			},
 			span: 3,
 		},
 		{
-			name: "bool bool-text encoding zero: main \"0\", eav float64(0), duck false",
+			name: "bool bool-text encoding zero: main \"0\", eav truthy bool, duck false",
 			cond: charKv("verified", "equals:0"),
 			want: DualClauses{
 				PgMainClause: "m.text_02 = ?", PgMainArgs: []any{"0"},
-				PgClause: charEavClause("$2", "value_numeric", "=", "$3"), PgArgs: []any{int16(6), float64(0)},
+				PgClause: charEXISTS+"$2 AND (x.value_numeric <> 0) = $3)", PgArgs: []any{int16(6), false},
 				DuckClause: "verified = CAST(? AS BOOLEAN)", DuckArgs: []any{false},
 			},
 			span: 3,
 		},
 		{
-			name: "bool unbound: eav float64, duck true",
+			name: "bool unbound: eav truthy bool, duck true",
 			cond: charKv("flag", "equals:1"),
 			want: DualClauses{
 				PgMainClause: "", PgMainArgs: nil,
-				PgClause: charEavClause("$1", "value_numeric", "=", "$2"), PgArgs: []any{int16(7), float64(1)},
+				PgClause: charEXISTS+"$1 AND (x.value_numeric <> 0) = $2)", PgArgs: []any{int16(7), true},
 				DuckClause: "flag = CAST(? AS BOOLEAN)", DuckArgs: []any{true},
 			},
 			span: 2,

--- a/internal/sqlgen/predicate_ir.go
+++ b/internal/sqlgen/predicate_ir.go
@@ -124,6 +124,21 @@ type PgEavLeafPayload struct {
 	ValueColumn string
 	SQLOp       string
 	Value       any
+	// Truthy marks a bool leaf: the comparison runs on the value_numeric <> 0
+	// truthiness every DuckDB leg already derives, with Value a Go bool, so a
+	// stored 2 answers the same on the OLTP route and the federated tiers
+	// (#384; the write-side truth table is #404).
+	Truthy bool
+}
+
+// ComparisonLHS renders the left-hand side of the EAV EXISTS comparison for
+// the payload's value column, qualified by the eav_data alias. Bool leaves
+// compare the <> 0 truthiness instead of the raw column (#384).
+func (p PgEavLeafPayload) ComparisonLHS(alias string) string {
+	if p.Truthy {
+		return "(" + alias + "." + p.ValueColumn + " <> 0)"
+	}
+	return alias + "." + p.ValueColumn
 }
 
 // PgMainLeafPayload is the entity_main pushdown payload (lenient parse

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -2,7 +2,6 @@ package sqlgen
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/lychee-technology/forma"
@@ -311,12 +310,13 @@ func parsePgEavValue(attr string, meta forma.AttributeMetadata, valStr string) (
 	case forma.ValueTypeBool:
 		// The bind is a Go bool compared against the (value_numeric <> 0)
 		// truthiness expression, not the raw column — the payload's Truthy
-		// flag drives the emitters (#384).
-		parsedInt, boolErr := strconv.Atoi(valStr)
-		if boolErr != nil {
+		// flag drives the emitters. The operand parse is the engine-shared
+		// parseBoolOperand rule (#384 P2b).
+		parsed, ok := parseBoolOperand(valStr)
+		if !ok {
 			return "", nil, forma.InvalidInputf("invalid boolean value for '%s': %s", attr, valStr)
 		}
-		return "value_numeric", parsedInt > 0, nil
+		return "value_numeric", parsed, nil
 
 	default:
 		return "", nil, fmt.Errorf("unsupported value_type '%s' for attribute '%s'", meta.ValueType, attr)

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -290,10 +290,11 @@ func parsePgEavValue(attr string, meta forma.AttributeMetadata, valStr string) (
 	case forma.ValueTypeNumeric, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeSmallInt:
 		switch v := numutil.TryParseNumber(valStr).(type) {
 		case int64:
-			// Exact bind (#281, #357): pgx encodes int64 into the NUMERIC
-			// comparison losslessly, in every integral spelling. Mirrors
-			// ConvertPgMainValue on the main-table path.
-			return "value_numeric", v, nil
+			// bigint binds the exact int64 (#281, #357); the DOUBLE-width
+			// classes narrow it through the same float64 funnel the stored
+			// data took, so both engines compare the float64 image above
+			// 2^53 (#384) — see NarrowEAVNumericOperand.
+			return "value_numeric", NarrowEAVNumericOperand(meta.ValueType, v), nil
 		case float64:
 			return "value_numeric", v, nil
 		default:
@@ -321,6 +322,24 @@ func parsePgEavValue(attr string, meta forma.AttributeMetadata, valStr string) (
 	default:
 		return "", nil, fmt.Errorf("unsupported value_type '%s' for attribute '%s'", meta.ValueType, attr)
 	}
+}
+
+// NarrowEAVNumericOperand converts a parsed integral operand into the Go
+// value the Postgres binders compare against value_numeric for the given
+// DECLARED type (#384). integer/smallint/numeric EAV storage holds float64
+// images (the write funnel narrows through numutil.Float64), so the operand
+// takes the same narrowing: above 2^53 both engines then compare the float64
+// image — the DuckDB leg's CAST(? AS DOUBLE) rounds identically — instead of
+// Postgres comparing the exact integer while DuckDB matches its rounded
+// neighbor. bigint keeps the exact int64 (#281/#357): its storage is
+// BIGINT-backed on every tier. Shared by the EAV predicate normalizer and the
+// batch attr-value anchor, which must reach the same verdict on the same
+// literal (#355).
+func NarrowEAVNumericOperand(vt forma.ValueType, v int64) any {
+	if vt == forma.ValueTypeBigInt {
+		return v
+	}
+	return float64(v)
 }
 
 // normalizePgMainPayload converts a leaf for entity_main pushdown: unknown

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -275,6 +275,7 @@ func normalizePgEavPayload(kv *forma.KvCondition, meta forma.AttributeMetadata, 
 		ValueColumn: valueColumn,
 		SQLOp:       sqlOp,
 		Value:       parsedValue,
+		Truthy:      meta.ValueType == forma.ValueTypeBool,
 	}
 }
 
@@ -308,14 +309,14 @@ func parsePgEavValue(attr string, meta forma.AttributeMetadata, valStr string) (
 		return "value_numeric", parsed, nil
 
 	case forma.ValueTypeBool:
+		// The bind is a Go bool compared against the (value_numeric <> 0)
+		// truthiness expression, not the raw column — the payload's Truthy
+		// flag drives the emitters (#384).
 		parsedInt, boolErr := strconv.Atoi(valStr)
 		if boolErr != nil {
 			return "", nil, forma.InvalidInputf("invalid boolean value for '%s': %s", attr, valStr)
 		}
-		if parsedInt > 0 {
-			return "value_numeric", float64(1), nil
-		}
-		return "value_numeric", float64(0), nil
+		return "value_numeric", parsedInt > 0, nil
 
 	default:
 		return "", nil, fmt.Errorf("unsupported value_type '%s' for attribute '%s'", meta.ValueType, attr)

--- a/internal/sqlgen/sql_generator.go
+++ b/internal/sqlgen/sql_generator.go
@@ -71,10 +71,10 @@ func (e *pgEavTypedEmitter) EmitTypedLeaf(leaf *PredicateLeaf) (string, []any, e
 	args = append(args, p.Value)
 
 	sql := fmt.Sprintf(
-		"EXISTS (SELECT 1 FROM %s x WHERE x.schema_id = e.schema_id AND x.row_id = e.row_id AND x.attr_id = %s AND x.%s %s %s)",
+		"EXISTS (SELECT 1 FROM %s x WHERE x.schema_id = e.schema_id AND x.row_id = e.row_id AND x.attr_id = %s AND %s %s %s)",
 		e.eavTable,
 		attrIDPlaceholder,
-		p.ValueColumn,
+		p.ComparisonLHS("x"),
 		p.SQLOp,
 		valuePlaceholder,
 	)

--- a/internal/sqlgen/sql_generator_test.go
+++ b/internal/sqlgen/sql_generator_test.go
@@ -73,10 +73,11 @@ func TestSQLGenerator_ToSQLClauses(t *testing.T) {
 		t.Fatalf("unexpected SQL clause.\nexpected: %s\nactual:   %s", expectedClause, sqlClause)
 	}
 
-	// price is `gt:10` on a numeric attribute: integral literals bind as exact
-	// int64 since #281 (fractional literals still bind float64).
+	// price is `gt:10` on a numeric attribute: integral literals narrow to
+	// the write funnel's float64 for the DOUBLE-width classes (#384;
+	// bigint keeps exact int64 per #281).
 	expectedArgs := []any{
-		int16(10), int64(10),
+		int16(10), float64(10),
 		int16(11), "active",
 		int16(12), "A%",
 	}

--- a/internal/sqlgen/sql_generator_test.go
+++ b/internal/sqlgen/sql_generator_test.go
@@ -128,12 +128,12 @@ func TestSQLGenerator_BoolEAV_UsesValueNumeric(t *testing.T) {
 	tests := []struct {
 		name    string
 		value   string
-		wantArg float64
+		wantArg bool
 		wantOp  string
 	}{
-		{name: "truthy value=1", value: "1", wantArg: float64(1), wantOp: "="},
-		{name: "falsy value=0", value: "0", wantArg: float64(0), wantOp: "="},
-		{name: "not-equal truthy neq:1", value: "neq:1", wantArg: float64(1), wantOp: "!="},
+		{name: "truthy value=1", value: "1", wantArg: true, wantOp: "="},
+		{name: "falsy value=0", value: "0", wantArg: false, wantOp: "="},
+		{name: "not-equal truthy neq:1", value: "neq:1", wantArg: true, wantOp: "!="},
 	}
 
 	for _, tc := range tests {
@@ -148,11 +148,14 @@ func TestSQLGenerator_BoolEAV_UsesValueNumeric(t *testing.T) {
 			gen := NewSQLGenerator()
 			clause, args, err := gen.ToSQLClauses(cond, "eav_data", 1, cache, &paramIndex)
 			require.NoError(t, err)
-			require.Contains(t, clause, "value_numeric", "bool filter must use value_numeric column")
+			// #384: bool compares (value_numeric <> 0) truthiness with a
+			// BOOLEAN bind, matching every DuckDB leg's derivation.
+			require.Contains(t, clause, "(x.value_numeric <> 0) "+tc.wantOp,
+				"bool filter must compare value_numeric truthiness")
 			require.NotContains(t, clause, "value_text", "bool filter must not use value_text column")
 			require.Len(t, args, 2)
 			require.Equal(t, int16(20), args[0], "first arg must be attr_id as int16")
-			require.Equal(t, tc.wantArg, args[1], "second arg must be float64")
+			require.Equal(t, tc.wantArg, args[1], "second arg must be the bool bind")
 		})
 	}
 }

--- a/internal/transform/typed_value.go
+++ b/internal/transform/typed_value.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/lychee-technology/forma"
@@ -38,6 +39,9 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 			return handleConversionError(err)
 		}
 		if numVal, err = finiteForEAV(numVal); err != nil {
+			return handleConversionError(err)
+		}
+		if err := checkDeclaredIntegerFit(value, numVal, meta.ValueType); err != nil {
 			return handleConversionError(err)
 		}
 		attr.ValueNumeric = &numVal
@@ -84,6 +88,52 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 	}
 
 	return true, nil
+}
+
+// checkDeclaredIntegerFit rejects a numeric-family value that cannot fit its
+// declared integer type (#384): eav_data.value_numeric is an unconstrained
+// NUMERIC, so Postgres would happily store and match a value the DuckDB tiers
+// project by width — the write funnel is the only place the declared type can
+// still be enforced. numeric stays unconstrained (#205 owns its float64
+// ceiling).
+func checkDeclaredIntegerFit(raw any, numVal float64, vt forma.ValueType) error {
+	var lo, hi float64
+	switch vt {
+	case forma.ValueTypeSmallInt:
+		lo, hi = math.MinInt16, math.MaxInt16
+	case forma.ValueTypeInteger:
+		lo, hi = math.MinInt32, math.MaxInt32
+	case forma.ValueTypeBigInt:
+		// An exactly-representable int64 fits by construction; this also
+		// admits boundary literals like "9223372036854775807" whose float64
+		// image rounds up to 2^63 and would fail the bound check below.
+		if _, ok := toInt64ExactForEAV(raw); ok {
+			return nil
+		}
+		// Constant conversion: math.MinInt64 converts to exactly -2^63
+		// (a valid value); math.MaxInt64 rounds up to exactly 2^63, so >=
+		// rejects the first float64 that no longer fits.
+		if numVal != math.Trunc(numVal) {
+			return errNonIntegralForType(numVal, vt)
+		}
+		if numVal < math.MinInt64 || numVal >= math.MaxInt64 {
+			return fmt.Errorf("value %v out of range for declared type %s (allowed [-9223372036854775808, 9223372036854775807])", numVal, vt)
+		}
+		return nil
+	default:
+		return nil
+	}
+	if numVal != math.Trunc(numVal) {
+		return errNonIntegralForType(numVal, vt)
+	}
+	if numVal < lo || numVal > hi {
+		return fmt.Errorf("value %v out of range for declared type %s (allowed [%.0f, %.0f])", numVal, vt, lo, hi)
+	}
+	return nil
+}
+
+func errNonIntegralForType(numVal float64, vt forma.ValueType) error {
+	return fmt.Errorf("non-integral value %v does not fit declared type %s (whole number required)", numVal, vt)
 }
 
 func toString(value any) (string, error) {

--- a/internal/transform/typed_value_range_test.go
+++ b/internal/transform/typed_value_range_test.go
@@ -1,0 +1,74 @@
+package transform
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// #384: the EAV write funnel must reject numeric-family values that do not
+// fit the declared integer type. eav_data.value_numeric is an unconstrained
+// NUMERIC, so this funnel is the only place the declared width can still be
+// enforced; anything admitted here must answer identically on every tier.
+func TestPopulateTypedValue_DeclaredIntegerFit(t *testing.T) {
+	meta := func(vt forma.ValueType) forma.AttributeMetadata {
+		return forma.AttributeMetadata{AttributeID: 7, ValueType: vt}
+	}
+	cases := []struct {
+		name    string
+		vt      forma.ValueType
+		value   any
+		wantErr bool
+	}{
+		{"integer max ok", forma.ValueTypeInteger, float64(math.MaxInt32), false},
+		{"integer min ok", forma.ValueTypeInteger, float64(math.MinInt32), false},
+		{"integer 2^31 rejected", forma.ValueTypeInteger, float64(math.MaxInt32) + 1, true},
+		{"integer 2^32 rejected", forma.ValueTypeInteger, float64(4294967296), true},
+		{"integer below min rejected", forma.ValueTypeInteger, float64(math.MinInt32) - 1, true},
+		{"integer non-integral rejected", forma.ValueTypeInteger, 1.5, true},
+		{"smallint max ok", forma.ValueTypeSmallInt, float64(math.MaxInt16), false},
+		{"smallint min ok", forma.ValueTypeSmallInt, float64(math.MinInt16), false},
+		{"smallint 40000 rejected", forma.ValueTypeSmallInt, float64(40000), true},
+		{"bigint max exact string ok", forma.ValueTypeBigInt, "9223372036854775807", false},
+		{"bigint min exact string ok", forma.ValueTypeBigInt, "-9223372036854775808", false},
+		{"bigint 2^63 rejected", forma.ValueTypeBigInt, math.Ldexp(1, 63), true},
+		{"bigint -2^63 float ok", forma.ValueTypeBigInt, math.Ldexp(-1, 63), false},
+		{"bigint 1e18 ok", forma.ValueTypeBigInt, float64(1e18), false},
+		{"bigint non-integral rejected", forma.ValueTypeBigInt, 1.5, true},
+		{"numeric stays unconstrained", forma.ValueTypeNumeric, math.Ldexp(1, 80), false},
+		{"numeric fractional ok", forma.ValueTypeNumeric, 1.5, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec model.EAVRecord
+			set, err := populateTypedValue(&rec, "qty", tc.value, meta(tc.vt))
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, forma.ErrInvalidInput,
+					"declared-width rejection must be user-facing invalid input")
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, set)
+		})
+	}
+}
+
+// List elements go through the same funnel with the items-typed elemMeta, so
+// the declared items type bounds each element (#384).
+func TestPopulateTypedValue_ListElementFit(t *testing.T) {
+	meta := forma.AttributeMetadata{
+		AttributeID: 7,
+		ValueType:   forma.ValueTypeList,
+		ItemsType:   forma.ValueTypeInteger,
+	}
+	var rec model.EAVRecord
+	rec.ArrayIndices = "0"
+	_, err := populateTypedValue(&rec, "levels", float64(4294967296), meta)
+	require.Error(t, err)
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+}


### PR DESCRIPTION
Closes #384.

## The contract (final form, after five review rounds; recorded in `docs/federated-query/design.md` §6.4)

`eav_data.value_numeric` is an unconstrained PG `NUMERIC`, but every value the write funnel puts there is a **float64 image** (`transform.populateTypedValue` narrows the whole numeric family through `numutil.Float64`) — so the effective EAV storage width is **DOUBLE**, regardless of the declared type. The two query engines used to resolve the declared-vs-storage disagreement differently; this PR applies one ruling on both sides:

1. **Write side** — the EAV write funnel rejects numeric-family values that do not fit the declared integer type (out of range **or non-integral** for `smallint`/`integer`/`bigint`) as `forma.InvalidInputf` (400). `numeric` stays unconstrained (#205 owns its float64 ceiling).
2. **Read side** — EAV-only `integer`/`smallint` project by **storage width `DOUBLE`**, exactly like the `numeric` class, on all four DuckDB surfaces in lockstep: the hot EAV pivot (`sqlgen.buildEAVPivotExpr`), list elements (`eavElementCastExpr`), the CDC parquet export (`cdc.castEAVValue`), and the cold NULL augmentation (`sqlgen.DuckDBNullScanType`, binding-aware). DOUBLE reproduces every float64 image faithfully, so over-range (2^32) **and** non-integral (1.5) history answer identically on every tier — the earlier BIGINT draft of this ruling NULLed the former and rounded the latter, only on the DuckDB legs, and was revised mid-review. Column-bound attrs keep declared width — their storage is physically int4/int2.
3. **Predicate operands** — `MapValueTypeToDuckDBType` casts by column storage width: `integer`/`smallint`/`numeric` → `DOUBLE` (an operand of any magnitude compares instead of raising a DuckDB Conversion Error; the former `DECIMAL(38,10)` numeric cast also truncated operand scale at 10 fractional digits and overflowed past ~1e28). To keep the Postgres route on the same verdict, integral operands for these DOUBLE-width classes **narrow through the same float64 funnel the stored data took** (`sqlgen.NarrowEAVNumericOperand`, applied by the EAV predicate normalizer and the batch attr-value anchor alike): above 2^53 both engines compare the operand's float64 image. Float64 operands bind in shortest round-trip form (`strconv.FormatFloat(v, 'g', -1, 64)`; `%.15g` dropped the 16th–17th significant digits). `bigint` keeps `BIGINT` columns and exact int64/decimal-string binds (#281/#357).
4. **Bool** — both engines compare the `value_numeric <> 0` truthiness (both PG EAV EXISTS emitters render it via `PgEavLeafPayload.ComparisonLHS`) and parse operands under one shared rule (`parseBoolOperand`: ParseBool spellings, else any integer at the historical `>0` truthiness), so no spelling errors on exactly one route.

## Deliberately out of scope (each has an open tracker)

- #459 — main-column-bound write fidelity (silent int16/int32 wrap into `entity_main`).
- #404 — the write-side bool truth-table divergence between the two write funnels.
- #205 — the EAV numeric float64 storage ceiling (values only a full NUMERIC can hold — direct-SQL plants — still read exactly on Postgres and as their float64 image on DuckDB).
- #468 — hybrid routing picking the route by page size.
- #501 — detecting/repairing rows whose out-of-range values were NULL-fixated in pre-#384 parquet.
- #502 — `bigint` operands beyond int64 still failing only on the DuckDB route (`CAST('1e+30' AS BIGINT)`).
- #503 — bound-bool operand spellings (`equals:true` rejected only by the PG main-column payload).

## Historical data

- Parquet files written before this change carry INT32/INT16 attribute columns; the existing `union_by_name=true` scans (federated read and compaction merge both verified) promote mixed widths to **DOUBLE** losslessly, so no re-export is required for in-range history.
- Rows whose out-of-range value was already exported carry NULL in parquet permanently — the value was destroyed at export time. They become consistent on the hot tier immediately and can only be repaired in parquet by re-flushing from Postgres (#501).

## Tests

- Unit: declared-width rejection matrix (`transform`); storage-width DOUBLE pivot/export/NULL-scan expectations plus the cross-engine `typeof()` lockstep proofs (`sqlgen`, `cdc`); operand-cast, float64 round-trip (`TestDecimalStringRoundTripsFloat64`), operand narrowing (`TestNarrowEAVNumericOperand`, batch-anchor twin), and bool-parity (`TestBoolOperandParityAcrossEngines`) tests; characterization matrix re-pinned.
- E2E (production harness, `numeric_width_parity_e2e_test.go`): every probe runs on **hot → warm (real CDC flush) → cold (real compaction)**. Coverage: planted `qty = 2^32` and `level = 40000` (equality + range, no query error); non-integral `qty = 1.5` (`equals:1.5` matches, `equals:2` misses, on both routes); `2^53` boundary (`equals:2^53+1` matches the stored image on both routes, a representable neighbor misses on both); numeric operands with 11 and 16 fractional/significant digits and `gt:1e28`/`gt:1e30` (answers, no error); bool `equals:1/0/true/2` under the shared parse rule; write-path rejection through the real EntityManager.
- Suite fixups: the full-type/evolution/compaction/manifest suites' physical parquet shape pins for EAV-only integer attributes moved to DOUBLE, and the wide parquet scanner reads them as DOUBLE.

## Verification

- `make fmt-check`, `make lint` (root + infra): clean.
- Full unit suite via `scripts/test_with_container_runtime.sh`: all packages ok.
- Federated E2E `-tags=e2e -short` + benchmark suite: ok.
- Full production E2E suite (`-tags=e2e`, including the parity suite above): ok on every revision of the branch.
- All five CI checks green on HEAD.
