### PR TITLE
fix(federated): unify the keyset cursor contract across the engine's entry points (#381)

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -222,20 +222,72 @@ direction side. No boundary value may be `nil`: alignment alone does not stop
 one, and a nil binds the very SQL NULL an unfilled arm did, so the comparison
 is unknown and every row tied at the boundary silently drops (a typed nil such
 as `(*string)(nil)` binds NULL too, and is refused with the untyped one).
-`Mode` must be `after` or `before`, and each column's `Direction` must be
-`asc`, `desc`, or empty for the documented `asc` default. Both enums are
-matched **byte-exactly**, unlike `row_id`: a mode and a direction are Go
-constants the renderer compares exactly and never identifiers DuckDB resolves,
-so admitting `After` or `DESC` would hand the renderer a spelling it reads as
-the fall-through default — *before*, and ascending — and the page would come
-back successfully in the wrong direction. A caller-facing decode boundary that
+`Mode` must be `after`, and each column's `Direction` must be `asc`, `desc`,
+or empty for the documented `asc` default. Both enums are matched
+**byte-exactly**, unlike `row_id`: a mode and a direction are Go constants the
+renderer compares exactly and never identifiers DuckDB resolves, so admitting
+`After` or `DESC` would hand the renderer a spelling it reads as the
+fall-through default — *before*, and ascending — and the page would come back
+successfully in the wrong direction. A caller-facing decode boundary that
 accepts other spellings normalizes them before building the cursor, as
 `normalizeSortOrder` does for the sort surface.
+
+`before` is declared (`model.KeysetCursorModeBefore`) but refused as well,
+until #513 lands its other half. The renderer flips the comparison operator
+for a `before` cursor but still fetches in the **forward** order under the
+`LIMIT`, so `key < 7 ORDER BY key ASC LIMIT 2` answers `[1, 2]` — the start
+of the prior range — where a caller stepping backwards expects `[5, 6]`;
+descending order has the symmetric defect. A backward page needs the reversed
+order under the `LIMIT` and the requested order restored outside it. Until
+that exists, a `before` cursor is a successfully-answered wrong page, and is
+refused for the same reason an unset mode is.
 
 An inactive cursor is exempt from all five: the open first page carries no
 continuation obligation. `IsActive` is the shared spelling of that predicate,
 used by every site that decides whether the clause is rendered and every site
 that decides whether a cursor is honoured or refused.
+
+**A cursor continues the request's order; it does not replace it.** The keyset
+`ORDER BY` renders from the cursor's columns alone, and the renderer never
+reads `AttributeOrders` while a cursor is active, so without a rule a request
+sorted on `count ASC` and continued with a valid `created_at DESC, row_id ASC`
+cursor answered a page ordered and filtered on `created_at`.
+`model.KeysetCursor.ValidateContinuation(orders)` closes that: when the request
+resolved `AttributeOrders`, the cursor must be exactly those orders — same
+attribute name at each position, matched byte-exactly, same direction —
+followed by an ascending `row_id`, because `row_id ASC` is the tiebreak the
+non-keyset `ORDER BY` appended to page one. A wrong attribute, a flipped
+direction, a `row_id DESC` tiebreak, or a longer or shorter cursor is refused.
+Every seam judges the order it is about to render (`fq.AttributeOrders` at
+`Query`, the `attributeOrders` argument elsewhere), and
+`sqlgen.injectDuckDBTemplateParams` repeats the check against the query it
+renders, so a direct `sqlgen` caller cannot bypass it either.
+
+When the request resolved **no** `AttributeOrders`, the cursor is honoured as
+written. That boundary is deliberate: the default `created_at DESC, row_id
+ASC` is the renderer's fallback rather than a caller statement, and
+`AttributeOrders` cannot express a system-column order at all (sort keys
+resolve against the schema; `created_at` is not a schema attribute). A
+cursor-only walk — an open first page bounded by a far-future `created_at`,
+then cursors on `created_at` in either direction with a `row_id` tiebreak in
+either direction — is a complete order specification with nothing to
+contradict, and it is how the production e2e walks and the federated
+benchmark page. Requiring an order-less request to match the default would
+make every `created_at` / `ver_ts` / `deleted_ts` cursor unreachable.
+
+**The explicit `limit`, `offset` and `attributeOrders` arguments are the
+pagination contract of every DuckDB seam.** The advanced template reads
+`LIMIT`, `OFFSET` and the non-keyset `ORDER BY` from the *query object*
+(`q.Limit`, `q.Offset`, `q.AttributeOrders`), so a caller that normalised or
+clamped its limit but passed the query unchanged used to have the clamp
+silently ignored: the keyset branch of `ExecuteFederatedPaginatedQuery`
+rendered `LIMIT 0` for a zero `fq.Limit` and an over-`MaxRows` `fq.Limit`
+verbatim, with only its in-memory slice honouring the clamp.
+`buildDuckDBQueryWithPlan` — the one point the direct render and the compiled
+plan cache both flow through — now renders a copy of the query carrying the
+dispatched arguments (`federated.dispatchedQuery`), so the rendered skeleton,
+the shape hash and the plan scope all see the query that was dispatched.
+`engine.Query` passes the query's own fields and is unaffected.
 
 The validator does not check that an attribute is registered in the schema:
 that needs the metadata cache, and an unregistered but well-formed name fails

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -208,16 +208,25 @@ for that check: it rejects a registered *attribute* whose fold collides with a
 reserved parquet column, but a cursor column is an arbitrary string that was
 never registered.
 
-Two rules travel with the cursor type itself (`model.KeysetCursor`), so
-`internal/sqlgen` can enforce them without reaching into `internal/federated`:
-`Values` must align one-for-one with `Columns` — a short slice used to bind SQL
-NULL and return a silently empty page — and the final column must be `row_id`,
-the trailing tiebreak that makes each page boundary resolvable (#183). That
-last comparison is case-insensitive for the same reason the sets above are, and
-no more so: `ROW_ID` is the tiebreak, `row.id` is not.
-`IsActive` is the shared spelling of "carries a continuation obligation", used
-by every site that decides whether the clause is rendered and every site that
-decides whether a cursor is honoured or refused.
+Three rules travel with the cursor type itself
+(`model.KeysetCursor.ValidateShape`), so `internal/sqlgen` can enforce them
+without reaching into `internal/federated`. Two govern the columns: `Values`
+must align one-for-one with `Columns` — a short slice used to bind SQL NULL and
+return a silently empty page — and the final column must be `row_id`, the
+trailing tiebreak that makes each page boundary resolvable (#183). That last
+comparison is case-insensitive for the same reason the sets above are, and no
+more so: `ROW_ID` is the tiebreak, `row.id` is not.
+
+The third closes the same silent-answer family from the value side: no boundary
+value may be `nil`. Alignment alone does not stop one, and a nil binds the very
+SQL NULL an unfilled arm did, so the comparison is unknown and every row tied at
+the boundary silently drops (a typed nil such as `(*string)(nil)` binds NULL
+too, and is refused with the untyped one).
+
+An inactive cursor is exempt from all three: the open first page carries no
+continuation obligation. `IsActive` is the shared spelling of that predicate,
+used by every site that decides whether the clause is rendered and every site
+that decides whether a cursor is honoured or refused.
 
 The validator does not check that an attribute is registered in the schema:
 that needs the metadata cache, and an unregistered but well-formed name fails

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -199,19 +199,32 @@ the same system column as `row_id`, and a folded `Attr` the same column as
 attribute genuinely named `Attr` — which folds to its own name — stays admitted
 while `[Attr]` is refused.
 
+Case is the whole of that latitude on the system-column set. A name the fold
+merely **transforms** onto one of the four — `created.at` onto `created_at`,
+`ver.ts` onto `ver_ts`, `[row_id]` onto `row_id` — is refused, because the
+generator would emit the real system column and answer a page ordered and
+filtered on a key the caller never named. Schema registration does not stand in
+for that check: it rejects a registered *attribute* whose fold collides with a
+reserved parquet column, but a cursor column is an arbitrary string that was
+never registered.
+
 Two rules travel with the cursor type itself (`model.KeysetCursor`), so
 `internal/sqlgen` can enforce them without reaching into `internal/federated`:
 `Values` must align one-for-one with `Columns` — a short slice used to bind SQL
 NULL and return a silently empty page — and the final column must be `row_id`,
-the trailing tiebreak that makes each page boundary resolvable (#183).
+the trailing tiebreak that makes each page boundary resolvable (#183). That
+last comparison is case-insensitive for the same reason the sets above are, and
+no more so: `ROW_ID` is the tiebreak, `row.id` is not.
 `IsActive` is the shared spelling of "carries a continuation obligation", used
 by every site that decides whether the clause is rendered and every site that
 decides whether a cursor is honoured or refused.
 
 The validator does not check that an attribute is registered in the schema:
 that needs the metadata cache, and an unregistered but well-formed name fails
-loudly at DuckDB's binder rather than silently. It is deferred to the
-caller-facing cursor surface the Postgres-side keyset feature introduces.
+loudly at DuckDB's binder rather than silently — which holds without exception
+only because a fold onto a `visible` column, system or dedup, is refused before
+it can reach the generator. It is deferred to the caller-facing cursor surface
+the Postgres-side keyset feature introduces.
 
 ## **5. SQL Execution Template**
 

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -191,10 +191,13 @@ bare identifiers — `rn` and `source_tier_priority`, the dedup machinery, on
 which a cursor would bind and then paginate over the dedup rank — as is any
 name that folds onto `ParquetAttrColumn`'s `attr` placeholder, whether because
 the fold empties the name or because it strips the name down onto that literal.
-Both the reject set and the system-column set are matched on the folded name
-**case-insensitively**: DuckDB resolves an unquoted identifier without regard to
-case, so `RN` reaches the same dedup column as `rn`, and `ROW_ID` the same
-system column as `row_id`.
+The reject set, the system-column set and the `attr` placeholder are all matched
+on the folded name **case-insensitively**: DuckDB resolves an unquoted identifier
+without regard to case, so `RN` reaches the same dedup column as `rn`, `ROW_ID`
+the same system column as `row_id`, and a folded `Attr` the same column as
+`attr`. The placeholder's exemption is folded case-insensitively too, so an
+attribute genuinely named `Attr` — which folds to its own name — stays admitted
+while `[Attr]` is refused.
 
 Two rules travel with the cursor type itself (`model.KeysetCursor`), so
 `internal/sqlgen` can enforce them without reaching into `internal/federated`:

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -208,7 +208,7 @@ for that check: it rejects a registered *attribute* whose fold collides with a
 reserved parquet column, but a cursor column is an arbitrary string that was
 never registered.
 
-Three rules travel with the cursor type itself
+Five rules travel with the cursor type itself
 (`model.KeysetCursor.ValidateShape`), so `internal/sqlgen` can enforce them
 without reaching into `internal/federated`. Two govern the columns: `Values`
 must align one-for-one with `Columns` — a short slice used to bind SQL NULL and
@@ -217,13 +217,22 @@ trailing tiebreak that makes each page boundary resolvable (#183). That last
 comparison is case-insensitive for the same reason the sets above are, and no
 more so: `ROW_ID` is the tiebreak, `row.id` is not.
 
-The third closes the same silent-answer family from the value side: no boundary
-value may be `nil`. Alignment alone does not stop one, and a nil binds the very
-SQL NULL an unfilled arm did, so the comparison is unknown and every row tied at
-the boundary silently drops (a typed nil such as `(*string)(nil)` binds NULL
-too, and is refused with the untyped one).
+The other three close the same silent-answer family from the value and
+direction side. No boundary value may be `nil`: alignment alone does not stop
+one, and a nil binds the very SQL NULL an unfilled arm did, so the comparison
+is unknown and every row tied at the boundary silently drops (a typed nil such
+as `(*string)(nil)` binds NULL too, and is refused with the untyped one).
+`Mode` must be `after` or `before`, and each column's `Direction` must be
+`asc`, `desc`, or empty for the documented `asc` default. Both enums are
+matched **byte-exactly**, unlike `row_id`: a mode and a direction are Go
+constants the renderer compares exactly and never identifiers DuckDB resolves,
+so admitting `After` or `DESC` would hand the renderer a spelling it reads as
+the fall-through default — *before*, and ascending — and the page would come
+back successfully in the wrong direction. A caller-facing decode boundary that
+accepts other spellings normalizes them before building the cursor, as
+`normalizeSortOrder` does for the sort surface.
 
-An inactive cursor is exempt from all three: the open first page carries no
+An inactive cursor is exempt from all five: the open first page carries no
 continuation obligation. `IsActive` is the shared spelling of that predicate,
 used by every site that decides whether the clause is rendered and every site
 that decides whether a cursor is honoured or refused.

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -174,15 +174,36 @@ generator (read side) and cannot diverge: the logical WHERE clause is applied
 both against raw `read_parquet` output (physical columns) and against the
 `visible` CTE (unified columns), so both must expose the same names (#260).
 The fold is lossy, so both sides fail fast if two attributes of one schema
-collide on the same folded column. Which columns a keyset cursor may carry is a
-per-seam contract, not a global one: `ExecuteFederatedPaginatedQuery` applies
-the `validateKeysetColumns` allowlist (`internal/federated/keyset.go`), which
-admits system columns only, while `DBFederatedQueryEngine.Query` requires only
-the trailing `row_id` tiebreak (`validateKeysetTiebreak`) and does accept
-attribute columns — which the fold does not reach: `generateKeysetWhereClause`
-emits `col.Attribute` verbatim (`internal/sqlgen/keyset_where.go`), so a cursor
-over `contact.annualIncome` would reference that dotted name against a `visible`
-CTE exposing only `contact_annualIncome`.
+collide on the same folded column.
+
+Keyset cursor columns obey the same contract as every other column reference,
+and it is one contract, not a per-seam one (#381). A single validator,
+`federated.validateKeysetCursor`, binds both entry points —
+`DBFederatedQueryEngine.Query` and `ExecuteFederatedPaginatedQuery` — and admits
+a column when it is one of the four system columns the `visible` CTE projects
+(`row_id`, `created_at`, `ver_ts`, `deleted_ts`) or an attribute whose
+`ParquetAttrColumn` fold is a bare SQL identifier. Cursor columns are emitted
+folded by `generateKeysetWhereClause` and `buildKeysetOrderBy`, so a cursor over
+`contact.annualIncome` references `contact_annualIncome`, the name the CTE
+actually exposes. Two columns of `visible` are refused by name despite being
+bare identifiers — `rn` and `source_tier_priority`, the dedup machinery, on
+which a cursor would bind and then paginate over the dedup rank — as is any
+name the fold empties, which `ParquetAttrColumn` would otherwise substitute
+with its `attr` placeholder.
+
+Two rules travel with the cursor type itself (`model.KeysetCursor`), so
+`internal/sqlgen` can enforce them without reaching into `internal/federated`:
+`Values` must align one-for-one with `Columns` — a short slice used to bind SQL
+NULL and return a silently empty page — and the final column must be `row_id`,
+the trailing tiebreak that makes each page boundary resolvable (#183).
+`IsActive` is the shared spelling of "carries a continuation obligation", used
+by every site that decides whether the clause is rendered and every site that
+decides whether a cursor is honoured or refused.
+
+The validator does not check that an attribute is registered in the schema:
+that needs the metadata cache, and an unregistered but well-formed name fails
+loudly at DuckDB's binder rather than silently. It is deferred to the
+caller-facing cursor surface the Postgres-side keyset feature introduces.
 
 ## **5. SQL Execution Template**
 
@@ -421,12 +442,17 @@ run triggered by count or by other rows.
 
 Keyset (cursor) pagination carries the same total-order requirement, and it is
 now **enforced**, not merely documented: the engine rejects any cursor whose
-final column is not `row_id` (`validateKeysetTiebreak`, guarding both the live
-renderer path in `DBFederatedQueryEngine.Query` and the `KeysetEnabled`
-`executeFederatedKeysetQuery` seam). A cursor ending on a non-unique key applies
-a strict inequality on that key at the boundary, which silently skips every row
-tied there; the trailing `row_id` gives the composite key a unique tiebreak so
-each boundary tie is resolvable (#183).
+final column is not `row_id`. The rule lives on the cursor type
+(`model.KeysetCursor.ValidateShape`) and is applied by the single validator
+`federated.validateKeysetCursor` at both entry points — the live renderer path
+in `DBFederatedQueryEngine.Query` and the keyset branch of
+`ExecuteFederatedPaginatedQuery`, which an active cursor alone now selects
+since the `KeysetEnabled` flag was retired (#381) — and again inside
+`generateKeysetWhereClause`, so a direct `internal/sqlgen` caller cannot bypass
+it. A cursor ending on a non-unique key applies a strict inequality on that key
+at the boundary, which silently skips every row tied there; the trailing
+`row_id` gives the composite key a unique tiebreak so each boundary tie is
+resolvable (#183).
 
 **Never-flushed columns (#255).** `union_by_name` can only union columns that
 exist in *some* file. An attribute added to the schema before its first flush is

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -178,8 +178,9 @@ collide on the same folded column.
 
 Keyset cursor columns obey the same contract as every other column reference,
 and it is one contract, not a per-seam one (#381). A single validator,
-`federated.validateKeysetCursor`, binds both entry points —
-`DBFederatedQueryEngine.Query` and `ExecuteFederatedPaginatedQuery` — and admits
+`federated.validateKeysetCursor`, binds every entry point onto the keyset
+renderer — `DBFederatedQueryEngine.Query`, `ExecuteFederatedPaginatedQuery`, and
+the exported `ExecuteDuckDBFederatedQuery` beneath them — and admits
 a column when it is one of the four system columns the `visible` CTE projects
 (`row_id`, `created_at`, `ver_ts`, `deleted_ts`) or an attribute whose
 `ParquetAttrColumn` fold is a bare SQL identifier. Cursor columns are emitted
@@ -188,8 +189,12 @@ folded by `generateKeysetWhereClause` and `buildKeysetOrderBy`, so a cursor over
 actually exposes. Two columns of `visible` are refused by name despite being
 bare identifiers — `rn` and `source_tier_priority`, the dedup machinery, on
 which a cursor would bind and then paginate over the dedup rank — as is any
-name the fold empties, which `ParquetAttrColumn` would otherwise substitute
-with its `attr` placeholder.
+name that folds onto `ParquetAttrColumn`'s `attr` placeholder, whether because
+the fold empties the name or because it strips the name down onto that literal.
+Both the reject set and the system-column set are matched on the folded name
+**case-insensitively**: DuckDB resolves an unquoted identifier without regard to
+case, so `RN` reaches the same dedup column as `rn`, and `ROW_ID` the same
+system column as `row_id`.
 
 Two rules travel with the cursor type itself (`model.KeysetCursor`), so
 `internal/sqlgen` can enforce them without reaching into `internal/federated`:

--- a/internal/e2e_harness/federated/benchmark/execute.go
+++ b/internal/e2e_harness/federated/benchmark/execute.go
@@ -159,15 +159,19 @@ func (r *Runner) executeKeysetServiceQuery(ctx context.Context, h *federated.Fed
 	}
 
 	// No AttributeOrders here, unlike the offset path: a keyset page is
-	// ordered by its cursor columns, and the engine supports keyset cursors on
-	// SYSTEM columns only (federated.isSupportedKeysetColumn rejects
-	// main-column and EAV attributes, so a tradeTime cursor errors outright).
-	// A keyset workload therefore pages by created_at DESC, row_id ASC — the
-	// default order — and sortExpectedRecordsForWorkload matches it. This used
-	// to build a tradeTime order and discard it, which read as an oversight
-	// but was in fact unobservable: tradeTime is generated FROM changed_at and
-	// the reader aliased changed_at into created_at, so both orders were the
-	// same sequence until #460 separated them.
+	// ordered by its cursor columns, and this workload builds its cursor below
+	// on created_at DESC, row_id ASC — the default order — so a keyset page is
+	// never in the tradeTime order the offset workloads use, and
+	// sortExpectedRecordsForWorkload matches the cursor instead. The cursor
+	// used to have no other choice: the retired federated allowlist accepted
+	// system columns only. #381 replaced it with validateKeysetCursor, which
+	// admits attribute columns too, but this workload's expectations are built
+	// around the default order and stay there.
+	//
+	// This code used to build a tradeTime order and discard it, which read as
+	// an oversight but was in fact unobservable: tradeTime is generated FROM
+	// changed_at and the reader aliased changed_at into created_at, so both
+	// orders were the same sequence until #460 separated them.
 
 	// Build the federated query with filter conditions
 	fq := &model.FederatedAttributeQuery{

--- a/internal/e2e_harness/federated/benchmark/execute.go
+++ b/internal/e2e_harness/federated/benchmark/execute.go
@@ -236,7 +236,6 @@ func (r *Runner) executeKeysetServiceQuery(ctx context.Context, h *federated.Fed
 
 	fq.KeysetCursor = cursor
 	opts := &model.FederatedQueryOptions{
-		KeysetEnabled:        true,
 		IncludeExecutionPlan: true,
 	}
 

--- a/internal/e2e_harness/federated/benchmark/oracle.go
+++ b/internal/e2e_harness/federated/benchmark/oracle.go
@@ -389,11 +389,13 @@ func benchmarkVisibleAttributeValue(record GeneratedRecord, attribute string) (a
 // sortExpectedRecordsForWorkload orders the oracle's winners the way the
 // engine orders the page it is checked against.
 //
-// Keyset workloads are the exception (#460). The engine supports keyset
-// cursors on SYSTEM columns only — federated.isSupportedKeysetColumn rejects
-// main-column and EAV attributes — so a keyset page can only be ordered by
-// created_at DESC, row_id ASC, never by the tradeTime order the offset
-// workloads use.
+// Keyset workloads are the exception (#460). Their cursor is built on
+// created_at DESC, row_id ASC (execute.go), so a keyset page comes back in
+// that order, never in the tradeTime order the offset workloads use. (The
+// cursor used to have no other choice: the retired federated allowlist
+// accepted system columns only. #381 replaced it with validateKeysetCursor,
+// which admits attribute columns too, but this workload stays on the default
+// order.)
 //
 // That divergence used to be invisible: the generator assigns tradeTime FROM
 // changed_at, and the reader aliased changed_at into created_at, so the two

--- a/internal/e2e_harness/production/keyset_lww_e2e_test.go
+++ b/internal/e2e_harness/production/keyset_lww_e2e_test.go
@@ -16,7 +16,7 @@ import (
 // fires on an exact tie with the preceding key, which a synthetic boundary
 // (a value no seeded row carries) never hits, so the arm is inert. Every cursor
 // must still END on row_id — the engine now rejects cursors lacking that
-// trailing tiebreak (validateKeysetTiebreak, #183).
+// trailing tiebreak (validateKeysetCursor, #183).
 const keysetZeroRowID = "00000000-0000-0000-0000-000000000000"
 
 // TestKeysetLWW (#212): the keyset cursor must be applied AFTER last-write-

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -62,7 +62,7 @@ func (e *DBFederatedQueryEngine) ExecuteDuckDBFederatedQuery(
 	// renderer directly, so validation cannot be inherited. Each seam validates
 	// independently by design; the contract is pure and idempotent (#381).
 	if q != nil {
-		if err := validateKeysetCursor(q.KeysetCursor); err != nil {
+		if err := validateKeysetCursor(q.KeysetCursor, attributeOrders); err != nil {
 			return nil, 0, fmt.Errorf("validate keyset cursor: %w", err)
 		}
 	}
@@ -190,7 +190,7 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 
 	// Validate the keyset cursor: the fourth seam (#381). Each entry point to
 	// the renderer validates independently by design, not through inheritance.
-	if err := validateKeysetCursor(q.KeysetCursor); err != nil {
+	if err := validateKeysetCursor(q.KeysetCursor, attributeOrders); err != nil {
 		return 0, fmt.Errorf("validate keyset cursor: %w", err)
 	}
 

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -58,15 +58,9 @@ func (e *DBFederatedQueryEngine) ExecuteDuckDBFederatedQuery(
 	attributeOrders []model.AttributeOrder,
 	opts *model.FederatedQueryOptions,
 ) ([]*model.PersistentRecord, int64, error) {
-	// The THIRD seam onto the keyset renderer. Query (engine.go) and
-	// ExecuteFederatedPaginatedQuery (pagination.go) both validate before they
-	// get here, but this method is exported and reaches the renderer directly,
-	// so a caller arriving straight at it would otherwise be held only to
-	// model.KeysetCursor.ValidateShape — no rn / source_tier_priority refusal
-	// and, more importantly, no safe-identifier barrier, which is the only
-	// injection guard on a name interpolated as an identifier. The contract is
-	// enforced identically at every entry point (#381), and validateKeysetCursor
-	// is pure and idempotent, so re-validating on the paginated path is free.
+	// Validate the keyset cursor at this exported seam: this method reaches the
+	// renderer directly, so validation cannot be inherited. Each seam validates
+	// independently by design; the contract is pure and idempotent (#381).
 	if q != nil {
 		if err := validateKeysetCursor(q.KeysetCursor); err != nil {
 			return nil, 0, fmt.Errorf("validate keyset cursor: %w", err)
@@ -192,6 +186,12 @@ func (e *DBFederatedQueryEngine) StreamDuckDBFederatedQuery(
 ) (int64, error) {
 	if q == nil {
 		return 0, fmt.Errorf("query cannot be nil")
+	}
+
+	// Validate the keyset cursor: the fourth seam (#381). Each entry point to
+	// the renderer validates independently by design, not through inheritance.
+	if err := validateKeysetCursor(q.KeysetCursor); err != nil {
+		return 0, fmt.Errorf("validate keyset cursor: %w", err)
 	}
 
 	// Initialize execution plan tracking

--- a/internal/federated/duckdb_query.go
+++ b/internal/federated/duckdb_query.go
@@ -58,6 +58,20 @@ func (e *DBFederatedQueryEngine) ExecuteDuckDBFederatedQuery(
 	attributeOrders []model.AttributeOrder,
 	opts *model.FederatedQueryOptions,
 ) ([]*model.PersistentRecord, int64, error) {
+	// The THIRD seam onto the keyset renderer. Query (engine.go) and
+	// ExecuteFederatedPaginatedQuery (pagination.go) both validate before they
+	// get here, but this method is exported and reaches the renderer directly,
+	// so a caller arriving straight at it would otherwise be held only to
+	// model.KeysetCursor.ValidateShape — no rn / source_tier_priority refusal
+	// and, more importantly, no safe-identifier barrier, which is the only
+	// injection guard on a name interpolated as an identifier. The contract is
+	// enforced identically at every entry point (#381), and validateKeysetCursor
+	// is pure and idempotent, so re-validating on the paginated path is free.
+	if q != nil {
+		if err := validateKeysetCursor(q.KeysetCursor); err != nil {
+			return nil, 0, fmt.Errorf("validate keyset cursor: %w", err)
+		}
+	}
 	mark := markExecutionPlan(opts)
 	recs, total, err := e.collectDuckDBFederatedQuery(ctx, tables, q, limit, offset, attributeOrders, opts)
 	var retry *corruptParquetRetryError

--- a/internal/federated/duckdb_query_build.go
+++ b/internal/federated/duckdb_query_build.go
@@ -206,9 +206,10 @@ type duckCompiledEntry struct {
 
 // serveFromPlanCache attempts the compiled-plan path. It returns ok=false
 // when the request is not cacheable (no cache injected, test hook installed,
-// non-advanced template, or shape hashing failed) — the caller then uses the
-// direct builder. On a miss the compile result serves the request too, so
-// rendering happens at most once per shape.
+// non-advanced template, shape hashing failed, or binding the compiled
+// skeleton failed) — the caller then uses the direct builder. On a miss the
+// compile result serves the request too, so rendering happens at most once
+// per shape.
 func (e *DBFederatedQueryEngine) serveFromPlanCache(
 	tables model.StorageTables,
 	q *model.FederatedAttributeQuery,
@@ -271,7 +272,13 @@ func (e *DBFederatedQueryEngine) serveFromPlanCache(
 		bound.PgMainClause = entry.dualPlan.PgMainClause
 		bound.DuckClause = entry.dualPlan.DuckClause
 	}
-	sqlStr, args := entry.compiled.Bind(q, bound, dirtyIDs, graceCutoffMs)
+	sqlStr, args, err := entry.compiled.Bind(q, bound, dirtyIDs, graceCutoffMs)
+	if err != nil {
+		// Same contract as every other failure here: ok=false hands the
+		// request to the direct builder, which carries the identical keyset
+		// validation (#381 item 7) and reports the error to the caller.
+		return "", nil, false
+	}
 	return sqlStr, args, true
 }
 

--- a/internal/federated/duckdb_query_build.go
+++ b/internal/federated/duckdb_query_build.go
@@ -34,6 +34,7 @@ func (e *DBFederatedQueryEngine) buildDuckDBQueryWithPlan(
 	coldMissing []sqlgen.NullScanColumn,
 	planCtx *duckDBExecutionPlanContext,
 ) (string, []any, int64, error) {
+	q = dispatchedQuery(q, limit, offset, attributeOrders)
 	sqlParams := e.buildDuckDBTemplateBaseParams(tables, q, attributeOrders, limit, offset, parquetPaths, graceCutoffMs, coldMissing)
 
 	startTranslate := time.Now()
@@ -101,6 +102,36 @@ func (e *DBFederatedQueryEngine) buildDuckDBQueryWithPlan(
 	}
 
 	return sqlStr, args, translateMs, nil
+}
+
+// dispatchedQuery returns a copy of q whose Limit, Offset and AttributeOrders
+// are the arguments the DuckDB seam was called with.
+//
+// The advanced template renders LIMIT, OFFSET and the non-keyset ORDER BY from
+// the QUERY OBJECT (sqlgen.injectDuckDBTemplateParams reads q.Limit, q.Offset,
+// q.AttributeOrders); the call arguments only reach the template map under
+// "Limit"/"Offset"/"PageSize"/"SortKeys", which it never reads. So a caller
+// that normalised or clamped its limit but passed q unchanged had its clamp
+// silently ignored: the keyset branch of ExecuteFederatedPaginatedQuery
+// rendered LIMIT 0 for a zero q.Limit and an over-MaxRows q.Limit verbatim,
+// with only its in-memory slice honouring the clamp (#381 review), and
+// computeFederatedCount hand-rolled the very copy made here (#181).
+//
+// Made at this function, the single point the direct render and the compiled
+// plan cache both flow through, so the rendered skeleton, the shape hash and
+// the plan scope all see the query that was dispatched. The explicit arguments
+// are the pagination contract of every seam; engine.Query passes q's own
+// fields and is unaffected. q itself is never mutated — the caller may still
+// be reading it (recordTranslation, the keyset page slice).
+func dispatchedQuery(q *model.FederatedAttributeQuery, limit, offset int, attributeOrders []model.AttributeOrder) *model.FederatedAttributeQuery {
+	if q == nil {
+		return nil
+	}
+	page := *q
+	page.Limit = limit
+	page.Offset = offset
+	page.AttributeOrders = attributeOrders
+	return &page
 }
 
 // buildDuckDBTemplateBaseParams assembles the static template parameter map:

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -152,15 +152,11 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 		opts.PartialScan = nil
 	}
 	// Guard the live renderer path: ExecuteDuckDBFederatedQuery below consumes
-	// the cursor unvalidated (duckdb_template_renderer.go), so reject a cursor
-	// lacking the trailing row_id tiebreak here, before it can silently skip a
-	// boundary tie group (#183). hasKeysetCursor (keyset.go) is the shared
-	// spelling of "carries an active cursor", so this gate, the postgres-only
-	// guard and the degrade refusal cannot drift apart.
-	if hasKeysetCursor(fq) {
-		if err := validateKeysetTiebreak(fq.KeysetCursor); err != nil {
-			return nil, fmt.Errorf("validate keyset cursor: %w", err)
-		}
+	// the cursor unvalidated (duckdb_template_renderer.go). validateKeysetCursor
+	// (keyset.go) is THE contract — the same call ExecuteFederatedPaginatedQuery
+	// makes, so the two seams cannot disagree about what a cursor may be (#381).
+	if err := validateKeysetCursor(fq.KeysetCursor); err != nil {
+		return nil, fmt.Errorf("validate keyset cursor: %w", err)
 	}
 	// Only explicit hot-only requests short-circuit to Postgres. Empty
 	// PreferredTiers means the default all-tier form (the same contract the

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -155,7 +155,7 @@ func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.Storage
 	// the cursor unvalidated (duckdb_template_renderer.go). validateKeysetCursor
 	// (keyset.go) is THE contract — the same call ExecuteFederatedPaginatedQuery
 	// makes, so the two seams cannot disagree about what a cursor may be (#381).
-	if err := validateKeysetCursor(fq.KeysetCursor); err != nil {
+	if err := validateKeysetCursor(fq.KeysetCursor, fq.AttributeOrders); err != nil {
 		return nil, fmt.Errorf("validate keyset cursor: %w", err)
 	}
 	// Only explicit hot-only requests short-circuit to Postgres. Empty

--- a/internal/federated/engine_fakes_test.go
+++ b/internal/federated/engine_fakes_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 type fakePostgresFederatedSource struct {
-	queryCalls       int
+	queryCalls        int
 	runOptimizedCalls int
-	lastQuery        *model.PersistentRecordQuery
-	page             *model.PersistentRecordPage
+	lastQuery         *model.PersistentRecordQuery
+	page              *model.PersistentRecordPage
 }
 
 func (f *fakePostgresFederatedSource) QueryPersistentRecords(ctx context.Context, query *model.PersistentRecordQuery) (*model.PersistentRecordPage, error) {

--- a/internal/federated/engine_fakes_test.go
+++ b/internal/federated/engine_fakes_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 type fakePostgresFederatedSource struct {
-	queryCalls int
-	lastQuery  *model.PersistentRecordQuery
-	page       *model.PersistentRecordPage
+	queryCalls       int
+	runOptimizedCalls int
+	lastQuery        *model.PersistentRecordQuery
+	page             *model.PersistentRecordPage
 }
 
 func (f *fakePostgresFederatedSource) QueryPersistentRecords(ctx context.Context, query *model.PersistentRecordQuery) (*model.PersistentRecordPage, error) {
@@ -28,6 +29,7 @@ func (f *fakePostgresFederatedSource) QueryPersistentRecords(ctx context.Context
 }
 
 func (f *fakePostgresFederatedSource) RunOptimizedQuery(ctx context.Context, tables model.StorageTables, schemaID int16, clause string, args []any, limit, offset int, attributeOrders []model.AttributeOrder, useMainTableAsAnchor bool) ([]*model.PersistentRecord, int64, error) {
+	f.runOptimizedCalls++
 	return nil, 0, nil
 }
 

--- a/internal/federated/keyset.go
+++ b/internal/federated/keyset.go
@@ -109,6 +109,12 @@ const parquetAttrFallbackColumn = "attr"
 //
 //   - the shape rules, shared with any package via model.KeysetCursor
 //     (value/column alignment and the trailing row_id tiebreak);
+//   - the continuation rule, also on model.KeysetCursor: when the request
+//     resolved AttributeOrders, the cursor must be those orders plus the
+//     row_id tiebreak, or the renderer — which builds the keyset ORDER BY
+//     from the cursor alone — would silently replace the request's order
+//     with the cursor's. orders is the order that will RENDER for this
+//     dispatch: each seam passes the AttributeOrders it hands the builder.
 //   - per column, all judged on the ParquetAttrColumn fold — the same fold the
 //     code generator emits, so validation and codegen agree by construction:
 //     never the writer's empty-name fallback, never the dedup machinery, and
@@ -126,12 +132,15 @@ const parquetAttrFallbackColumn = "attr"
 //
 // A plain read-path error mirroring the rest of this file: the route or the
 // cursor is wrong for an operator to see, not a caller-facing 4xx.
-func validateKeysetCursor(cursor *model.KeysetCursor) error {
+func validateKeysetCursor(cursor *model.KeysetCursor, orders []model.AttributeOrder) error {
 	if err := cursor.ValidateShape(); err != nil {
-		// Deliberately unwrapped: both call sites (engine.go, pagination.go)
-		// already wrap this function's result with "validate keyset cursor",
-		// so adding context here would double that prefix. The sqlgen copy of
-		// the same call DOES wrap, because there it is the outermost frame.
+		// Deliberately unwrapped: every call site already wraps this
+		// function's result with "validate keyset cursor", so adding context
+		// here would double that prefix. The sqlgen copies of the same calls
+		// DO wrap, because there they are the outermost frame.
+		return err
+	}
+	if err := cursor.ValidateContinuation(orders); err != nil {
 		return err
 	}
 	if !cursor.IsActive() {

--- a/internal/federated/keyset.go
+++ b/internal/federated/keyset.go
@@ -31,10 +31,21 @@ import (
 // DuckDB resolves an unquoted identifier case-insensitively, so a cursor on
 // "ROW_ID" or "Created_At" binds to exactly these columns; normalising the
 // lookup key routes those spellings through the system-column branch instead
-// of treating them as ordinary attribute names (#381). ParquetAttrColumn is
-// the identity on all four, and schema registration already rejects an
-// attribute whose fold collides with a reserved parquet column
-// (sqlgen.ValidateParquetAttrColumns), so no real attribute can reach them.
+// of treating them as ordinary attribute names (#381).
+//
+// Case-insensitivity is the whole of the latitude: reaching one of these four
+// by a NON-IDENTITY fold is refused. ParquetAttrColumn is the identity on all
+// four, so "created.at", "ver.ts", "deleted.ts" and "[row_id]" are not
+// spellings of a system column — they are arbitrary names the fold TRANSFORMS
+// onto one, and admitting them would emit the real system column for a cursor
+// the caller wrote against a key of their own: a page ordered and filtered on
+// something never named, the silent-wrong-answer outcome (#354) this file
+// exists to refuse. Schema registration cannot stand in for the check: it
+// rejects a registered ATTRIBUTE whose fold collides with a reserved parquet
+// column (sqlgen.ValidateParquetAttrColumns), but a cursor column is an
+// arbitrary string that was never registered. The refusal is also what keeps
+// validateKeysetCursor's "an unregistered name fails loudly at DuckDB's
+// binder" promise true without exception.
 var keysetSystemColumns = map[string]struct{}{
 	"row_id":     {},
 	"created_at": {},
@@ -101,7 +112,11 @@ const parquetAttrFallbackColumn = "attr"
 //   - per column, all judged on the ParquetAttrColumn fold — the same fold the
 //     code generator emits, so validation and codegen agree by construction:
 //     never the writer's empty-name fallback, never the dedup machinery, and
-//     otherwise a visible-CTE system column or a safe SQL identifier.
+//     otherwise a visible-CTE system column named under its own spelling or a
+//     safe SQL identifier. Case is the only latitude anywhere in that list:
+//     every rule below is matched case-insensitively because DuckDB resolves
+//     unquoted identifiers that way, and no rule admits a name that reached a
+//     column of visible by a non-identity fold.
 //
 // It deliberately does NOT check that an attribute is registered in the
 // schema: that needs the metadata cache, and an unregistered but well-formed
@@ -150,7 +165,14 @@ func validateKeysetCursor(cursor *model.KeysetCursor) error {
 		// every error message keep the caller's spelling.
 		key := strings.ToLower(folded)
 		if _, ok := keysetSystemColumns[key]; ok {
-			continue
+			// A system column is admitted only under its OWN name, case
+			// aside: the fold must have been the identity. Anything else
+			// reached the column by transformation, and the generator would
+			// emit the system column for a cursor that named something else.
+			if strings.EqualFold(col.Attribute, folded) {
+				continue
+			}
+			return fmt.Errorf("keyset cursor column %q folds to %q, a system column of the visible CTE, which would silently paginate on that column instead of the attribute named: cursor on %s under its own name, or on a schema attribute that folds to its own name", col.Attribute, folded, key)
 		}
 		if _, ok := keysetRejectedColumns[key]; ok {
 			return fmt.Errorf("keyset cursor column %q is federated dedup machinery, not a queryable column: cursor on row_id, created_at, ver_ts, deleted_ts or a schema attribute", col.Attribute)

--- a/internal/federated/keyset.go
+++ b/internal/federated/keyset.go
@@ -2,8 +2,10 @@ package federated
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/sqlgen"
 )
 
 // This file holds the keyset *validation* seams used by the federated
@@ -14,47 +16,116 @@ import (
 // with no production callers; it was deleted in #217 so the repo carries
 // exactly one keyset codegen.
 
-// isSupportedKeysetColumn returns true if the attribute is supported for keyset cursor extraction.
-// Currently only system columns and known main table columns are supported.
-// EAV-only attributes require schema cache integration and are not yet supported.
-func isSupportedKeysetColumn(attribute string) bool {
-	switch attribute {
-	case "row_id", "created_at", "updated_at", "deleted_at", "ver_ts", "deleted_ts", "schema_id":
-		return true
-	default:
-		// EAV attributes and main column attributes are not yet supported
-		return false
-	}
+// keysetSystemColumns are the system columns the visible CTE actually
+// projects. Both source legs agree on exactly these four names
+// (sqlgen.SchemaProjection.buildS3Projection and buildPGProjection): row_id,
+// ltbase_created_at AS created_at, changed_at AS ver_ts, deleted_at AS
+// deleted_ts. The retired allowlist also admitted updated_at, deleted_at and
+// schema_id, which are NOT columns of visible — a cursor on one could only
+// ever reach DuckDB's binder. They are no longer blessed here; being
+// well-formed identifiers they now pass as ordinary attribute names and fail
+// at the binder, which is honest rather than falsely supported (#381).
+//
+// Looked up on the FOLDED name, like every other rule below. ParquetAttrColumn
+// is the identity on all four, and schema registration already rejects an
+// attribute whose fold collides with a reserved parquet column
+// (sqlgen.ValidateParquetAttrColumns), so no real attribute can reach them.
+var keysetSystemColumns = map[string]struct{}{
+	"row_id":     {},
+	"created_at": {},
+	"ver_ts":     {},
+	"deleted_ts": {},
 }
 
-// validateKeysetColumns checks if all keyset cursor columns are supported.
-// Returns an error if any column is unsupported.
-func validateKeysetColumns(columns []model.KeysetColumn) error {
-	for _, col := range columns {
-		if !isSupportedKeysetColumn(col.Attribute) {
-			return fmt.Errorf("keyset pagination on attribute %q is not supported (EAV attributes require schema cache)", col.Attribute)
-		}
-	}
-	return nil
+// keysetRejectedColumns are columns of visible that are dedup machinery, not
+// data. A cursor on either would bind successfully and paginate over the
+// dedup rank, so it fails silently-wrong rather than loudly — the one case
+// the identifier rule below cannot catch. Both are in scope where the keyset
+// predicate renders: the visible CTE selects over ranked, which projects them.
+//
+// The lookup is on the FOLDED name, because the raw name is not the name that
+// reaches SQL: ParquetAttrColumn maps dots and spaces onto underscores and
+// strips backticks and brackets, so "source_tier.priority" and "[rn]" land on
+// these columns just as surely as the bare spellings do. Checking the raw name
+// would leave the guard bypassable by punctuation. No registered attribute is
+// caught by mistake: schema registration rejects an attribute whose fold
+// collides with a reserved parquet column, and rn and source_tier_priority are
+// both in that reserved set (sqlgen.ValidateParquetAttrColumns).
+var keysetRejectedColumns = map[string]struct{}{
+	"rn":                   {},
+	"source_tier_priority": {},
 }
 
-// validateKeysetTiebreak enforces the keyset caller contract: the final cursor
-// column MUST be row_id. The continuation predicate for the last cursor key is
-// a strict inequality, so a cursor ending on a non-unique key (created_at, a
-// business attribute, ...) excludes every row sharing that key's value at the
-// page boundary — an entire tie group is silently skipped (#183). row_id is the
-// only version-invariant unique column, so ending the cursor there gives the
-// composite key a total order and makes each boundary tie resolvable. Empty and
-// nil cursors are a no-op (the open first page carries no tiebreak obligation).
-// Mirrors validateKeysetColumns: a plain read-path error, not an
-// ErrInvalidInput-wrapped write-path validation.
-func validateKeysetTiebreak(cursor *model.KeysetCursor) error {
-	if cursor == nil || len(cursor.Columns) == 0 {
+// safeSQLIdentifier matches a bare, unquoted DuckDB identifier. Cursor
+// attributes are interpolated into SQL as identifiers, not bound as
+// parameters, so this pattern IS the injection barrier (#381 item 2). It is
+// applied to the FOLDED name: ParquetAttrColumn turns dots and spaces into
+// underscores and strips backticks and brackets, so a legitimate nested
+// attribute like "contact.annualIncome" passes, while a quote, semicolon,
+// parenthesis or leading digit does not.
+var safeSQLIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// parquetAttrFallbackColumn is the column name ParquetAttrColumn substitutes
+// when the fold empties an attribute name. It is a legitimate attribute name
+// in its own right, so the cursor rule can only reject the SUBSTITUTION — a
+// folded "attr" whose raw attribute was something else.
+const parquetAttrFallbackColumn = "attr"
+
+// validateKeysetCursor is THE keyset cursor contract, and the only validation
+// entry point. Both seams call it — the engine gate (engine.go) and the
+// paginated keyset branch (pagination.go) — so the two can no longer disagree
+// about what a cursor may be (#381 item 1). It replaces the retired pair
+// validateKeysetColumns (a system-column allowlist reachable only from
+// ExecuteFederatedPaginatedQuery) and validateKeysetTiebreak (all that
+// DBFederatedQueryEngine.Query applied, so that seam accepted arbitrary
+// attribute columns the code generator could not correctly reference).
+//
+// It enforces, in order:
+//
+//   - the shape rules, shared with any package via model.KeysetCursor
+//     (value/column alignment and the trailing row_id tiebreak);
+//   - per column, all judged on the ParquetAttrColumn fold — the same fold the
+//     code generator emits, so validation and codegen agree by construction:
+//     never the writer's empty-name fallback, never the dedup machinery, and
+//     otherwise a visible-CTE system column or a safe SQL identifier.
+//
+// It deliberately does NOT check that an attribute is registered in the
+// schema: that needs the metadata cache, and an unregistered but well-formed
+// name fails loudly at DuckDB's binder, never silently. The check belongs with
+// the caller-facing cursor surface the Postgres-side keyset feature
+// introduces.
+//
+// A plain read-path error mirroring the rest of this file: the route or the
+// cursor is wrong for an operator to see, not a caller-facing 4xx.
+func validateKeysetCursor(cursor *model.KeysetCursor) error {
+	if err := cursor.ValidateShape(); err != nil {
+		return err
+	}
+	if !cursor.IsActive() {
 		return nil
 	}
-	last := cursor.Columns[len(cursor.Columns)-1].Attribute
-	if last != "row_id" {
-		return fmt.Errorf("keyset cursor final column is %q, expected \"row_id\": a cursor not ending on the unique row_id tiebreak silently skips every row tied on the composite key at the page boundary", last)
+	for _, col := range cursor.Columns {
+		// Fold ONCE, then judge every rule on the folded name: that is the
+		// name the code generator emits, so a rule applied to the raw name
+		// guards a string that never reaches SQL.
+		folded := sqlgen.ParquetAttrColumn(col.Attribute)
+		if folded == parquetAttrFallbackColumn && col.Attribute != parquetAttrFallbackColumn {
+			// ParquetAttrColumn substitutes the literal "attr" whenever the
+			// fold empties the name — "", "[]", "``". That fallback exists for
+			// the export writer, which needs some column name for every
+			// attribute; here it would silently retarget a degenerate cursor
+			// column at a real attribute called "attr".
+			return fmt.Errorf("keyset cursor column %q folds to the placeholder %q because the ParquetAttrColumn fold empties it: name a visible-CTE system column (row_id, created_at, ver_ts, deleted_ts) or a schema attribute that survives the fold", col.Attribute, folded)
+		}
+		if _, ok := keysetSystemColumns[folded]; ok {
+			continue
+		}
+		if _, ok := keysetRejectedColumns[folded]; ok {
+			return fmt.Errorf("keyset cursor column %q is federated dedup machinery, not a queryable column: cursor on row_id, created_at, ver_ts, deleted_ts or a schema attribute", col.Attribute)
+		}
+		if !safeSQLIdentifier.MatchString(folded) {
+			return fmt.Errorf("keyset cursor column %q folds to %q, which is not a safe SQL identifier: a cursor column is interpolated as an identifier, so it must match %s after the ParquetAttrColumn fold", col.Attribute, folded, safeSQLIdentifier.String())
+		}
 	}
 	return nil
 }
@@ -98,7 +169,7 @@ func hasKeysetCursor(fq *model.FederatedAttributeQuery) bool {
 // (#243/#185). Accepted over duplicating this guard at every gate, which would
 // trade the single confluence for a set of checks that must be kept in sync.
 //
-// A plain read-path error mirroring validateKeysetTiebreak: the submitted
+// A plain read-path error mirroring validateKeysetCursor: the submitted
 // cursor is well-formed, it is the route that cannot serve it.
 func rejectKeysetOnPostgresOnly(fq *model.FederatedAttributeQuery) error {
 	if !hasKeysetCursor(fq) {

--- a/internal/federated/keyset.go
+++ b/internal/federated/keyset.go
@@ -3,6 +3,7 @@ package federated
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/sqlgen"
@@ -26,8 +27,12 @@ import (
 // well-formed identifiers they now pass as ordinary attribute names and fail
 // at the binder, which is honest rather than falsely supported (#381).
 //
-// Looked up on the FOLDED name, like every other rule below. ParquetAttrColumn
-// is the identity on all four, and schema registration already rejects an
+// Looked up on the FOLDED name, LOWER-CASED, like every other map rule below.
+// DuckDB resolves an unquoted identifier case-insensitively, so a cursor on
+// "ROW_ID" or "Created_At" binds to exactly these columns; normalising the
+// lookup key routes those spellings through the system-column branch instead
+// of treating them as ordinary attribute names (#381). ParquetAttrColumn is
+// the identity on all four, and schema registration already rejects an
 // attribute whose fold collides with a reserved parquet column
 // (sqlgen.ValidateParquetAttrColumns), so no real attribute can reach them.
 var keysetSystemColumns = map[string]struct{}{
@@ -43,11 +48,17 @@ var keysetSystemColumns = map[string]struct{}{
 // the identifier rule below cannot catch. Both are in scope where the keyset
 // predicate renders: the visible CTE selects over ranked, which projects them.
 //
-// The lookup is on the FOLDED name, because the raw name is not the name that
-// reaches SQL: ParquetAttrColumn maps dots and spaces onto underscores and
-// strips backticks and brackets, so "source_tier.priority" and "[rn]" land on
-// these columns just as surely as the bare spellings do. Checking the raw name
-// would leave the guard bypassable by punctuation. No registered attribute is
+// The lookup is on the FOLDED name, LOWER-CASED, because the raw name is not
+// the name that reaches SQL: ParquetAttrColumn maps dots and spaces onto
+// underscores and strips backticks and brackets, so "source_tier.priority" and
+// "[rn]" land on these columns just as surely as the bare spellings do, and it
+// preserves case, so "RN" and "Source_Tier_Priority" survive the fold intact.
+// DuckDB resolves an unquoted identifier case-insensitively, so those spellings
+// bind to the very rn and source_tier_priority the ranked CTE projects: without
+// case normalisation the guard is defeated by the shift key, and the cursor
+// paginates over the dedup rank — the silently-wrong outcome this set exists to
+// prevent (#381). Checking the raw name, or the folded name verbatim, would
+// leave the guard bypassable by punctuation or by case. No registered attribute is
 // caught by mistake: schema registration rejects an attribute whose fold
 // collides with a reserved parquet column, and rn and source_tier_priority are
 // both in that reserved set (sqlgen.ValidateParquetAttrColumns).
@@ -65,10 +76,13 @@ var keysetRejectedColumns = map[string]struct{}{
 // parenthesis or leading digit does not.
 var safeSQLIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
-// parquetAttrFallbackColumn is the column name ParquetAttrColumn substitutes
-// when the fold empties an attribute name. It is a legitimate attribute name
-// in its own right, so the cursor rule can only reject the SUBSTITUTION — a
-// folded "attr" whose raw attribute was something else.
+// parquetAttrFallbackColumn is the placeholder column name ParquetAttrColumn
+// substitutes when the fold empties an attribute name. It is a legitimate
+// attribute name in its own right, so the cursor rule can only reject a name
+// that FOLDS ONTO it — a folded "attr" whose raw attribute was something else,
+// whether the fold emptied the name (the empty string, "[]", a bare pair of
+// backticks) or merely stripped it down to the literal placeholder, as
+// "[attr]" and a backtick-wrapped attr do.
 const parquetAttrFallbackColumn = "attr"
 
 // validateKeysetCursor is THE keyset cursor contract, and the only validation
@@ -99,6 +113,10 @@ const parquetAttrFallbackColumn = "attr"
 // cursor is wrong for an operator to see, not a caller-facing 4xx.
 func validateKeysetCursor(cursor *model.KeysetCursor) error {
 	if err := cursor.ValidateShape(); err != nil {
+		// Deliberately unwrapped: both call sites (engine.go, pagination.go)
+		// already wrap this function's result with "validate keyset cursor",
+		// so adding context here would double that prefix. The sqlgen copy of
+		// the same call DOES wrap, because there it is the outermost frame.
 		return err
 	}
 	if !cursor.IsActive() {
@@ -110,17 +128,24 @@ func validateKeysetCursor(cursor *model.KeysetCursor) error {
 		// guards a string that never reaches SQL.
 		folded := sqlgen.ParquetAttrColumn(col.Attribute)
 		if folded == parquetAttrFallbackColumn && col.Attribute != parquetAttrFallbackColumn {
-			// ParquetAttrColumn substitutes the literal "attr" whenever the
-			// fold empties the name — "", "[]", "``". That fallback exists for
-			// the export writer, which needs some column name for every
-			// attribute; here it would silently retarget a degenerate cursor
-			// column at a real attribute called "attr".
-			return fmt.Errorf("keyset cursor column %q folds to the placeholder %q because the ParquetAttrColumn fold empties it: name a visible-CTE system column (row_id, created_at, ver_ts, deleted_ts) or a schema attribute that survives the fold", col.Attribute, folded)
+			// The literal "attr" is ParquetAttrColumn's placeholder: it
+			// substitutes it whenever the fold empties the name — "", "[]",
+			// "``" — and a name like "[attr]" or "`attr`" strips down onto it
+			// directly. That placeholder exists for the export writer, which
+			// needs some column name for every attribute; here either route
+			// would silently retarget the cursor at a real attribute called
+			// "attr".
+			return fmt.Errorf("keyset cursor column %q folds onto the placeholder %q, which would silently retarget the cursor at a real attribute of that name: name a visible-CTE system column (row_id, created_at, ver_ts, deleted_ts) or a schema attribute that folds to its own name", col.Attribute, folded)
 		}
-		if _, ok := keysetSystemColumns[folded]; ok {
+		// Both map lookups are case-normalised: DuckDB resolves unquoted
+		// identifiers case-insensitively, so "RN" reaches the same column
+		// as "rn". Only the LOOKUP KEY is lower-cased — the emitted name and
+		// every error message keep the caller's spelling.
+		key := strings.ToLower(folded)
+		if _, ok := keysetSystemColumns[key]; ok {
 			continue
 		}
-		if _, ok := keysetRejectedColumns[folded]; ok {
+		if _, ok := keysetRejectedColumns[key]; ok {
 			return fmt.Errorf("keyset cursor column %q is federated dedup machinery, not a queryable column: cursor on row_id, created_at, ver_ts, deleted_ts or a schema attribute", col.Attribute)
 		}
 		if !safeSQLIdentifier.MatchString(folded) {

--- a/internal/federated/keyset.go
+++ b/internal/federated/keyset.go
@@ -61,10 +61,15 @@ func validateKeysetTiebreak(cursor *model.KeysetCursor) error {
 
 // hasKeysetCursor reports whether the query carries an ACTIVE keyset cursor.
 // A nil cursor or an empty column list is the open first page, which carries
-// no continuation obligation — the same no-op contract validateKeysetTiebreak
-// applies.
+// no continuation obligation.
+//
+// The predicate itself lives on model.KeysetCursor (IsActive) so the
+// internal/sqlgen sites that decide whether the clause is RENDERED share it
+// with the sites here that decide whether a cursor is HONOURED OR REFUSED
+// (#381 item 9). This function is the package-local convenience wrapper that
+// also absorbs a nil query.
 func hasKeysetCursor(fq *model.FederatedAttributeQuery) bool {
-	return fq != nil && fq.KeysetCursor != nil && len(fq.KeysetCursor.Columns) > 0
+	return fq != nil && fq.KeysetCursor.IsActive()
 }
 
 // rejectKeysetOnPostgresOnly fails a cursor-bearing request that reached the

--- a/internal/federated/keyset.go
+++ b/internal/federated/keyset.go
@@ -127,7 +127,7 @@ func validateKeysetCursor(cursor *model.KeysetCursor) error {
 		// name the code generator emits, so a rule applied to the raw name
 		// guards a string that never reaches SQL.
 		folded := sqlgen.ParquetAttrColumn(col.Attribute)
-		if folded == parquetAttrFallbackColumn && col.Attribute != parquetAttrFallbackColumn {
+		if strings.EqualFold(folded, parquetAttrFallbackColumn) && !strings.EqualFold(col.Attribute, parquetAttrFallbackColumn) {
 			// The literal "attr" is ParquetAttrColumn's placeholder: it
 			// substitutes it whenever the fold empties the name — "", "[]",
 			// "``" — and a name like "[attr]" or "`attr`" strips down onto it
@@ -135,6 +135,13 @@ func validateKeysetCursor(cursor *model.KeysetCursor) error {
 			// needs some column name for every attribute; here either route
 			// would silently retarget the cursor at a real attribute called
 			// "attr".
+			//
+			// Both comparisons are case-insensitive, for the same reason the
+			// two map lookups below are: DuckDB resolves unquoted identifiers
+			// case-insensitively, so a folded "Attr" reaches the very column
+			// "attr" does — the shift key must not be a bypass. The exemption
+			// is folded too, or an attribute legitimately named "Attr" (which
+			// folds to its own name) would be newly refused.
 			return fmt.Errorf("keyset cursor column %q folds onto the placeholder %q, which would silently retarget the cursor at a real attribute of that name: name a visible-CTE system column (row_id, created_at, ver_ts, deleted_ts) or a schema attribute that folds to its own name", col.Attribute, folded)
 		}
 		// Both map lookups are case-normalised: DuckDB resolves unquoted

--- a/internal/federated/keyset_continuation_test.go
+++ b/internal/federated/keyset_continuation_test.go
@@ -1,0 +1,79 @@
+package federated
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEverySeamRefusesACursorThatReplacesTheRequestOrder pins the
+// continuation rule at all four seams (#381 review): the renderer builds the
+// keyset ORDER BY from the cursor alone, so a request sorted on `count ASC`
+// continued with a valid `created_at DESC, row_id ASC` cursor used to answer a
+// page ordered and filtered on created_at. Each seam is handed the order it
+// will render — fq.AttributeOrders at Query, the attributeOrders argument
+// elsewhere — so the check and the render see one order.
+func TestEverySeamRefusesACursorThatReplacesTheRequestOrder(t *testing.T) {
+	orders := []model.AttributeOrder{{AttrID: 3, AttrName: "count", SortOrder: forma.SortOrderAsc,
+		ValueType: forma.ValueTypeNumeric, StorageLocation: forma.AttributeStorageLocationEAV}}
+	createdAtCursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{
+			{Attribute: "created_at", Direction: forma.SortOrderDesc},
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+		},
+		Values: []interface{}{int64(5), "r1"},
+		Mode:   model.KeysetCursorModeAfter,
+	}
+	tables := model.StorageTables{EntityMain: "main", EAVData: "eav"}
+	newQuery := func() *model.FederatedAttributeQuery {
+		return &model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10, AttributeOrders: orders},
+			KeysetCursor:   createdAtCursor,
+		}
+	}
+	const want = `keyset cursor column 1 is "created_at" but the request sorts on "count"`
+
+	engine := NewDBFederatedQueryEngine(
+		&fakePostgresFederatedSource{page: &model.PersistentRecordPage{}},
+		nil, nil, nil, forma.DuckDBConfig{Enabled: true}, nil, "")
+	ctx := context.Background()
+
+	_, err := engine.Query(ctx, tables, newQuery(), &model.FederatedQueryOptions{})
+	require.ErrorContains(t, err, want, "Query seam")
+
+	_, _, err = engine.ExecuteFederatedPaginatedQuery(ctx, tables, newQuery(), 10, 0, orders, &model.FederatedQueryOptions{})
+	require.ErrorContains(t, err, want, "paginated seam")
+
+	_, _, err = engine.ExecuteDuckDBFederatedQuery(ctx, tables, newQuery(), 10, 0, orders, nil)
+	require.ErrorContains(t, err, want, "ExecuteDuckDBFederatedQuery seam")
+
+	_, err = engine.StreamDuckDBFederatedQuery(ctx, tables, newQuery(), 10, 0, orders, nil,
+		func(context.Context, *model.PersistentRecord) error { return nil })
+	require.ErrorContains(t, err, want, "StreamDuckDBFederatedQuery seam")
+}
+
+// TestValidateKeysetCursorContinuesTheDispatchedOrder pins which order the
+// validator judges: the one passed for this dispatch, not any other. A cursor
+// continuing `count ASC` is admitted against those orders and against none,
+// and refused against a different sort.
+func TestValidateKeysetCursorContinuesTheDispatchedOrder(t *testing.T) {
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{
+			{Attribute: "count", Direction: forma.SortOrderAsc},
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+		},
+		Values: []interface{}{int64(5), "r1"},
+		Mode:   model.KeysetCursorModeAfter,
+	}
+	countAsc := []model.AttributeOrder{{AttrID: 3, AttrName: "count", SortOrder: forma.SortOrderAsc}}
+	amountDesc := []model.AttributeOrder{{AttrID: 4, AttrName: "amount", SortOrder: forma.SortOrderDesc}}
+
+	require.NoError(t, validateKeysetCursor(cursor, countAsc), "the cursor continues count ASC")
+	require.NoError(t, validateKeysetCursor(cursor, nil), "with no request order the cursor is the order")
+	require.ErrorContains(t, validateKeysetCursor(cursor, amountDesc),
+		`keyset cursor column 1 is "count" but the request sorts on "amount"`)
+}

--- a/internal/federated/keyset_routing_test.go
+++ b/internal/federated/keyset_routing_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // keysetCursorAfterCreatedAt builds a minimal well-formed cursor: one ordering
-// column plus the trailing row_id tiebreak validateKeysetTiebreak requires
+// column plus the trailing row_id tiebreak validateKeysetCursor requires
 // (#183). The values are inert — these tests assert routing, never row
 // selection, so no seeded row needs to match.
 func keysetCursorAfterCreatedAt() *model.KeysetCursor {
@@ -95,7 +95,7 @@ func TestQueryRejectsKeysetCursorWhenDuckDBDisabled(t *testing.T) {
 // TestQueryWithoutCursorStillServesPostgresOnly is the negative control: the
 // guard must key on an ACTIVE cursor only, so an absent cursor and an empty
 // column list (the open first page — the same no-op contract
-// validateKeysetTiebreak applies) both keep the Postgres-only path working.
+// validateKeysetCursor applies) both keep the Postgres-only path working.
 func TestQueryWithoutCursorStillServesPostgresOnly(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -2,6 +2,7 @@ package federated
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -10,111 +11,142 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateKeysetColumns_SystemColumnsSupported(t *testing.T) {
-	supportedColumns := []model.KeysetColumn{
-		{Attribute: "row_id", Direction: forma.SortOrderAsc},
-		{Attribute: "created_at", Direction: forma.SortOrderDesc},
-		{Attribute: "updated_at", Direction: forma.SortOrderAsc},
-		{Attribute: "deleted_at", Direction: forma.SortOrderAsc},
-		{Attribute: "ver_ts", Direction: forma.SortOrderDesc},
-		{Attribute: "deleted_ts", Direction: forma.SortOrderAsc},
-		{Attribute: "schema_id", Direction: forma.SortOrderAsc},
+func TestValidateKeysetCursor(t *testing.T) {
+	col := func(attr string) model.KeysetColumn {
+		return model.KeysetColumn{Attribute: attr, Direction: forma.SortOrderAsc}
+	}
+	cursorOn := func(attrs ...string) *model.KeysetCursor {
+		cols := make([]model.KeysetColumn, 0, len(attrs))
+		vals := make([]interface{}, 0, len(attrs))
+		for _, a := range attrs {
+			cols = append(cols, col(a))
+			vals = append(vals, "v")
+		}
+		return &model.KeysetCursor{Columns: cols, Values: vals, Mode: model.KeysetCursorModeAfter}
 	}
 
-	err := validateKeysetColumns(supportedColumns)
-	if err != nil {
-		t.Errorf("expected no error for supported columns, got: %v", err)
+	cases := []struct {
+		name    string
+		cursor  *model.KeysetCursor
+		wantErr string // "" means accepted
+	}{
+		// The four system columns the visible CTE actually projects.
+		{"row_id alone", cursorOn("row_id"), ""},
+		{"created_at then row_id", cursorOn("created_at", "row_id"), ""},
+		{"ver_ts then row_id", cursorOn("ver_ts", "row_id"), ""},
+		{"deleted_ts then row_id", cursorOn("deleted_ts", "row_id"), ""},
+
+		// Attribute columns: admitted, and the dotted form is the #260 case
+		// the old code emitted verbatim against a folded CTE column.
+		{"plain attribute", cursorOn("count", "row_id"), ""},
+		{"dotted attribute folds to a safe identifier", cursorOn("contact.annualIncome", "row_id"), ""},
+		{"spaced attribute folds to a safe identifier", cursorOn("annual income", "row_id"), ""},
+		{"bracketed attribute folds to a safe identifier", cursorOn("a[0]", "row_id"), ""},
+
+		// #381 amendment: the three names the old allowlist wrongly blessed are
+		// ordinary attribute names now. They are ACCEPTED here and fail at
+		// DuckDB's binder like any other unknown column — the false claim of
+		// support is what this change removes, not the acceptance.
+		{"updated_at is no longer blessed but is well-formed", cursorOn("updated_at", "row_id"), ""},
+		{"schema_id is no longer blessed but is well-formed", cursorOn("schema_id", "row_id"), ""},
+
+		// Dedup machinery: real columns of visible, never a caller's. The
+		// lookup folds first, so the punctuation that ParquetAttrColumn
+		// erases cannot smuggle a cursor onto the dedup rank.
+		{"rn is rejected", cursorOn("rn", "row_id"), `keyset cursor column "rn"`},
+		{"source_tier_priority is rejected", cursorOn("source_tier_priority", "row_id"),
+			`keyset cursor column "source_tier_priority"`},
+		{"dotted name folding onto source_tier_priority is rejected",
+			cursorOn("source_tier.priority", "row_id"), `keyset cursor column "source_tier.priority"`},
+		{"bracketed name folding onto rn is rejected", cursorOn("[rn]", "row_id"),
+			`keyset cursor column "[rn]"`},
+
+		// The ParquetAttrColumn fallback: every attribute the fold empties
+		// lands on the literal "attr", which would silently retarget the
+		// cursor at a real attribute of that name.
+		{"empty attribute is rejected", cursorOn("", "row_id"), `folds to the placeholder "attr"`},
+		{"bracket-only attribute is rejected", cursorOn("[]", "row_id"), `folds to the placeholder "attr"`},
+		{"backtick-only attribute is rejected", cursorOn("`", "row_id"), `folds to the placeholder "attr"`},
+		{"an attribute genuinely named attr is accepted", cursorOn("attr", "row_id"), ""},
+
+		// Injection barrier (#381 item 2).
+		{"quote is rejected", cursorOn(`a"b`, "row_id"), "is not a safe SQL identifier"},
+		{"semicolon is rejected", cursorOn("a;DROP TABLE t", "row_id"), "is not a safe SQL identifier"},
+		{"paren is rejected", cursorOn("count(*)", "row_id"), "is not a safe SQL identifier"},
+		{"leading digit is rejected", cursorOn("1st", "row_id"), "is not a safe SQL identifier"},
+
+		// Shape rules reach callers through this one entry point.
+		{"missing trailing row_id", cursorOn("created_at"), `expected "row_id"`},
+		{
+			"misaligned values",
+			&model.KeysetCursor{
+				Columns: []model.KeysetColumn{col("created_at"), col("row_id")},
+				Values:  []interface{}{"v"},
+				Mode:    model.KeysetCursorModeAfter,
+			},
+			"carries 2 column(s) but 1 value(s)",
+		},
+
+		// The open first page carries no obligation.
+		{"nil cursor", nil, ""},
+		{"empty cursor", &model.KeysetCursor{Mode: model.KeysetCursorModeAfter}, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateKeysetCursor(tc.cursor)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateKeysetCursor() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateKeysetCursor() = nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("validateKeysetCursor() = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+			if errors.Is(err, forma.ErrInvalidInput) {
+				t.Error("keyset validation is a read-path error, never a write-path ErrInvalidInput carrier")
+			}
+		})
 	}
 }
 
-func TestValidateKeysetColumns_EAVAttributeUnsupported(t *testing.T) {
-	unsupportedColumns := []model.KeysetColumn{
-		{Attribute: "created_at", Direction: forma.SortOrderDesc},
-		{Attribute: "user_email", Direction: forma.SortOrderAsc}, // EAV attribute
-		{Attribute: "row_id", Direction: forma.SortOrderAsc},
-	}
-
-	err := validateKeysetColumns(unsupportedColumns)
-	if err == nil {
-		t.Fatal("expected error for EAV attribute, got nil")
-	}
-
-	expectedMsg := "keyset pagination on attribute \"user_email\" is not supported"
-	if !strings.Contains(err.Error(), expectedMsg) {
-		t.Errorf("expected error message to contain %q, got: %v", expectedMsg, err)
-	}
-}
-
-func TestValidateKeysetColumns_EmptyColumnsValid(t *testing.T) {
-	err := validateKeysetColumns(nil)
-	if err != nil {
-		t.Errorf("expected no error for nil columns, got: %v", err)
-	}
-
-	err = validateKeysetColumns([]model.KeysetColumn{})
-	if err != nil {
-		t.Errorf("expected no error for empty columns, got: %v", err)
-	}
-}
-
-func TestValidateKeysetTiebreak_TrailingRowIDAccepted(t *testing.T) {
-	cursor := &model.KeysetCursor{
+// TestBothSeamsShareOneCursorValidator pins #381 item 1: the engine seam and
+// the paginated seam must refuse exactly the same cursors. Before this change
+// Query accepted arbitrary attribute columns that ExecuteFederatedPaginatedQuery
+// rejected, and neither checked value alignment.
+func TestBothSeamsShareOneCursorValidator(t *testing.T) {
+	bad := &model.KeysetCursor{
 		Columns: []model.KeysetColumn{
 			{Attribute: "created_at", Direction: forma.SortOrderDesc},
 			{Attribute: "row_id", Direction: forma.SortOrderAsc},
 		},
+		Values: []interface{}{int64(5)}, // one value short
+		Mode:   model.KeysetCursorModeAfter,
 	}
-	if err := validateKeysetTiebreak(cursor); err != nil {
-		t.Errorf("expected no error for cursor ending on row_id, got: %v", err)
+	tables := model.StorageTables{EntityMain: "main", EAVData: "eav"}
+	newQuery := func() *model.FederatedAttributeQuery {
+		return &model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10},
+			KeysetCursor:   bad,
+		}
 	}
-}
 
-func TestValidateKeysetTiebreak_RowIDOnlyAccepted(t *testing.T) {
-	cursor := &model.KeysetCursor{
-		Columns: []model.KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
-	}
-	if err := validateKeysetTiebreak(cursor); err != nil {
-		t.Errorf("expected no error for row_id-only cursor, got: %v", err)
-	}
-}
+	engine := NewDBFederatedQueryEngine(
+		&fakePostgresFederatedSource{page: &model.PersistentRecordPage{}},
+		nil, nil, nil, forma.DuckDBConfig{Enabled: true}, nil, "")
 
-func TestValidateKeysetTiebreak_MissingRowIDRejected(t *testing.T) {
-	cursor := &model.KeysetCursor{
-		Columns: []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}},
-	}
-	err := validateKeysetTiebreak(cursor)
-	if err == nil {
-		t.Fatal("expected error for cursor lacking trailing row_id, got nil")
-	}
-	// The message must name the offending column and the expected state.
-	if !strings.Contains(err.Error(), "created_at") {
-		t.Errorf("expected error to name the offending column %q, got: %v", "created_at", err)
-	}
-	if !strings.Contains(err.Error(), "row_id") {
-		t.Errorf("expected error to name the expected \"row_id\" tiebreak, got: %v", err)
-	}
-}
+	_, queryErr := engine.Query(context.Background(), tables, newQuery(), &model.FederatedQueryOptions{})
+	require.Error(t, queryErr, "engine seam must refuse a misaligned cursor")
+	require.Contains(t, queryErr.Error(), "carries 2 column(s) but 1 value(s)")
 
-func TestValidateKeysetTiebreak_NonTrailingRowIDRejected(t *testing.T) {
-	// row_id present but not last: the trailing "count" is still non-unique.
-	cursor := &model.KeysetCursor{
-		Columns: []model.KeysetColumn{
-			{Attribute: "row_id", Direction: forma.SortOrderAsc},
-			{Attribute: "created_at", Direction: forma.SortOrderDesc},
-		},
-	}
-	if err := validateKeysetTiebreak(cursor); err == nil {
-		t.Fatal("expected error when row_id is not the final column, got nil")
-	}
-}
-
-func TestValidateKeysetTiebreak_EmptyAndNilNoOp(t *testing.T) {
-	if err := validateKeysetTiebreak(nil); err != nil {
-		t.Errorf("expected no error for nil cursor, got: %v", err)
-	}
-	if err := validateKeysetTiebreak(&model.KeysetCursor{}); err != nil {
-		t.Errorf("expected no error for empty cursor, got: %v", err)
-	}
+	_, _, pageErr := engine.ExecuteFederatedPaginatedQuery(
+		context.Background(), tables, newQuery(), 10, 0, nil, &model.FederatedQueryOptions{})
+	require.Error(t, pageErr, "paginated seam must refuse the same cursor")
+	require.Contains(t, pageErr.Error(), "carries 2 column(s) but 1 value(s)")
 }
 
 // TestPaginatedQueryTakesKeysetPathOnCursorAlone pins #381 item 3. The keyset

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -217,7 +217,12 @@ func TestValidateKeysetCursorValueAndEnumShape(t *testing.T) {
 		{
 			"an unset mode is refused at the seam",
 			withValues("", forma.SortOrderDesc, int64(5), "r1"),
-			`keyset cursor mode is "", expected "after" or "before"`,
+			`keyset cursor mode is "", expected "after"`,
+		},
+		{
+			"a before cursor is refused at the seam until its backward window exists (#513)",
+			withValues(model.KeysetCursorModeBefore, forma.SortOrderDesc, int64(5), "r1"),
+			`keyset cursor mode is "before", which is not supported yet (#513)`,
 		},
 		{
 			"an unrecognised direction is refused at the seam",
@@ -226,7 +231,7 @@ func TestValidateKeysetCursorValueAndEnumShape(t *testing.T) {
 		},
 		{
 			"a fully specified cursor is admitted",
-			withValues(model.KeysetCursorModeBefore, forma.SortOrderDesc, int64(5), "r1"),
+			withValues(model.KeysetCursorModeAfter, forma.SortOrderDesc, int64(5), "r1"),
 			"",
 		},
 	})

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -189,6 +189,49 @@ func TestValidateKeysetCursorIdentifierAndShape(t *testing.T) {
 	})
 }
 
+// TestValidateKeysetCursorValueAndEnumShape pins that the seam validator
+// carries the shape rules that guard the RENDERER's defaults, not just the
+// ones that guard its column references: a nil boundary binds SQL NULL, an
+// unset Mode reads as "before", and an unrecognised Direction reads as
+// ascending. Each answers a successful page of the wrong rows. The rules live
+// in model.KeysetCursor.ValidateShape; these cases pin that they reach the
+// seams through it, and that a rejection stays a read-path error (the shared
+// runner asserts !errors.Is(err, forma.ErrInvalidInput) on every case).
+func TestValidateKeysetCursorValueAndEnumShape(t *testing.T) {
+	withValues := func(mode model.KeysetCursorMode, dir forma.SortOrder, values ...interface{}) *model.KeysetCursor {
+		return &model.KeysetCursor{
+			Columns: []model.KeysetColumn{
+				{Attribute: "created_at", Direction: dir},
+				{Attribute: "row_id", Direction: forma.SortOrderAsc},
+			},
+			Values: values,
+			Mode:   mode,
+		}
+	}
+	runKeysetCursorCases(t, []keysetCursorCase{
+		{
+			"a nil boundary value is refused at the seam",
+			withValues(model.KeysetCursorModeAfter, forma.SortOrderDesc, int64(5), nil),
+			`keyset cursor value 2 (for column "row_id") is nil`,
+		},
+		{
+			"an unset mode is refused at the seam",
+			withValues("", forma.SortOrderDesc, int64(5), "r1"),
+			`keyset cursor mode is "", expected "after" or "before"`,
+		},
+		{
+			"an unrecognised direction is refused at the seam",
+			withValues(model.KeysetCursorModeAfter, "sideways", int64(5), "r1"),
+			`keyset cursor column "created_at" has direction "sideways"`,
+		},
+		{
+			"a fully specified cursor is admitted",
+			withValues(model.KeysetCursorModeBefore, forma.SortOrderDesc, int64(5), "r1"),
+			"",
+		},
+	})
+}
+
 // TestBothSeamsShareOneCursorValidator pins #381 item 1: the engine seam and
 // the paginated seam must refuse exactly the same cursors. Before this change
 // Query accepted arbitrary attribute columns that ExecuteFederatedPaginatedQuery

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -11,115 +11,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateKeysetCursor(t *testing.T) {
-	col := func(attr string) model.KeysetColumn {
-		return model.KeysetColumn{Attribute: attr, Direction: forma.SortOrderAsc}
+// keysetCursorCase is one row of the cursor contract. The table is split
+// across the functions below by RULE FAMILY rather than kept as one list:
+// each family is a separate clause of validateKeysetCursor, and a failure
+// then names the clause that broke.
+type keysetCursorCase struct {
+	name    string
+	cursor  *model.KeysetCursor
+	wantErr string // "" means accepted
+}
+
+func keysetCol(attr string) model.KeysetColumn {
+	return model.KeysetColumn{Attribute: attr, Direction: forma.SortOrderAsc}
+}
+
+// keysetCursorOn builds an aligned, active cursor over the named columns, so
+// a case exercises the column rules rather than the shape rules.
+func keysetCursorOn(attrs ...string) *model.KeysetCursor {
+	cols := make([]model.KeysetColumn, 0, len(attrs))
+	vals := make([]interface{}, 0, len(attrs))
+	for _, a := range attrs {
+		cols = append(cols, keysetCol(a))
+		vals = append(vals, "v")
 	}
-	cursorOn := func(attrs ...string) *model.KeysetCursor {
-		cols := make([]model.KeysetColumn, 0, len(attrs))
-		vals := make([]interface{}, 0, len(attrs))
-		for _, a := range attrs {
-			cols = append(cols, col(a))
-			vals = append(vals, "v")
-		}
-		return &model.KeysetCursor{Columns: cols, Values: vals, Mode: model.KeysetCursorModeAfter}
-	}
+	return &model.KeysetCursor{Columns: cols, Values: vals, Mode: model.KeysetCursorModeAfter}
+}
 
-	cases := []struct {
-		name    string
-		cursor  *model.KeysetCursor
-		wantErr string // "" means accepted
-	}{
-		// The four system columns the visible CTE actually projects.
-		{"row_id alone", cursorOn("row_id"), ""},
-		{"created_at then row_id", cursorOn("created_at", "row_id"), ""},
-		{"ver_ts then row_id", cursorOn("ver_ts", "row_id"), ""},
-		{"deleted_ts then row_id", cursorOn("deleted_ts", "row_id"), ""},
-
-		// Attribute columns: admitted, and the dotted form is the #260 case
-		// the old code emitted verbatim against a folded CTE column.
-		{"plain attribute", cursorOn("count", "row_id"), ""},
-		{"dotted attribute folds to a safe identifier", cursorOn("contact.annualIncome", "row_id"), ""},
-		{"spaced attribute folds to a safe identifier", cursorOn("annual income", "row_id"), ""},
-		{"bracketed attribute folds to a safe identifier", cursorOn("a[0]", "row_id"), ""},
-
-		// #381 amendment: the three names the old allowlist wrongly blessed are
-		// ordinary attribute names now. They are ACCEPTED here and fail at
-		// DuckDB's binder like any other unknown column — the false claim of
-		// support is what this change removes, not the acceptance.
-		{"updated_at is no longer blessed but is well-formed", cursorOn("updated_at", "row_id"), ""},
-		{"schema_id is no longer blessed but is well-formed", cursorOn("schema_id", "row_id"), ""},
-
-		// Dedup machinery: real columns of visible, never a caller's. The
-		// lookup folds first, so the punctuation that ParquetAttrColumn
-		// erases cannot smuggle a cursor onto the dedup rank.
-		{"rn is rejected", cursorOn("rn", "row_id"), `keyset cursor column "rn"`},
-		{"source_tier_priority is rejected", cursorOn("source_tier_priority", "row_id"),
-			`keyset cursor column "source_tier_priority"`},
-		{"dotted name folding onto source_tier_priority is rejected",
-			cursorOn("source_tier.priority", "row_id"), `keyset cursor column "source_tier.priority"`},
-		{"bracketed name folding onto rn is rejected", cursorOn("[rn]", "row_id"),
-			`keyset cursor column "[rn]"`},
-
-		// Case is not a bypass. DuckDB resolves an unquoted identifier
-		// case-insensitively, so "RN" binds to the rn the ranked CTE
-		// projects exactly as "rn" does; the reject lookup therefore
-		// normalises case on the folded name.
-		{"upper-case RN is rejected", cursorOn("RN", "row_id"), `keyset cursor column "RN"`},
-		{"mixed-case Source_Tier_Priority is rejected", cursorOn("Source_Tier_Priority", "row_id"),
-			`keyset cursor column "Source_Tier_Priority"`},
-		{"bracketed upper-case name folding onto rn is rejected", cursorOn("[RN]", "row_id"),
-			`keyset cursor column "[RN]"`},
-		// The same normalisation on the system lookup: ROW_ID resolves to
-		// row_id in DuckDB, so it takes the system-column branch.
-		{"upper-case ROW_ID is accepted as a system column", cursorOn("ROW_ID", "row_id"), ""},
-
-		// The ParquetAttrColumn placeholder: an attribute the fold empties
-		// lands on the literal "attr", and so does one the fold merely strips
-		// down onto it — either would silently retarget the cursor at a real
-		// attribute of that name.
-		{"empty attribute is rejected", cursorOn("", "row_id"), `folds onto the placeholder "attr"`},
-		{"bracket-only attribute is rejected", cursorOn("[]", "row_id"), `folds onto the placeholder "attr"`},
-		{"backtick-only attribute is rejected", cursorOn("`", "row_id"), `folds onto the placeholder "attr"`},
-		{"a name stripping down onto the placeholder is rejected", cursorOn("[attr]", "row_id"),
-			`folds onto the placeholder "attr"`},
-		{"an attribute genuinely named attr is accepted", cursorOn("attr", "row_id"), ""},
-
-		// Case is not a bypass on the placeholder rule either: DuckDB resolves
-		// the emitted "Attr" to the same column as "attr", so a name that folds
-		// onto the placeholder in ANY casing is the same silent retarget.
-		{"bracketed mixed-case name folding onto the placeholder is rejected",
-			cursorOn("[Attr]", "row_id"), `folds onto the placeholder "Attr"`},
-		{"bracketed upper-case name folding onto the placeholder is rejected",
-			cursorOn("[ATTR]", "row_id"), `folds onto the placeholder "ATTR"`},
-		// The exemption is case-insensitive on both sides, so an attribute
-		// genuinely named "Attr" folds to its own name and stays accepted.
-		{"an attribute genuinely named Attr is accepted", cursorOn("Attr", "row_id"), ""},
-		{"an attribute genuinely named ATTR is accepted", cursorOn("ATTR", "row_id"), ""},
-
-		// Injection barrier (#381 item 2).
-		{"quote is rejected", cursorOn(`a"b`, "row_id"), "is not a safe SQL identifier"},
-		{"semicolon is rejected", cursorOn("a;DROP TABLE t", "row_id"), "is not a safe SQL identifier"},
-		{"paren is rejected", cursorOn("count(*)", "row_id"), "is not a safe SQL identifier"},
-		{"leading digit is rejected", cursorOn("1st", "row_id"), "is not a safe SQL identifier"},
-
-		// Shape rules reach callers through this one entry point.
-		{"missing trailing row_id", cursorOn("created_at"), `expected "row_id"`},
-		{
-			"misaligned values",
-			&model.KeysetCursor{
-				Columns: []model.KeysetColumn{col("created_at"), col("row_id")},
-				Values:  []interface{}{"v"},
-				Mode:    model.KeysetCursorModeAfter,
-			},
-			"carries 2 column(s) but 1 value(s)",
-		},
-
-		// The open first page carries no obligation.
-		{"nil cursor", nil, ""},
-		{"empty cursor", &model.KeysetCursor{Mode: model.KeysetCursorModeAfter}, ""},
-	}
-
+func runKeysetCursorCases(t *testing.T, cases []keysetCursorCase) {
+	t.Helper()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validateKeysetCursor(tc.cursor)
@@ -140,6 +59,134 @@ func TestValidateKeysetCursor(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateKeysetCursorSystemColumns pins the system-column clause: the
+// four columns the visible CTE actually projects, admitted under their own
+// name in any casing and by no other route.
+func TestValidateKeysetCursorSystemColumns(t *testing.T) {
+	runKeysetCursorCases(t, []keysetCursorCase{
+		{"row_id alone", keysetCursorOn("row_id"), ""},
+		{"created_at then row_id", keysetCursorOn("created_at", "row_id"), ""},
+		{"ver_ts then row_id", keysetCursorOn("ver_ts", "row_id"), ""},
+		{"deleted_ts then row_id", keysetCursorOn("deleted_ts", "row_id"), ""},
+
+		// DuckDB resolves an unquoted identifier case-insensitively, so
+		// ROW_ID reaches the very column row_id does: it takes the
+		// system-column branch, and it is the trailing tiebreak the shape
+		// rule reaches first.
+		{"upper-case ROW_ID is accepted as a system column", keysetCursorOn("ROW_ID", "row_id"), ""},
+		{"upper-case ROW_ID is accepted as the trailing tiebreak", keysetCursorOn("created_at", "ROW_ID"), ""},
+		{"upper-case ROW_ID alone is accepted", keysetCursorOn("ROW_ID"), ""},
+		{"mixed-case Created_At is accepted as a system column", keysetCursorOn("Created_At", "row_id"), ""},
+
+		// Case is the whole of that latitude. A name the fold TRANSFORMS onto
+		// one of the four — "created.at" onto created_at — is refused: the
+		// generator would emit the real system column and answer a page
+		// ordered and filtered on a key the caller never named. Schema
+		// registration cannot stand in for this check, because a cursor
+		// column is an arbitrary string that was never registered.
+		{"dotted name folding onto created_at is rejected", keysetCursorOn("created.at", "row_id"),
+			`keyset cursor column "created.at"`},
+		{"dotted name folding onto ver_ts is rejected", keysetCursorOn("ver.ts", "row_id"),
+			`keyset cursor column "ver.ts"`},
+		{"dotted name folding onto deleted_ts is rejected", keysetCursorOn("deleted.ts", "row_id"),
+			`keyset cursor column "deleted.ts"`},
+		{"bracketed name folding onto row_id is rejected", keysetCursorOn("[row_id]", "row_id"),
+			`keyset cursor column "[row_id]"`},
+		{"spaced name folding onto created_at is rejected", keysetCursorOn("created at", "row_id"),
+			`keyset cursor column "created at"`},
+	})
+}
+
+// TestValidateKeysetCursorAdmitsAttributes pins what an ordinary schema
+// attribute may be, including the dotted form (#260) the old code emitted
+// verbatim against a folded CTE column.
+func TestValidateKeysetCursorAdmitsAttributes(t *testing.T) {
+	runKeysetCursorCases(t, []keysetCursorCase{
+		{"plain attribute", keysetCursorOn("count", "row_id"), ""},
+		{"dotted attribute folds to a safe identifier", keysetCursorOn("contact.annualIncome", "row_id"), ""},
+		{"spaced attribute folds to a safe identifier", keysetCursorOn("annual income", "row_id"), ""},
+		{"bracketed attribute folds to a safe identifier", keysetCursorOn("a[0]", "row_id"), ""},
+
+		// #381 amendment: the three names the old allowlist wrongly blessed are
+		// ordinary attribute names now. They are ACCEPTED here and fail at
+		// DuckDB's binder like any other unknown column — the false claim of
+		// support is what this change removes, not the acceptance.
+		{"updated_at is no longer blessed but is well-formed", keysetCursorOn("updated_at", "row_id"), ""},
+		{"schema_id is no longer blessed but is well-formed", keysetCursorOn("schema_id", "row_id"), ""},
+	})
+}
+
+// TestValidateKeysetCursorRejectsDedupMachinery pins the reject set: real
+// columns of visible, never a caller's, on which a cursor would bind and then
+// paginate over the dedup rank. The lookup folds and lower-cases first, so
+// neither punctuation nor the shift key is a bypass.
+func TestValidateKeysetCursorRejectsDedupMachinery(t *testing.T) {
+	runKeysetCursorCases(t, []keysetCursorCase{
+		{"rn is rejected", keysetCursorOn("rn", "row_id"), `keyset cursor column "rn"`},
+		{"source_tier_priority is rejected", keysetCursorOn("source_tier_priority", "row_id"),
+			`keyset cursor column "source_tier_priority"`},
+		{"dotted name folding onto source_tier_priority is rejected",
+			keysetCursorOn("source_tier.priority", "row_id"), `keyset cursor column "source_tier.priority"`},
+		{"bracketed name folding onto rn is rejected", keysetCursorOn("[rn]", "row_id"),
+			`keyset cursor column "[rn]"`},
+		{"upper-case RN is rejected", keysetCursorOn("RN", "row_id"), `keyset cursor column "RN"`},
+		{"mixed-case Source_Tier_Priority is rejected", keysetCursorOn("Source_Tier_Priority", "row_id"),
+			`keyset cursor column "Source_Tier_Priority"`},
+		{"bracketed upper-case name folding onto rn is rejected", keysetCursorOn("[RN]", "row_id"),
+			`keyset cursor column "[RN]"`},
+	})
+}
+
+// TestValidateKeysetCursorPlaceholder pins the ParquetAttrColumn placeholder
+// rule: an attribute the fold empties lands on the literal "attr", and so does
+// one the fold merely strips down onto it — either would silently retarget the
+// cursor at a real attribute of that name. The exemption for an attribute
+// genuinely named attr is folded and case-insensitive on both sides.
+func TestValidateKeysetCursorPlaceholder(t *testing.T) {
+	runKeysetCursorCases(t, []keysetCursorCase{
+		{"empty attribute is rejected", keysetCursorOn("", "row_id"), `folds onto the placeholder "attr"`},
+		{"bracket-only attribute is rejected", keysetCursorOn("[]", "row_id"), `folds onto the placeholder "attr"`},
+		{"backtick-only attribute is rejected", keysetCursorOn("`", "row_id"), `folds onto the placeholder "attr"`},
+		{"a name stripping down onto the placeholder is rejected", keysetCursorOn("[attr]", "row_id"),
+			`folds onto the placeholder "attr"`},
+		{"an attribute genuinely named attr is accepted", keysetCursorOn("attr", "row_id"), ""},
+
+		{"bracketed mixed-case name folding onto the placeholder is rejected",
+			keysetCursorOn("[Attr]", "row_id"), `folds onto the placeholder "Attr"`},
+		{"bracketed upper-case name folding onto the placeholder is rejected",
+			keysetCursorOn("[ATTR]", "row_id"), `folds onto the placeholder "ATTR"`},
+		{"an attribute genuinely named Attr is accepted", keysetCursorOn("Attr", "row_id"), ""},
+		{"an attribute genuinely named ATTR is accepted", keysetCursorOn("ATTR", "row_id"), ""},
+	})
+}
+
+// TestValidateKeysetCursorIdentifierAndShape pins the injection barrier
+// (#381 item 2) and the model-level shape rules, which reach callers through
+// this one entry point.
+func TestValidateKeysetCursorIdentifierAndShape(t *testing.T) {
+	runKeysetCursorCases(t, []keysetCursorCase{
+		{"quote is rejected", keysetCursorOn(`a"b`, "row_id"), "is not a safe SQL identifier"},
+		{"semicolon is rejected", keysetCursorOn("a;DROP TABLE t", "row_id"), "is not a safe SQL identifier"},
+		{"paren is rejected", keysetCursorOn("count(*)", "row_id"), "is not a safe SQL identifier"},
+		{"leading digit is rejected", keysetCursorOn("1st", "row_id"), "is not a safe SQL identifier"},
+
+		{"missing trailing row_id", keysetCursorOn("created_at"), `expected "row_id"`},
+		{
+			"misaligned values",
+			&model.KeysetCursor{
+				Columns: []model.KeysetColumn{keysetCol("created_at"), keysetCol("row_id")},
+				Values:  []interface{}{"v"},
+				Mode:    model.KeysetCursorModeAfter,
+			},
+			"carries 2 column(s) but 1 value(s)",
+		},
+
+		// The open first page carries no obligation.
+		{"nil cursor", nil, ""},
+		{"empty cursor", &model.KeysetCursor{Mode: model.KeysetCursorModeAfter}, ""},
+	})
 }
 
 // TestBothSeamsShareOneCursorValidator pins #381 item 1: the engine seam and

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -1,12 +1,13 @@
 package federated
 
 import (
+	"context"
 	"strings"
 	"testing"
 
-	"github.com/lychee-technology/forma/internal/model"
-
 	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateKeysetColumns_SystemColumnsSupported(t *testing.T) {
@@ -114,4 +115,40 @@ func TestValidateKeysetTiebreak_EmptyAndNilNoOp(t *testing.T) {
 	if err := validateKeysetTiebreak(&model.KeysetCursor{}); err != nil {
 		t.Errorf("expected no error for empty cursor, got: %v", err)
 	}
+}
+
+// TestPaginatedQueryTakesKeysetPathOnCursorAlone pins #381 item 3. The keyset
+// branch used to require opts.KeysetEnabled as well as a cursor; with the flag
+// unset, control fell into the in-memory merge, where RunOptimizedQuery
+// applies no cursor while the DuckDB leg does (the renderer keys off
+// q.KeysetCursor, never off the flag). The merged page was then
+// hot-rows-unfiltered union cold-rows-filtered — the same silent-wrong-answer
+// family as #354. An active cursor alone now selects the keyset path.
+func TestPaginatedQueryTakesKeysetPathOnCursorAlone(t *testing.T) {
+	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{}}
+	engine := NewDBFederatedQueryEngine(pg, nil, nil, nil, forma.DuckDBConfig{Enabled: true}, nil, "")
+
+	fq := &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10},
+		KeysetCursor: &model.KeysetCursor{
+			Columns: []model.KeysetColumn{
+				{Attribute: "created_at", Direction: forma.SortOrderDesc},
+				// No trailing row_id: the keyset path validates and refuses,
+				// while the in-memory merge path would have run happily. The
+				// refusal is therefore proof of which branch was taken,
+				// without needing a live DuckDB.
+			},
+			Values: []interface{}{int64(5)},
+			Mode:   model.KeysetCursorModeAfter,
+		},
+	}
+
+	_, _, err := engine.ExecuteFederatedPaginatedQuery(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav"},
+		fq, 10, 0, nil, &model.FederatedQueryOptions{})
+
+	require.Error(t, err, "an active cursor alone must select the keyset path")
+	require.Contains(t, err.Error(), `expected "row_id"`)
+	require.Zero(t, pg.runOptimizedCalls,
+		"the keyset path runs, not the in-memory merge path which calls RunOptimizedQuery")
 }

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -41,7 +41,7 @@ func runKeysetCursorCases(t *testing.T, cases []keysetCursorCase) {
 	t.Helper()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateKeysetCursor(tc.cursor)
+			err := validateKeysetCursor(tc.cursor, nil)
 			if tc.wantErr == "" {
 				if err != nil {
 					t.Fatalf("validateKeysetCursor() = %v, want nil", err)

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -61,12 +61,28 @@ func TestValidateKeysetCursor(t *testing.T) {
 		{"bracketed name folding onto rn is rejected", cursorOn("[rn]", "row_id"),
 			`keyset cursor column "[rn]"`},
 
-		// The ParquetAttrColumn fallback: every attribute the fold empties
-		// lands on the literal "attr", which would silently retarget the
-		// cursor at a real attribute of that name.
-		{"empty attribute is rejected", cursorOn("", "row_id"), `folds to the placeholder "attr"`},
-		{"bracket-only attribute is rejected", cursorOn("[]", "row_id"), `folds to the placeholder "attr"`},
-		{"backtick-only attribute is rejected", cursorOn("`", "row_id"), `folds to the placeholder "attr"`},
+		// Case is not a bypass. DuckDB resolves an unquoted identifier
+		// case-insensitively, so "RN" binds to the rn the ranked CTE
+		// projects exactly as "rn" does; the reject lookup therefore
+		// normalises case on the folded name.
+		{"upper-case RN is rejected", cursorOn("RN", "row_id"), `keyset cursor column "RN"`},
+		{"mixed-case Source_Tier_Priority is rejected", cursorOn("Source_Tier_Priority", "row_id"),
+			`keyset cursor column "Source_Tier_Priority"`},
+		{"bracketed upper-case name folding onto rn is rejected", cursorOn("[RN]", "row_id"),
+			`keyset cursor column "[RN]"`},
+		// The same normalisation on the system lookup: ROW_ID resolves to
+		// row_id in DuckDB, so it takes the system-column branch.
+		{"upper-case ROW_ID is accepted as a system column", cursorOn("ROW_ID", "row_id"), ""},
+
+		// The ParquetAttrColumn placeholder: an attribute the fold empties
+		// lands on the literal "attr", and so does one the fold merely strips
+		// down onto it — either would silently retarget the cursor at a real
+		// attribute of that name.
+		{"empty attribute is rejected", cursorOn("", "row_id"), `folds onto the placeholder "attr"`},
+		{"bracket-only attribute is rejected", cursorOn("[]", "row_id"), `folds onto the placeholder "attr"`},
+		{"backtick-only attribute is rejected", cursorOn("`", "row_id"), `folds onto the placeholder "attr"`},
+		{"a name stripping down onto the placeholder is rejected", cursorOn("[attr]", "row_id"),
+			`folds onto the placeholder "attr"`},
 		{"an attribute genuinely named attr is accepted", cursorOn("attr", "row_id"), ""},
 
 		// Injection barrier (#381 item 2).

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -85,6 +85,18 @@ func TestValidateKeysetCursor(t *testing.T) {
 			`folds onto the placeholder "attr"`},
 		{"an attribute genuinely named attr is accepted", cursorOn("attr", "row_id"), ""},
 
+		// Case is not a bypass on the placeholder rule either: DuckDB resolves
+		// the emitted "Attr" to the same column as "attr", so a name that folds
+		// onto the placeholder in ANY casing is the same silent retarget.
+		{"bracketed mixed-case name folding onto the placeholder is rejected",
+			cursorOn("[Attr]", "row_id"), `folds onto the placeholder "Attr"`},
+		{"bracketed upper-case name folding onto the placeholder is rejected",
+			cursorOn("[ATTR]", "row_id"), `folds onto the placeholder "ATTR"`},
+		// The exemption is case-insensitive on both sides, so an attribute
+		// genuinely named "Attr" folds to its own name and stays accepted.
+		{"an attribute genuinely named Attr is accepted", cursorOn("Attr", "row_id"), ""},
+		{"an attribute genuinely named ATTR is accepted", cursorOn("ATTR", "row_id"), ""},
+
 		// Injection barrier (#381 item 2).
 		{"quote is rejected", cursorOn(`a"b`, "row_id"), "is not a safe SQL identifier"},
 		{"semicolon is rejected", cursorOn("a;DROP TABLE t", "row_id"), "is not a safe SQL identifier"},

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -242,10 +242,12 @@ func (e *DBFederatedQueryEngine) computeFederatedCount(
 ) (int64, error) {
 	strippedQuery := *fq
 	strippedQuery.KeysetCursor = nil
-	// The advanced template renders LIMIT/OFFSET from the query object, not
-	// from the call parameters (injectDuckDBTemplateParams), so the count
-	// query must zero the pagination on the copy — otherwise a deep offset
-	// re-renders into the recount and it streams zero rows again (#181).
+	// The pagination on the copy is now redundant with dispatchedQuery, which
+	// renders every DuckDB query with the arguments it was dispatched with;
+	// it stays so this copy reads as the query it is — a limit-1 recount with
+	// no offset. Before that helper, the copy was the only thing keeping a
+	// deep offset out of the recount, which otherwise streamed zero rows
+	// again (#181).
 	strippedQuery.Limit = 1
 	strippedQuery.Offset = 0
 

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -33,7 +33,13 @@ func (e *DBFederatedQueryEngine) ExecuteFederatedPaginatedQuery(
 		offset = 0
 	}
 
-	if opts != nil && opts.KeysetEnabled && hasKeysetCursor(fq) {
+	// An ACTIVE CURSOR ALONE selects the keyset path (#381 item 3). The
+	// retired opts.KeysetEnabled conjunct meant a cursor with the flag unset
+	// fell into the in-memory merge below, where the Postgres leg applies no
+	// cursor while the DuckDB leg does — a half-filtered page. The flag had no
+	// config wiring and was never read by the production entry point, so it
+	// was deleted rather than made symmetric.
+	if hasKeysetCursor(fq) {
 		return e.executeFederatedKeysetQuery(ctx, tables, fq, limit, attributeOrders, opts)
 	}
 

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -172,7 +172,7 @@ func (e *DBFederatedQueryEngine) executeFederatedKeysetQuery(
 	// The DuckDB template below consumes the cursor unvalidated, so refuse a
 	// malformed one here. Same call as the engine gate (engine.go): one
 	// contract, both seams (#381).
-	if err := validateKeysetCursor(fq.KeysetCursor); err != nil {
+	if err := validateKeysetCursor(fq.KeysetCursor, attributeOrders); err != nil {
 		return nil, 0, fmt.Errorf("validate keyset cursor: %w", err)
 	}
 

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -169,16 +169,11 @@ func (e *DBFederatedQueryEngine) executeFederatedKeysetQuery(
 	attributeOrders []model.AttributeOrder,
 	opts *model.FederatedQueryOptions,
 ) ([]*model.PersistentRecord, int64, error) {
-	// Validate keyset cursor columns are supported and end on the row_id
-	// tiebreak (#183): an unsupported column or a missing trailing row_id would
-	// otherwise be consumed silently by the DuckDB template below.
-	if fq.KeysetCursor != nil {
-		if err := validateKeysetColumns(fq.KeysetCursor.Columns); err != nil {
-			return nil, 0, err
-		}
-		if err := validateKeysetTiebreak(fq.KeysetCursor); err != nil {
-			return nil, 0, err
-		}
+	// The DuckDB template below consumes the cursor unvalidated, so refuse a
+	// malformed one here. Same call as the engine gate (engine.go): one
+	// contract, both seams (#381).
+	if err := validateKeysetCursor(fq.KeysetCursor); err != nil {
+		return nil, 0, fmt.Errorf("validate keyset cursor: %w", err)
 	}
 
 	maxRows := model.FederatedMaxRows

--- a/internal/federated/pagination_limit_test.go
+++ b/internal/federated/pagination_limit_test.go
@@ -1,0 +1,86 @@
+package federated
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPaginatedKeysetQueryDispatchesTheEffectiveLimit pins that the keyset
+// branch of ExecuteFederatedPaginatedQuery renders the limit it normalised and
+// clamped, not the caller's fq.Limit (#381 review). The advanced template
+// reads LIMIT/OFFSET from the query object, so before dispatchedQuery a zero
+// fq.Limit rendered LIMIT 0 and an over-MaxRows one rendered verbatim, with
+// only the in-memory slice honouring the clamp. The captured query is the one
+// the builder received, i.e. what renders.
+func TestPaginatedKeysetQueryDispatchesTheEffectiveLimit(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	cases := []struct {
+		name      string
+		fqLimit   int
+		argLimit  int
+		maxRows   int
+		wantLimit int
+	}{
+		{"a zero fq.Limit renders the default page size, not LIMIT 0", 0, 0, 0, model.DefaultPageSize},
+		{"an over-MaxRows fq.Limit renders the clamp", 5000, 5000, 100, 100},
+		{"the argument wins over a differing fq.Limit", 3, 25, 0, 25},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var built []model.FederatedAttributeQuery
+			engine := newEmptyPageTestEngine(t, &fakePostgresFederatedSource{}, &sequencedDuckDBExecutor{}, &built)
+			fq := &model.FederatedAttributeQuery{
+				// A stale Offset proves the keyset dispatch zeroes it too.
+				AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: tc.fqLimit, Offset: 30},
+				PreferredTiers: []model.DataTier{model.DataTierHot, model.DataTierWarm, model.DataTierCold},
+				KeysetCursor: &model.KeysetCursor{
+					Columns: []model.KeysetColumn{
+						{Attribute: "created_at", Direction: forma.SortOrderDesc},
+						{Attribute: "row_id", Direction: forma.SortOrderAsc},
+					},
+					Values: []interface{}{int64(5), "r1"},
+					Mode:   model.KeysetCursorModeAfter,
+				},
+			}
+
+			_, _, err := engine.ExecuteFederatedPaginatedQuery(context.Background(),
+				model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+				fq, tc.argLimit, 0, nil, &model.FederatedQueryOptions{MaxRows: tc.maxRows})
+			require.NoError(t, err)
+
+			require.GreaterOrEqual(t, len(built), 2, "the keyset page and its count are both rendered")
+			page := built[0]
+			require.Equal(t, tc.wantLimit, page.Limit, "the page renders the effective limit")
+			require.Zero(t, page.Offset, "a keyset page has no offset")
+			require.True(t, page.KeysetCursor.IsActive(), "the page keeps its cursor")
+			require.Equal(t, 1, built[1].Limit, "the recount renders LIMIT 1")
+			require.Nil(t, built[1].KeysetCursor, "the recount strips the cursor")
+			require.Equal(t, tc.fqLimit, fq.Limit, "the caller's query is not mutated")
+			require.Equal(t, 30, fq.Offset, "the caller's query is not mutated")
+		})
+	}
+}
+
+// TestDispatchedQueryCopiesThePaginationArguments pins the helper itself:
+// the copy carries the arguments, the original is untouched, and a nil query
+// stays nil.
+func TestDispatchedQueryCopiesThePaginationArguments(t *testing.T) {
+	orders := []model.AttributeOrder{{AttrID: 3, AttrName: "count", SortOrder: forma.SortOrderAsc}}
+	q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 0, Offset: 40}}
+
+	page := dispatchedQuery(q, 25, 0, orders)
+	require.Equal(t, 25, page.Limit)
+	require.Zero(t, page.Offset)
+	require.Equal(t, orders, page.AttributeOrders)
+	require.Equal(t, int16(7), page.SchemaID)
+	require.Zero(t, q.Limit, "the original is not mutated")
+	require.Equal(t, 40, q.Offset, "the original is not mutated")
+	require.Nil(t, dispatchedQuery(nil, 25, 0, nil))
+}

--- a/internal/federated/routing_hotonly_test.go
+++ b/internal/federated/routing_hotonly_test.go
@@ -1,0 +1,98 @@
+package federated
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHotOnlyHeuristicStaysPreferHotOnly pins #381 item 5. applyStrategyHeuristics
+// uses a LOCAL hotOnly that means PreferHot only, deliberately narrower than the
+// shared isHotOnlyRequest (which also counts PreferredTiers == [hot]). The
+// asymmetry is correct but was guarded only by a comment: a mutation widening
+// hotOnly survived the whole package during the #354 review, because nothing
+// pinned the shape it would change.
+//
+// This is that shape. Under freshness-first and cost-first with a high scan-size
+// threshold, a cursor-free request with PreferredTiers == [hot] and PreferHot false
+// hits no strategy branch, so UseDuckDB keeps the default cfg.Enabled and Reason
+// stays "default". Widening hotOnly to include PreferredTiers == [hot] would force
+// UseDuckDB to false and reroute the query.
+func TestHotOnlyHeuristicStaysPreferHotOnly(t *testing.T) {
+	for _, strategy := range []forma.RoutingStrategy{
+		forma.RoutingStrategyFreshnessFirst,
+		forma.RoutingStrategyCostFirst,
+	} {
+		t.Run(string(strategy), func(t *testing.T) {
+			cfg := forma.DuckDBConfig{Enabled: true}
+			cfg.Routing.Strategy = strategy
+			cfg.Routing.MaxDuckDBScanRows = 100000 // High threshold ensures no scan-size branch fires
+
+			dec := EvaluateRoutingPolicy(cfg, &model.FederatedAttributeQuery{
+				AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10},
+				PreferredTiers: []model.DataTier{model.DataTierHot},
+			}, nil)
+
+			require.True(t, dec.UseDuckDB,
+				"PreferredTiers:[hot] without PreferHot must not trip the strategy hot-only branch")
+			require.Equal(t, "default", dec.Reason,
+				"no strategy branch fires for hot-only without PreferHot; widening the local hotOnly would change this and reroute cursor-free queries")
+
+			decPreferHot := EvaluateRoutingPolicy(cfg, &model.FederatedAttributeQuery{
+				AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10},
+				PreferHot:      true,
+			}, nil)
+			require.False(t, decPreferHot.UseDuckDB,
+				"PreferHot is what the strategy heuristics react to")
+			expectedReason := map[forma.RoutingStrategy]string{
+				forma.RoutingStrategyFreshnessFirst: "prefer hot",
+				forma.RoutingStrategyCostFirst:      "cost-first prefer hot",
+			}[strategy]
+			require.Equal(t, expectedReason, decPreferHot.Reason,
+				"PreferHot triggers the strategy-specific hot-only branch")
+		})
+	}
+}
+
+// TestEvaluateRoutingPolicyDisagreesWithEngineOnHotOnlyCursor pins #381 item 8.
+// For PreferredTiers == [hot] plus a cursor, the exported EvaluateRoutingPolicy
+// answers UseDuckDB: true. engine.Query on the same input answers the opposite:
+// the isHotOnlyRequest gate intercepts before the policy runs, routes to the
+// postgres-only path, and that path refuses the cursor.
+//
+// There is no live bug — the gate dominates every reachable path — but the
+// exported contract genuinely disagrees with the engine, and a standalone
+// caller of the exported function must know it. Pinned so the disagreement is
+// a documented decision rather than a discovery.
+func TestEvaluateRoutingPolicyDisagreesWithEngineOnHotOnlyCursor(t *testing.T) {
+	cfg := forma.DuckDBConfig{Enabled: true}
+	cfg.Routing.Strategy = forma.RoutingStrategyFreshnessFirst
+	opts := &model.FederatedQueryOptions{}
+
+	newQuery := func() *model.FederatedAttributeQuery {
+		return &model.FederatedAttributeQuery{
+			AttributeQuery: model.AttributeQuery{SchemaID: 7, Limit: 10},
+			PreferredTiers: []model.DataTier{model.DataTierHot},
+			KeysetCursor:   keysetCursorAfterCreatedAt(),
+		}
+	}
+
+	dec := EvaluateRoutingPolicy(cfg, newQuery(), opts)
+	require.True(t, dec.UseDuckDB,
+		"the exported policy says the federated path serves this cursor")
+
+	pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{}}
+	engine := NewDBFederatedQueryEngine(pg, nil, nil, nil, cfg, nil, "")
+	page, err := engine.Query(context.Background(),
+		model.StorageTables{EntityMain: "main", EAVData: "eav"},
+		newQuery(), opts)
+
+	require.Nil(t, page)
+	require.ErrorIs(t, err, ErrKeysetUnsupportedOnPostgres,
+		"the engine says the opposite for the same input: the hot-only gate reaches postgres-only, which cannot apply a cursor")
+	require.Zero(t, pg.queryCalls,
+		"fail closed: postgres must not be queried at all, or the engine pays for a page the caller must never see")
+}

--- a/internal/model/keyset.go
+++ b/internal/model/keyset.go
@@ -71,8 +71,28 @@ func (c *KeysetCursor) IsActive() bool {
 //     is unknown, so WHERE drops every disjunct carrying it. The caller gets a
 //     silently empty or short page — item 1's failure with the count right.
 //
+//  4. Mode must be one of the two modes. `keysetComparisonOp` computes
+//     `mode == KeysetCursorModeAfter`, so ANY other value — the zero value most
+//     of all — means BEFORE, and a cursor that lost its mode paginates
+//     backwards while answering successfully.
+//
+//  5. Each column's Direction must be asc, desc, or empty. The renderer treats
+//     everything that is not desc as ascending, so an unrecognised direction
+//     paginates against its own ORDER BY. Empty is admitted because asc is the
+//     documented default of this repository's sort surface
+//     (internal.normalizeSortOrder), and the renderer already agrees with it.
+//
+// Rules 4 and 5 compare BYTE-EXACTLY, unlike rule 2's case-insensitive
+// row_id. That is not an inconsistency: rule 2 governs a SQL identifier, which
+// DuckDB resolves without regard to case, so "ROW_ID" IS row_id. A mode and a
+// direction are Go constants that never reach SQL as text, and the renderer
+// compares them exactly — admitting "DESC" here would hand the renderer a
+// spelling it reads as ascending, reinstating the silent default this rule
+// exists to remove. A future decode boundary that accepts caller spellings
+// normalizes them before building the cursor, as normalizeSortOrder does.
+//
 // An inactive cursor is a no-op: the open first page carries no continuation
-// obligation, and nothing renders from it — no values to bind.
+// obligation, and nothing renders from it — no values, no mode, no directions.
 //
 // A plain read-path error, not an ErrInvalidInput-wrapped write-path
 // validation carrier.
@@ -85,6 +105,12 @@ func (c *KeysetCursor) ValidateShape() error {
 			len(c.Columns), len(c.Values))
 	}
 	if err := c.validateBoundaryValues(); err != nil {
+		return err
+	}
+	if err := c.validateDirections(); err != nil {
+		return err
+	}
+	if err := c.validateMode(); err != nil {
 		return err
 	}
 	last := c.Columns[len(c.Columns)-1].Attribute
@@ -122,5 +148,32 @@ func isNilBoundary(v interface{}) bool {
 		return rv.IsNil()
 	default:
 		return false
+	}
+}
+
+// validateDirections refuses a direction the renderer would read as ascending
+// without being told to (rule 5).
+func (c *KeysetCursor) validateDirections() error {
+	for _, col := range c.Columns {
+		switch col.Direction {
+		case "", forma.SortOrderAsc, forma.SortOrderDesc:
+			continue
+		default:
+			return fmt.Errorf("keyset cursor column %q has direction %q, expected \"asc\", \"desc\" or empty (asc): the renderer reads every other value as ascending, so the cursor would page against its own ORDER BY and answer successfully",
+				col.Attribute, col.Direction)
+		}
+	}
+	return nil
+}
+
+// validateMode refuses a mode the renderer would read as before without being
+// told to (rule 4), the zero value included.
+func (c *KeysetCursor) validateMode() error {
+	switch c.Mode {
+	case KeysetCursorModeAfter, KeysetCursorModeBefore:
+		return nil
+	default:
+		return fmt.Errorf("keyset cursor mode is %q, expected \"after\" or \"before\": the renderer reads every other value — an unset mode above all — as \"before\", so a cursor that lost its mode paginates backwards and still answers successfully",
+			c.Mode)
 	}
 }

--- a/internal/model/keyset.go
+++ b/internal/model/keyset.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/lychee-technology/forma"
 )
@@ -47,12 +48,22 @@ func (c *KeysetCursor) IsActive() bool {
 //     treats that as not-true, and every disjunct carrying the arm drops out,
 //     so the caller received a SILENTLY EMPTY PAGE rather than an error
 //     (#381 item 7).
+//
 //  2. The final column must be row_id. The continuation predicate for the last
 //     cursor key is a strict inequality, so a cursor ending on a non-unique key
 //     excludes every row sharing that key's value at the page boundary — an
 //     entire tie group is silently skipped (#183). row_id is the only
 //     version-invariant unique column, so ending there gives the composite key
 //     a total order.
+//
+//     The comparison is case-insensitive because DuckDB resolves an unquoted
+//     identifier without regard to case: an emitted "ROW_ID" reaches the very
+//     column "row_id" does, so it IS the tiebreak and refusing it would
+//     contradict the case-insensitive system-column rule the federated
+//     validator applies one layer up (#381). It is case-insensitive and
+//     nothing more — a name that merely FOLDS onto row_id, like "row.id", is
+//     not the tiebreak and is refused here, matching that validator's refusal
+//     of any non-identity fold onto a system column.
 //
 // An inactive cursor is a no-op: the open first page carries no continuation
 // obligation, and nothing renders from it.
@@ -68,7 +79,7 @@ func (c *KeysetCursor) ValidateShape() error {
 			len(c.Columns), len(c.Values))
 	}
 	last := c.Columns[len(c.Columns)-1].Attribute
-	if last != "row_id" {
+	if !strings.EqualFold(last, "row_id") {
 		return fmt.Errorf("keyset cursor final column is %q, expected \"row_id\": a cursor not ending on the unique row_id tiebreak silently skips every row tied on the composite key at the page boundary", last)
 	}
 	return nil

--- a/internal/model/keyset.go
+++ b/internal/model/keyset.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/lychee-technology/forma"
+)
+
+type KeysetCursorMode string
+
+const (
+	KeysetCursorModeAfter  KeysetCursorMode = "after"
+	KeysetCursorModeBefore KeysetCursorMode = "before"
+)
+
+type KeysetColumn struct {
+	Attribute string
+	Direction forma.SortOrder
+}
+
+type KeysetCursor struct {
+	Columns []KeysetColumn
+	Values  []interface{}
+	Mode    KeysetCursorMode
+}
+
+// IsActive reports whether this cursor carries a continuation obligation.
+// A nil cursor or one with no columns is the OPEN FIRST PAGE: nothing to
+// filter, nothing to refuse.
+//
+// This predicate lives on the type rather than in internal/federated because
+// the sites that decide whether the keyset clause is RENDERED live in
+// internal/sqlgen (duckdb_template_renderer.go, duckdb_compiled_query.go) and
+// cannot reach an unexported federated helper. They must never disagree with
+// the sites that decide whether a cursor is HONOURED OR REFUSED (#381 item 9):
+// a cursor the engine accepts but the renderer ignores answers an unfiltered
+// page, which is the #354 silent-wrong-answer family.
+func (c *KeysetCursor) IsActive() bool {
+	return c != nil && len(c.Columns) > 0
+}
+
+// ValidateShape enforces the two cursor rules that need no knowledge of the
+// physical schema, so they can be checked from any package:
+//
+//  1. Values must align with Columns one-for-one. A short or nil Values used
+//     to bind SQL NULL for the unfilled arm; `col > NULL` is NULL, WHERE
+//     treats that as not-true, and every disjunct carrying the arm drops out,
+//     so the caller received a SILENTLY EMPTY PAGE rather than an error
+//     (#381 item 7).
+//  2. The final column must be row_id. The continuation predicate for the last
+//     cursor key is a strict inequality, so a cursor ending on a non-unique key
+//     excludes every row sharing that key's value at the page boundary — an
+//     entire tie group is silently skipped (#183). row_id is the only
+//     version-invariant unique column, so ending there gives the composite key
+//     a total order.
+//
+// An inactive cursor is a no-op: the open first page carries no continuation
+// obligation, and nothing renders from it.
+//
+// A plain read-path error, not an ErrInvalidInput-wrapped write-path
+// validation carrier.
+func (c *KeysetCursor) ValidateShape() error {
+	if !c.IsActive() {
+		return nil
+	}
+	if len(c.Values) != len(c.Columns) {
+		return fmt.Errorf("keyset cursor carries %d column(s) but %d value(s): every cursor column needs exactly one boundary value, or the unfilled comparison binds SQL NULL and silently returns an empty page",
+			len(c.Columns), len(c.Values))
+	}
+	last := c.Columns[len(c.Columns)-1].Attribute
+	if last != "row_id" {
+		return fmt.Errorf("keyset cursor final column is %q, expected \"row_id\": a cursor not ending on the unique row_id tiebreak silently skips every row tied on the composite key at the page boundary", last)
+	}
+	return nil
+}

--- a/internal/model/keyset.go
+++ b/internal/model/keyset.go
@@ -71,10 +71,20 @@ func (c *KeysetCursor) IsActive() bool {
 //     is unknown, so WHERE drops every disjunct carrying it. The caller gets a
 //     silently empty or short page — item 1's failure with the count right.
 //
-//  4. Mode must be one of the two modes. `keysetComparisonOp` computes
+//  4. Mode must be after. `keysetComparisonOp` computes
 //     `mode == KeysetCursorModeAfter`, so ANY other value — the zero value most
 //     of all — means BEFORE, and a cursor that lost its mode paginates
 //     backwards while answering successfully.
+//
+//     Before is declared (KeysetCursorModeBefore) but refused too, until #513
+//     lands the other half of it: the renderer flips the comparison operator
+//     for a before cursor yet still fetches in the FORWARD order under the
+//     LIMIT, so `key < 7 ORDER BY key ASC LIMIT 2` answers [1, 2] — the start
+//     of the prior range — where a caller stepping backwards expects [5, 6].
+//     A backward page needs the reversed order under the LIMIT and the
+//     requested order restored outside it. Until then a before cursor is a
+//     successfully-answered wrong page, and is refused for the same reason
+//     an unset mode is.
 //
 //  5. Each column's Direction must be asc, desc, or empty. The renderer treats
 //     everything that is not desc as ascending, so an unrecognised direction
@@ -166,14 +176,17 @@ func (c *KeysetCursor) validateDirections() error {
 	return nil
 }
 
-// validateMode refuses a mode the renderer would read as before without being
-// told to (rule 4), the zero value included.
+// validateMode refuses every mode but after (rule 4): an unknown one, the
+// zero value the renderer reads as before, and before itself, whose backward
+// window the renderer does not build yet (#513).
 func (c *KeysetCursor) validateMode() error {
 	switch c.Mode {
-	case KeysetCursorModeAfter, KeysetCursorModeBefore:
+	case KeysetCursorModeAfter:
 		return nil
+	case KeysetCursorModeBefore:
+		return fmt.Errorf("keyset cursor mode is \"before\", which is not supported yet (#513): the renderer flips the comparison but fetches in the forward order under the LIMIT, so a before page would answer the start of the prior range rather than the page preceding the cursor")
 	default:
-		return fmt.Errorf("keyset cursor mode is %q, expected \"after\" or \"before\": the renderer reads every other value — an unset mode above all — as \"before\", so a cursor that lost its mode paginates backwards and still answers successfully",
+		return fmt.Errorf("keyset cursor mode is %q, expected \"after\": the renderer reads every other value — an unset mode above all — as \"before\", so a cursor that lost its mode paginates backwards and still answers successfully",
 			c.Mode)
 	}
 }

--- a/internal/model/keyset.go
+++ b/internal/model/keyset.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/lychee-technology/forma"
@@ -40,7 +41,7 @@ func (c *KeysetCursor) IsActive() bool {
 	return c != nil && len(c.Columns) > 0
 }
 
-// ValidateShape enforces the two cursor rules that need no knowledge of the
+// ValidateShape enforces the cursor rules that need no knowledge of the
 // physical schema, so they can be checked from any package:
 //
 //  1. Values must align with Columns one-for-one. A short or nil Values used
@@ -65,8 +66,13 @@ func (c *KeysetCursor) IsActive() bool {
 //     not the tiebreak and is refused here, matching that validator's refusal
 //     of any non-identity fold onto a system column.
 //
+//  3. Every boundary value must be non-nil. Alignment alone does not stop a
+//     nil: it binds SQL NULL just as an unfilled arm does, and `row_id > NULL`
+//     is unknown, so WHERE drops every disjunct carrying it. The caller gets a
+//     silently empty or short page — item 1's failure with the count right.
+//
 // An inactive cursor is a no-op: the open first page carries no continuation
-// obligation, and nothing renders from it.
+// obligation, and nothing renders from it — no values to bind.
 //
 // A plain read-path error, not an ErrInvalidInput-wrapped write-path
 // validation carrier.
@@ -78,9 +84,43 @@ func (c *KeysetCursor) ValidateShape() error {
 		return fmt.Errorf("keyset cursor carries %d column(s) but %d value(s): every cursor column needs exactly one boundary value, or the unfilled comparison binds SQL NULL and silently returns an empty page",
 			len(c.Columns), len(c.Values))
 	}
+	if err := c.validateBoundaryValues(); err != nil {
+		return err
+	}
 	last := c.Columns[len(c.Columns)-1].Attribute
 	if !strings.EqualFold(last, "row_id") {
 		return fmt.Errorf("keyset cursor final column is %q, expected \"row_id\": a cursor not ending on the unique row_id tiebreak silently skips every row tied on the composite key at the page boundary", last)
 	}
 	return nil
+}
+
+// validateBoundaryValues refuses a nil boundary (rule 3). Positions are
+// reported 1-based alongside the column name, because a caller assembling a
+// cursor from a row reads it as "the value for created_at", not as Values[0].
+func (c *KeysetCursor) validateBoundaryValues() error {
+	for i, v := range c.Values {
+		if !isNilBoundary(v) {
+			continue
+		}
+		return fmt.Errorf("keyset cursor value %d (for column %q) is nil: a nil boundary binds SQL NULL, and a comparison against NULL is unknown rather than false, so every row tied at the page boundary is silently dropped instead of the cursor being refused",
+			i+1, c.Columns[i].Attribute)
+	}
+	return nil
+}
+
+// isNilBoundary reports whether a boundary value binds SQL NULL. A typed nil
+// — (*string)(nil) in an interface — is not == nil but binds NULL exactly as
+// an untyped one does, and a cursor decoded into typed fields is precisely
+// where one appears, so the reflective check is the one that guards the
+// failure rather than the syntax.
+func isNilBoundary(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	switch rv := reflect.ValueOf(v); rv.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+		return rv.IsNil()
+	default:
+		return false
+	}
 }

--- a/internal/model/keyset_continuation.go
+++ b/internal/model/keyset_continuation.go
@@ -1,0 +1,93 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/lychee-technology/forma"
+)
+
+// ValidateContinuation enforces that an active cursor CONTINUES the order the
+// request resolved, rather than replacing it (#381 review).
+//
+// The DuckDB renderer builds the keyset ORDER BY from the cursor's columns and
+// never reads AttributeOrders while a cursor is active, so before this rule a
+// caller that sorted page one by `count ASC` and then sent a valid
+// `created_at DESC, row_id ASC` cursor received a page ordered and filtered
+// on created_at, answered successfully — the #354 silent-wrong-answer family.
+//
+// The rule has two halves, and the boundary between them is deliberate:
+//
+//   - AttributeOrders PRESENT: the cursor must be exactly those orders followed
+//     by the row_id tiebreak. Column i must name orders[i].AttrName and carry
+//     its direction; the trailing row_id must be ascending (or empty, which is
+//     ascending), because that is the tiebreak the non-keyset ORDER BY appended
+//     to page one (sqlgen.buildNonKeysetOrderBy). A longer or shorter cursor, a
+//     different attribute, a flipped direction, or a row_id DESC tiebreak is
+//     refused. The attribute name is compared byte-exactly: the sort key was
+//     resolved against the schema, so its spelling is the canonical one, and a
+//     cursor built from the same request carries the same spelling.
+//
+//   - AttributeOrders EMPTY: the cursor is honoured as written. The default
+//     `created_at DESC, row_id ASC` is the renderer's fallback, not a caller
+//     statement, and AttributeOrders cannot express a system-column order at
+//     all — sort keys resolve against the schema, and created_at is not a
+//     schema attribute. A cursor-only walk (an open first page bounded by a
+//     far-future created_at, then cursors on created_at ASC or DESC with a
+//     row_id tiebreak in either direction) is a complete order specification
+//     with nothing to contradict, and refusing it would make every
+//     created_at / ver_ts / deleted_ts cursor unreachable.
+//
+// An order without an AttrName cannot be continued and is refused by
+// position: every production builder sets it (internal.buildAttributeOrders,
+// the production e2e harness), and the one that does not (the federated
+// benchmark) never combines orders with a cursor.
+//
+// A plain read-path error, like ValidateShape.
+func (c *KeysetCursor) ValidateContinuation(orders []AttributeOrder) error {
+	if !c.IsActive() || len(orders) == 0 {
+		return nil
+	}
+	if len(c.Columns) != len(orders)+1 {
+		return fmt.Errorf("keyset cursor carries %d column(s) but the request sorts on %d attribute(s): a cursor must continue the request's order — its columns are the sort attributes in order, then the row_id tiebreak — or the page would be ordered by the cursor instead of the sort it continues",
+			len(c.Columns), len(orders))
+	}
+	for i, ao := range orders {
+		if err := c.continuesOrder(i, ao); err != nil {
+			return err
+		}
+	}
+	tiebreak := c.Columns[len(c.Columns)-1]
+	if tiebreak.Direction == forma.SortOrderDesc {
+		return fmt.Errorf("keyset cursor tiebreak %q is descending but the sorted page it continues breaks ties on row_id ASC: a cursor must carry the same tiebreak direction as the order it continues, or rows tied on the sort key are paged in a different order than page one",
+			tiebreak.Attribute)
+	}
+	return nil
+}
+
+// continuesOrder checks that cursor column i names sort key i with its
+// direction. Positions are reported 1-based, alongside both names, because a
+// caller reads the mismatch as "the second cursor column should be count".
+func (c *KeysetCursor) continuesOrder(i int, ao AttributeOrder) error {
+	col := c.Columns[i]
+	if ao.AttrName == "" {
+		return fmt.Errorf("keyset cursor cannot continue sort key %d: the resolved order carries no attribute name to match cursor column %q against", i+1, col.Attribute)
+	}
+	if col.Attribute != ao.AttrName {
+		return fmt.Errorf("keyset cursor column %d is %q but the request sorts on %q at that position: a cursor must continue the request's order, or the page would be ordered and filtered on an attribute the request never sorted on",
+			i+1, col.Attribute, ao.AttrName)
+	}
+	if (col.Direction == forma.SortOrderDesc) != ao.Desc() {
+		return fmt.Errorf("keyset cursor column %d (%q) is %s but the request sorts %q %s: a cursor must continue the request's order, or the page would run against the direction of the page it continues",
+			i+1, col.Attribute, directionWord(col.Direction), ao.AttrName, directionWord(ao.SortOrder))
+	}
+	return nil
+}
+
+// directionWord spells a sort order for an error message, reading the empty
+// direction as ascending exactly as the renderer does.
+func directionWord(dir forma.SortOrder) string {
+	if dir == forma.SortOrderDesc {
+		return "descending"
+	}
+	return "ascending"
+}

--- a/internal/model/keyset_continuation_test.go
+++ b/internal/model/keyset_continuation_test.go
@@ -1,0 +1,118 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+)
+
+func sortOn(attr string, order forma.SortOrder) AttributeOrder {
+	return AttributeOrder{AttrID: 1, AttrName: attr, SortOrder: order, ValueType: forma.ValueTypeNumeric}
+}
+
+func continuation(cols ...KeysetColumn) *KeysetCursor {
+	vals := make([]interface{}, len(cols))
+	for i := range vals {
+		vals[i] = "v"
+	}
+	return &KeysetCursor{Columns: cols, Values: vals, Mode: KeysetCursorModeAfter}
+}
+
+// TestKeysetCursorValidateContinuation pins the continuation rule (#381
+// review): with AttributeOrders present the cursor must be those orders plus
+// an ascending row_id tiebreak; with none, the cursor is the order.
+func TestKeysetCursorValidateContinuation(t *testing.T) {
+	countAsc := []AttributeOrder{sortOn("count", forma.SortOrderAsc)}
+	cases := []struct {
+		name    string
+		cursor  *KeysetCursor
+		orders  []AttributeOrder
+		wantErr string
+	}{
+		{
+			name:   "an inactive cursor has nothing to continue",
+			cursor: &KeysetCursor{},
+			orders: countAsc,
+		},
+		{
+			name:   "with no request order the cursor is the order",
+			cursor: continuation(KeysetColumn{"created_at", forma.SortOrderAsc}, KeysetColumn{"row_id", forma.SortOrderDesc}),
+		},
+		{
+			name:   "the sort attribute then row_id continues the order",
+			cursor: continuation(KeysetColumn{"count", forma.SortOrderAsc}, KeysetColumn{"row_id", forma.SortOrderAsc}),
+			orders: countAsc,
+		},
+		{
+			name:   "an empty direction reads as ascending on both sides",
+			cursor: continuation(KeysetColumn{"count", ""}, KeysetColumn{"row_id", ""}),
+			orders: countAsc,
+		},
+		{
+			name: "two sort keys continue in order",
+			cursor: continuation(KeysetColumn{"region", forma.SortOrderDesc}, KeysetColumn{"count", forma.SortOrderAsc},
+				KeysetColumn{"row_id", forma.SortOrderAsc}),
+			orders: []AttributeOrder{sortOn("region", forma.SortOrderDesc), sortOn("count", forma.SortOrderAsc)},
+		},
+		{
+			name:    "a cursor on another attribute replaces the request order and is refused",
+			cursor:  continuation(KeysetColumn{"created_at", forma.SortOrderDesc}, KeysetColumn{"row_id", forma.SortOrderAsc}),
+			orders:  countAsc,
+			wantErr: `keyset cursor column 1 is "created_at" but the request sorts on "count"`,
+		},
+		{
+			name:    "a flipped direction is refused",
+			cursor:  continuation(KeysetColumn{"count", forma.SortOrderDesc}, KeysetColumn{"row_id", forma.SortOrderAsc}),
+			orders:  countAsc,
+			wantErr: `keyset cursor column 1 ("count") is descending but the request sorts "count" ascending`,
+		},
+		{
+			name:    "a descending row_id tiebreak is refused: page one broke ties on row_id ASC",
+			cursor:  continuation(KeysetColumn{"count", forma.SortOrderAsc}, KeysetColumn{"row_id", forma.SortOrderDesc}),
+			orders:  countAsc,
+			wantErr: `keyset cursor tiebreak "row_id" is descending but the sorted page it continues breaks ties on row_id ASC`,
+		},
+		{
+			name:    "a cursor with an extra column is refused",
+			cursor:  continuation(KeysetColumn{"count", forma.SortOrderAsc}, KeysetColumn{"created_at", forma.SortOrderDesc}, KeysetColumn{"row_id", forma.SortOrderAsc}),
+			orders:  countAsc,
+			wantErr: "keyset cursor carries 3 column(s) but the request sorts on 1 attribute(s)",
+		},
+		{
+			name:    "a cursor on row_id alone does not continue a sorted request",
+			cursor:  continuation(KeysetColumn{"row_id", forma.SortOrderAsc}),
+			orders:  countAsc,
+			wantErr: "keyset cursor carries 1 column(s) but the request sorts on 1 attribute(s)",
+		},
+		{
+			name:    "the attribute name is matched byte-exactly: the sort key spelling is canonical",
+			cursor:  continuation(KeysetColumn{"Count", forma.SortOrderAsc}, KeysetColumn{"row_id", forma.SortOrderAsc}),
+			orders:  countAsc,
+			wantErr: `keyset cursor column 1 is "Count" but the request sorts on "count"`,
+		},
+		{
+			name:    "an order without an attribute name cannot be continued",
+			cursor:  continuation(KeysetColumn{"integer_01", forma.SortOrderAsc}, KeysetColumn{"row_id", forma.SortOrderAsc}),
+			orders:  []AttributeOrder{{AttrID: 1, ColumnName: "integer_01", SortOrder: forma.SortOrderAsc}},
+			wantErr: "keyset cursor cannot continue sort key 1: the resolved order carries no attribute name",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cursor.ValidateContinuation(tc.orders)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateContinuation() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateContinuation() = nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("ValidateContinuation() = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/model/keyset_test.go
+++ b/internal/model/keyset_test.go
@@ -174,21 +174,29 @@ func TestKeysetCursorValidateShapeMode(t *testing.T) {
 	}
 	runValidateShapeCases(t, []validateShapeCase{
 		{name: "after is a mode", cursor: modeCursor(KeysetCursorModeAfter)},
-		{name: "before is a mode", cursor: modeCursor(KeysetCursorModeBefore)},
+		{
+			// The renderer flips the operator for before but still fetches
+			// in the forward order under the LIMIT, so a before page answers
+			// the start of the prior range (#513). Refused until the
+			// backward window exists — not silently answered.
+			name:    "before is declared but refused until its backward window exists",
+			cursor:  modeCursor(KeysetCursorModeBefore),
+			wantErr: `keyset cursor mode is "before", which is not supported yet (#513)`,
+		},
 		{
 			name:    "an unset mode is rejected rather than silently meaning before",
 			cursor:  modeCursor(""),
-			wantErr: `keyset cursor mode is "", expected "after" or "before"`,
+			wantErr: `keyset cursor mode is "", expected "after"`,
 		},
 		{
 			name:    "an unknown mode is rejected",
 			cursor:  modeCursor("sideways"),
-			wantErr: `keyset cursor mode is "sideways", expected "after" or "before"`,
+			wantErr: `keyset cursor mode is "sideways", expected "after"`,
 		},
 		{
 			name:    "the mode enum is matched exactly: the renderer compares it byte-for-byte",
 			cursor:  modeCursor("After"),
-			wantErr: `keyset cursor mode is "After", expected "after" or "before"`,
+			wantErr: `keyset cursor mode is "After", expected "after"`,
 		},
 		{
 			name:   "an inactive cursor carries no mode obligation",

--- a/internal/model/keyset_test.go
+++ b/internal/model/keyset_test.go
@@ -81,6 +81,27 @@ func TestKeysetCursorValidateShape(t *testing.T) {
 			wantErr: "carries 1 column(s) but 2 value(s)",
 		},
 		{
+			name: "upper-case ROW_ID is the tiebreak: DuckDB resolves it to row_id",
+			cursor: &KeysetCursor{
+				Columns: []KeysetColumn{
+					{Attribute: "created_at", Direction: forma.SortOrderDesc},
+					{Attribute: "ROW_ID", Direction: forma.SortOrderAsc},
+				},
+				Values: []interface{}{int64(5), "r1"},
+			},
+		},
+		{
+			name: "a name that merely FOLDS onto row_id is not the tiebreak",
+			cursor: &KeysetCursor{
+				Columns: []KeysetColumn{
+					{Attribute: "created_at", Direction: forma.SortOrderDesc},
+					{Attribute: "row.id", Direction: forma.SortOrderAsc},
+				},
+				Values: []interface{}{int64(5), "r1"},
+			},
+			wantErr: `final column is "row.id", expected "row_id"`,
+		},
+		{
 			name: "cursor not ending on row_id is rejected",
 			cursor: &KeysetCursor{
 				Columns: []KeysetColumn{

--- a/internal/model/keyset_test.go
+++ b/internal/model/keyset_test.go
@@ -30,89 +30,14 @@ func TestKeysetCursorIsActive(t *testing.T) {
 	}
 }
 
-func TestKeysetCursorValidateShape(t *testing.T) {
-	cases := []struct {
-		name    string
-		cursor  *KeysetCursor
-		wantErr string // "" means no error
-	}{
-		{
-			name:   "nil cursor carries no obligation",
-			cursor: nil,
-		},
-		{
-			name:   "inactive cursor carries no obligation even with stray values",
-			cursor: &KeysetCursor{Values: []interface{}{1, 2}},
-		},
-		{
-			name: "aligned cursor ending on row_id is valid",
-			cursor: &KeysetCursor{
-				Columns: []KeysetColumn{
-					{Attribute: "created_at", Direction: forma.SortOrderDesc},
-					{Attribute: "row_id", Direction: forma.SortOrderAsc},
-				},
-				Values: []interface{}{int64(5), "r1"},
-			},
-		},
-		{
-			name: "short values are rejected",
-			cursor: &KeysetCursor{
-				Columns: []KeysetColumn{
-					{Attribute: "created_at", Direction: forma.SortOrderDesc},
-					{Attribute: "row_id", Direction: forma.SortOrderAsc},
-				},
-				Values: []interface{}{int64(5)},
-			},
-			wantErr: "carries 2 column(s) but 1 value(s)",
-		},
-		{
-			name: "nil values are rejected",
-			cursor: &KeysetCursor{
-				Columns: []KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
-			},
-			wantErr: "carries 1 column(s) but 0 value(s)",
-		},
-		{
-			name: "surplus values are rejected",
-			cursor: &KeysetCursor{
-				Columns: []KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
-				Values:  []interface{}{"r1", "r2"},
-			},
-			wantErr: "carries 1 column(s) but 2 value(s)",
-		},
-		{
-			name: "upper-case ROW_ID is the tiebreak: DuckDB resolves it to row_id",
-			cursor: &KeysetCursor{
-				Columns: []KeysetColumn{
-					{Attribute: "created_at", Direction: forma.SortOrderDesc},
-					{Attribute: "ROW_ID", Direction: forma.SortOrderAsc},
-				},
-				Values: []interface{}{int64(5), "r1"},
-			},
-		},
-		{
-			name: "a name that merely FOLDS onto row_id is not the tiebreak",
-			cursor: &KeysetCursor{
-				Columns: []KeysetColumn{
-					{Attribute: "created_at", Direction: forma.SortOrderDesc},
-					{Attribute: "row.id", Direction: forma.SortOrderAsc},
-				},
-				Values: []interface{}{int64(5), "r1"},
-			},
-			wantErr: `final column is "row.id", expected "row_id"`,
-		},
-		{
-			name: "cursor not ending on row_id is rejected",
-			cursor: &KeysetCursor{
-				Columns: []KeysetColumn{
-					{Attribute: "row_id", Direction: forma.SortOrderAsc},
-					{Attribute: "created_at", Direction: forma.SortOrderDesc},
-				},
-				Values: []interface{}{"r1", int64(5)},
-			},
-			wantErr: `final column is "created_at", expected "row_id"`,
-		},
-	}
+type validateShapeCase struct {
+	name    string
+	cursor  *KeysetCursor
+	wantErr string // "" means accepted
+}
+
+func runValidateShapeCases(t *testing.T, cases []validateShapeCase) {
+	t.Helper()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.cursor.ValidateShape()
@@ -130,4 +55,111 @@ func TestKeysetCursorValidateShape(t *testing.T) {
 			}
 		})
 	}
+}
+
+// cursorOn builds an aligned, active, after-mode cursor over the named
+// columns so a case exercises one rule rather than tripping another first.
+func cursorOn(cols []KeysetColumn, values ...interface{}) *KeysetCursor {
+	return &KeysetCursor{Columns: cols, Values: values, Mode: KeysetCursorModeAfter}
+}
+
+func createdAtThenRowID() []KeysetColumn {
+	return []KeysetColumn{
+		{Attribute: "created_at", Direction: forma.SortOrderDesc},
+		{Attribute: "row_id", Direction: forma.SortOrderAsc},
+	}
+}
+
+func TestKeysetCursorValidateShapeAlignment(t *testing.T) {
+	runValidateShapeCases(t, []validateShapeCase{
+		{
+			name:   "nil cursor carries no obligation",
+			cursor: nil,
+		},
+		{
+			name:   "inactive cursor carries no obligation even with stray values",
+			cursor: &KeysetCursor{Values: []interface{}{1, 2}},
+		},
+		{
+			name:   "aligned cursor ending on row_id is valid",
+			cursor: cursorOn(createdAtThenRowID(), int64(5), "r1"),
+		},
+		{
+			name:    "short values are rejected",
+			cursor:  cursorOn(createdAtThenRowID(), int64(5)),
+			wantErr: "carries 2 column(s) but 1 value(s)",
+		},
+		{
+			name: "nil values are rejected",
+			cursor: &KeysetCursor{
+				Columns: []KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
+				Mode:    KeysetCursorModeAfter,
+			},
+			wantErr: "carries 1 column(s) but 0 value(s)",
+		},
+		{
+			name: "surplus values are rejected",
+			cursor: cursorOn(
+				[]KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
+				"r1", "r2"),
+			wantErr: "carries 1 column(s) but 2 value(s)",
+		},
+	})
+}
+
+func TestKeysetCursorValidateShapeTiebreak(t *testing.T) {
+	runValidateShapeCases(t, []validateShapeCase{
+		{
+			name: "upper-case ROW_ID is the tiebreak: DuckDB resolves it to row_id",
+			cursor: cursorOn([]KeysetColumn{
+				{Attribute: "created_at", Direction: forma.SortOrderDesc},
+				{Attribute: "ROW_ID", Direction: forma.SortOrderAsc},
+			}, int64(5), "r1"),
+		},
+		{
+			name: "a name that merely FOLDS onto row_id is not the tiebreak",
+			cursor: cursorOn([]KeysetColumn{
+				{Attribute: "created_at", Direction: forma.SortOrderDesc},
+				{Attribute: "row.id", Direction: forma.SortOrderAsc},
+			}, int64(5), "r1"),
+			wantErr: `final column is "row.id", expected "row_id"`,
+		},
+		{
+			name: "cursor not ending on row_id is rejected",
+			cursor: cursorOn([]KeysetColumn{
+				{Attribute: "row_id", Direction: forma.SortOrderAsc},
+				{Attribute: "created_at", Direction: forma.SortOrderDesc},
+			}, "r1", int64(5)),
+			wantErr: `final column is "created_at", expected "row_id"`,
+		},
+	})
+}
+
+func TestKeysetCursorValidateShapeBoundaryValues(t *testing.T) {
+	var nilPtr *string
+	runValidateShapeCases(t, []validateShapeCase{
+		{
+			name:    "a nil tiebreak boundary is rejected",
+			cursor:  cursorOn(createdAtThenRowID(), int64(5), nil),
+			wantErr: `keyset cursor value 2 (for column "row_id") is nil`,
+		},
+		{
+			name:    "a nil prefix boundary is rejected",
+			cursor:  cursorOn(createdAtThenRowID(), nil, "r1"),
+			wantErr: `keyset cursor value 1 (for column "created_at") is nil`,
+		},
+		{
+			name:    "a typed nil pointer binds NULL too, so it is rejected",
+			cursor:  cursorOn(createdAtThenRowID(), nilPtr, "r1"),
+			wantErr: `keyset cursor value 1 (for column "created_at") is nil`,
+		},
+		{
+			name:   "zero-valued boundaries are legitimate and stay accepted",
+			cursor: cursorOn(createdAtThenRowID(), int64(0), ""),
+		},
+		{
+			name:   "a false boundary is legitimate and stays accepted",
+			cursor: cursorOn(createdAtThenRowID(), false, "r1"),
+		},
+	})
 }

--- a/internal/model/keyset_test.go
+++ b/internal/model/keyset_test.go
@@ -1,0 +1,112 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+)
+
+func TestKeysetCursorIsActive(t *testing.T) {
+	cases := []struct {
+		name   string
+		cursor *KeysetCursor
+		want   bool
+	}{
+		{"nil cursor is the open first page", nil, false},
+		{"nil column slice is the open first page", &KeysetCursor{}, false},
+		{"empty column slice is the open first page", &KeysetCursor{Columns: []KeysetColumn{}}, false},
+		{"one column is active", &KeysetCursor{
+			Columns: []KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
+			Values:  []interface{}{"r1"},
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cursor.IsActive(); got != tc.want {
+				t.Errorf("IsActive() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKeysetCursorValidateShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		cursor  *KeysetCursor
+		wantErr string // "" means no error
+	}{
+		{
+			name:   "nil cursor carries no obligation",
+			cursor: nil,
+		},
+		{
+			name:   "inactive cursor carries no obligation even with stray values",
+			cursor: &KeysetCursor{Values: []interface{}{1, 2}},
+		},
+		{
+			name: "aligned cursor ending on row_id is valid",
+			cursor: &KeysetCursor{
+				Columns: []KeysetColumn{
+					{Attribute: "created_at", Direction: forma.SortOrderDesc},
+					{Attribute: "row_id", Direction: forma.SortOrderAsc},
+				},
+				Values: []interface{}{int64(5), "r1"},
+			},
+		},
+		{
+			name: "short values are rejected",
+			cursor: &KeysetCursor{
+				Columns: []KeysetColumn{
+					{Attribute: "created_at", Direction: forma.SortOrderDesc},
+					{Attribute: "row_id", Direction: forma.SortOrderAsc},
+				},
+				Values: []interface{}{int64(5)},
+			},
+			wantErr: "carries 2 column(s) but 1 value(s)",
+		},
+		{
+			name: "nil values are rejected",
+			cursor: &KeysetCursor{
+				Columns: []KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
+			},
+			wantErr: "carries 1 column(s) but 0 value(s)",
+		},
+		{
+			name: "surplus values are rejected",
+			cursor: &KeysetCursor{
+				Columns: []KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
+				Values:  []interface{}{"r1", "r2"},
+			},
+			wantErr: "carries 1 column(s) but 2 value(s)",
+		},
+		{
+			name: "cursor not ending on row_id is rejected",
+			cursor: &KeysetCursor{
+				Columns: []KeysetColumn{
+					{Attribute: "row_id", Direction: forma.SortOrderAsc},
+					{Attribute: "created_at", Direction: forma.SortOrderDesc},
+				},
+				Values: []interface{}{"r1", int64(5)},
+			},
+			wantErr: `final column is "created_at", expected "row_id"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cursor.ValidateShape()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateShape() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateShape() = nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("ValidateShape() = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/model/keyset_test.go
+++ b/internal/model/keyset_test.go
@@ -163,3 +163,68 @@ func TestKeysetCursorValidateShapeBoundaryValues(t *testing.T) {
 		},
 	})
 }
+
+func TestKeysetCursorValidateShapeMode(t *testing.T) {
+	modeCursor := func(mode KeysetCursorMode) *KeysetCursor {
+		return &KeysetCursor{
+			Columns: createdAtThenRowID(),
+			Values:  []interface{}{int64(5), "r1"},
+			Mode:    mode,
+		}
+	}
+	runValidateShapeCases(t, []validateShapeCase{
+		{name: "after is a mode", cursor: modeCursor(KeysetCursorModeAfter)},
+		{name: "before is a mode", cursor: modeCursor(KeysetCursorModeBefore)},
+		{
+			name:    "an unset mode is rejected rather than silently meaning before",
+			cursor:  modeCursor(""),
+			wantErr: `keyset cursor mode is "", expected "after" or "before"`,
+		},
+		{
+			name:    "an unknown mode is rejected",
+			cursor:  modeCursor("sideways"),
+			wantErr: `keyset cursor mode is "sideways", expected "after" or "before"`,
+		},
+		{
+			name:    "the mode enum is matched exactly: the renderer compares it byte-for-byte",
+			cursor:  modeCursor("After"),
+			wantErr: `keyset cursor mode is "After", expected "after" or "before"`,
+		},
+		{
+			name:   "an inactive cursor carries no mode obligation",
+			cursor: &KeysetCursor{Mode: "sideways"},
+		},
+	})
+}
+
+func TestKeysetCursorValidateShapeDirection(t *testing.T) {
+	directionCursor := func(dir forma.SortOrder) *KeysetCursor {
+		return cursorOn([]KeysetColumn{
+			{Attribute: "created_at", Direction: dir},
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+		}, int64(5), "r1")
+	}
+	runValidateShapeCases(t, []validateShapeCase{
+		{name: "asc is a direction", cursor: directionCursor(forma.SortOrderAsc)},
+		{name: "desc is a direction", cursor: directionCursor(forma.SortOrderDesc)},
+		{name: "an empty direction is the documented asc default", cursor: directionCursor("")},
+		{
+			name:    "an unknown direction is rejected rather than silently meaning asc",
+			cursor:  directionCursor("sideways"),
+			wantErr: `keyset cursor column "created_at" has direction "sideways", expected "asc", "desc" or empty`,
+		},
+		{
+			name:    "the direction enum is matched exactly: the renderer compares it byte-for-byte",
+			cursor:  directionCursor("DESC"),
+			wantErr: `keyset cursor column "created_at" has direction "DESC", expected "asc", "desc" or empty`,
+		},
+		{
+			name: "the tiebreak column's direction is checked too",
+			cursor: cursorOn([]KeysetColumn{
+				{Attribute: "created_at", Direction: forma.SortOrderDesc},
+				{Attribute: "row_id", Direction: "ascending"},
+			}, int64(5), "r1"),
+			wantErr: `keyset cursor column "row_id" has direction "ascending"`,
+		},
+	})
+}

--- a/internal/model/query.go
+++ b/internal/model/query.go
@@ -37,7 +37,6 @@ type FederatedQueryOptions struct {
 	MaxRows                  int
 	Parallelism              int
 	AllowPartialDegradedMode bool
-	KeysetEnabled            bool
 	IncludeExecutionPlan     bool
 	ExecutionPlan            *ExecutionPlan
 	ConsistencyMode          ConsistencyMode

--- a/internal/model/query.go
+++ b/internal/model/query.go
@@ -2,8 +2,6 @@ package model
 
 import (
 	"time"
-
-	"github.com/lychee-technology/forma"
 )
 
 type DataTier string
@@ -109,22 +107,4 @@ type MergePlan struct {
 	DedupKeys  []string
 	DurationMs int64
 	Notes      []string
-}
-
-type KeysetCursorMode string
-
-const (
-	KeysetCursorModeAfter  KeysetCursorMode = "after"
-	KeysetCursorModeBefore KeysetCursorMode = "before"
-)
-
-type KeysetColumn struct {
-	Attribute string
-	Direction forma.SortOrder
-}
-
-type KeysetCursor struct {
-	Columns []KeysetColumn
-	Values  []interface{}
-	Mode    KeysetCursorMode
 }

--- a/internal/queryplan/shape.go
+++ b/internal/queryplan/shape.go
@@ -53,7 +53,11 @@ func HashFederatedQueryShape(q *model.FederatedAttributeQuery) (string, error) {
 	// sqlgen.FederatedQueryHasHot — keep the two in lockstep.
 	write("tiers", strconv.FormatBool(queryHasHot(q)))
 
-	if q.KeysetCursor != nil {
+	// IsActive, not a nil check: a non-nil zero-column cursor renders the
+	// OFFSET form (sqlgen keys the clause off the same predicate), so hashing
+	// it apart from a nil cursor split the cache on two spellings of one
+	// skeleton (#381 item 9). Columns and Mode participate; Values do not.
+	if q.KeysetCursor.IsActive() {
 		write("pagination", "keyset", string(q.KeysetCursor.Mode))
 		for _, col := range q.KeysetCursor.Columns {
 			write(col.Attribute, string(col.Direction))

--- a/internal/sqlgen/duckdb_cold_scan_test.go
+++ b/internal/sqlgen/duckdb_cold_scan_test.go
@@ -115,7 +115,7 @@ func minimalAdvancedParams(t *testing.T, missing []NullScanColumn) map[string]an
 // s3_source's FROM and the pushdown semijoin's inner FROM.
 func TestAdvancedTemplateRendersScanSourceAtBothSites(t *testing.T) {
 	params := map[string]any{"S3_PATHS": "'s3://b/base/a.parquet'"}
-	injectDuckDBTemplateParams(params, nil, nil)
+	require.NoError(t, injectDuckDBTemplateParams(params, nil, nil))
 	// nil query keeps this a pure param-derivation probe.
 	src, _ := params["S3_SCAN_SOURCE"].(string)
 	require.Equal(t, BuildParquetScanSource("'s3://b/base/a.parquet'", nil), src)
@@ -125,7 +125,7 @@ func TestAdvancedTemplateRendersScanSourceAtBothSites(t *testing.T) {
 		"S3_PATHS":           "'s3://b/base/a.parquet'",
 		"ColdMissingColumns": []NullScanColumn{{Name: "score", DuckDBType: "INTEGER"}},
 	}
-	injectDuckDBTemplateParams(params, nil, nil)
+	require.NoError(t, injectDuckDBTemplateParams(params, nil, nil))
 	src, _ = params["S3_SCAN_SOURCE"].(string)
 	require.Contains(t, src, "NULL::INTEGER AS score")
 

--- a/internal/sqlgen/duckdb_compiled_query.go
+++ b/internal/sqlgen/duckdb_compiled_query.go
@@ -136,7 +136,7 @@ func (c *DuckDBCompiledQuery) Bind(q *model.FederatedAttributeQuery, dual DualCl
 	}
 	args = append(args, dual.DuckArgs...)
 	if q != nil && q.KeysetCursor.IsActive() {
-		_, keysetArgs, err := generateKeysetWhereClause(q.KeysetCursor, "")
+		_, keysetArgs, err := generateKeysetWhereClause(q.KeysetCursor)
 		if err != nil {
 			return "", nil, fmt.Errorf("bind keyset args: %w", err)
 		}

--- a/internal/sqlgen/duckdb_compiled_query.go
+++ b/internal/sqlgen/duckdb_compiled_query.go
@@ -131,7 +131,7 @@ func (c *DuckDBCompiledQuery) Bind(q *model.FederatedAttributeQuery, dual DualCl
 		args = append(args, dual.PgMainArgs...)
 	}
 	args = append(args, dual.DuckArgs...)
-	if q != nil && q.KeysetCursor != nil && len(q.KeysetCursor.Columns) > 0 {
+	if q != nil && q.KeysetCursor.IsActive() {
 		_, keysetArgs := generateKeysetWhereClause(q.KeysetCursor, "")
 		args = append(args, keysetArgs...)
 	}

--- a/internal/sqlgen/duckdb_compiled_query.go
+++ b/internal/sqlgen/duckdb_compiled_query.go
@@ -86,7 +86,9 @@ func CompileDuckDBQuery(tpl *template.Template, params map[string]any, q *model.
 	hasHot := FederatedQueryHasHot(q)
 	m["HasHot"] = hasHot
 
-	injectDuckDBTemplateParams(m, q, dual)
+	if err := injectDuckDBTemplateParams(m, q, dual); err != nil {
+		return nil, fmt.Errorf("compile DuckDB query: %w", err)
+	}
 	if err := requireProjectionParams(m); err != nil {
 		return nil, fmt.Errorf("compile DuckDB query: %w", err)
 	}
@@ -118,7 +120,9 @@ func CompileDuckDBQuery(tpl *template.Template, params map[string]any, q *model.
 // shape matches the compiled skeleton: dirty CSV and flush-grace cutoff
 // spliced, condition args in the advanced-template interleave (DuckArgs,
 // PgMainArgs, DuckArgs), keyset cursor values, then the cached template args.
-func (c *DuckDBCompiledQuery) Bind(q *model.FederatedAttributeQuery, dual DualClauses, dirtyIDs []uuid.UUID, graceCutoffMs int64) (string, []any) {
+// It errors on a cursor that fails model.KeysetCursor.ValidateShape rather
+// than binding SQL NULL for an unfilled arm (#381 item 7).
+func (c *DuckDBCompiledQuery) Bind(q *model.FederatedAttributeQuery, dual DualClauses, dirtyIDs []uuid.UUID, graceCutoffMs int64) (string, []any, error) {
 	sql := c.Skeleton
 	if c.HasDirty {
 		sql = strings.ReplaceAll(sql, dirtyIDsSentinel, RenderDirtyIDsValuesCSV(dirtyIDs))
@@ -132,9 +136,12 @@ func (c *DuckDBCompiledQuery) Bind(q *model.FederatedAttributeQuery, dual DualCl
 	}
 	args = append(args, dual.DuckArgs...)
 	if q != nil && q.KeysetCursor.IsActive() {
-		_, keysetArgs := generateKeysetWhereClause(q.KeysetCursor, "")
+		_, keysetArgs, err := generateKeysetWhereClause(q.KeysetCursor, "")
+		if err != nil {
+			return "", nil, fmt.Errorf("bind keyset args: %w", err)
+		}
 		args = append(args, keysetArgs...)
 	}
 	args = append(args, c.TplArgs...)
-	return sql, args
+	return sql, args, nil
 }

--- a/internal/sqlgen/duckdb_compiled_query_test.go
+++ b/internal/sqlgen/duckdb_compiled_query_test.go
@@ -210,3 +210,45 @@ func TestCompileDuckDBQueryRejectsNonCacheablePaths(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, compiled, "non-advanced templates are not cacheable")
 }
+
+// TestCompiledQueryBindRejectsMisalignedCursor pins the error path #381 item 7
+// gave Bind. The plan cache's shape hash covers cursor COLUMNS but deliberately
+// not cursor VALUES (internal/queryplan/shape.go, pinned by
+// TestShapeHashKeysetValuesDoNotParticipate), so a cached skeleton really can be
+// handed a cursor whose values no longer align with its columns. Binding SQL
+// NULL for the unfilled arm would answer a silently empty page; Bind must fail
+// instead, and must return nothing an unchecked caller could execute.
+func TestCompiledQueryBindRejectsMisalignedCursor(t *testing.T) {
+	cache := dualPlanTestCache()
+	cols := []model.KeysetColumn{
+		{Attribute: "created_at", Direction: forma.SortOrderDesc},
+		{Attribute: "row_id", Direction: forma.SortOrderDesc},
+	}
+	newQuery := func(values []any) *model.FederatedAttributeQuery {
+		q := &model.FederatedAttributeQuery{AttributeQuery: model.AttributeQuery{
+			SchemaID: 7,
+			Condition: &forma.CompositeCondition{Logic: forma.LogicAnd, Conditions: []forma.Condition{
+				&forma.KvCondition{Attr: "age", Value: "gt:10"},
+				&forma.KvCondition{Attr: "tag", Value: "equals:x"},
+			}},
+		}}
+		q.KeysetCursor = &model.KeysetCursor{Mode: model.KeysetCursorModeAfter, Columns: cols, Values: values}
+		return q
+	}
+
+	// Compile from a well-formed cursor: the skeleton is the one a cache hit
+	// would serve.
+	wellFormed := newQuery([]any{int64(1700000000000), "11111111-1111-1111-1111-111111111111"})
+	dual := parityDual(t, wellFormed.Condition, cache)
+	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), wellFormed, &dual, false)
+	require.NoError(t, err)
+	require.NotNil(t, compiled)
+
+	// Same columns, one value short — the shape the values-blind hash admits.
+	sql, args, err := compiled.Bind(newQuery([]any{int64(1700000000000)}), dual, nil, FlushGraceCutoffDisabled)
+	require.Error(t, err, "a cursor whose values do not align with its columns must not bind")
+	require.Contains(t, err.Error(), "carries 2 column(s) but 1 value(s)",
+		"the failure must name the counts, as model.KeysetCursor.ValidateShape does")
+	require.Empty(t, sql, "a failed Bind must return no executable SQL")
+	require.Empty(t, args, "a failed Bind must return no args")
+}

--- a/internal/sqlgen/duckdb_compiled_query_test.go
+++ b/internal/sqlgen/duckdb_compiled_query_test.go
@@ -50,7 +50,8 @@ func requireCompiledParity(t *testing.T, q *model.FederatedAttributeQuery, dual 
 	require.NoError(t, err)
 	require.NotNil(t, compiled)
 
-	gotSQL, gotArgs := compiled.Bind(q, dual, dirtyIDs, FlushGraceCutoffDisabled)
+	gotSQL, gotArgs, err := compiled.Bind(q, dual, dirtyIDs, FlushGraceCutoffDisabled)
+	require.NoError(t, err)
 	require.Equal(t, wantSQL, gotSQL)
 	require.Equal(t, wantArgs, gotArgs)
 
@@ -152,7 +153,8 @@ func TestCompiledQueryColdOnlyParityOmitsPgSource(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, compiled)
 
-	gotSQL, gotArgs := compiled.Bind(q, dual, nil, FlushGraceCutoffDisabled)
+	gotSQL, gotArgs, err := compiled.Bind(q, dual, nil, FlushGraceCutoffDisabled)
+	require.NoError(t, err)
 	require.NotContains(t, gotSQL, "pg_source",
 		"hot excluded: the compiled skeleton must omit the pg_source CTE")
 	wantArgs := append(append([]any{}, dual.DuckArgs...), dual.DuckArgs...)
@@ -186,7 +188,8 @@ func TestCompiledQueryReuseAcrossRequests(t *testing.T) {
 	dualB, err := plan.Bind(qB.Condition, cache, nil)
 	require.NoError(t, err)
 
-	gotSQL, gotArgs := compiled.Bind(qB, dualB, dirtyB, FlushGraceCutoffDisabled)
+	gotSQL, gotArgs, err := compiled.Bind(qB, dualB, dirtyB, FlushGraceCutoffDisabled)
+	require.NoError(t, err)
 	wantSQL, wantArgs, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, compiledParityParams(t), qB, dirtyB, &dualB)
 	require.NoError(t, err)
 	require.Equal(t, wantSQL, gotSQL, "request B served from request A's skeleton must equal the direct build")

--- a/internal/sqlgen/duckdb_flush_grace_test.go
+++ b/internal/sqlgen/duckdb_flush_grace_test.go
@@ -137,8 +137,10 @@ func TestFlushGraceCompiledSkeletonIsCutoffIndependent(t *testing.T) {
 	require.NotContains(t, compiled.Skeleton, "flushed_at >= 111",
 		"a per-request cutoff must never bake into the skeleton")
 
-	sqlA, argsA := compiled.Bind(q, dual, nil, 1000)
-	sqlB, argsB := compiled.Bind(q, dual, nil, 2000)
+	sqlA, argsA, err := compiled.Bind(q, dual, nil, 1000)
+	require.NoError(t, err)
+	sqlB, argsB, err := compiled.Bind(q, dual, nil, 2000)
+	require.NoError(t, err)
 	requireGraceSites(t, sqlA, "1000")
 	requireGraceSites(t, sqlB, "2000")
 	require.NotContains(t, sqlA, flushGraceCutoffSentinel)

--- a/internal/sqlgen/duckdb_namespace_render_test.go
+++ b/internal/sqlgen/duckdb_namespace_render_test.go
@@ -68,7 +68,8 @@ func TestDuckDBNamespace_RenderPaths_AttributeAliasedClause(t *testing.T) {
 	compiled, err := CompileDuckDBQuery(AdvancedQueryTemplateDuckDB, nonBenchmarkNamespaceParams(t, cache), q, &dc, true)
 	require.NoError(t, err)
 	require.NotNil(t, compiled, "non-benchmark column-bound composite must be cacheable")
-	boundSQL, boundArgs := compiled.Bind(q, dc, dirty, FlushGraceCutoffDisabled)
+	boundSQL, boundArgs, err := compiled.Bind(q, dc, dirty, FlushGraceCutoffDisabled)
+	require.NoError(t, err)
 
 	for name, sql := range map[string]string{"direct": builtSQL, "compiled": boundSQL} {
 		// The attribute-aliased clause flows into the DuckDB CTE WHERE clauses.

--- a/internal/sqlgen/duckdb_render_and_dirtyids_test.go
+++ b/internal/sqlgen/duckdb_render_and_dirtyids_test.go
@@ -76,7 +76,7 @@ func TestInjectDuckDBTemplateParams_KeysetPositionalPlaceholders(t *testing.T) {
 		KeysetCursor:   cursor,
 	}
 	params := map[string]any{}
-	injectDuckDBTemplateParams(params, q, nil)
+	require.NoError(t, injectDuckDBTemplateParams(params, q, nil))
 
 	clause, ok := params["KEYSET_WHERE_CLAUSE"].(string)
 	require.True(t, ok, "KEYSET_WHERE_CLAUSE should be a string")
@@ -94,10 +94,16 @@ func TestInjectDuckDBTemplateParams_KeysetPositionalPlaceholders(t *testing.T) {
 // a keyset query: [DuckArgs, PgMainArgs, DuckArgs, keysetArgs], one "?" per
 // arg in appearance order, no "$n" anywhere (#212).
 func TestBuildDuckDBQuery_KeysetArgsBindLast(t *testing.T) {
+	// The cursor carries the mandatory row_id tiebreak (#183): a cursor
+	// ending on a non-unique key is refused by ValidateShape, which
+	// generateKeysetWhereClause now enforces (#381 item 7).
 	cursor := &model.KeysetCursor{
-		Columns: []model.KeysetColumn{{Attribute: "created_at", Direction: forma.SortOrderDesc}},
-		Values:  []interface{}{int64(1000)},
-		Mode:    model.KeysetCursorModeAfter,
+		Columns: []model.KeysetColumn{
+			{Attribute: "created_at", Direction: forma.SortOrderDesc},
+			{Attribute: "row_id", Direction: forma.SortOrderDesc},
+		},
+		Values: []interface{}{int64(1000), "11111111-1111-1111-1111-111111111111"},
+		Mode:   model.KeysetCursorModeAfter,
 	}
 	q := &model.FederatedAttributeQuery{
 		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10, Offset: 0},
@@ -111,10 +117,13 @@ func TestBuildDuckDBQuery_KeysetArgsBindLast(t *testing.T) {
 	sql, args, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, injectTestRenderParams(t, map[string]any{}, 1), q, nil, dual)
 	require.NoError(t, err)
 
-	// [DuckArgs(2), PgMainArgs(0), DuckArgs(2), keyset(1)]
-	require.Len(t, args, 5)
-	require.Equal(t, int64(1000), args[4], "keyset value must be the last arg")
+	// [DuckArgs(2), PgMainArgs(0), DuckArgs(2), keyset(3)] — a 2-column
+	// cursor contributes n(n+1)/2 args.
+	require.Len(t, args, 7)
+	require.Equal(t, []any{
+		int64(1000), int64(1000), "11111111-1111-1111-1111-111111111111",
+	}, args[4:], "keyset values must be the last args, in placeholder order")
 	require.NotContains(t, sql, "$", "keyset queries must not reintroduce $n placeholders")
-	require.Equal(t, 5, strings.Count(sql, "?"),
+	require.Equal(t, 7, strings.Count(sql, "?"),
 		"placeholder count must equal arg count for positional binding")
 }

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -312,6 +312,15 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	// all condition args by appendKeysetArgs, matching the clause's position at
 	// the end of the visible CTE.
 	if q.KeysetCursor.IsActive() {
+		// The ORDER BY below renders from the cursor alone, so the cursor must
+		// be a continuation of q.AttributeOrders rather than a replacement
+		// for it. The federated seams check this too (validateKeysetCursor);
+		// repeated here, like ValidateShape in generateKeysetWhereClause, so
+		// a direct sqlgen caller cannot render a page ordered on something
+		// the request never sorted on (#381 review).
+		if err := q.KeysetCursor.ValidateContinuation(q.AttributeOrders); err != nil {
+			return fmt.Errorf("inject keyset params: %w", err)
+		}
 		keysetClause, keysetArgs, err := generateKeysetWhereClause(q.KeysetCursor)
 		if err != nil {
 			return fmt.Errorf("inject keyset params: %w", err)

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -307,7 +307,7 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	// The clause uses positional "?" placeholders; its args are appended after
 	// all condition args by appendKeysetArgs, matching the clause's position at
 	// the end of the visible CTE.
-	if q.KeysetCursor != nil && len(q.KeysetCursor.Columns) > 0 {
+	if q.KeysetCursor.IsActive() {
 		keysetClause, keysetArgs := generateKeysetWhereClause(q.KeysetCursor, "")
 		params["HAS_KEYSET"] = true
 		params["KEYSET_WHERE_CLAUSE"] = keysetClause

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -312,7 +312,7 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	// all condition args by appendKeysetArgs, matching the clause's position at
 	// the end of the visible CTE.
 	if q.KeysetCursor.IsActive() {
-		keysetClause, keysetArgs, err := generateKeysetWhereClause(q.KeysetCursor, "")
+		keysetClause, keysetArgs, err := generateKeysetWhereClause(q.KeysetCursor)
 		if err != nil {
 			return fmt.Errorf("inject keyset params: %w", err)
 		}

--- a/internal/sqlgen/duckdb_template_renderer.go
+++ b/internal/sqlgen/duckdb_template_renderer.go
@@ -86,7 +86,9 @@ func BuildDuckDBQuery(tpl *template.Template, params any, q *model.FederatedAttr
 				whereArgs = append(whereArgs, dual.DuckArgs...)
 			}
 		}
-		injectDuckDBTemplateParams(m, q, dual)
+		if err := injectDuckDBTemplateParams(m, q, dual); err != nil {
+			return "", nil, fmt.Errorf("build DuckDB query: %w", err)
+		}
 		if isAdvancedTemplate {
 			if err := requireProjectionParams(m); err != nil {
 				return "", nil, fmt.Errorf("build DuckDB query: %w", err)
@@ -132,7 +134,9 @@ func buildDuckDBQueryLegacy(tpl *template.Template, m map[string]any, anchor map
 			whereArgs = append(whereArgs, whereArgs...)
 		}
 	}
-	injectDuckDBTemplateParams(m, q, nil)
+	if err := injectDuckDBTemplateParams(m, q, nil); err != nil {
+		return "", nil, fmt.Errorf("build DuckDB query: %w", err)
+	}
 	if isAdvancedTemplate {
 		if err := requireProjectionParams(m); err != nil {
 			return "", nil, fmt.Errorf("build DuckDB query: %w", err)
@@ -231,7 +235,7 @@ func FederatedQueryHasHot(q *model.FederatedAttributeQuery) bool {
 	return false
 }
 
-func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttributeQuery, dual *DualClauses) {
+func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttributeQuery, dual *DualClauses) error {
 	// Defensive default for the #252 flush-grace cutoff, set before the nil-q
 	// return so every render path (dual, legacy, nil query) produces valid
 	// SQL with the pre-#252 barrier when the engine did not supply a cutoff.
@@ -260,7 +264,7 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	}
 
 	if q == nil {
-		return
+		return nil
 	}
 
 	params["SCHEMA_ID"] = q.SchemaID
@@ -308,7 +312,10 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	// all condition args by appendKeysetArgs, matching the clause's position at
 	// the end of the visible CTE.
 	if q.KeysetCursor.IsActive() {
-		keysetClause, keysetArgs := generateKeysetWhereClause(q.KeysetCursor, "")
+		keysetClause, keysetArgs, err := generateKeysetWhereClause(q.KeysetCursor, "")
+		if err != nil {
+			return fmt.Errorf("inject keyset params: %w", err)
+		}
 		params["HAS_KEYSET"] = true
 		params["KEYSET_WHERE_CLAUSE"] = keysetClause
 		params["KEYSET_ARGS"] = keysetArgs
@@ -321,6 +328,7 @@ func injectDuckDBTemplateParams(params map[string]any, q *model.FederatedAttribu
 	if _, ok := params["NON_KEYSET_ORDER_BY"]; !ok {
 		params["NON_KEYSET_ORDER_BY"] = buildNonKeysetOrderBy(q)
 	}
+	return nil
 }
 
 func formatDuckDBPathList(paths []string) string {

--- a/internal/sqlgen/duckdb_template_renderer_test.go
+++ b/internal/sqlgen/duckdb_template_renderer_test.go
@@ -202,7 +202,7 @@ func TestPGConnIsEscapedForSQLLiteral(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]any{"DuckDBPGConnString": tt.conn}
-			injectDuckDBTemplateParams(params, &model.FederatedAttributeQuery{}, nil)
+			require.NoError(t, injectDuckDBTemplateParams(params, &model.FederatedAttributeQuery{}, nil))
 
 			got, ok := params["PG_CONN"].(string)
 			require.True(t, ok, "PG_CONN was not populated")
@@ -225,7 +225,7 @@ func TestPGConnExplicitOverrideIsNotDoubleEscaped(t *testing.T) {
 		"PG_CONN":            "host=already port=1",
 		"DuckDBPGConnString": `host='ignored'`,
 	}
-	injectDuckDBTemplateParams(params, &model.FederatedAttributeQuery{}, nil)
+	require.NoError(t, injectDuckDBTemplateParams(params, &model.FederatedAttributeQuery{}, nil))
 	require.Equal(t, "host=already port=1", params["PG_CONN"])
 }
 

--- a/internal/sqlgen/keyset_continuation_test.go
+++ b/internal/sqlgen/keyset_continuation_test.go
@@ -1,0 +1,53 @@
+package sqlgen
+
+import (
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+func continuationQuery(cursorAttr string, cursorDir forma.SortOrder) *model.FederatedAttributeQuery {
+	return &model.FederatedAttributeQuery{
+		AttributeQuery: model.AttributeQuery{
+			SchemaID: 1,
+			Limit:    10,
+			AttributeOrders: []model.AttributeOrder{{
+				AttrID: 42, AttrName: "count", ValueType: forma.ValueTypeNumeric,
+				SortOrder: forma.SortOrderAsc, StorageLocation: forma.AttributeStorageLocationEAV,
+			}},
+		},
+		KeysetCursor: &model.KeysetCursor{
+			Columns: []model.KeysetColumn{
+				{Attribute: cursorAttr, Direction: cursorDir},
+				{Attribute: "row_id", Direction: forma.SortOrderAsc},
+			},
+			Values: []interface{}{int64(5), "r1"},
+			Mode:   model.KeysetCursorModeAfter,
+		},
+	}
+}
+
+// TestBuildDuckDBQuery_KeysetMustContinueAttributeOrders pins the renderer's
+// copy of the continuation rule (#381 review): the keyset ORDER BY renders
+// from the cursor alone, so a cursor that does not continue q.AttributeOrders
+// is refused here as well as at the federated seams, and a continuing cursor
+// renders the very order page one was sorted by.
+func TestBuildDuckDBQuery_KeysetMustContinueAttributeOrders(t *testing.T) {
+	dual := &DualClauses{DuckClause: "1=1"}
+
+	_, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, injectTestRenderParams(t, map[string]any{}, 1),
+		continuationQuery("created_at", forma.SortOrderDesc), nil, dual)
+	require.ErrorContains(t, err, `keyset cursor column 1 is "created_at" but the request sorts on "count"`)
+
+	_, _, err = BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, injectTestRenderParams(t, map[string]any{}, 1),
+		continuationQuery("count", forma.SortOrderDesc), nil, dual)
+	require.ErrorContains(t, err, `keyset cursor column 1 ("count") is descending but the request sorts "count" ascending`)
+
+	sql, _, err := BuildDuckDBQuery(AdvancedQueryTemplateDuckDB, injectTestRenderParams(t, map[string]any{}, 1),
+		continuationQuery("count", forma.SortOrderAsc), nil, dual)
+	require.NoError(t, err)
+	require.Contains(t, sql, "ORDER BY count ASC, row_id ASC", "a continuing cursor renders the request's order")
+}

--- a/internal/sqlgen/keyset_fold_test.go
+++ b/internal/sqlgen/keyset_fold_test.go
@@ -57,7 +57,7 @@ func TestKeysetColumnsAreFolded(t *testing.T) {
 		Mode:   model.KeysetCursorModeAfter,
 	}
 
-	where, args, err := generateKeysetWhereClause(cursor, "")
+	where, args, err := generateKeysetWhereClause(cursor)
 	if err != nil {
 		t.Fatalf("generateKeysetWhereClause: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestKeysetWhereClauseRejectsMisalignedValues(t *testing.T) {
 		Mode:   model.KeysetCursorModeAfter,
 	}
 
-	_, _, err := generateKeysetWhereClause(cursor, "")
+	_, _, err := generateKeysetWhereClause(cursor)
 	if err == nil {
 		t.Fatal("generateKeysetWhereClause() = nil error, want a misalignment error")
 	}

--- a/internal/sqlgen/keyset_fold_test.go
+++ b/internal/sqlgen/keyset_fold_test.go
@@ -39,3 +39,60 @@ func TestRendererKeysetGateMatchesIsActive(t *testing.T) {
 		})
 	}
 }
+
+// TestKeysetColumnsAreFolded pins #381 item 1's live bug: cursor columns must
+// be emitted through ParquetAttrColumn like every other column reference, or a
+// dotted attribute renders "contact.annualIncome" against a visible CTE that
+// exposes only "contact_annualIncome" — parsed by DuckDB as table "contact",
+// column "annualIncome" (#260).
+func TestKeysetColumnsAreFolded(t *testing.T) {
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{
+			{Attribute: "contact.annualIncome", Direction: forma.SortOrderDesc},
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+		},
+		Values: []interface{}{int64(90000), "r1"},
+		Mode:   model.KeysetCursorModeAfter,
+	}
+
+	where, args := generateKeysetWhereClause(cursor, "")
+	if strings.Contains(where, "contact.annualIncome") {
+		t.Errorf("WHERE clause emits the unfolded dotted name: %s", where)
+	}
+	if !strings.Contains(where, "contact_annualIncome") {
+		t.Errorf("WHERE clause is missing the folded column: %s", where)
+	}
+	if len(args) != 3 { // n(n+1)/2 for a 2-column cursor
+		t.Errorf("args = %d, want 3", len(args))
+	}
+
+	order := buildKeysetOrderBy(cursor)
+	if strings.Contains(order, "contact.annualIncome") {
+		t.Errorf("ORDER BY emits the unfolded dotted name: %s", order)
+	}
+	if order != "contact_annualIncome DESC, row_id ASC" {
+		t.Errorf("ORDER BY = %q, want %q", order, "contact_annualIncome DESC, row_id ASC")
+	}
+}
+
+// TestKeysetSystemColumnsSurviveTheFold guards the no-op half: the fold is the
+// identity on every visible-CTE system column, so this change must not alter
+// any cursor that production already renders.
+func TestKeysetSystemColumnsSurviveTheFold(t *testing.T) {
+	for _, attr := range []string{"row_id", "created_at", "ver_ts", "deleted_ts"} {
+		if got := ParquetAttrColumn(attr); got != attr {
+			t.Errorf("ParquetAttrColumn(%q) = %q, want the identity", attr, got)
+		}
+	}
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{
+			{Attribute: "created_at", Direction: forma.SortOrderDesc},
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+		},
+		Values: []interface{}{int64(5), "r1"},
+		Mode:   model.KeysetCursorModeAfter,
+	}
+	if got := buildKeysetOrderBy(cursor); got != "created_at DESC, row_id ASC" {
+		t.Errorf("ORDER BY = %q, want %q", got, "created_at DESC, row_id ASC")
+	}
+}

--- a/internal/sqlgen/keyset_fold_test.go
+++ b/internal/sqlgen/keyset_fold_test.go
@@ -28,7 +28,9 @@ func TestRendererKeysetGateMatchesIsActive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			params := map[string]any{}
 			q := &model.FederatedAttributeQuery{KeysetCursor: tc.cursor}
-			injectDuckDBTemplateParams(params, q, nil)
+			if err := injectDuckDBTemplateParams(params, q, nil); err != nil {
+				t.Fatalf("injectDuckDBTemplateParams: %v", err)
+			}
 			got, _ := params["HAS_KEYSET"].(bool)
 			if want := tc.cursor.IsActive(); got != want {
 				t.Errorf("HAS_KEYSET = %v, want IsActive() = %v", got, want)
@@ -55,7 +57,10 @@ func TestKeysetColumnsAreFolded(t *testing.T) {
 		Mode:   model.KeysetCursorModeAfter,
 	}
 
-	where, args := generateKeysetWhereClause(cursor, "")
+	where, args, err := generateKeysetWhereClause(cursor, "")
+	if err != nil {
+		t.Fatalf("generateKeysetWhereClause: %v", err)
+	}
 	if strings.Contains(where, "contact.annualIncome") {
 		t.Errorf("WHERE clause emits the unfolded dotted name: %s", where)
 	}
@@ -94,5 +99,35 @@ func TestKeysetSystemColumnsSurviveTheFold(t *testing.T) {
 	}
 	if got := buildKeysetOrderBy(cursor); got != "created_at DESC, row_id ASC" {
 		t.Errorf("ORDER BY = %q, want %q", got, "created_at DESC, row_id ASC")
+	}
+}
+
+// TestKeysetWhereClauseRejectsMisalignedValues pins #381 item 7 at the codegen
+// seam. The retired valueAt fallback returned nil for an index past the end of
+// Values, binding SQL NULL; `col > NULL` is NULL, WHERE treats that as
+// not-true, and every disjunct carrying the unfilled arm dropped out — the
+// caller received a silently empty page instead of an error.
+func TestKeysetWhereClauseRejectsMisalignedValues(t *testing.T) {
+	cursor := &model.KeysetCursor{
+		Columns: []model.KeysetColumn{
+			{Attribute: "created_at", Direction: forma.SortOrderDesc},
+			{Attribute: "row_id", Direction: forma.SortOrderAsc},
+		},
+		Values: []interface{}{int64(5)}, // one short
+		Mode:   model.KeysetCursorModeAfter,
+	}
+
+	_, _, err := generateKeysetWhereClause(cursor, "")
+	if err == nil {
+		t.Fatal("generateKeysetWhereClause() = nil error, want a misalignment error")
+	}
+	if !strings.Contains(err.Error(), "carries 2 column(s) but 1 value(s)") {
+		t.Errorf("err = %q, want it to name the column/value counts", err.Error())
+	}
+
+	params := map[string]any{}
+	q := &model.FederatedAttributeQuery{KeysetCursor: cursor}
+	if err := injectDuckDBTemplateParams(params, q, nil); err == nil {
+		t.Error("injectDuckDBTemplateParams() = nil error, want the misalignment to propagate")
 	}
 }

--- a/internal/sqlgen/keyset_fold_test.go
+++ b/internal/sqlgen/keyset_fold_test.go
@@ -1,0 +1,41 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// TestRendererKeysetGateMatchesIsActive pins that the renderer's decision to
+// emit the keyset clause is exactly model.KeysetCursor.IsActive (#381 item 9).
+// A renderer that ignored an active cursor would answer an unfiltered page.
+func TestRendererKeysetGateMatchesIsActive(t *testing.T) {
+	cases := []struct {
+		name   string
+		cursor *model.KeysetCursor
+	}{
+		{"nil cursor", nil},
+		{"empty columns", &model.KeysetCursor{Mode: model.KeysetCursorModeAfter}},
+		{"active cursor", &model.KeysetCursor{
+			Columns: []model.KeysetColumn{{Attribute: "row_id", Direction: forma.SortOrderAsc}},
+			Values:  []interface{}{"r1"},
+			Mode:    model.KeysetCursorModeAfter,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]any{}
+			q := &model.FederatedAttributeQuery{KeysetCursor: tc.cursor}
+			injectDuckDBTemplateParams(params, q, nil)
+			got, _ := params["HAS_KEYSET"].(bool)
+			if want := tc.cursor.IsActive(); got != want {
+				t.Errorf("HAS_KEYSET = %v, want IsActive() = %v", got, want)
+			}
+			if got && !strings.Contains(params["KEYSET_WHERE_CLAUSE"].(string), "row_id") {
+				t.Errorf("active cursor rendered no row_id predicate: %v", params["KEYSET_WHERE_CLAUSE"])
+			}
+		})
+	}
+}

--- a/internal/sqlgen/keyset_placement_test.go
+++ b/internal/sqlgen/keyset_placement_test.go
@@ -16,10 +16,15 @@ import (
 func TestAdvancedTemplate_KeysetAppliedAfterDedup(t *testing.T) {
 	q := &model.FederatedAttributeQuery{
 		AttributeQuery: model.AttributeQuery{SchemaID: 1, Limit: 10},
+		// row_id closes the cursor (#183); ValidateShape refuses a cursor
+		// ending on the non-unique "count" key (#381 item 7).
 		KeysetCursor: &model.KeysetCursor{
-			Columns: []model.KeysetColumn{{Attribute: "count", Direction: forma.SortOrderAsc}},
-			Values:  []any{float64(500)},
-			Mode:    model.KeysetCursorModeAfter,
+			Columns: []model.KeysetColumn{
+				{Attribute: "count", Direction: forma.SortOrderAsc},
+				{Attribute: "row_id", Direction: forma.SortOrderAsc},
+			},
+			Values: []any{float64(500), "11111111-1111-1111-1111-111111111111"},
+			Mode:   model.KeysetCursorModeAfter,
 		},
 	}
 	dual := &DualClauses{DuckClause: "1=1"}

--- a/internal/sqlgen/keyset_where.go
+++ b/internal/sqlgen/keyset_where.go
@@ -82,11 +82,18 @@ func generateKeysetWhereClause(cursor *model.KeysetCursor) (string, []interface{
 
 // keysetComparisonOp picks the continuation operator. The two switches below
 // are exhaustive rather than defaulting: ValidateShape has already refused any
-// mode outside {after, before} and any direction outside {asc, desc, ""}, so
-// the fall-through arms are reached only by the values they name. Before that
+// mode other than after and any direction outside {asc, desc, ""}, so the
+// fall-through arms are reached only by the values they name. Before that
 // rule existed, an unset mode silently meant BEFORE and an unrecognised
 // direction silently meant ASC, and both answered a successful page in the
 // wrong direction (#381).
+//
+// The before arms are currently unreachable: ValidateShape refuses a before
+// cursor because this flip is only half of a backward page — buildKeysetOrderBy
+// still fetches in the forward order under the LIMIT, so `key < 7 ORDER BY key
+// ASC LIMIT 2` answers [1, 2] rather than [5, 6]. They are kept because they
+// are the correct half; #513 adds the reversed fetch order and re-admits the
+// mode.
 func keysetComparisonOp(direction forma.SortOrder, mode model.KeysetCursorMode) string {
 	isAfter := mode == model.KeysetCursorModeAfter
 	switch direction {

--- a/internal/sqlgen/keyset_where.go
+++ b/internal/sqlgen/keyset_where.go
@@ -25,9 +25,11 @@ import (
 // future decoder must produce int64 for integer values (UseNumber /
 // numutil.Int64Exact), pinned by TestKeysetArgsPreserveInt64Above2p53.
 // The cursor must satisfy model.KeysetCursor.ValidateShape: values align
-// one-for-one with Columns and none of them is nil, and the last column is
-// the row_id tiebreak. A cursor that would bind SQL NULL is an error rather
-// than a silently empty page (#381 item 7).
+// one-for-one with Columns and none of them is nil, the last column is the
+// row_id tiebreak, and the mode and directions are the enum values this file
+// compares against. A cursor that would bind SQL NULL, or that the operator
+// choice below would read as its fall-through default, is an error rather
+// than a quietly wrong page (#381 item 7 and its two review follow-ups).
 func generateKeysetWhereClause(cursor *model.KeysetCursor) (string, []interface{}, error) {
 	if !cursor.IsActive() {
 		return "1=1", nil, nil
@@ -78,6 +80,13 @@ func generateKeysetWhereClause(cursor *model.KeysetCursor) (string, []interface{
 	return strings.Join(clauses, " OR "), args, nil
 }
 
+// keysetComparisonOp picks the continuation operator. The two switches below
+// are exhaustive rather than defaulting: ValidateShape has already refused any
+// mode outside {after, before} and any direction outside {asc, desc, ""}, so
+// the fall-through arms are reached only by the values they name. Before that
+// rule existed, an unset mode silently meant BEFORE and an unrecognised
+// direction silently meant ASC, and both answered a successful page in the
+// wrong direction (#381).
 func keysetComparisonOp(direction forma.SortOrder, mode model.KeysetCursorMode) string {
 	isAfter := mode == model.KeysetCursorModeAfter
 	switch direction {

--- a/internal/sqlgen/keyset_where.go
+++ b/internal/sqlgen/keyset_where.go
@@ -25,8 +25,9 @@ import (
 // future decoder must produce int64 for integer values (UseNumber /
 // numutil.Int64Exact), pinned by TestKeysetArgsPreserveInt64Above2p53.
 // The cursor must satisfy model.KeysetCursor.ValidateShape: values align
-// one-for-one with Columns, and the last column is the row_id tiebreak. A
-// misaligned cursor is an error rather than a NULL bind (#381 item 7).
+// one-for-one with Columns and none of them is nil, and the last column is
+// the row_id tiebreak. A cursor that would bind SQL NULL is an error rather
+// than a silently empty page (#381 item 7).
 func generateKeysetWhereClause(cursor *model.KeysetCursor) (string, []interface{}, error) {
 	if !cursor.IsActive() {
 		return "1=1", nil, nil

--- a/internal/sqlgen/keyset_where.go
+++ b/internal/sqlgen/keyset_where.go
@@ -29,7 +29,14 @@ func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (s
 		return "1=1", nil
 	}
 
-	colRef := func(col string) string {
+	// Cursor columns fold like every other column reference in this dialect
+	// (#260/#381): the visible CTE projects each attribute under its
+	// ParquetAttrColumn alias, so an unfolded "contact.annualIncome" would
+	// parse as table "contact", column "annualIncome". The fold is the
+	// identity on every visible-CTE system column, so this is a no-op for
+	// row_id / created_at / ver_ts / deleted_ts cursors.
+	colRef := func(attr string) string {
+		col := ParquetAttrColumn(attr)
 		if tableAlias == "" {
 			return col
 		}
@@ -82,6 +89,11 @@ func keysetComparisonOp(direction forma.SortOrder, mode model.KeysetCursorMode) 
 	}
 }
 
+// buildKeysetOrderBy renders the keyset ORDER BY. Columns fold through
+// ParquetAttrColumn for the same reason generateKeysetWhereClause's do: the
+// ORDER BY runs against the visible CTE, whose attribute columns carry folded
+// names (#260/#381). It must stay consistent with the WHERE clause — an
+// ORDER BY disagreeing with the cursor predicate paginates incoherently.
 func buildKeysetOrderBy(cursor *model.KeysetCursor) string {
 	if cursor == nil || len(cursor.Columns) == 0 {
 		return "created_at DESC"
@@ -92,7 +104,7 @@ func buildKeysetOrderBy(cursor *model.KeysetCursor) string {
 		if col.Direction == forma.SortOrderDesc {
 			dir = "DESC"
 		}
-		parts = append(parts, fmt.Sprintf("%s %s", col.Attribute, dir))
+		parts = append(parts, fmt.Sprintf("%s %s", ParquetAttrColumn(col.Attribute), dir))
 	}
 	return strings.Join(parts, ", ")
 }

--- a/internal/sqlgen/keyset_where.go
+++ b/internal/sqlgen/keyset_where.go
@@ -24,9 +24,18 @@ import (
 // row — #281 / #205 M-2). No continuation-token codec exists today; a
 // future decoder must produce int64 for integer values (UseNumber /
 // numutil.Int64Exact), pinned by TestKeysetArgsPreserveInt64Above2p53.
-func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (string, []interface{}) {
-	if cursor == nil || len(cursor.Columns) == 0 {
-		return "1=1", nil
+// The cursor must satisfy model.KeysetCursor.ValidateShape: values align
+// one-for-one with Columns, and the last column is the row_id tiebreak. A
+// misaligned cursor is an error rather than a NULL bind (#381 item 7).
+func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (string, []interface{}, error) {
+	if !cursor.IsActive() {
+		return "1=1", nil, nil
+	}
+	// The federated seams validate this too (federated.validateKeysetCursor),
+	// but the check is repeated here so a direct sqlgen caller cannot bind SQL
+	// NULL for an unfilled arm and receive a silently empty page (#381 item 7).
+	if err := cursor.ValidateShape(); err != nil {
+		return "", nil, fmt.Errorf("render keyset where clause: %w", err)
 	}
 
 	// Cursor columns fold like every other column reference in this dialect
@@ -42,12 +51,6 @@ func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (s
 		}
 		return tableAlias + col
 	}
-	valueAt := func(i int) interface{} {
-		if i < len(cursor.Values) {
-			return cursor.Values[i]
-		}
-		return nil
-	}
 
 	var clauses []string
 	var args []interface{}
@@ -59,18 +62,18 @@ func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (s
 		var parts []string
 		for j := 0; j < i; j++ {
 			parts = append(parts, fmt.Sprintf("%s = ?", colRef(cursor.Columns[j].Attribute)))
-			args = append(args, valueAt(j))
+			args = append(args, cursor.Values[j])
 		}
 		parts = append(parts, fmt.Sprintf("%s %s ?", colRef(col.Attribute), op))
-		args = append(args, valueAt(i))
+		args = append(args, cursor.Values[i])
 
 		clauses = append(clauses, "("+strings.Join(parts, " AND ")+")")
 	}
 
 	if len(clauses) == 1 {
-		return clauses[0], args
+		return clauses[0], args, nil
 	}
-	return strings.Join(clauses, " OR "), args
+	return strings.Join(clauses, " OR "), args, nil
 }
 
 func keysetComparisonOp(direction forma.SortOrder, mode model.KeysetCursorMode) string {

--- a/internal/sqlgen/keyset_where.go
+++ b/internal/sqlgen/keyset_where.go
@@ -27,7 +27,7 @@ import (
 // The cursor must satisfy model.KeysetCursor.ValidateShape: values align
 // one-for-one with Columns, and the last column is the row_id tiebreak. A
 // misaligned cursor is an error rather than a NULL bind (#381 item 7).
-func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (string, []interface{}, error) {
+func generateKeysetWhereClause(cursor *model.KeysetCursor) (string, []interface{}, error) {
 	if !cursor.IsActive() {
 		return "1=1", nil, nil
 	}
@@ -44,13 +44,14 @@ func generateKeysetWhereClause(cursor *model.KeysetCursor, tableAlias string) (s
 	// parse as table "contact", column "annualIncome". The fold is the
 	// identity on every visible-CTE system column, so this is a no-op for
 	// row_id / created_at / ver_ts / deleted_ts cursors.
-	colRef := func(attr string) string {
-		col := ParquetAttrColumn(attr)
-		if tableAlias == "" {
-			return col
-		}
-		return tableAlias + col
-	}
+	//
+	// The clause always renders against the unqualified columns of visible, so
+	// there is no table alias to prefix. A tableAlias parameter used to exist:
+	// both callers passed "", and its branch concatenated WITHOUT a separator
+	// ("visible" + "row_id" = "visiblerow_id"), so the first caller to pass a
+	// real alias would have emitted a broken identifier. Removed rather than
+	// fixed — the qualification it promised has no use here (#381).
+	colRef := ParquetAttrColumn
 
 	var clauses []string
 	var args []interface{}
@@ -98,7 +99,7 @@ func keysetComparisonOp(direction forma.SortOrder, mode model.KeysetCursorMode) 
 // names (#260/#381). It must stay consistent with the WHERE clause — an
 // ORDER BY disagreeing with the cursor predicate paginates incoherently.
 func buildKeysetOrderBy(cursor *model.KeysetCursor) string {
-	if cursor == nil || len(cursor.Columns) == 0 {
+	if !cursor.IsActive() {
 		return "created_at DESC"
 	}
 	var parts []string


### PR DESCRIPTION
Closes #381.

The keyset cursor contract differed depending on which engine entry point a cursor arrived through, and one of those differences was a live correctness bug. This makes the contract single and uniform.

## The contract

A cursor is valid when `len(Values) == len(Columns)`, no boundary value is nil, the final column is `row_id` (case aside), `Mode` is `after` (`before` is refused until #513 builds its backward window), each column's `Direction` is `asc`, `desc` or empty, it **continues** the request's `AttributeOrders` when there are any (same attributes in order, same directions, then `row_id ASC`; with no `AttributeOrders` the cursor is the order), and every column — judged on its `sqlgen.ParquetAttrColumn` **fold** — is one of the four `visible`-CTE system columns (`row_id`, `created_at`, `ver_ts`, `deleted_ts`), is not dedup machinery (`rn`, `source_tier_priority`), did not trigger `ParquetAttrColumn`'s `"attr"` empty-fold fallback, and matches `^[A-Za-z_][A-Za-z0-9_]*$`.

`federated.validateKeysetCursor` enforces it, and every seam that can reach the DuckDB keyset renderer calls it independently, each with the order it is about to render: `Query`, `ExecuteFederatedPaginatedQuery`, `ExecuteDuckDBFederatedQuery`, `StreamDuckDBFederatedQuery`. The shape and continuation rules are re-checked inside `sqlgen` as well.

Separately, the explicit `limit`, `offset` and `attributeOrders` arguments are now the pagination contract of every DuckDB seam: `buildDuckDBQueryWithPlan` renders a copy of the query carrying them (`federated.dispatchedQuery`), so a normalised or clamped limit is what renders.

## What changed, by issue item

| Item | Change |
| --- | --- |
| 1. Seams disagreed on admissible columns | One validator at every seam; cursor columns emitted folded |
| 2. `col.Attribute` interpolated unquoted | Safe-identifier check on the folded name is the injection barrier |
| 3. Split-brain page in `ExecuteFederatedPaginatedQuery` | An active cursor alone selects the keyset path |
| 4. `opts.KeysetEnabled` inert on `Query` | Field deleted |
| 5. `hotOnly` / `isHotOnlyRequest` asymmetry | Characterization test; no behaviour change |
| 6. Stale `isSupportedKeysetColumn` doc comment | Function removed |
| 7. `Columns` without `Values` returned an empty page | `ValidateShape` rejects it; codegen errors instead of binding SQL NULL |
| 8. `EvaluateRoutingPolicy` vs engine disagreement | Pinned as documented, deliberate behaviour |
| 9. Active-cursor predicate unshareable across packages | `model.KeysetCursor.IsActive()`, delegated to everywhere |

The live bug is item 1's second half: `generateKeysetWhereClause` and `buildKeysetOrderBy` emitted `col.Attribute` verbatim, so a cursor over `contact.annualIncome` referenced that dotted name against a CTE exposing only `contact_annualIncome` — DuckDB parses it as table `contact`, column `annualIncome`. Existing tests passed only because they cursored on fold-invariant names.

`docs/federated-query/design.md` §4.4 is rewritten to describe the single contract, and the stale references it carried are repaired.

## Two defects found during implementation

Both were in the plan, and both would have shipped a guard that does not guard:

1. The validator keyed its column sets on the **raw** attribute while applying the injection barrier to the **folded** one. `source_tier.priority` folds to `source_tier_priority` and `[rn]` folds to `rn`, so both bypassed the dedup-machinery refusal. It was harmless only because the code generator still emitted raw names at that point — and the next commit removes exactly that accident.
2. Even after folding, the guard was defeated by letter case. `ParquetAttrColumn` preserves case, so `RN` missed the reject map and passed the identifier regex, while DuckDB resolves unquoted identifiers case-insensitively and would have bound it to the dedup rank — pagination over `ROW_NUMBER()`. Both map lookups are now case-normalised; emission and error messages keep the caller's spelling.

## Deliberately out of scope

- **Cache-backed validation** that a cursor attribute is registered in the schema. It needs the metadata cache, and an unregistered but well-formed name fails loudly at DuckDB's binder rather than silently. It belongs with the caller-facing cursor surface the Postgres-side keyset feature introduces — which this issue is sequenced before.
- ~~**`model.KeysetCursor.Mode` is still unvalidated**~~ — closed here after the second review. `Mode` and `KeysetColumn.Direction` are both validated in `ValidateShape`, which **closes #510**; see "Three rules added on review" below.
- **Backward (`before`) keyset windowing** — #513. The renderer flips the operator but fetches in the forward order under the `LIMIT`, so a `before` page answered the start of the prior range; it is refused here and implemented there, sequenced with #382.
- `DBFederatedQueryEngine.Query` remains at 101 lines against the 100-line standard (this branch reduced it from 105), and `internal/federated/duckdb_query.go` now sits at exactly the 500-line file cap with no headroom.

## Three rules added on review

The third review found the shape contract still admitted cursors whose *values and enums* produce a successful page of the wrong rows. All three are the same family as item 7 and all three land in `ValidateShape`, so one edit binds all four seams and the `sqlgen` re-check:

| Rule | Silent failure it removes |
| --- | --- |
| No boundary value may be `nil` | Alignment was the only rule on `Values`, so a right-sized cursor with a nil boundary bound SQL NULL; `row_id > NULL` is unknown, not false, so the tie group at the boundary silently dropped. Typed nils (`(*string)(nil)`) are refused too — they bind NULL just the same. |
| `Mode` is `after` | `keysetComparisonOp` computes `mode == after`, so every other value — the zero value above all — meant **before**: a cursor that lost its mode paginated backwards and still answered. (Tightened to `after` only in the fourth round; see below.) |
| `Direction` is `asc`, `desc`, or empty | The renderer reads anything that is not `desc` as ascending, so an unrecognised direction paged against its own `ORDER BY`. Empty stays admitted because `asc` is this repository's documented sort default (`normalizeSortOrder`) and the renderer already agrees with it. |

The two enums are matched **byte-exactly**, unlike the case-insensitive `row_id` tiebreak. That asymmetry is deliberate: `row_id` is a SQL identifier DuckDB resolves case-insensitively, while a mode and a direction are Go constants the renderer compares exactly — admitting `DESC` or `After` would hand the renderer a spelling it reads as its fall-through default, reinstating the defect. A caller-facing decode boundary that accepts other spellings normalizes them first.

## Three contract changes from the fourth review

Ruling with the reasoning: https://github.com/Lychee-Technology/forma/issues/381#issuecomment-5517754660.

| Finding | Change |
| --- | --- |
| P1 — a `before` cursor answers the start of the prior range (`key < 7 ORDER BY key ASC LIMIT 2` → `[1, 2]`, not `[5, 6]`) | `ValidateShape` refuses `before`; the constant and the operator flip stay for #513, which adds the reversed fetch order and execution-level ASC/DESC tests. |
| P1 — an active cursor silently replaces `AttributeOrders` | `model.KeysetCursor.ValidateContinuation(orders)`: with `AttributeOrders` present the cursor must be those orders plus `row_id ASC`; with none, the cursor is the order (the default is a renderer fallback, `AttributeOrders` cannot name `created_at`, and the production e2e walks and the benchmark page cursor-only). Checked at all four seams against the order each renders, and again in `injectDuckDBTemplateParams`. |
| P1 — the keyset branch discards the normalised/clamped `limit` | `buildDuckDBQueryWithPlan` renders `dispatchedQuery(q, limit, offset, attributeOrders)`, the one point both the direct render and the plan cache flow through. Tests pin `fq.Limit = 0` → `DefaultPageSize`, over-`MaxRows` → the clamp, offset zeroed, recount `LIMIT 1`, caller's query untouched. |
| P2 — `Claude-Session:` trailers in five commits | Stripped from history; the branch was force-pushed. |

## Verification

`make fmt-check`, `make lint`, the container-backed `make test`, and `make test-e2e-production` all pass at the current head (re-run after the fourth round).

Two federated e2e performance tests fail on the development machine — `TestPerformance_SimplePagination` and `TestPerformance_ConcurrentQueries`. Both are pure latency-threshold assertions and reported 100% success rate. Run on `main` under identical serial conditions they fail there too, by a wider margin (p95 1303.8ms vs this branch's 593.8ms; 12.086s vs 6.382s), so the thresholds are not met by this hardware and this is not a regression. CI runs the federated suite with `-short`, which skips them; their signal is the nightly workflow.

Full verification record, including the deviations from the implementation plan and their reasoning, is on the issue: https://github.com/Lychee-Technology/forma/issues/381#issuecomment-5490360349



