### PR TITLE
fix(sqlgen): refuse an unregistered filter attribute that folds onto a visible column (#512)

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -296,6 +296,19 @@ only because a fold onto a `visible` column, system or dedup, is refused before
 it can reach the generator. It is deferred to the caller-facing cursor surface
 the Postgres-side keyset feature introduces.
 
+Filter attributes follow the same fold rule (#512). The predicate normalizer
+does not require a filter attribute to be registered either: the PG EAV
+payload refuses an unregistered name with `attribute not found in cache`, and
+because `ToDualClauses` renders that payload before the DuckDB one, the
+federated route answers 4xx before any DuckDB clause exists. The DuckDB payload
+is nevertheless guarded on its own, so the rule holds whatever emitter order a
+caller uses: for an unregistered name, `sqlgen.ValidateUnregisteredParquetAttrColumn`
+refuses a non-identity fold onto the `attr` placeholder or onto any reserved
+parquet column, refuses `rn` and `source_tier_priority` under any spelling, and
+admits an identity-up-to-case fold, exactly as `validateKeysetCursor` does for
+cursor columns. Registered names never reach it: `ValidateParquetAttrColumns`
+already rejected any whose fold collides with a reserved column.
+
 ## **5. SQL Execution Template**
 
 This SQL template represents the core logic of the Federated Query Engine.

--- a/internal/sqlgen/duck_clause_test.go
+++ b/internal/sqlgen/duck_clause_test.go
@@ -123,3 +123,64 @@ func TestParseDateValue_ISO8601EncodingFromUnixMs(t *testing.T) {
 	_, err = ParseDateValue("not-a-date", meta)
 	require.Error(t, err)
 }
+
+// An unregistered filter attribute must never fold onto a column the visible
+// CTE projects (#512). ParquetAttrColumn is lossy, so "created.at" would
+// otherwise render as created_at and silently filter on the creation
+// timestamp. The rule mirrors federated.validateKeysetCursor (#509): a
+// non-identity fold onto the "attr" placeholder or a reserved parquet column
+// is refused, the dedup machinery is refused under any spelling, and an
+// identity-up-to-case fold stays admitted.
+func TestBuildDuckClause_UnregisteredAttr_RefusesFoldOntoVisibleColumn(t *testing.T) {
+	refused := []struct{ attr, folded string }{
+		{"created.at", "created_at"},
+		{"ver.ts", "ver_ts"},
+		{"deleted.ts", "deleted_ts"},
+		{"row.id", "row_id"},
+		{"[row_id]", "row_id"},
+		{"Created.At", "Created_At"},
+		{"rn", "rn"},
+		{"RN", "RN"},
+		{"source_tier.priority", "source_tier_priority"},
+		{"source_tier_priority", "source_tier_priority"},
+		{"[]", "attr"},
+		{"`", "attr"},
+		{"[attr]", "attr"},
+	}
+	for _, tc := range refused {
+		t.Run("refused/"+tc.attr, func(t *testing.T) {
+			cond := &forma.KvCondition{Attr: tc.attr, Value: "equals:1"}
+			clause, _, err := buildDuckClause(cond, forma.SchemaAttributeCache{})
+			require.Error(t, err, "clause %q emitted for unregistered attribute %q", clause, tc.attr)
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			require.Contains(t, err.Error(), tc.attr)
+			require.Contains(t, err.Error(), tc.folded)
+		})
+	}
+
+	admitted := []string{"created_at", "Created_At", "attr", "Attr", "unknown_ts"}
+	for _, attr := range admitted {
+		t.Run("admitted/"+attr, func(t *testing.T) {
+			cond := &forma.KvCondition{Attr: attr, Value: "equals:1"}
+			clause, _, err := buildDuckClause(cond, forma.SchemaAttributeCache{})
+			require.NoError(t, err)
+			require.Contains(t, clause, attr)
+		})
+	}
+}
+
+// The production federated route builds all three clauses through
+// ToDualClauses, where an unregistered attribute is refused by the PG EAV
+// payload before the DuckDB clause is rendered (#512 investigation). This
+// pins that the folded spellings never reach DuckDB on that route either.
+func TestToDualClauses_UnregisteredAttr_RefusedBeforeDuckEmission(t *testing.T) {
+	for _, attr := range []string{"created.at", "rn", "[]", "ghost"} {
+		t.Run(attr, func(t *testing.T) {
+			paramIndex := 1
+			cond := &forma.KvCondition{Attr: attr, Value: "equals:1"}
+			_, err := ToDualClauses(cond, "eav_table", 22, forma.SchemaAttributeCache{}, &paramIndex)
+			require.Error(t, err)
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+		})
+	}
+}

--- a/internal/sqlgen/duck_clause_test.go
+++ b/internal/sqlgen/duck_clause_test.go
@@ -139,13 +139,18 @@ func TestBuildDuckClause_UnregisteredAttr_RefusesFoldOntoVisibleColumn(t *testin
 		{"row.id", "row_id"},
 		{"[row_id]", "row_id"},
 		{"Created.At", "Created_At"},
+		{"schema.id", "schema_id"},
+		{"attributes.json", "attributes_json"},
+		{"ltbase.row_id", "ltbase_row_id"},
 		{"rn", "rn"},
 		{"RN", "RN"},
+		{"[rn]", "rn"},
 		{"source_tier.priority", "source_tier_priority"},
 		{"source_tier_priority", "source_tier_priority"},
 		{"[]", "attr"},
 		{"`", "attr"},
 		{"[attr]", "attr"},
+		{"", "attr"},
 	}
 	for _, tc := range refused {
 		t.Run("refused/"+tc.attr, func(t *testing.T) {
@@ -172,7 +177,10 @@ func TestBuildDuckClause_UnregisteredAttr_RefusesFoldOntoVisibleColumn(t *testin
 // The production federated route builds all three clauses through
 // ToDualClauses, where an unregistered attribute is refused by the PG EAV
 // payload before the DuckDB clause is rendered (#512 investigation). This
-// pins that the folded spellings never reach DuckDB on that route either.
+// pins that the folded spellings never reach DuckDB on that route either,
+// and pins the ORDER: the error must be the PG EAV refusal, not the DuckDB
+// fold guard, so an emitter reorder that let the DuckDB guard fire first
+// would fail here rather than silently change the documented behaviour.
 func TestToDualClauses_UnregisteredAttr_RefusedBeforeDuckEmission(t *testing.T) {
 	for _, attr := range []string{"created.at", "rn", "[]", "ghost"} {
 		t.Run(attr, func(t *testing.T) {
@@ -181,6 +189,9 @@ func TestToDualClauses_UnregisteredAttr_RefusedBeforeDuckEmission(t *testing.T) 
 			_, err := ToDualClauses(cond, "eav_table", 22, forma.SchemaAttributeCache{}, &paramIndex)
 			require.Error(t, err)
 			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			require.Contains(t, err.Error(), "attribute not found in cache",
+				"PG EAV payload must refuse before the DuckDB fold guard runs")
+			require.NotContains(t, err.Error(), "folds")
 		})
 	}
 }

--- a/internal/sqlgen/parquet_attr_column.go
+++ b/internal/sqlgen/parquet_attr_column.go
@@ -61,6 +61,58 @@ var reservedParquetColumns = map[string]struct{}{
 	"ltbase_deleted_at":    {},
 }
 
+// parquetAttrPlaceholder is the column ParquetAttrColumn substitutes when the
+// fold empties a name ("", "[]", a lone backtick); a name like "[attr]"
+// strips down onto it directly.
+const parquetAttrPlaceholder = "attr"
+
+// federatedDedupColumns are the visible-CTE columns that are dedup machinery,
+// not data: a filter on either binds successfully and compares against the
+// dedup rank, so it fails silently-wrong rather than loudly. Refused under
+// any spelling, identity fold included (the keyset counterpart is
+// federated.keysetRejectedColumns).
+var federatedDedupColumns = map[string]struct{}{
+	"rn":                   {},
+	"source_tier_priority": {},
+}
+
+// ValidateUnregisteredParquetAttrColumn guards a filter attribute the schema
+// cache does not know (#512). ValidateParquetAttrColumns cannot cover it: it
+// checks registered attributes at registration, and an unregistered filter
+// name is an arbitrary caller-supplied string that never went through it.
+// The fold is lossy, so "created.at" lands on created_at and the DuckDB
+// clause would silently filter on the creation timestamp instead of failing
+// at the binder — the silent-wrong-answer family of #354.
+//
+// The rule mirrors federated.validateKeysetCursor (#509), judged on the
+// FOLDED name because that is the identifier the generator emits, with the
+// lookups lower-cased because DuckDB resolves unquoted identifiers
+// case-insensitively. A non-identity fold onto the "attr" placeholder or onto
+// any reserved parquet column is refused; the dedup machinery is refused
+// under any spelling; an identity-up-to-case fold ("created_at",
+// "Created_At") is admitted and left to fail at the binder or, on the
+// federated route, at the PG EAV payload. Caller fault, so the error is a
+// forma.InvalidInputf carrier that keeps the caller's spelling.
+func ValidateUnregisteredParquetAttrColumn(attr, folded string) error {
+	if strings.EqualFold(folded, parquetAttrPlaceholder) && !strings.EqualFold(attr, parquetAttrPlaceholder) {
+		return forma.InvalidInputf(
+			"filter attribute %q is not registered and folds onto the placeholder column %q, which would silently filter on a real attribute of that name: filter on a registered schema attribute",
+			attr, folded)
+	}
+	key := strings.ToLower(folded)
+	if _, ok := federatedDedupColumns[key]; ok {
+		return forma.InvalidInputf(
+			"filter attribute %q folds to %q, which is federated dedup machinery, not a queryable column: filter on a registered schema attribute",
+			attr, folded)
+	}
+	if _, ok := reservedParquetColumns[key]; ok && !strings.EqualFold(attr, folded) {
+		return forma.InvalidInputf(
+			"filter attribute %q is not registered and folds to %q, a reserved system column, which would silently filter on that column instead of the attribute named: filter on a registered schema attribute, or name the system column %s directly",
+			attr, folded, key)
+	}
+	return nil
+}
+
 // ValidateParquetAttrColumns rejects attribute sets whose folded parquet
 // column names land on a reserved system column or collide with each other
 // (the fold is lossy: "contact.name" and "contact_name" both become

--- a/internal/sqlgen/parquet_attr_column.go
+++ b/internal/sqlgen/parquet_attr_column.go
@@ -107,8 +107,8 @@ func ValidateUnregisteredParquetAttrColumn(attr, folded string) error {
 	}
 	if _, ok := reservedParquetColumns[key]; ok && !strings.EqualFold(attr, folded) {
 		return forma.InvalidInputf(
-			"filter attribute %q is not registered and folds to %q, a reserved system column, which would silently filter on that column instead of the attribute named: filter on a registered schema attribute, or name the system column %s directly",
-			attr, folded, key)
+			"filter attribute %q is not registered and folds to %q, a reserved system column, which would silently filter on that column instead of the attribute named: filter on a registered schema attribute",
+			attr, folded)
 	}
 	return nil
 }

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -381,7 +381,11 @@ func normalizePgMainPayload(
 
 // normalizeDuckPayload converts a leaf for the DuckDB emitter, keeping the
 // no-metadata fallback inference (detectValueType) and the text/LIKE
-// no-cast emission.
+// no-cast emission. An unregistered attribute keeps that lenient path only
+// if its folded column is not a visible-CTE system or dedup column (#512):
+// the fold is lossy, and an unchecked "created.at" would silently filter
+// on created_at. Registered names were already checked at registration by
+// ValidateParquetAttrColumns.
 func normalizeDuckPayload(
 	kv *forma.KvCondition,
 	meta forma.AttributeMetadata,
@@ -394,6 +398,11 @@ func normalizeDuckPayload(
 	}
 
 	column := resolveDuckDBColumn(kv.Attr)
+	if !hasMeta {
+		if err := ValidateUnregisteredParquetAttrColumn(kv.Attr, column); err != nil {
+			return DuckLeafPayload{Err: err}
+		}
+	}
 
 	if lenientSQL.SQLOperator == "LIKE" {
 		return DuckLeafPayload{Column: column, SQLOp: lenientSQL.SQLOperator, TextLike: true, Param: lenientSQL.Value}


### PR DESCRIPTION
Closes #512.

## What

`normalizeDuckPayload` folded an unregistered filter attribute through `ParquetAttrColumn` unchecked, so a filter on `created.at`, `row.id`, `rn` or `[]` rendered a DuckDB clause on `created_at`, `row_id`, the dedup rank or the `attr` placeholder: a well-formed page filtered on a column the caller never named (the #354 silent-wrong-answer family).

This applies the #509 cursor rule to filters, in the DuckDB leaf normalizer (`normalizeDuckPayload`): the PG EAV payload already refuses an unregistered name and the PG main payload skips it, so the DuckDB payload is the one path that needed guarding on its own. Only when the attribute is **not** in the schema cache, judged on the folded name with case-insensitive lookups:

- a non-identity fold onto the `attr` placeholder is refused (`[]`, `` ` ``, `[attr]`);
- a non-identity fold onto any `reservedParquetColumns` entry is refused (`created.at`, `ver.ts`, `deleted.ts`, `row.id`, `[row_id]`, `Created.At`);
- `rn` and `source_tier_priority` are refused under any spelling;
- an identity-up-to-case fold (`created_at`, `Created_At`, `attr`) stays admitted, as for cursors.

Refusals are `forma.InvalidInputf` carriers naming the attribute, the folded column and what to do instead. Registered names never reach the check: `ValidateParquetAttrColumns` already rejects them at registration.

## Why option 2 (refuse the fold) and not option 1 (refuse any unregistered name)

Investigation notes and the ruling are on the issue: https://github.com/Lychee-Technology/forma/issues/512#issuecomment-5555953273. In short: on the federated route `ToDualClauses` renders the PG EAV payload before the DuckDB one, and that payload already refuses an unregistered name with `attribute not found in cache`, so option 1 would have zero production delta while forcing rewrites of the 32 nil-cache test sites that use the standalone `BuildDuckClause`. Option 2 makes the DuckDB payload safe on its own, whatever emitter order a caller uses, and keeps one rule for filters and cursors.

## Changes

- `internal/sqlgen/parquet_attr_column.go`: `ValidateUnregisteredParquetAttrColumn`, `parquetAttrPlaceholder`, `federatedDedupColumns`.
- `internal/sqlgen/predicate_normalizer.go`: `normalizeDuckPayload` calls it when `hasMeta` is false.
- `internal/sqlgen/duck_clause_test.go`: `TestBuildDuckClause_UnregisteredAttr_RefusesFoldOntoVisibleColumn` (18 refused spellings, 5 admitted) and `TestToDualClauses_UnregisteredAttr_RefusedBeforeDuckEmission` (pins the production-route behaviour the ruling relies on, including that the PG EAV refusal fires before the DuckDB guard).
- `docs/federated-query/design.md`: section 4 now states the shared filter/cursor fold rule.

## Verification

- Test written first and watched fail: all 13 refused spellings emitted a clause (e.g. `created_at = CAST(? AS BOOLEAN)` for `created.at`); green after the fix.
- `make fmt-check`: clean.
- `make lint` (golangci-lint v1.64.8, root and infra modules): clean.
- `./scripts/test_with_container_runtime.sh` (full `make test` under rootless Podman): 34 packages ok, no failures. `TestNoBareSentinelWraps` included.
- File sizes stay under the limits: `parquet_attr_column.go` 147 lines, `predicate_normalizer.go` 431 lines.

## Out of scope, recorded on the issue

- The cursor rule also requires the folded name to match `safeSQLIdentifier`; `parquetAttrReplacer` only folds backtick, dot, space and brackets, so the standalone `BuildDuckClause` route still interpolates other punctuation as-is. Not reachable in production.
- Retiring the lenient `hasMeta == false` DuckDB path altogether (option 1) is a possible later cleanup once the test corpus is migrated to registered caches.

## Review follow-ups

- #531: `federatedDedupColumns` / `parquetAttrPlaceholder` duplicate their `federated` keyset counterparts with no sync guard.
- #532: pre-existing, `ValidateParquetAttrColumns` looks reserved columns up case-sensitively, so a registered `Created_At` passes registration and binds to `created_at` in DuckDB.

