### PR TITLE
fix(manifest): refuse a non-positive requested schema ID in VerifySchemaStamp (#536)

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -757,6 +757,13 @@ being read. It is raised before any path reaches a scan.
   `VerifySchemaStamp` refuses a non-positive request before comparing any
   stamp, as a plain error (an invariant violation by the caller, not a
   property of the manifest), so it does not classify as a schema mismatch.
+  Because it is unclassified, the federated engine must not let it reach the
+  parquet source at all: `resolveParquetPaths` relabels every unclassified
+  source failure as `ErrFederatedReadFailed`, which `AllowPartialDegradedMode`
+  absorbs into a Postgres-only answer. So `Query` and
+  `ExecuteFederatedPaginatedQuery` refuse a non-positive `SchemaID` at entry,
+  before routing (PR #537 review) — the same `schema id must be positive`
+  invariant the OLTP repository enforces — and no degraded fallback runs.
 - **Where the zero-stamp rule is enforced.** The same single site,
   `manifest.VerifySchemaStamp`, reached through `LoadOrCreateForSchema` by the
   federated read path, `cdc-flush`, `cdc-init` and `manifest-reconcile`, and

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -751,6 +751,12 @@ being read. It is raised before any path reaches a scan.
   `schema_id` on the object, rather than fix the template. An empty
   zero-stamped manifest has nothing another schema could own and loads stamped
   for the requested schema in memory; the consumer's next save persists it.
+  The *requested* schema ID must be positive too (#536): a request for schema
+  0 is never a schema, and without the guard it would satisfy the stamp
+  equality against a zero-stamped manifest and admit its entries.
+  `VerifySchemaStamp` refuses a non-positive request before comparing any
+  stamp, as a plain error (an invariant violation by the caller, not a
+  property of the manifest), so it does not classify as a schema mismatch.
 - **Where the zero-stamp rule is enforced.** The same single site,
   `manifest.VerifySchemaStamp`, reached through `LoadOrCreateForSchema` by the
   federated read path, `cdc-flush`, `cdc-init` and `manifest-reconcile`, and

--- a/internal/federated/engine.go
+++ b/internal/federated/engine.go
@@ -130,13 +130,34 @@ func NewDBFederatedQueryEngine(pgSource PostgresFederatedSource, dirtyIDFetcher 
 	return e
 }
 
+// validateFederatedQueryTarget is the entry guard shared by Query and
+// ExecuteFederatedPaginatedQuery. A non-positive schema ID can never name a
+// schema (schema IDs are always positive), so a request carrying one is a
+// caller invariant violation (an unguarded enumerator or a hand-inserted
+// registry row), not a state of the read surface. It is refused here, before
+// routing, because nothing below classifies it: the manifest source reports
+// it as a plain error (#536), resolveParquetPaths relabels unclassified source
+// failures as ErrFederatedReadFailed, and AllowPartialDegradedMode would then
+// absorb it into a Postgres-only answer — the caller's error served as a
+// hot-only page (PR #537 review). The Postgres leg already rejects the same
+// ID, so the guard makes the two routes agree rather than adding a rule.
+func validateFederatedQueryTarget(fq *model.FederatedAttributeQuery) error {
+	if fq == nil {
+		return fmt.Errorf("federated query cannot be nil")
+	}
+	if fq.SchemaID <= 0 {
+		return fmt.Errorf("federated query for schema id %d cannot be served: schema id must be positive", fq.SchemaID)
+	}
+	return nil
+}
+
 // Query implements FederatedQueryEngine. Hot-only requests delegate directly
 // to Postgres; otherwise the routing policy decides between Postgres and the
 // DuckDB federated path, falling back to Postgres on DuckDB failure when
 // opts.AllowPartialDegradedMode is set.
 func (e *DBFederatedQueryEngine) Query(ctx context.Context, tables model.StorageTables, fq *model.FederatedAttributeQuery, opts *model.FederatedQueryOptions) (*model.PersistentRecordPage, error) {
-	if fq == nil {
-		return nil, fmt.Errorf("federated query cannot be nil")
+	if err := validateFederatedQueryTarget(fq); err != nil {
+		return nil, fmt.Errorf("validate federated query: %w", err)
 	}
 	if e == nil || e.pgSource == nil {
 		return nil, fmt.Errorf("postgres federated source is not available")

--- a/internal/federated/engine_schema_id_test.go
+++ b/internal/federated/engine_schema_id_test.go
@@ -1,0 +1,94 @@
+package federated
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// nonPositiveSchemaQuery is coldTierQuery() re-targeted at an ID that can
+// never name a schema.
+func nonPositiveSchemaQuery(schemaID int16) *model.FederatedAttributeQuery {
+	fq := coldTierQuery()
+	fq.SchemaID = schemaID
+	return fq
+}
+
+// TestQuery_NonPositiveSchemaIDIsNotDegradable pins the PR #537 review
+// finding: a request for schema 0 or a negative ID is a caller invariant
+// violation, and VerifySchemaStamp reports it as a plain error (#536) that
+// resolveParquetPaths would relabel ErrFederatedReadFailed — degradable. With
+// AllowPartialDegradedMode the invalid request would then be served as a
+// Postgres-only page. The engine refuses it at entry instead: no source is
+// consulted, no DuckDB pass runs, and no Postgres-only fallback answers.
+func TestQuery_NonPositiveSchemaIDIsNotDegradable(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	for _, schemaID := range []int16{0, -1} {
+		t.Run(fmt.Sprintf("schema_%d", schemaID), func(t *testing.T) {
+			// The source answers the way the manifest package does for this
+			// ID: a plain, unclassified error. If the guard regressed, this is
+			// what the degraded fallback would absorb.
+			src := &fakeParquetSource{pathsErr: fmt.Errorf(
+				"manifest manifest/%d.json: requested schema id %d is not a schema (schema IDs are positive); refusing to verify the stamp",
+				schemaID, schemaID)}
+			duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: uuid.New()}}
+			pg := &fakePostgresFederatedSource{page: &model.PersistentRecordPage{TotalRecords: 3}}
+			engine := NewDBFederatedQueryEngine(pg, &fakeDirtyIDFetcher{}, duck, nil,
+				hybridDuckConfig(), testMetadataCacheSchema7(t), "host=x", WithParquetSource(src))
+			opts := &model.FederatedQueryOptions{AllowPartialDegradedMode: true, IncludeExecutionPlan: true}
+
+			page, err := engine.Query(context.Background(),
+				model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+				nonPositiveSchemaQuery(schemaID), opts)
+
+			require.Nil(t, page)
+			require.ErrorContains(t, err, "schema id must be positive")
+			require.NotErrorIs(t, err, ErrFederatedReadFailed,
+				"an invalid schema id is the caller's error, not a read failure to degrade around")
+			require.Equal(t, 0, pg.queryCalls, "degraded mode must not serve an invalid schema id as a Postgres-only page")
+			require.Equal(t, 0, duck.calls)
+			require.Equal(t, 0, src.pathsCalls, "the guard runs before the parquet source is consulted")
+			require.Nil(t, opts.ExecutionPlan, "refused before routing: no plan is recorded")
+		})
+	}
+}
+
+// TestExecuteFederatedPaginatedQuery_NonPositiveSchemaIDRefused pins the same
+// guard on the second entry point: the paginated coordinator shares the
+// degraded fallback through its keyset and ordered paths, so it must refuse
+// the same request at entry rather than rely on the Postgres leg to notice.
+func TestExecuteFederatedPaginatedQuery_NonPositiveSchemaIDRefused(t *testing.T) {
+	restore := initTestDescriptors()
+	defer restore()
+
+	for _, schemaID := range []int16{0, -1} {
+		t.Run(fmt.Sprintf("schema_%d", schemaID), func(t *testing.T) {
+			src := &fakeParquetSource{paths: []string{"s3://b/1/a.parquet"}}
+			duck := &fakeDuckDBExecutor{rows: &singleDuckDBRow{rowID: uuid.New()}}
+			pg := &fakePostgresFederatedSource{}
+			engine := NewDBFederatedQueryEngine(pg, &fakeDirtyIDFetcher{}, duck, nil,
+				hybridDuckConfig(), testMetadataCacheSchema7(t), "host=x", WithParquetSource(src))
+
+			records, total, err := engine.ExecuteFederatedPaginatedQuery(context.Background(),
+				model.StorageTables{EntityMain: "main", EAVData: "eav", ChangeLog: "change_log"},
+				nonPositiveSchemaQuery(schemaID), 10, 0, nil,
+				&model.FederatedQueryOptions{AllowPartialDegradedMode: true})
+
+			require.Nil(t, records)
+			require.Zero(t, total)
+			require.ErrorContains(t, err, "schema id must be positive")
+			require.NotErrorIs(t, err, ErrFederatedReadFailed)
+			require.Equal(t, 0, pg.queryCalls)
+			require.Equal(t, 0, pg.runOptimizedCalls)
+			require.Equal(t, 0, duck.calls)
+			require.Equal(t, 0, src.pathsCalls)
+		})
+	}
+}

--- a/internal/federated/engine_test.go
+++ b/internal/federated/engine_test.go
@@ -211,7 +211,7 @@ func TestDBFederatedQueryEngine_NilQueryReturnsError(t *testing.T) {
 	page, err := engine.Query(context.Background(), model.StorageTables{EntityMain: "main", EAVData: "eav"}, nil, nil)
 
 	require.Nil(t, page)
-	require.EqualError(t, err, "federated query cannot be nil")
+	require.ErrorContains(t, err, "federated query cannot be nil")
 }
 
 func TestDBFederatedQueryEngine_ExecutionPlanPopulated(t *testing.T) {

--- a/internal/federated/pagination.go
+++ b/internal/federated/pagination.go
@@ -23,8 +23,8 @@ func (e *DBFederatedQueryEngine) ExecuteFederatedPaginatedQuery(
 	attributeOrders []model.AttributeOrder,
 	opts *model.FederatedQueryOptions,
 ) ([]*model.PersistentRecord, int64, error) {
-	if fq == nil {
-		return nil, 0, fmt.Errorf("federated query cannot be nil")
+	if err := validateFederatedQueryTarget(fq); err != nil {
+		return nil, 0, fmt.Errorf("validate federated query: %w", err)
 	}
 	if limit <= 0 {
 		limit = model.DefaultPageSize

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -287,10 +287,21 @@ func LoadOrCreateForSchema(ctx context.Context, st Store, path string, schemaID 
 //     is stamped for schemaID in place and accepted; the caller's next save
 //     persists the stamp and every later load is checked.
 //
+// The requested schemaID must itself be positive (#536): schema IDs are
+// always positive, so a request for schema 0 is never a schema and would
+// otherwise satisfy the equality branch against a zero-stamped manifest and
+// admit its entries. A non-positive request is refused before any stamp is
+// compared or written, as a plain error — it is an invariant violation by the
+// caller (an unguarded enumerator or a hand-inserted registry row), not a
+// property of the manifest.
+//
 // Callers that load without LoadOrCreate semantics (the compactor) apply it
 // to the manifest they loaded; LoadOrCreateForSchema applies it for everyone
 // else.
 func VerifySchemaStamp(m *Manifest, path string, schemaID int16) error {
+	if schemaID <= 0 {
+		return fmt.Errorf("manifest %s: requested schema id %d is not a schema (schema IDs are positive); refusing to verify the stamp", path, schemaID)
+	}
 	if m.SchemaID == schemaID {
 		return nil
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -396,6 +396,52 @@ func TestLoadOrCreateForSchema(t *testing.T) {
 	require.Equal(t, "manifest/7.json", mismatch.Path)
 }
 
+// #536: schema IDs are always positive, so a request for schema 0 (or a
+// negative ID) is never a schema. Without a guard it would satisfy the
+// equality branch against a zero-stamped manifest and admit its entries — the
+// one shape the #522 rule exists to refuse. The guard runs before any stamp is
+// compared, so it holds for every manifest shape and never stamps or saves.
+func TestVerifySchemaStamp_RefusesNonPositiveRequestedSchemaID(t *testing.T) {
+	shapes := map[string]func() *Manifest{
+		"zero-stamped with entries": func() *Manifest {
+			return &Manifest{Files: []FileEntry{{Tier: "base", Path: "base/a.parquet"}}}
+		},
+		"zero-stamped empty": func() *Manifest { return &Manifest{Files: []FileEntry{}} },
+		"stamped for schema 7": func() *Manifest {
+			return &Manifest{SchemaID: 7, Files: []FileEntry{{Tier: "base", Path: "base/7/a.parquet"}}}
+		},
+	}
+	for name, mk := range shapes {
+		for _, requested := range []int16{0, -1} {
+			t.Run(fmt.Sprintf("%s/requested %d", name, requested), func(t *testing.T) {
+				m := mk()
+				before := m.SchemaID
+				err := VerifySchemaStamp(m, "manifest/0.json", requested)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "manifest/0.json")
+				require.Contains(t, err.Error(), fmt.Sprintf("requested schema id %d", requested))
+				require.NotErrorIs(t, err, forma.ErrManifestSchemaMismatch, "an invalid request is not a property of the manifest")
+				require.NotErrorIs(t, err, forma.ErrManifestUnstamped)
+				require.Equal(t, before, m.SchemaID, "the stamp is never written for an invalid request")
+			})
+		}
+	}
+
+	// Through LoadOrCreateForSchema the store is untouched: a populated
+	// zero-stamped object at the path schema 0 renders is refused, not
+	// loaded and not saved.
+	ctx := context.Background()
+	st := &memStore{}
+	unstamped := &Manifest{Files: []FileEntry{{Tier: "base", Path: "base/a.parquet"}}}
+	_, err := Save(ctx, st, "manifest/0.json", unstamped, "")
+	require.NoError(t, err)
+	genBefore := st.gen
+	m, _, err := LoadOrCreateForSchema(ctx, st, "manifest/0.json", 0)
+	require.Error(t, err)
+	require.Nil(t, m)
+	require.Equal(t, genBefore, st.gen, "refusal must not save")
+}
+
 // AppendFile and AppendFiles are cdc-flush's manifest writers. A manifest
 // stamped for another schema is a collided or mis-pointed template, and the
 // delta entry must not be appended to it (#520).


### PR DESCRIPTION
Closes #536. Follow-up to #535 (post-merge review, finding 2).

## What

`manifest.VerifySchemaStamp` checked `m.SchemaID == schemaID` before it checked for a zero stamp, so a request for schema `0` against a zero-stamped manifest with entries took the equality branch and was accepted. Schema IDs are always positive, so `0` (or a negative ID) is never a schema. The helper now refuses a non-positive requested ID before comparing or writing any stamp:

```
manifest <path>: requested schema id 0 is not a schema (schema IDs are positive); refusing to verify the stamp
```

It is a plain error, not a `ManifestSchemaMismatchError` / `ManifestUnstampedError` carrier: an invalid request is an invariant violation by the caller (an unguarded enumerator or a hand-inserted registry row), not a property of the manifest. Every consumer inherits it through the single enforcement site (`LoadOrCreateForSchema`, cdc-init, compactor).

## Federated entry guard (review follow-up)

The plain error is unclassified, and the federated read path relabels every unclassified parquet-source failure as `ErrFederatedReadFailed`, which `AllowPartialDegradedMode` absorbs into a Postgres-only answer. So `Query` and `ExecuteFederatedPaginatedQuery` now share one entry guard, `validateFederatedQueryTarget`, that refuses a nil query or `SchemaID <= 0` before routing, with the same `schema id must be positive` invariant the OLTP repository enforces. No parquet source is consulted, no DuckDB pass runs, and no degraded fallback answers.

## Reachability

Not from an HTTP caller (schemas are named and resolved through the registry) and not from the OLTP path (the repository rejects `schemaID <= 0`). It is reachable through `reconcile.RegistrySchemaEnumerator`, `cdc.getSchemaIDsToInit` and `cdc.getUnflushedSchemaIDs`, which enumerate every row without a positivity guard, given an out-of-band registry or change_log row with `schema_id = 0`. Hardening those enumerators and adding `CHECK (schema_id > 0)` to the registry DDL is #538; this PR closes the consumer-side boundaries.

## Tests

`TestQuery_NonPositiveSchemaIDIsNotDegradable` and `TestExecuteFederatedPaginatedQuery_NonPositiveSchemaIDRefused` (`internal/federated/engine_schema_id_test.go`): schema `0` and `-1` through both engine entry points with `AllowPartialDegradedMode: true` are refused before routing: no Postgres-only fallback, no DuckDB pass, no parquet-source call, no `ErrFederatedReadFailed` classification. Red without the entry guard (the degraded fallback answered), green with it.

`TestVerifySchemaStamp_RefusesNonPositiveRequestedSchemaID`: requested `0` and `-1` against a populated zero-stamped, an empty zero-stamped, and a stamped-for-7 manifest are all refused, neither sentinel matches, the stamp is never written; through `LoadOrCreateForSchema` the store is not saved. Red without the guard, green with it.

## Docs

`docs/error-handling.md`, zero-stamp bullet under `ErrManifestSchemaMismatch`, including why the engine stops the plain error at entry instead of classifying it downstream.

## Verification

`make fmt-check`, `make lint`, and `go test -count=1` on `.`, `internal`, `internal/manifest`, `internal/cdc`, `internal/compaction`, `internal/reconcile`, `internal/httpapi`, `internal/federated`, `cmd/...`, `factory` all pass locally.

