### PR TITLE
fix(cdc-init): mint write-once base keys and retry a confirmed-412 publish

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -646,8 +646,8 @@ while still never excluding it.
 **Trust boundary.** A stamp is trusted without reading bytes only because every
 object behind one was written by a Forma writer under manifest transactionality:
 flush and compaction mint fresh keys and stamp what they just wrote, an init
-rerun overwrites its deterministic key and re-stamps it in the same
-`ReplaceTierFiles` publish, and `manifest-reconcile --repair`'s init promotion
+rerun likewise mints fresh write-once keys (#416) and stamps them in the same
+`ReplaceTierFiles` publish that replaces the base tier, and `manifest-reconcile --repair`'s init promotion
 (#292) recomputes the stamp from the footer rather than inventing one. Outside
 that boundary — an out-of-band overwrite of a listed object's bytes while its
 entry keeps a stamp that still satisfies the system-column invariant — the read
@@ -701,11 +701,13 @@ connection by default, #285), and bails on context cancellation.
 
 **Cache invalidation.** The validator caches each path it validates, keyed by
 path **and by the stamp it was validated under** (nil for probe-validated). Path
-alone would be wrong: objects are write-once for flush and compaction, which
-mint fresh UUIDv7 keys, but **not for init** — `cdc.BuildBasePath` is
-deterministic (`{min}_{max}.parquet`), so an init rerun overwrites the object in
-place and rewrites its entry under the same key. A path-keyed cache would serve
-a warmed server the pre-rerun columns for the life of the process. The manifest
+alone would be wrong: Forma's writers mint write-once keys (flush and compaction
+always did; `cdc.BuildBasePath` mints `{min}_{max}_{uuid}.parquet` since #416,
+before which an init rerun overwrote its deterministic `{min}_{max}.parquet` key
+in place), but a rewrite under a listed path is still reachable — legacy
+deployments, or an operator repair that republishes bytes under an existing
+key — and each re-stamps the entry under the same key. A path-keyed cache would
+serve a warmed server the pre-rewrite columns for the life of the process. The manifest
 rewrite is therefore the invalidation signal: same stamp, keep the entry; new
 stamp, re-validate. An unchanged stamp still costs zero probes, so the
 cold-start win is intact. When a probe *does* run on a stamped path — which

--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -29,10 +29,10 @@ manifest 条目，双向报告差异，并可选修复。它是两条既有故�
 |------|------|------|------|
 | delta 孤儿 | `{prefix}/{schemaID}/{uuid}.parquet` | flush 的 manifest-append 失败（#252 起 append 先于 mark-flushed：行留 dirty、重试自愈覆盖，孤儿通常判为可 GC 残留；#252 前为 #197 丢失数据形态）或 #461 起每次 rewrite 保留的 merged source | `--repair` 经守卫判定后补录或转残留（见下） |
 | merged base 孤儿 | `base-{uuid}.parquet` | #188 崩溃 / #461 起每次 rewrite 保留的 merged source | `--gc` 两阶段删除（见下） |
-| init base 孤儿 | `{min}_{max}.parquet` | cdc-init 导出 | `--repair` 下先经晋升守卫（三重证明，见下）整组判定：证明通过则整组补录进 manifest base 层；证明不通过（或未开 `--repair`）保持 GC 候选，走 `--gc` 两阶段删除（见下）。#290 起 cdc-init 与 reconcile 持同一把 per-schema advisory lock，故此锁下的 init 形态孤儿必非 in-flight init——只可能是发布失败的 manifest 或被后续 init 覆盖的旧文件 |
+| init base 孤儿 | `{min}_{max}_{uuid}.parquet`（#416 起 write-once；旧版 `{min}_{max}.parquet` 仍被识别） | cdc-init 导出 | `--repair` 下先经晋升守卫（三重证明，见下）整组判定：证明通过则整组补录进 manifest base 层；证明不通过（或未开 `--repair`）保持 GC 候选，走 `--gc` 两阶段删除（见下）。#290 起 cdc-init 与 reconcile 持同一把 per-schema advisory lock，故此锁下的 init 形态孤儿必非 in-flight init——只可能是发布失败的 manifest 或被后续 init 取代的旧文件（#416 起 init 重跑铸造新键，旧文件原样留在 S3 而不再被原地覆盖） |
 | `_tmp` 孤儿 | `{prefix}/{schemaID}/_tmp/*` | staging 残留（#188 崩溃 / #226 swallowed-delete） | `--gc` 两阶段删除（见下） |
 
-形态匹配是严格的：`base-` 后缀与 `{min}_{max}` 两段都必须是合法 UUID，否则归
+形态匹配是严格的：`base-` 后缀与 `{min}_{max}[_{uuid}]` 的每一段都必须是合法 UUID，否则归
 unknown（只报告，永不删除）。
 
 另报告两类只读发现：
@@ -102,7 +102,7 @@ base 层（`SpliceTierFiles`：整个 base 层被这组条目替换，其他 tie
 
 - schema 当前**没有存活行** → 拒绝（此时 init 形态孤儿必然已被取代）；
 - 逐文件重算 parquet 统计；统计读不到 → 拒绝；
-- 文件名 `{min}_{max}` 与重算出的 row_id 区间**不一致** → 拒绝（元数据永不取自文件名，
+- 文件名 `{min}_{max}[_{uuid}]` 与重算出的 row_id 区间**不一致** → 拒绝（元数据永不取自文件名，
   该检查只是为了让"看起来像 init 形态"的外来/截断文件进不了 base 层）；
 - 任意两文件的 `[min, max]` 区间**重叠** → 拒绝：一次导出的批次互不相交，重叠说明这组
   文件混了多代 init，晋升会把重复行版本塞进 base 层；

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -331,7 +331,10 @@ func buildSchemaBatchExport(runCtx *initRunContext, state *schemaInitState, rowI
 
 	tmpUUID := uuid.Must(uuid.NewV7()).String()
 	tmpKey := BuildBaseTempPath(runCtx.cfg.S3Prefix, state.schemaID, tmpUUID)
-	finalKey := BuildBasePath(runCtx.cfg.S3Prefix, state.schemaID, minRowID, maxRowID)
+	// tmp and final share the batch's UUID: the final key is write-once
+	// (#416), and a shared id lets an operator pair a stranded _tmp object
+	// with the final it was meant to become.
+	finalKey := BuildBasePath(runCtx.cfg.S3Prefix, state.schemaID, minRowID, maxRowID, tmpUUID)
 	s3TmpPath := fmt.Sprintf("s3://%s/%s", runCtx.cfg.S3Bucket, tmpKey)
 
 	return schemaBatchExport{
@@ -414,34 +417,6 @@ func exportSchemaBatch(ctx context.Context, runCtx *initRunContext, state *schem
 		zap.Int64("rows_exported", state.rowsExported),
 		zap.Int("files_created", state.filesCreated),
 		zap.String("final_key", batch.finalKey))
-	return nil
-}
-
-// updateSchemaManifest records the exported base files in the schema
-// manifest. Failures propagate: base files absent from the manifest are
-// invisible to manifest consumers (e.g. compaction), and a silent miss here
-// would let RunInit report success for an unusable export. Init is a full
-// re-export, so the base tier is replaced wholesale with this run's files:
-// reruns neither duplicate entries nor leave stale ranges behind (#176).
-// Obsolete S3 objects are not deleted here — glob-based readers stay exact
-// via LWW/tombstones, and object cleanup belongs to
-// `forma-tools manifest-reconcile --gc` (#203).
-func updateSchemaManifest(ctx context.Context, runCtx *initRunContext, state *schemaInitState) error {
-	if runCtx.manifestStore == nil || len(state.fileEntries) == 0 || runCtx.dryRun {
-		return nil
-	}
-
-	manifestPath, err := runCtx.manifestResolver.Resolve(state.schemaID)
-	if err != nil {
-		return fmt.Errorf("resolve manifest path: %w", err)
-	}
-	if err := manifest.ReplaceTierFiles(ctx, runCtx.manifestStore, manifestPath, state.schemaID, "base", state.fileEntries); err != nil {
-		return fmt.Errorf("update manifest: %w", err)
-	}
-	runCtx.logger.Info("manifest updated",
-		zap.Int16("schema_id", state.schemaID),
-		zap.String("manifest_path", manifestPath),
-		zap.Int("files_added", len(state.fileEntries)))
 	return nil
 }
 

--- a/internal/cdc/init_publish.go
+++ b/internal/cdc/init_publish.go
@@ -1,0 +1,63 @@
+package cdc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lychee-technology/forma/internal/manifest"
+	"go.uber.org/zap"
+)
+
+// initPublishConflictRetries bounds how many confirmed-412 conflicts the
+// final manifest publish absorbs before the run fails. The only writer that
+// can race it is the compactor (init holds the schema advisory lock against
+// the flusher and reconcile, not the compactor), and its swaps are seconds
+// apart at most, so a handful of reloads is plenty.
+const initPublishConflictRetries = 3
+
+// updateSchemaManifest records the exported base files in the schema
+// manifest. Failures propagate: base files absent from the manifest are
+// invisible to manifest consumers (e.g. compaction), and a silent miss here
+// would let RunInit report success for an unusable export. Init is a full
+// re-export, so the base tier is replaced wholesale with this run's files:
+// reruns neither duplicate entries nor leave stale ranges behind (#176).
+// The previous run's objects are not deleted here: since #416 every batch
+// lands on a fresh write-once key, so after a re-run the superseded set is
+// unlisted and reclaimed by `forma-tools manifest-reconcile --gc` (#203) —
+// never overwritten under a listed entry's stamp.
+//
+// The publish is a CAS under the loaded etag. A CONFIRMED 412 means a
+// compactor swap landed during the export; the run reloads the manifest and
+// re-splices its base tier rather than discard hours of export (#416). Only a
+// confirmed 412 is retried, and only initPublishConflictRetries times — an
+// ambiguous save error may have committed, and a blind retry could publish
+// twice.
+func updateSchemaManifest(ctx context.Context, runCtx *initRunContext, state *schemaInitState) error {
+	if runCtx.manifestStore == nil || len(state.fileEntries) == 0 || runCtx.dryRun {
+		return nil
+	}
+
+	manifestPath, err := runCtx.manifestResolver.Resolve(state.schemaID)
+	if err != nil {
+		return fmt.Errorf("resolve manifest path: %w", err)
+	}
+	for attempt := 0; ; attempt++ {
+		err := manifest.ReplaceTierFiles(ctx, runCtx.manifestStore, manifestPath, state.schemaID, "base", state.fileEntries)
+		if err == nil {
+			break
+		}
+		if !manifest.IsPreconditionFailed(err) || attempt >= initPublishConflictRetries {
+			return fmt.Errorf("update manifest: %w", err)
+		}
+		runCtx.logger.Warn("manifest publish lost a conditional-put race; reloading and re-splicing the base tier",
+			zap.Int16("schema_id", state.schemaID),
+			zap.String("manifest_path", manifestPath),
+			zap.Int("attempt", attempt+1),
+			zap.Error(err))
+	}
+	runCtx.logger.Info("manifest updated",
+		zap.Int16("schema_id", state.schemaID),
+		zap.String("manifest_path", manifestPath),
+		zap.Int("files_added", len(state.fileEntries)))
+	return nil
+}

--- a/internal/cdc/init_test.go
+++ b/internal/cdc/init_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/smithy-go"
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma/internal/manifest"
 	"go.uber.org/zap"
@@ -334,5 +335,130 @@ func TestInitStampColumnsShortCircuitWhenNoManifestStore(t *testing.T) {
 	}
 	if cols := initStampColumns(context.Background(), runCtx, 7, schemaBatchExport{finalKey: "base/7/x.parquet"}); cols != nil {
 		t.Fatalf("manifest store nil must yield nil stamp, got %#v", cols)
+	}
+}
+
+// A re-run over an unchanged row range must not overwrite the object the
+// manifest still lists: the compactor's pre-merge checksum gate hashes listed
+// objects against their stamps, and an in-place overwrite makes a healthy
+// system read as corrupt (#416). Each batch therefore mints a fresh key.
+func TestExportSchemaBatch_RerunOverSameRangeMintsFreshKey(t *testing.T) {
+	runCtx, _ := newChecksumInitContext(func(context.Context, string) (string, error) { return "sha256:x", nil })
+
+	first := &schemaInitState{schemaID: 7}
+	if err := exportSchemaBatch(context.Background(), runCtx, first, initBatchRowIDs()); err != nil {
+		t.Fatalf("first export: %v", err)
+	}
+	second := &schemaInitState{schemaID: 7}
+	if err := exportSchemaBatch(context.Background(), runCtx, second, initBatchRowIDs()); err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+
+	a, b := first.fileEntries[0].Path, second.fileEntries[0].Path
+	if a == b {
+		t.Fatalf("re-run reused key %q; init base keys must be write-once", a)
+	}
+	rowID := initBatchRowIDs()[0].String()
+	for _, p := range []string{a, b} {
+		if !strings.HasPrefix(p, "cdc/7/"+rowID+"_"+rowID+"_") {
+			t.Fatalf("key %q does not keep the {min}_{max}_ prefix", p)
+		}
+	}
+}
+
+// conflictingSaveStore rejects the first N saves with a confirmed 412 and
+// bumps the stored manifest in between, the way a compactor swap landing
+// during the export does.
+type conflictingSaveStore struct {
+	memManifestStore
+	rejectFirst int
+	saves       int
+}
+
+func (s *conflictingSaveStore) Save(ctx context.Context, path string, data []byte, etag string) (string, error) {
+	s.saves++
+	if s.saves <= s.rejectFirst {
+		return "", &preconditionFailedErr{}
+	}
+	return s.memManifestStore.Save(ctx, path, data, etag)
+}
+
+// preconditionFailedErr implements smithy.APIError with code
+// PreconditionFailed — the confirmed-412 shape S3 returns for a stale If-Match.
+type preconditionFailedErr struct{}
+
+func (*preconditionFailedErr) Error() string                 { return "api error PreconditionFailed (test)" }
+func (*preconditionFailedErr) ErrorCode() string             { return "PreconditionFailed" }
+func (*preconditionFailedErr) ErrorMessage() string          { return "precondition failed (test)" }
+func (*preconditionFailedErr) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
+
+// The final publish is the only step a compactor swap can race (init holds
+// the schema lock against the flusher and reconcile, not the compactor). A
+// confirmed 412 must reload the manifest and re-splice this run's base tier
+// rather than discard the whole export (#416).
+func TestUpdateSchemaManifest_RetriesConfirmed412(t *testing.T) {
+	st := &conflictingSaveStore{rejectFirst: 2}
+	seed := &manifest.Manifest{SchemaID: 1, Files: []manifest.FileEntry{
+		{Tier: "delta", Path: "prefix/1/d.parquet", RowCount: 5},
+		{Tier: "base", Path: "prefix/1/base-old.parquet", RowCount: 1},
+	}}
+	if _, err := manifest.Save(context.Background(), &st.memManifestStore, "manifest/1.json", seed, ""); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+	runCtx := &initRunContext{
+		manifestStore:    st,
+		manifestResolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
+		logger:           zap.NewNop(),
+	}
+
+	if err := updateSchemaManifest(context.Background(), runCtx, initStateWithOneEntry(1)); err != nil {
+		t.Fatalf("publish under 412 conflicts: %v", err)
+	}
+	if st.saves != 3 {
+		t.Fatalf("saves = %d, want 3 (two rejected, one committed)", st.saves)
+	}
+	m, _, err := manifest.Load(context.Background(), st, "manifest/1.json")
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	if len(m.Files) != 2 || m.Files[0].Path != "prefix/1/d.parquet" || m.Files[1].Path != "prefix/1/a_b.parquet" {
+		t.Fatalf("manifest after retried publish = %+v, want delta preserved and base replaced", m.Files)
+	}
+}
+
+// Retries are bounded: a conflict that never clears must surface, not spin.
+func TestUpdateSchemaManifest_GivesUpAfterBoundedConflicts(t *testing.T) {
+	st := &conflictingSaveStore{rejectFirst: 100}
+	runCtx := &initRunContext{
+		manifestStore:    st,
+		manifestResolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
+		logger:           zap.NewNop(),
+	}
+
+	err := updateSchemaManifest(context.Background(), runCtx, initStateWithOneEntry(1))
+	if err == nil {
+		t.Fatal("publish succeeded under a conflict that never clears")
+	}
+	if !manifest.IsPreconditionFailed(err) {
+		t.Fatalf("error does not carry the 412 cause: %v", err)
+	}
+	if st.saves != 1+initPublishConflictRetries {
+		t.Fatalf("saves = %d, want %d (one attempt plus the bounded retries)", st.saves, 1+initPublishConflictRetries)
+	}
+}
+
+// An ambiguous save error (not a confirmed 412) is not retried: the put may
+// have landed, and a blind retry could publish twice.
+func TestUpdateSchemaManifest_DoesNotRetryAmbiguousSaveError(t *testing.T) {
+	saveErr := errors.New("connection reset")
+	st := &failingSaveStore{saveErr: saveErr}
+	runCtx := &initRunContext{
+		manifestStore:    st,
+		manifestResolver: manifest.PathResolver{PathTemplate: "manifest/{{.SchemaID}}.json"},
+		logger:           zap.NewNop(),
+	}
+	err := updateSchemaManifest(context.Background(), runCtx, initStateWithOneEntry(1))
+	if !errors.Is(err, saveErr) {
+		t.Fatalf("err = %v, want the ambiguous save error surfaced", err)
 	}
 }

--- a/internal/cdc/manifest.go
+++ b/internal/cdc/manifest.go
@@ -3,6 +3,8 @@ package cdc
 import (
 	"fmt"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // ManifestEntry describes a parquet file tracked for a schema.
@@ -36,11 +38,41 @@ func BuildTempPath(prefix string, schemaID int16, fileUUID string) string {
 	return fmt.Sprintf("%s/%d/_tmp/%s.parquet", trimmed, schemaID, fileUUID)
 }
 
-// BuildBasePath returns the canonical base file path for a schema.
-// Base files use min/max row_id naming to indicate the row range covered.
-func BuildBasePath(prefix string, schemaID int16, minRowID, maxRowID string) string {
+// BuildBasePath returns the path of a cdc-init base file:
+// {prefix}/{schema}/{minRowID}_{maxRowID}_{fileUUID}.parquet. The row range
+// stays in the name for operators and for manifest-reconcile's
+// filename/content cross-check; the UUID makes the key write-once. It used
+// to be {min}_{max} alone, so a re-run over an unchanged range overwrote an
+// object the manifest still listed under the previous run's column and
+// checksum stamps — the compactor's pre-merge checksum gate then read a
+// healthy system as corrupt, and a failed re-run left the stale stamps
+// behind for good (#416). Flush and compaction never reuse a key
+// (BuildDeltaPath, BuildMergedBasePath); init now honours the same rule.
+// ParseInitBaseStem is the inverse and still accepts the legacy shape.
+func BuildBasePath(prefix string, schemaID int16, minRowID, maxRowID, fileUUID string) string {
 	trimmed := strings.TrimSuffix(prefix, "/")
-	return fmt.Sprintf("%s/%d/%s_%s.parquet", trimmed, schemaID, minRowID, maxRowID)
+	return fmt.Sprintf("%s/%d/%s_%s_%s.parquet", trimmed, schemaID, minRowID, maxRowID, fileUUID)
+}
+
+// ParseInitBaseStem recognises an init base object's filename stem (the key's
+// last path segment without ".parquet") and returns the row range it names.
+// Both shapes are init-shaped: the write-once {min}_{max}_{fileUUID} that
+// BuildBasePath mints since #416 and the legacy deterministic {min}_{max}
+// still present in buckets written before it. Every part must be a UUID —
+// the shape drives repair and GC decisions, so anything that merely
+// resembles it must not match. Row-range text is returned verbatim; callers
+// that compare ranges canonicalise case themselves.
+func ParseInitBaseStem(stem string) (minRowID, maxRowID string, ok bool) {
+	parts := strings.Split(stem, "_")
+	if len(parts) != 2 && len(parts) != 3 {
+		return "", "", false
+	}
+	for _, p := range parts {
+		if uuid.Validate(p) != nil {
+			return "", "", false
+		}
+	}
+	return parts[0], parts[1], true
 }
 
 // BuildBaseTempPath returns the temp path for a base file during init.

--- a/internal/cdc/manifest_test.go
+++ b/internal/cdc/manifest_test.go
@@ -1,0 +1,59 @@
+package cdc
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	testRowMin  = "018f05c0-0000-7000-8000-000000000001"
+	testRowMax  = "018f05c0-0000-7000-8000-000000000009"
+	testFileID  = "019bed54-48eb-7cdc-aed3-8d38ec9c1394"
+	testFileID2 = "019bed54-48eb-7cdc-aed3-8d38ec9c1395"
+)
+
+// Init base keys are write-once (#416): the same row range exported twice
+// must land on two different keys, so a re-run never overwrites an object
+// the manifest still lists under the previous run's stamp.
+func TestBuildBasePath_SameRangeDistinctFileIDsMintDistinctKeys(t *testing.T) {
+	a := BuildBasePath("data", 7, testRowMin, testRowMax, testFileID)
+	b := BuildBasePath("data", 7, testRowMin, testRowMax, testFileID2)
+	if a == b {
+		t.Fatalf("two file ids rendered the same key %q; init keys must be write-once", a)
+	}
+	want := "data/7/" + testRowMin + "_" + testRowMax + "_" + testFileID + ".parquet"
+	if a != want {
+		t.Fatalf("BuildBasePath = %q, want %q", a, want)
+	}
+	if strings.HasPrefix(a, "data//") {
+		t.Fatalf("prefix trailing slash not normalized: %q", a)
+	}
+}
+
+func TestParseInitBaseStem(t *testing.T) {
+	tests := []struct {
+		name     string
+		stem     string
+		min, max string
+		ok       bool
+	}{
+		{"write-once shape", testRowMin + "_" + testRowMax + "_" + testFileID, testRowMin, testRowMax, true},
+		{"legacy deterministic shape", testRowMin + "_" + testRowMax, testRowMin, testRowMax, true},
+		{"delta uuid", testFileID, "", "", false},
+		{"merged base", "base-" + testFileID, "", "", false},
+		{"junk two parts", "a_b", "", "", false},
+		{"junk file id", testRowMin + "_" + testRowMax + "_nope", "", "", false},
+		{"four parts", testRowMin + "_" + testRowMax + "_" + testFileID + "_" + testFileID2, "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max, ok := ParseInitBaseStem(tt.stem)
+			if ok != tt.ok {
+				t.Fatalf("ParseInitBaseStem(%q) ok = %v, want %v", tt.stem, ok, tt.ok)
+			}
+			if min != tt.min || max != tt.max {
+				t.Fatalf("ParseInitBaseStem(%q) = %q,%q want %q,%q", tt.stem, min, max, tt.min, tt.max)
+			}
+		})
+	}
+}

--- a/internal/compaction/compactor.go
+++ b/internal/compaction/compactor.go
@@ -5,13 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"sort"
 	"strings"
 	"time"
 
-	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/smithy-go"
 	"github.com/lychee-technology/forma/internal/cdc"
 	"github.com/lychee-technology/forma/internal/manifest"
 	"github.com/lychee-technology/forma/internal/telemetry"
@@ -158,16 +155,12 @@ func isRetryable(err error) bool {
 
 // isPreconditionFailed reports whether err is a CONFIRMED HTTP 412
 // conditional-put rejection from the object store — the only save failure
-// that proves the write did not commit. Transport errors, timeouts and
-// other API failures are deliberately excluded: after those the put may
-// have landed, and callers must treat the outcome as ambiguous.
+// that proves the write did not commit. The classification lives with the
+// store that produces it (manifest.IsPreconditionFailed) so every etag
+// writer — compactor, reconcile, cdc-init — agrees on what counts as a
+// retryable conflict.
 func isPreconditionFailed(err error) bool {
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "PreconditionFailed" {
-		return true
-	}
-	var respErr *awshttp.ResponseError
-	return errors.As(err, &respErr) && respErr.HTTPStatusCode() == http.StatusPreconditionFailed
+	return manifest.IsPreconditionFailed(err)
 }
 
 func (c *Compactor) compactSchema(ctx context.Context, schemaID int16, cfg cdc.CompactionConfig) (CompactionResult, error) {

--- a/internal/e2e_harness/production/init_rerun_e2e_test.go
+++ b/internal/e2e_harness/production/init_rerun_e2e_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/lychee-technology/forma/internal/manifest"
 )
 
-// TestInitRerunIdempotency (#176 scenario 4): rerunning cdc-init with no
-// data changes rewrites the same deterministic base keys (min/max row-id
-// naming -> S3 overwrite, no new objects) and must not duplicate manifest
-// entries. The federated result is unchanged.
+// TestInitRerunIdempotency (#176 scenario 4, re-keyed by #416): rerunning
+// cdc-init with no data changes exports the same batches to FRESH write-once
+// base keys ({min}_{max}_{uuid}: same row ranges, new file ids), replaces the
+// manifest's base tier with exactly that set (no duplicates), and leaves the
+// first run's objects byte-for-byte untouched on S3 as unlisted orphans for
+// manifest-reconcile --gc. The federated result is unchanged.
 func TestInitRerunIdempotency(t *testing.T) {
 	cluster := SharedCluster(t)
 	env := NewEnv(t, cluster)
@@ -36,16 +38,36 @@ func TestInitRerunIdempotency(t *testing.T) {
 		t.Fatalf("first init produced %d base entries, want 3", len(firstPaths))
 	}
 
+	firstObjects := snapshotS3Inventory(t, ctx, env, buildSchemaKeyPrefix(env, wide))
+
 	second, err := env.RunInit(ctx, wide)
 	if err != nil {
 		t.Fatalf("second init: %v", err)
 	}
-	// No duplicate objects: identical batching -> identical keys -> overwrite.
-	// (_tmp keys are copy-staging garbage, not duplicates, if one survives —
-	// swallowed-delete residue is reclaimed by manifest-reconcile --gc, #226.)
+	// Write-once keys (#416): the rerun mints exactly one fresh base object per
+	// batch and never reuses a first-run key. (_tmp keys are copy-staging
+	// garbage, not exports, if one survives — swallowed-delete residue is
+	// reclaimed by manifest-reconcile --gc, #226.)
+	minted := make(map[string]bool)
 	for _, k := range second.NewObjects {
-		if !strings.Contains(k, "/_tmp/") {
-			t.Errorf("rerun created new object %s, want overwrite of existing keys only", k)
+		if strings.Contains(k, "/_tmp/") {
+			continue
+		}
+		if _, dup := firstObjects[k]; dup {
+			t.Errorf("rerun reported %s as new, but the first run already wrote it", k)
+		}
+		minted[k] = true
+	}
+	if len(minted) != 3 {
+		t.Fatalf("rerun minted %d base objects, want 3 (one fresh key per batch): %v", len(minted), second.NewObjects)
+	}
+	// The superseded set is left alone: same stat and ETag for every
+	// first-run object, so no listed-under-a-stamp bytes ever changed (the
+	// TOCTOU the compactor's checksum gate false-positived on, #416).
+	afterObjects := snapshotS3Inventory(t, ctx, env, buildSchemaKeyPrefix(env, wide))
+	for k, before := range firstObjects {
+		if after, ok := afterObjects[k]; !ok || after != before {
+			t.Errorf("rerun touched first-run object %s: before %+v, after %+v", k, before, after)
 		}
 	}
 	// No duplicate manifest entries: count RAW entries, not unique paths —
@@ -54,11 +76,14 @@ func TestInitRerunIdempotency(t *testing.T) {
 	if len(rawEntries) != 3 {
 		t.Fatalf("manifest holds %d base entries after rerun, want 3 (no duplicates)", len(rawEntries))
 	}
-	// Path identity with the first run: the rerun must reference the same
-	// deterministic keys, not introduce new ones.
+	// The base tier is exactly the rerun's file set: every entry is a key the
+	// rerun minted, and none of the first run's keys survives in the manifest.
 	for _, f := range rawEntries {
-		if !firstPaths[f.Path] {
-			t.Errorf("rerun introduced unexpected base path %s", f.Path)
+		if !minted[f.Path] {
+			t.Errorf("manifest base entry %s is not a key the rerun minted (stale first-run path or unexpected key)", f.Path)
+		}
+		if firstPaths[f.Path] {
+			t.Errorf("rerun left first-run base path %s listed", f.Path)
 		}
 	}
 	assertBaseRows(ctx, t, env, second.Manifest, 20)

--- a/internal/e2e_harness/production/manifest_stamp_rerun_e2e_test.go
+++ b/internal/e2e_harness/production/manifest_stamp_rerun_e2e_test.go
@@ -17,12 +17,13 @@ import (
 //
 // The pre-read validator caches every path it validates so a warm server pays
 // no footer probe. That was justified by "parquet objects are write-once",
-// which holds for flush and compaction — both mint fresh UUIDv7 keys — and
-// FAILS for init: cdc.BuildBasePath is deterministic ({min}_{max}.parquet), so
-// an init rerun overwrites the object in place and rewrites its manifest entry
-// under the same key. A path-keyed cache then serves the pre-rerun column set
-// for the rest of the process's life, with no eviction and no restart short of
-// bouncing the server.
+// which Forma's writers honour (flush and compaction always minted fresh
+// UUIDv7 keys; init does too since #416) but which a rewrite under a listed
+// key still violates: a pre-#416 init overwrote its deterministic
+// {min}_{max}.parquet key in place, and an operator repair can republish bytes
+// under an existing key, each re-stamping the entry under the same path. A
+// path-keyed cache then serves the pre-rewrite column set for the rest of the
+// process's life, with no eviction and no restart short of bouncing the server.
 //
 // The scenario keeps ONE engine alive across the rewrites — that is the whole
 // point, and it is why no EvolveSchema appears after the warm-up (EvolveSchema
@@ -30,10 +31,13 @@ import (
 //
 // Two rewrites, because they probe opposite halves of the contract:
 //
-//  1. An init rerun over unchanged rows: same key, byte-identical schema,
-//     IDENTICAL stamp. The entry must stay valid — re-keying the cache must not
-//     cost a probe on every rerun, which is the cold-start win #256 exists for.
-//  2. A rewrite that DROPS a column, with the manifest re-stamped to match.
+//  1. An init rerun over unchanged rows: a FRESH key (#416) carrying a
+//     byte-identical schema and an IDENTICAL stamp. The stamp must not move on
+//     an unchanged rerun — re-keying the cache must not cost a probe per
+//     rerun beyond the new object's own, which is the cold-start win #256
+//     exists for.
+//  2. An out-of-band rewrite of the listed key that DROPS a column, with the
+//     manifest re-stamped to match — the pre-#416 init shape, still reachable.
 //     A stale union still claims the column, so #255 augments nothing and the
 //     projection binds a column the object no longer has — a permanent
 //     ErrFederatedReadFailed for this schema that no retry clears. Re-validating
@@ -65,16 +69,18 @@ func TestManifestStamp_InPlaceRewriteInvalidatesValidatorCache(t *testing.T) {
 		t.Fatalf("precondition: the stamp does not claim score: %#v", stampA)
 	}
 
-	// Rewrite 1 — init rerun, nothing changed. Same key, same stamp.
+	// Rewrite 1 — init rerun, nothing changed. Fresh write-once key (#416),
+	// identical stamp.
 	rerun, err := env.RunInit(ctx, simple)
 	if err != nil {
 		t.Fatalf("init rerun: %v", err)
 	}
 	env.ExecSQL(ctx, "DELETE FROM change_log WHERE schema_id = $1", simple.ID)
 	baseEntries := manifest.FilterByTier(rerun.Manifest, "base")
-	if len(baseEntries) != 1 || baseEntries[0].Path != baseKey {
-		t.Fatalf("init rerun did not overwrite %s in place; base entries: %+v", baseKey, baseEntries)
+	if len(baseEntries) != 1 || baseEntries[0].Path == baseKey {
+		t.Fatalf("init rerun did not replace %s with a fresh write-once key; base entries: %+v", baseKey, baseEntries)
 	}
+	baseKey = baseEntries[0].Path
 	stampB := stampedEntryFor(ctx, t, env, simple, baseKey)
 	if !maps.Equal(stampA, stampB) {
 		t.Fatalf("an unchanged rerun moved the stamp; the cache would re-validate needlessly:\n a: %#v\n b: %#v", stampA, stampB)

--- a/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
+++ b/internal/e2e_harness/production/multi_schema_isolation_e2e_test.go
@@ -279,15 +279,15 @@ func TestInitSchemaScopedIsolation(t *testing.T) {
 		t.Fatal("schema 22 init must produce base entries (positive control)")
 	}
 
-	// #248: the NewObjects key diff is blind to overwrites that reuse the
-	// deterministic min_max keys, and the base-path comparison below is blind
-	// to a manifest rewritten with the same paths. Require exact stat/byte
-	// identity of the sibling's whole S3 surface across the rerun.
+	// #248: the NewObjects key diff is blind to a rewrite that reuses an
+	// existing key, and the base-path comparison below is blind to a manifest
+	// rewritten with the same paths. Require exact stat/byte identity of the
+	// sibling's whole S3 surface across the rerun.
 	siblingBefore := captureSchemaS3State(t, ctx, env, second)
 
 	// Rerun schema 20's init: the sibling's manifest and objects must be
-	// byte-for-byte uninvolved (deterministic keys make the rerun itself a
-	// pure overwrite, so any sibling-partition key here is a leak).
+	// byte-for-byte uninvolved (since #416 the rerun mints fresh write-once
+	// keys under its own partition, so any sibling-partition key is a leak).
 	rerun, err := env.RunInit(ctx, simple)
 	if err != nil {
 		t.Fatalf("rerun init schema %d: %v", simple.ID, err)

--- a/internal/federated/parquet_schema_validation.go
+++ b/internal/federated/parquet_schema_validation.go
@@ -27,14 +27,15 @@ import (
 // objects land — hit the same cache through their concrete matches.
 //
 // The cache is keyed by path AND by the manifest stamp the entry was validated
-// under (nil for a probe-validated path). Path alone would be wrong: parquet
-// objects are write-once for flush and compaction, which always mint fresh
-// UUIDv7 keys, but NOT for init — cdc.BuildBasePath is deterministic
-// ({min}_{max}.parquet), so an init rerun overwrites the object in place and
-// rewrites its manifest entry under the same key. A path-keyed cache would
-// serve a warmed server the pre-rerun columns for the rest of its life. Adding
-// the stamp to the key makes the manifest rewrite the invalidation signal:
-// same stamp, same bytes, keep the entry; new stamp, re-validate.
+// under (nil for a probe-validated path). Path alone would be wrong: Forma's
+// writers mint write-once keys (flush and compaction always did; init since
+// #416), but a rewrite under a listed path is still reachable — a pre-#416
+// init overwrote its deterministic {min}_{max}.parquet key in place, and an
+// operator repair can republish bytes under an existing key — and each
+// re-stamps the entry under the same key. A path-keyed cache would serve a
+// warmed server the pre-rewrite columns for the rest of its life. Adding the
+// stamp to the key makes the manifest rewrite the invalidation signal: same
+// stamp, same bytes, keep the entry; new stamp, re-validate.
 //
 // The cache stores each validated path's columns so a repeat query can
 // contribute them to the column union (#255) without a second probe. It has

--- a/internal/federated/parquet_schema_validation_stamps_test.go
+++ b/internal/federated/parquet_schema_validation_stamps_test.go
@@ -11,12 +11,14 @@ import (
 )
 
 // The validator's cache used to be keyed by URI alone, on the premise that
-// parquet objects are write-once. That premise is false for init: cdc's base
-// keys are deterministic ({min}_{max}.parquet), so an init rerun overwrites
-// the object in place and rewrites its manifest stamp under the SAME path. A
-// warmed server would then serve the pre-rerun columns forever. These tests
-// pin the fix: an entry is only a hit while the manifest stamp it was
-// validated under still matches the current one.
+// parquet objects are write-once. Forma's writers honour that premise (flush
+// and compaction always did; init mints write-once keys since #416), but a
+// rewrite under a listed path is still reachable — a pre-#416 init overwrote
+// its deterministic {min}_{max}.parquet key in place, and an operator repair
+// can republish bytes under an existing key — and each re-stamps the entry
+// under the SAME path. A warmed server would then serve the pre-rewrite
+// columns forever. These tests pin the fix: an entry is only a hit while the
+// manifest stamp it was validated under still matches the current one.
 
 const stampCachePath = "s3://b/7/base/0_9.parquet"
 

--- a/internal/manifest/store_s3.go
+++ b/internal/manifest/store_s3.go
@@ -3,11 +3,15 @@ package manifest
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 )
 
 type S3Client interface {
@@ -72,4 +76,24 @@ func (s *S3Store) Save(ctx context.Context, path string, data []byte, etag strin
 		newETag = *out.ETag
 	}
 	return newETag, nil
+}
+
+// IsPreconditionFailed reports whether err is a CONFIRMED HTTP 412
+// conditional-put rejection from the object store — the only Save failure
+// that proves the write did not commit, and therefore the only one a caller
+// may answer by reloading and retrying. Transport errors, timeouts and other
+// API failures are deliberately excluded: after those the put may have
+// landed, and callers must treat the outcome as ambiguous. Shared by the
+// compactor's CAS swap, manifest-reconcile's retried saves, and cdc-init's
+// final publish (#416).
+func IsPreconditionFailed(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "PreconditionFailed" {
+		return true
+	}
+	var respErr *awshttp.ResponseError
+	return errors.As(err, &respErr) && respErr.HTTPStatusCode() == http.StatusPreconditionFailed
 }

--- a/internal/manifest/store_s3_precondition_test.go
+++ b/internal/manifest/store_s3_precondition_test.go
@@ -1,0 +1,45 @@
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+type testAPIErr struct{ code string }
+
+func (e *testAPIErr) Error() string                 { return "api error " + e.code }
+func (e *testAPIErr) ErrorCode() string             { return e.code }
+func (e *testAPIErr) ErrorMessage() string          { return e.code }
+func (e *testAPIErr) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
+
+func TestIsPreconditionFailed(t *testing.T) {
+	respErr := &awshttp.ResponseError{ResponseError: &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusPreconditionFailed}},
+		Err:      errors.New("412"),
+	}}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"api error PreconditionFailed", &testAPIErr{code: "PreconditionFailed"}, true},
+		{"wrapped api error", fmt.Errorf("put manifest: %w", &testAPIErr{code: "PreconditionFailed"}), true},
+		{"other api error", &testAPIErr{code: "NoSuchKey"}, false},
+		{"http 412 response error", respErr, true},
+		{"plain error", errors.New("connection reset"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPreconditionFailed(tt.err); got != tt.want {
+				t.Fatalf("IsPreconditionFailed(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reconcile/classify.go
+++ b/internal/reconcile/classify.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/lychee-technology/forma/internal/cdc"
 	"github.com/lychee-technology/forma/internal/manifest"
 )
 
@@ -70,9 +71,9 @@ func classifyObjectKey(prefix, key string) (OrphanClass, bool) {
 		}
 		return ClassUnknown, true
 	}
-	if minID, maxID, found := strings.Cut(stem, "_"); found {
-		if uuid.Validate(minID) == nil && uuid.Validate(maxID) == nil {
-			return ClassBaseInit, true // cdc.BuildBasePath: {minRowID}_{maxRowID}.parquet
+	if strings.Contains(stem, "_") {
+		if _, _, ok := cdc.ParseInitBaseStem(stem); ok {
+			return ClassBaseInit, true // cdc.BuildBasePath: {min}_{max}_{uuid}.parquet, or legacy {min}_{max}
 		}
 		return ClassUnknown, true
 	}

--- a/internal/reconcile/classify_test.go
+++ b/internal/reconcile/classify_test.go
@@ -22,7 +22,8 @@ func TestClassifyObjectKey(t *testing.T) {
 		ok    bool
 	}{
 		{"delta uuid", "data/7/" + uuidA + ".parquet", ClassDelta, true},
-		{"init base min_max", "data/7/" + uuidA + "_" + uuidB + ".parquet", ClassBaseInit, true},
+		{"init base min_max (legacy deterministic key)", "data/7/" + uuidA + "_" + uuidB + ".parquet", ClassBaseInit, true},
+		{"init base min_max_fileid (write-once key, #416)", "data/7/" + uuidA + "_" + uuidB + "_" + uuidC + ".parquet", ClassBaseInit, true},
 		{"merged base", "data/7/base-" + uuidA + ".parquet", ClassBaseMerged, true},
 		{"tmp staged", "data/7/_tmp/" + uuidA + ".parquet", ClassTmp, true},
 		{"unrecognized stem", "data/7/weird.parquet", ClassUnknown, true},
@@ -154,6 +155,9 @@ func TestClassifyObjectKey_RequiresUUIDShapes(t *testing.T) {
 		{"base prefix valid uuid", "data/7/base-" + uuidA + ".parquet", ClassBaseMerged},
 		{"underscore junk", "data/7/a_b.parquet", ClassUnknown},
 		{"underscore valid uuids", "data/7/" + uuidA + "_" + uuidB + ".parquet", ClassBaseInit},
+		{"underscore valid uuids with file id", "data/7/" + uuidA + "_" + uuidB + "_" + uuidC + ".parquet", ClassBaseInit},
+		{"underscore valid range junk file id", "data/7/" + uuidA + "_" + uuidB + "_nope.parquet", ClassUnknown},
+		{"four underscore parts", "data/7/" + uuidA + "_" + uuidB + "_" + uuidC + "_" + uuidA + ".parquet", ClassUnknown},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/reconcile/promote.go
+++ b/internal/reconcile/promote.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/lychee-technology/forma/internal/cdc"
 	"github.com/lychee-technology/forma/internal/compaction"
 	"github.com/lychee-technology/forma/internal/manifest"
 )
@@ -29,7 +30,7 @@ type initCoverage struct {
 }
 
 // verifyInitCoverage proves an init-shaped orphan set is a complete init
-// export: per-file stats readable and consistent with the {min}_{max} name,
+// export: per-file stats readable and consistent with the {min}_{max}[_{uuid}] name,
 // pairwise-disjoint row ranges (one run exports disjoint ordered batches, so
 // an overlap means the set mixes init generations), no tombstones (cdc-init
 // exports live rows only), and — the #292 completeness proof — the set's
@@ -100,14 +101,15 @@ func (r *Reconciler) verifyInitCoverage(ctx context.Context, schemaID int16, orp
 	return cov, ""
 }
 
-// checkInitFilenameStats cross-checks the {min}_{max} filename against the
+// checkInitFilenameStats cross-checks the {min}_{max} row range in the
+// filename (write-once {min}_{max}_{uuid} or legacy {min}_{max}) against the
 // recomputed parquet stats. Entry metadata is never trusted from filenames
 // (mirrors buildRepairEntry); the check exists so a foreign or truncated
 // file that merely looks init-shaped cannot enter the base tier.
 func checkInitFilenameStats(key string, stats compaction.MergeStats) string {
 	base := key[strings.LastIndex(key, "/")+1:]
 	stem := strings.TrimSuffix(base, ".parquet")
-	minID, maxID, found := strings.Cut(stem, "_")
+	minID, maxID, found := cdc.ParseInitBaseStem(stem)
 	if !found {
 		// Unreachable after classifyObjectKey, kept as a defensive refusal.
 		return fmt.Sprintf("%s is not an init-shaped key", key)

--- a/internal/reconcile/promote_test.go
+++ b/internal/reconcile/promote_test.go
@@ -29,7 +29,13 @@ const (
 	rid4 = "00000000-0000-7000-8000-000000000004"
 )
 
-func initKey(minID, maxID string) string { return "data/7/" + minID + "_" + maxID + ".parquet" }
+// initKey renders the write-once init base shape cdc-init mints since #416;
+// legacyInitKey the deterministic pre-#416 shape still found in buckets.
+func initKey(minID, maxID string) string {
+	return "data/7/" + minID + "_" + maxID + "_" + uuidC + ".parquet"
+}
+
+func legacyInitKey(minID, maxID string) string { return "data/7/" + minID + "_" + maxID + ".parquet" }
 
 // preInitClock is the listing time an object must carry to clear the survivor
 // fence on ground 1 (checkSurvivorDates): a listed non-base entry may only
@@ -208,6 +214,18 @@ func TestPromote_RefusesUnreadableStats(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, report.Schemas[0].InitPromotionRefusal, "unreadable parquet stats")
 	require.Empty(t, report.Schemas[0].PromotedBase, "one unreadable file refuses the whole set")
+}
+
+func TestCheckInitFilenameStats_AcceptsBothInitShapes(t *testing.T) {
+	stats := compaction.MergeStats{RowIDMin: rid1, RowIDMax: rid2}
+	for _, key := range []string{initKey(rid1, rid2), legacyInitKey(rid1, rid2)} {
+		if refusal := checkInitFilenameStats(key, stats); refusal != "" {
+			t.Fatalf("checkInitFilenameStats(%q) refused a matching file: %s", key, refusal)
+		}
+	}
+	if refusal := checkInitFilenameStats(legacyInitKey(rid1, rid2), compaction.MergeStats{RowIDMin: rid1, RowIDMax: rid4}); refusal == "" {
+		t.Fatal("legacy key with mismatching stats was accepted")
+	}
 }
 
 func TestPromote_RefusesFilenameStatsMismatch(t *testing.T) {

--- a/internal/reconcile/race_guard_test.go
+++ b/internal/reconcile/race_guard_test.go
@@ -34,9 +34,10 @@ func TestGC_CollectsInitShapedBaseOrphans(t *testing.T) {
 	report, err := r.Run(context.Background())
 	require.NoError(t, err)
 	// Since #290 cdc-init holds the same per-schema advisory lock, so under
-	// this lock an init-shaped {min}_{max} base orphan is provably not from
-	// an in-flight init — it is either a failed manifest publish or a file
-	// superseded by a later init run, and joins the two-phase --gc sweep.
+	// this lock an init-shaped ({min}_{max}[_{uuid}]) base orphan is provably
+	// not from an in-flight init — it is either a failed manifest publish or a
+	// set superseded by a later init run (write-once keys since #416), and
+	// joins the two-phase --gc sweep.
 	require.ElementsMatch(t, []string{initShaped, merged}, deleter.deleted)
 	require.ElementsMatch(t, []string{initShaped, merged}, report.Schemas[0].Deleted)
 	require.ElementsMatch(t, []string{initShaped, merged}, report.Schemas[0].BaseOrphans)

--- a/internal/reconcile/repair.go
+++ b/internal/reconcile/repair.go
@@ -29,7 +29,7 @@ type repairOutcome struct {
 // Entry metadata is recomputed from the parquet contents, never trusted
 // from filenames. Runs under the schema advisory lock; the manifest save
 // still goes through etag optimistic concurrency (creates are If-None-Match
-// guarded) because compaction and init do not take the lock. Only a
+// guarded) because the compactor does not take the lock. Only a
 // confirmed 412 precondition failure is retried — after an ambiguous save
 // error the write may have landed, and a blind retry could duplicate
 // entries.


### PR DESCRIPTION
Closes #416.

## What

- `cdc.BuildBasePath` now mints `{min}_{max}_{uuidv7}.parquet`. The row range stays in the name for operators and for reconcile's filename/stats cross-check; the UUID makes the key write-once, matching `BuildDeltaPath` and `BuildMergedBasePath`. The final key shares the batch's `_tmp` UUID.
- `cdc.ParseInitBaseStem` is the inverse. It accepts the legacy two-part shape, so `manifest-reconcile` classification and `checkInitFilenameStats` handle buckets written before this change.
- cdc-init's final `ReplaceTierFiles` publish retries a **confirmed** 412 up to three times by reloading and re-splicing the base tier, instead of discarding the whole export. Ambiguous save errors are not retried. The 412 classification is centralized as `manifest.IsPreconditionFailed`, and the compactor delegates to it.
- `updateSchemaManifest` moves to `internal/cdc/init_publish.go` so `init.go` stays under 500 lines.

## Why

With a deterministic key, a re-run over an unchanged range overwrote an object the manifest still listed under the previous run's column and checksum stamps. The compactor's pre-merge checksum gate could then read the stamp before the overwrite and the bytes after it, and fail with a terminal `ErrSourceChecksumMismatch` on a healthy system. A re-run that failed between its copies and its publish left the stale stamps behind for good. Both scenarios are impossible once no writer ever PUTs under a listed key. The design and scenario triage are on the issue: https://github.com/Lychee-Technology/forma/issues/416#issuecomment-5533929247.

## What a re-run leaves behind

The superseded set stays on S3, unlisted and init-shaped, and `manifest-reconcile --gc` reclaims it. `--repair` cannot reverse-promote it: the promotion date fence requires any evicted listed base to be strictly older than the candidate set. Compaction, the flusher, and reads are unaffected, since nothing ever changed under a listed entry's stamp.

## Tests

- Unit: `TestBuildBasePath_SameRangeDistinctFileIDsMintDistinctKeys`, `TestParseInitBaseStem`, `TestExportSchemaBatch_RerunOverSameRangeMintsFreshKey`, `TestUpdateSchemaManifest_RetriesConfirmed412`, `TestUpdateSchemaManifest_GivesUpAfterBoundedConflicts`, `TestUpdateSchemaManifest_DoesNotRetryAmbiguousSaveError`, `TestIsPreconditionFailed`, reconcile classify/promote cases for both shapes.
- Production e2e: `TestInitRerunIdempotency` now asserts one fresh key per batch, identical stat and ETag on every first-run object, and a base tier equal to the new set. `TestManifestStamp_InPlaceRewriteInvalidatesValidatorCache` step 1 asserts the re-run replaced the key with an identical stamp, then follows the new key into the out-of-band rewrite.
- Docs and comments that described the deterministic key are reworded (`docs/federated-query/design.md`, `docs/manifest-reconcile.md`, validator cache rationale). The validator's path+stamp cache key stays: an out-of-band rewrite under a listed key remains reachable.

## Verification

- `make fmt-check`, `make lint`: clean.
- `./scripts/test_with_container_runtime.sh` (full unit suite): green.
- `go test ./internal/e2e_harness/production/ -tags=e2e` (full production suite): green.
