### PR TITLE
fix(reconcile): fail closed on an unfollowable ListObjectsV2 page (#521)

### DIFF
--- a/internal/cdc/init_wiring.go
+++ b/internal/cdc/init_wiring.go
@@ -2,10 +2,7 @@ package cdc
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/lychee-technology/forma/internal/manifest"
 )
@@ -15,7 +12,7 @@ import (
 // inventory (#371). *s3.Client satisfies it.
 type S3InitClient interface {
 	S3FullClient
-	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	S3ListClient
 }
 
 // applyInitS3Wiring sets every S3-derived field of an init run context: the
@@ -70,48 +67,4 @@ func newDeltaTierSeams(client S3InitClient, bucket string) (
 		return DeleteObjectKey(ctx, client, bucket, key)
 	}
 	return list, del
-}
-
-// ErrIncompleteObjectListing marks a listing whose pages cannot be followed
-// to the end: a truncated page without a continuation token, or a token the
-// listing has already used. The inventory built on such a listing would be
-// short, and a short inventory under --replace-delta would purge less than
-// the delta tier holds, so the listing fails closed instead (#371 review).
-var ErrIncompleteObjectListing = errors.New("object listing incomplete")
-
-// ListObjectKeys returns every object key under prefix, following
-// continuation tokens. A page that claims to be truncated but carries no
-// usable token, or hands back a token already used, fails with
-// ErrIncompleteObjectListing rather than returning the keys seen so far.
-func ListObjectKeys(ctx context.Context, client S3InitClient, bucket, prefix string) ([]string, error) {
-	var keys []string
-	var token *string
-	seen := map[string]struct{}{}
-	for {
-		out, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(bucket),
-			Prefix:            aws.String(prefix),
-			ContinuationToken: token,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("list objects under %s: %w", prefix, err)
-		}
-		for _, obj := range out.Contents {
-			keys = append(keys, aws.ToString(obj.Key))
-		}
-		if !aws.ToBool(out.IsTruncated) {
-			return keys, nil
-		}
-		next := aws.ToString(out.NextContinuationToken)
-		if next == "" {
-			return nil, fmt.Errorf("list objects under %s: page %d is truncated but carries no continuation token: %w",
-				prefix, len(seen)+1, ErrIncompleteObjectListing)
-		}
-		if _, repeated := seen[next]; repeated {
-			return nil, fmt.Errorf("list objects under %s: page %d repeats continuation token %q: %w",
-				prefix, len(seen)+1, next, ErrIncompleteObjectListing)
-		}
-		seen[next] = struct{}{}
-		token = aws.String(next)
-	}
 }

--- a/internal/cdc/init_wiring_test.go
+++ b/internal/cdc/init_wiring_test.go
@@ -248,14 +248,6 @@ func (c *malformedListClient) DeleteObject(_ context.Context, in *s3.DeleteObjec
 	return &s3.DeleteObjectOutput{}, nil
 }
 
-func listPage(truncated bool, token *string, keys ...string) *s3.ListObjectsV2Output {
-	out := &s3.ListObjectsV2Output{IsTruncated: aws.Bool(truncated), NextContinuationToken: token}
-	for _, k := range keys {
-		out.Contents = append(out.Contents, types.Object{Key: aws.String(k)})
-	}
-	return out
-}
-
 // A page that claims to be truncated but carries no usable continuation
 // token, or hands back a token the listing already used, cannot be followed
 // to the end. The listing fails closed with the named sentinel instead of

--- a/internal/cdc/list_objects.go
+++ b/internal/cdc/list_objects.go
@@ -1,0 +1,103 @@
+package cdc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// S3ListClient is the one-method surface a prefix listing needs. *s3.Client
+// satisfies it, as does every wider client interface that carries
+// ListObjectsV2 (S3InitClient, reconcile's object API, the e2e harness's
+// cluster client).
+type S3ListClient interface {
+	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+}
+
+// ErrIncompleteObjectListing marks a listing whose pages cannot be followed
+// to the end: a truncated page without a continuation token, or a token the
+// listing has already used. The inventory built on such a listing would be
+// short — cdc-init's --replace-delta purge would delete less than the delta
+// tier holds (#371 review), and manifest-reconcile would under-report
+// orphans and over-report dangling entries while still saying "ok" (#521) —
+// so the listing fails closed instead.
+var ErrIncompleteObjectListing = errors.New("object listing incomplete")
+
+// ForEachObject is the shared ListObjectsV2 paginator: it calls fn for every
+// object under prefix, following continuation tokens until the listing is
+// exhausted. A page that claims to be truncated but carries no usable
+// token, or hands back a token already used, is not delivered to fn; the
+// listing fails with ErrIncompleteObjectListing rather than presenting the
+// objects seen so far as the whole prefix. An error from fn stops the
+// listing at that page and is returned unwrapped, so callers keep the
+// context they attached themselves.
+//
+// Every production and harness paginator routes through here so the
+// fail-closed rule has exactly one copy (#521).
+func ForEachObject(ctx context.Context, client S3ListClient, bucket, prefix string, fn func(types.Object) error) error {
+	var token *string
+	seen := map[string]struct{}{}
+	for {
+		out, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(bucket),
+			Prefix:            aws.String(prefix),
+			ContinuationToken: token,
+		})
+		if err != nil {
+			return fmt.Errorf("list objects under %s: %w", prefix, err)
+		}
+		next, err := nextListingToken(out, prefix, len(seen)+1, seen)
+		if err != nil {
+			return err
+		}
+		for _, obj := range out.Contents {
+			if err := fn(obj); err != nil {
+				return err
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		token = next
+	}
+}
+
+// nextListingToken validates one page's pagination state and returns the
+// token to forward, or nil when the page is the last one. It records the
+// token in seen so a later page that hands it back again is refused.
+func nextListingToken(out *s3.ListObjectsV2Output, prefix string, page int, seen map[string]struct{}) (*string, error) {
+	if !aws.ToBool(out.IsTruncated) {
+		return nil, nil
+	}
+	next := aws.ToString(out.NextContinuationToken)
+	if next == "" {
+		return nil, fmt.Errorf("list objects under %s: page %d is truncated but carries no continuation token: %w",
+			prefix, page, ErrIncompleteObjectListing)
+	}
+	if _, repeated := seen[next]; repeated {
+		return nil, fmt.Errorf("list objects under %s: page %d repeats continuation token %q: %w",
+			prefix, page, next, ErrIncompleteObjectListing)
+	}
+	seen[next] = struct{}{}
+	return aws.String(next), nil
+}
+
+// ListObjectKeys returns every object key under prefix, following
+// continuation tokens through ForEachObject and inheriting its fail-closed
+// rule: an unfollowable page fails with ErrIncompleteObjectListing rather
+// than returning the keys seen so far.
+func ListObjectKeys(ctx context.Context, client S3ListClient, bucket, prefix string) ([]string, error) {
+	var keys []string
+	err := ForEachObject(ctx, client, bucket, prefix, func(obj types.Object) error {
+		keys = append(keys, aws.ToString(obj.Key))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return keys, nil
+}

--- a/internal/cdc/list_objects.go
+++ b/internal/cdc/list_objects.go
@@ -36,8 +36,8 @@ var ErrIncompleteObjectListing = errors.New("object listing incomplete")
 // listing at that page and is returned unwrapped, so callers keep the
 // context they attached themselves.
 //
-// Every production and harness paginator routes through here so the
-// fail-closed rule has exactly one copy (#521).
+// Every production and harness ListObjectsV2 caller routes through here so
+// the fail-closed rule has exactly one copy (#521).
 func ForEachObject(ctx context.Context, client S3ListClient, bucket, prefix string, fn func(types.Object) error) error {
 	var token *string
 	seen := map[string]struct{}{}

--- a/internal/cdc/list_objects_test.go
+++ b/internal/cdc/list_objects_test.go
@@ -1,0 +1,99 @@
+package cdc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedListClient answers ListObjectsV2 with a fixed page sequence and
+// records the token each call forwarded.
+type scriptedListClient struct {
+	pages  []*s3.ListObjectsV2Output
+	tokens []*string
+}
+
+func (c *scriptedListClient) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	c.tokens = append(c.tokens, in.ContinuationToken)
+	if len(c.tokens) > len(c.pages) {
+		return nil, errors.New("unexpected ListObjectsV2 call")
+	}
+	return c.pages[len(c.tokens)-1], nil
+}
+
+// ForEachObject hands the callback every listed object with its metadata
+// intact, across pages, forwarding each page's continuation token (#521:
+// reconcile needs Size and LastModified, so the shared paginator must not
+// flatten objects to keys).
+func TestForEachObject_VisitsEveryObjectAcrossPages(t *testing.T) {
+	mod := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	client := &scriptedListClient{pages: []*s3.ListObjectsV2Output{
+		{
+			Contents: []types.Object{
+				{Key: aws.String("data/7/a.parquet"), Size: aws.Int64(10), LastModified: aws.Time(mod)},
+			},
+			IsTruncated:           aws.Bool(true),
+			NextContinuationToken: aws.String("page-2"),
+		},
+		{
+			Contents: []types.Object{
+				{Key: aws.String("data/7/b.parquet"), Size: aws.Int64(20), LastModified: aws.Time(mod)},
+			},
+		},
+	}}
+
+	var seen []types.Object
+	err := ForEachObject(context.Background(), client, "test-bucket", "data/7/", func(obj types.Object) error {
+		seen = append(seen, obj)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, seen, 2)
+	require.Equal(t, "data/7/a.parquet", aws.ToString(seen[0].Key))
+	require.Equal(t, int64(10), aws.ToInt64(seen[0].Size))
+	require.True(t, aws.ToTime(seen[0].LastModified).Equal(mod))
+	require.Equal(t, "data/7/b.parquet", aws.ToString(seen[1].Key))
+	require.Equal(t, int64(20), aws.ToInt64(seen[1].Size))
+	require.Equal(t, []*string{nil, aws.String("page-2")}, client.tokens)
+}
+
+// A callback error stops the listing at that page and reaches the caller
+// unwrapped, so callers keep the context they attached themselves.
+func TestForEachObject_CallbackErrorStopsListing(t *testing.T) {
+	client := &scriptedListClient{pages: []*s3.ListObjectsV2Output{
+		listPage(true, aws.String("page-2"), "data/7/a.parquet", "data/7/b.parquet"),
+		listPage(false, nil, "data/7/c.parquet"),
+	}}
+	stop := errors.New("stop here")
+
+	var seen []string
+	err := ForEachObject(context.Background(), client, "test-bucket", "data/7/", func(obj types.Object) error {
+		seen = append(seen, aws.ToString(obj.Key))
+		return stop
+	})
+	require.ErrorIs(t, err, stop)
+	require.Equal(t, []string{"data/7/a.parquet"}, seen)
+	require.Len(t, client.tokens, 1, "the listing must not fetch another page after the callback failed")
+}
+
+// ForEachObject carries the fail-closed rule ListObjectKeys is specified
+// against, so every paginator routed through it inherits the guard.
+func TestForEachObject_UnfollowableTruncationFailsClosed(t *testing.T) {
+	client := &scriptedListClient{pages: []*s3.ListObjectsV2Output{
+		listPage(true, nil, "data/7/a.parquet"),
+	}}
+	var seen int
+	err := ForEachObject(context.Background(), client, "test-bucket", "data/7/", func(types.Object) error {
+		seen++
+		return nil
+	})
+	require.ErrorIs(t, err, ErrIncompleteObjectListing)
+	require.Contains(t, err.Error(), "list objects under data/7/: page 1 is truncated but carries no continuation token")
+	require.Equal(t, 0, seen, "a page that cannot be followed must not be delivered to the callback")
+}

--- a/internal/cdc/list_objects_test.go
+++ b/internal/cdc/list_objects_test.go
@@ -27,6 +27,17 @@ func (c *scriptedListClient) ListObjectsV2(_ context.Context, in *s3.ListObjects
 	return c.pages[len(c.tokens)-1], nil
 }
 
+// listPage builds one ListObjectsV2 page carrying only keys. It lives with
+// the paginator it exercises; init_wiring_test.go reuses it for the
+// ListObjectKeys and pre-flight cases.
+func listPage(truncated bool, token *string, keys ...string) *s3.ListObjectsV2Output {
+	out := &s3.ListObjectsV2Output{IsTruncated: aws.Bool(truncated), NextContinuationToken: token}
+	for _, k := range keys {
+		out.Contents = append(out.Contents, types.Object{Key: aws.String(k)})
+	}
+	return out
+}
+
 // ForEachObject hands the callback every listed object with its metadata
 // intact, across pages, forwarding each page's continuation token (#521:
 // reconcile needs Size and LastModified, so the shared paginator must not

--- a/internal/e2e_harness/federated/s3_operations.go
+++ b/internal/e2e_harness/federated/s3_operations.go
@@ -14,6 +14,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/lychee-technology/forma/internal/cdc"
 )
 
 // WriteParquet writes records to a parquet file in S3.
@@ -187,23 +190,26 @@ func (h *FederatedTestHarness) uploadToS3(ctx context.Context, localPath, s3Key 
 	return err
 }
 
-// ListParquetFiles lists parquet files in a tier.
+// ListParquetFiles lists parquet files in a tier, following every
+// ListObjectsV2 page through the shared paginator so a tier holding more
+// than one page of files is counted in full (#521).
 func (h *FederatedTestHarness) ListParquetFiles(ctx context.Context, tier string) ([]string, error) {
 	prefix := fmt.Sprintf("%s/%d/%s/", h.S3Prefix, h.SchemaID, tier)
+	return listParquetKeys(ctx, h.s3Client, h.S3Bucket, prefix)
+}
 
-	resp, err := h.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(h.S3Bucket),
-		Prefix: aws.String(prefix),
+// listParquetKeys returns every ".parquet" key under prefix. It takes the
+// narrow listing surface so a unit test can drive it with a scripted client.
+func listParquetKeys(ctx context.Context, client cdc.S3ListClient, bucket, prefix string) ([]string, error) {
+	var files []string
+	err := cdc.ForEachObject(ctx, client, bucket, prefix, func(obj types.Object) error {
+		if key := aws.ToString(obj.Key); strings.HasSuffix(key, ".parquet") {
+			files = append(files, key)
+		}
+		return nil
 	})
 	if err != nil {
-		return nil, err
-	}
-
-	var files []string
-	for _, obj := range resp.Contents {
-		if strings.HasSuffix(*obj.Key, ".parquet") {
-			files = append(files, *obj.Key)
-		}
+		return nil, fmt.Errorf("list parquet files in bucket %s: %w", bucket, err)
 	}
 	return files, nil
 }
@@ -243,20 +249,32 @@ func (h *FederatedTestHarness) ReadParquetMetadata(ctx context.Context, s3Key st
 	return meta, nil
 }
 
-// deleteS3Prefix deletes all objects under a prefix.
-func (h *FederatedTestHarness) deleteS3Prefix(ctx context.Context, prefix string) error {
-	resp, err := h.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-		Bucket: aws.String(h.S3Bucket),
-		Prefix: aws.String(prefix),
-	})
-	if err != nil {
-		return err
-	}
+// s3PrefixClient is the surface deleteAllUnderPrefix needs: the shared
+// listing method plus DeleteObject. *s3.Client satisfies it.
+type s3PrefixClient interface {
+	cdc.S3ListClient
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
 
-	for _, obj := range resp.Contents {
-		_, _ = h.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-			Bucket: aws.String(h.S3Bucket),
-			Key:    obj.Key,
+// deleteS3Prefix deletes all objects under a prefix, across every listing
+// page, so a cleanup between cases cannot leave later-page objects behind
+// for the next case to see (#521).
+func (h *FederatedTestHarness) deleteS3Prefix(ctx context.Context, prefix string) error {
+	return deleteAllUnderPrefix(ctx, h.s3Client, h.S3Bucket, prefix)
+}
+
+// deleteAllUnderPrefix lists the whole prefix first, then deletes each key.
+// The listing fails closed through the shared paginator; individual delete
+// failures stay best-effort, as the cleanup callers expect.
+func deleteAllUnderPrefix(ctx context.Context, client s3PrefixClient, bucket, prefix string) error {
+	keys, err := cdc.ListObjectKeys(ctx, client, bucket, prefix)
+	if err != nil {
+		return fmt.Errorf("list objects to delete in bucket %s: %w", bucket, err)
+	}
+	for _, key := range keys {
+		_, _ = client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
 		})
 	}
 	return nil

--- a/internal/e2e_harness/federated/s3_operations_test.go
+++ b/internal/e2e_harness/federated/s3_operations_test.go
@@ -1,0 +1,96 @@
+package federated
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma/internal/cdc"
+)
+
+// scriptedPrefixClient answers ListObjectsV2 with a fixed page sequence,
+// records the token each call forwarded, and records every DeleteObject key.
+type scriptedPrefixClient struct {
+	pages   []*s3.ListObjectsV2Output
+	tokens  []*string
+	deleted []string
+}
+
+func (c *scriptedPrefixClient) ListObjectsV2(_ context.Context, in *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	c.tokens = append(c.tokens, in.ContinuationToken)
+	if len(c.tokens) > len(c.pages) {
+		return nil, errors.New("unexpected ListObjectsV2 call")
+	}
+	return c.pages[len(c.tokens)-1], nil
+}
+
+func (c *scriptedPrefixClient) DeleteObject(_ context.Context, in *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	c.deleted = append(c.deleted, aws.ToString(in.Key))
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+func page(truncated bool, token *string, keys ...string) *s3.ListObjectsV2Output {
+	out := &s3.ListObjectsV2Output{IsTruncated: aws.Bool(truncated), NextContinuationToken: token}
+	for _, k := range keys {
+		out.Contents = append(out.Contents, types.Object{Key: aws.String(k)})
+	}
+	return out
+}
+
+// A tier spanning more than one ListObjectsV2 page is counted in full, with
+// the ".parquet" filter applied on every page (#521: the harness used to
+// read only the first page).
+func TestListParquetKeys_FollowsEveryPage(t *testing.T) {
+	client := &scriptedPrefixClient{pages: []*s3.ListObjectsV2Output{
+		page(true, aws.String("page-2"), "p/1/base/a.parquet", "p/1/base/_manifest.json"),
+		page(false, nil, "p/1/base/b.parquet"),
+	}}
+
+	files, err := listParquetKeys(context.Background(), client, "bkt", "p/1/base/")
+	require.NoError(t, err)
+	require.Equal(t, []string{"p/1/base/a.parquet", "p/1/base/b.parquet"}, files)
+	require.Equal(t, []*string{nil, aws.String("page-2")}, client.tokens)
+}
+
+// An unfollowable page fails the listing instead of reporting a short file
+// count that a test assertion would then trust.
+func TestListParquetKeys_UnfollowableTruncationFailsClosed(t *testing.T) {
+	client := &scriptedPrefixClient{pages: []*s3.ListObjectsV2Output{
+		page(true, nil, "p/1/base/a.parquet"),
+	}}
+
+	files, err := listParquetKeys(context.Background(), client, "bkt", "p/1/base/")
+	require.ErrorIs(t, err, cdc.ErrIncompleteObjectListing)
+	require.Nil(t, files)
+}
+
+// A cleanup deletes objects from every page, so a prefix larger than one
+// page cannot leak later-page objects into the next test case (#521).
+func TestDeleteAllUnderPrefix_DeletesEveryPage(t *testing.T) {
+	client := &scriptedPrefixClient{pages: []*s3.ListObjectsV2Output{
+		page(true, aws.String("page-2"), "p/1/base/a.parquet", "p/1/delta/b.parquet"),
+		page(false, nil, "p/1/delta/c.parquet"),
+	}}
+
+	err := deleteAllUnderPrefix(context.Background(), client, "bkt", "p/")
+	require.NoError(t, err)
+	require.Equal(t, []string{"p/1/base/a.parquet", "p/1/delta/b.parquet", "p/1/delta/c.parquet"}, client.deleted)
+	require.Equal(t, []*string{nil, aws.String("page-2")}, client.tokens)
+}
+
+// A cleanup whose listing cannot be followed reports the failure rather than
+// deleting a partial set and returning nil.
+func TestDeleteAllUnderPrefix_UnfollowableTruncationFailsClosed(t *testing.T) {
+	client := &scriptedPrefixClient{pages: []*s3.ListObjectsV2Output{
+		page(true, aws.String(""), "p/1/base/a.parquet"),
+	}}
+
+	err := deleteAllUnderPrefix(context.Background(), client, "bkt", "p/")
+	require.ErrorIs(t, err, cdc.ErrIncompleteObjectListing)
+	require.Empty(t, client.deleted, "nothing may be deleted on the strength of an incomplete listing")
+}

--- a/internal/e2e_harness/production/artifacts.go
+++ b/internal/e2e_harness/production/artifacts.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
+	"github.com/lychee-technology/forma/internal/cdc"
 	"github.com/lychee-technology/forma/internal/sqlutil"
 )
 
@@ -188,31 +190,20 @@ func uuidString(b [16]byte) string {
 
 func (e *Env) dumpS3Listing(ctx context.Context, dir string) error {
 	var listing []map[string]any
-	var token *string
-	for {
-		out, err := e.Cluster.S3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(e.Cluster.Bucket),
-			Prefix:            aws.String(e.S3Prefix + "/"),
-			ContinuationToken: token,
-		})
-		if err != nil {
-			return fmt.Errorf("list s3 objects: %w", err)
+	err := cdc.ForEachObject(ctx, e.Cluster.S3, e.Cluster.Bucket, e.S3Prefix+"/", func(obj types.Object) error {
+		entry := map[string]any{
+			"key":  aws.ToString(obj.Key),
+			"size": aws.ToInt64(obj.Size),
+			"etag": aws.ToString(obj.ETag),
 		}
-		for _, obj := range out.Contents {
-			entry := map[string]any{
-				"key":  aws.ToString(obj.Key),
-				"size": aws.ToInt64(obj.Size),
-				"etag": aws.ToString(obj.ETag),
-			}
-			if obj.LastModified != nil {
-				entry["last_modified"] = obj.LastModified.UTC().Format(time.RFC3339)
-			}
-			listing = append(listing, entry)
+		if obj.LastModified != nil {
+			entry["last_modified"] = obj.LastModified.UTC().Format(time.RFC3339)
 		}
-		if out.NextContinuationToken == nil {
-			break
-		}
-		token = out.NextContinuationToken
+		listing = append(listing, entry)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("list s3 objects: %w", err)
 	}
 	return writeJSONArtifact(dir, "s3_listing.json", listing)
 }

--- a/internal/e2e_harness/production/env.go
+++ b/internal/e2e_harness/production/env.go
@@ -366,27 +366,15 @@ func (e *Env) deleteS3Prefix(ctx context.Context) {
 	}
 }
 
-// listS3Keys returns all object keys under the Env's S3 prefix.
+// listS3Keys returns all object keys under the Env's S3 prefix through the
+// shared paginator, so a truncated page without a token fails the listing
+// instead of passing as its end (#521).
 func (e *Env) listS3Keys(ctx context.Context) ([]string, error) {
-	var keys []string
-	var token *string
-	for {
-		out, err := e.Cluster.S3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(e.Cluster.Bucket),
-			Prefix:            aws.String(e.S3Prefix + "/"),
-			ContinuationToken: token,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("list objects under %s: %w", e.S3Prefix, err)
-		}
-		for _, obj := range out.Contents {
-			keys = append(keys, aws.ToString(obj.Key))
-		}
-		if out.NextContinuationToken == nil {
-			return keys, nil
-		}
-		token = out.NextContinuationToken
+	keys, err := cdc.ListObjectKeys(ctx, e.Cluster.S3, e.Cluster.Bucket, e.S3Prefix+"/")
+	if err != nil {
+		return nil, fmt.Errorf("list env s3 keys: %w", err)
 	}
+	return keys, nil
 }
 
 func deriveSeed(clusterSeed int64, testName string, override *int64) int64 {

--- a/internal/e2e_harness/production/state_snapshot_helpers_e2e_test.go
+++ b/internal/e2e_harness/production/state_snapshot_helpers_e2e_test.go
@@ -11,8 +11,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
+	"github.com/lychee-technology/forma/internal/cdc"
 	"github.com/lychee-technology/forma/internal/manifest"
 )
 
@@ -34,28 +35,18 @@ type s3ObjectStat struct {
 func snapshotS3Inventory(t *testing.T, ctx context.Context, env *Env, prefix string) map[string]s3ObjectStat {
 	t.Helper()
 	inv := make(map[string]s3ObjectStat)
-	var token *string
-	for {
-		out, err := env.Cluster.S3.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(env.Cluster.Bucket),
-			Prefix:            aws.String(prefix),
-			ContinuationToken: token,
-		})
-		if err != nil {
-			t.Fatalf("snapshot s3 inventory: %v", err)
+	err := cdc.ForEachObject(ctx, env.Cluster.S3, env.Cluster.Bucket, prefix, func(obj types.Object) error {
+		stat := s3ObjectStat{Size: aws.ToInt64(obj.Size), ETag: aws.ToString(obj.ETag)}
+		if obj.LastModified != nil {
+			stat.LastModified = obj.LastModified.UTC()
 		}
-		for _, obj := range out.Contents {
-			stat := s3ObjectStat{Size: aws.ToInt64(obj.Size), ETag: aws.ToString(obj.ETag)}
-			if obj.LastModified != nil {
-				stat.LastModified = obj.LastModified.UTC()
-			}
-			inv[aws.ToString(obj.Key)] = stat
-		}
-		if out.NextContinuationToken == nil {
-			return inv
-		}
-		token = out.NextContinuationToken
+		inv[aws.ToString(obj.Key)] = stat
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot s3 inventory: %v", err)
 	}
+	return inv
 }
 
 // snapshotManifest returns the manifest's raw bytes and ETag. Callers snapshot

--- a/internal/reconcile/deps.go
+++ b/internal/reconcile/deps.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
+	"github.com/lychee-technology/forma/internal/cdc"
 	"github.com/lychee-technology/forma/internal/compaction"
 	"github.com/lychee-technology/forma/internal/parquetcheck"
 )
@@ -41,11 +43,11 @@ type ObjectReader interface {
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 }
 
-// s3ObjectAPI is the slice of *s3.Client the reconciler consumes. None of
-// the production S3 interfaces (cdc.S3ObjectClient, manifest.S3Client)
-// expose ListObjectsV2, so the tool declares its own.
+// s3ObjectAPI is the slice of *s3.Client the reconciler consumes: the
+// listing surface shared with cdc-init (cdc.S3ListClient, the client
+// cdc.ForEachObject paginates over) plus DeleteObject for --gc.
 type s3ObjectAPI interface {
-	ListObjectsV2(ctx context.Context, in *s3.ListObjectsV2Input, opts ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	cdc.S3ListClient
 	DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, opts ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }
 
@@ -56,32 +58,25 @@ type S3ObjectStore struct {
 	Bucket string
 }
 
-// ListObjects lists all objects under prefix, following continuation tokens
-// until the listing is exhausted.
+// ListObjects lists all objects under prefix through the shared paginator,
+// following continuation tokens until the listing is exhausted. A page the
+// paginator cannot follow fails with cdc.ErrIncompleteObjectListing instead
+// of returning the objects seen so far (#521): the reconciler must not
+// diff a schema against a listing that stopped short.
 func (s *S3ObjectStore) ListObjects(ctx context.Context, prefix string) ([]ObjectInfo, error) {
 	var objs []ObjectInfo
-	var token *string
-	for {
-		out, err := s.Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(s.Bucket),
-			Prefix:            aws.String(prefix),
-			ContinuationToken: token,
+	err := cdc.ForEachObject(ctx, s.Client, s.Bucket, prefix, func(obj types.Object) error {
+		objs = append(objs, ObjectInfo{
+			Key:          aws.ToString(obj.Key),
+			Size:         aws.ToInt64(obj.Size),
+			LastModified: aws.ToTime(obj.LastModified),
 		})
-		if err != nil {
-			return nil, fmt.Errorf("list s3 objects under %s/%s: %w", s.Bucket, prefix, err)
-		}
-		for _, obj := range out.Contents {
-			objs = append(objs, ObjectInfo{
-				Key:          aws.ToString(obj.Key),
-				Size:         aws.ToInt64(obj.Size),
-				LastModified: aws.ToTime(obj.LastModified),
-			})
-		}
-		if !aws.ToBool(out.IsTruncated) || out.NextContinuationToken == nil {
-			return objs, nil
-		}
-		token = out.NextContinuationToken
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list s3 objects in bucket %s: %w", s.Bucket, err)
 	}
+	return objs, nil
 }
 
 // DeleteObject deletes one object by key.

--- a/internal/reconcile/deps_test.go
+++ b/internal/reconcile/deps_test.go
@@ -2,13 +2,17 @@ package reconcile
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/lychee-technology/forma/internal/cdc"
 )
 
 type pagingS3 struct {
@@ -75,5 +79,90 @@ func TestS3ObjectStore_ListObjectsPaginates(t *testing.T) {
 	}
 	if got := aws.ToString(fake.calls[1].ContinuationToken); got != "page-1" {
 		t.Fatalf("second call token = %q, want page-1", got)
+	}
+}
+
+// scriptedS3 answers ListObjectsV2 with a fixed sequence of pages, whatever
+// token the caller forwards, so malformed pagination can be replayed.
+type scriptedS3 struct {
+	pages []*s3.ListObjectsV2Output
+	calls int
+}
+
+func (p *scriptedS3) ListObjectsV2(_ context.Context, _ *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if p.calls >= len(p.pages) {
+		return nil, fmt.Errorf("unexpected ListObjectsV2 call %d", p.calls+1)
+	}
+	out := p.pages[p.calls]
+	p.calls++
+	return out, nil
+}
+
+func (p *scriptedS3) DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+func listPage(truncated bool, token *string, keys ...string) *s3.ListObjectsV2Output {
+	out := &s3.ListObjectsV2Output{IsTruncated: aws.Bool(truncated), NextContinuationToken: token}
+	for _, k := range keys {
+		out.Contents = append(out.Contents, types.Object{Key: aws.String(k)})
+	}
+	return out
+}
+
+// A page that claims to be truncated but carries no usable continuation
+// token, or repeats one the listing already used, cannot be followed to the
+// end. The store fails closed with cdc.ErrIncompleteObjectListing instead of
+// handing the reconciler the objects seen so far as if they were the whole
+// prefix (#521): a short listing under-reports orphans and over-reports
+// dangling entries while the run still says "ok".
+func TestS3ObjectStore_ListObjectsUnfollowableTruncationFailsClosed(t *testing.T) {
+	cases := []struct {
+		name  string
+		pages []*s3.ListObjectsV2Output
+		calls int
+		want  string
+	}{
+		{
+			name:  "truncated without token",
+			pages: []*s3.ListObjectsV2Output{listPage(true, nil, "data/7/a.parquet")},
+			calls: 1,
+			want:  "page 1 is truncated but carries no continuation token",
+		},
+		{
+			name:  "truncated with empty token",
+			pages: []*s3.ListObjectsV2Output{listPage(true, aws.String(""), "data/7/a.parquet")},
+			calls: 1,
+			want:  "page 1 is truncated but carries no continuation token",
+		},
+		{
+			name: "repeated token",
+			pages: []*s3.ListObjectsV2Output{
+				listPage(true, aws.String("page-2"), "data/7/a.parquet"),
+				listPage(true, aws.String("page-2"), "data/7/b.parquet"),
+			},
+			calls: 2,
+			want:  `page 2 repeats continuation token "page-2"`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fake := &scriptedS3{pages: c.pages}
+			store := &S3ObjectStore{Client: fake, Bucket: "bkt"}
+			objs, err := store.ListObjects(context.Background(), "data/7/")
+			if !errors.Is(err, cdc.ErrIncompleteObjectListing) {
+				t.Fatalf("ListObjects error = %v, want cdc.ErrIncompleteObjectListing", err)
+			}
+			want := "list s3 objects in bucket bkt: list objects under data/7/: " + c.want
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("ListObjects error = %q, want it to contain %q", err.Error(), want)
+			}
+			if objs != nil {
+				t.Fatalf("an incomplete listing must not hand back a partial object set, got %v", objectKeys(objs))
+			}
+			if fake.calls != c.calls {
+				t.Fatalf("ListObjectsV2 calls = %d, want %d", fake.calls, c.calls)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #521.

## Problem

`S3ObjectStore.ListObjects` in `internal/reconcile/deps.go` returned the objects seen so far when a `ListObjectsV2` page was `IsTruncated` without a `NextContinuationToken`, and forwarded an empty token unchecked. The reconciler then diffed a schema against a short listing: fewer orphans reported (silent `--gc` / `--repair` no-op), spurious dangling entries, and a run that still said "ok". #518 closed the same branch for cdc-init only. The three production e2e harness paginators stopped on a nil token without looking at `IsTruncated`, so a malformed page passed as the last one there too. The two federated e2e harness listings (`ListParquetFiles`, `deleteS3Prefix`) issued a single request and never paginated at all.

## Change

- **`internal/cdc/list_objects.go` (new)** — `cdc.ForEachObject(ctx, client, bucket, prefix, fn)` is now the one ListObjectsV2 paginator. It carries the #518 fail-closed rule: a truncated page without a non-empty token, or a repeated token, fails with `cdc.ErrIncompleteObjectListing` and is not delivered to the callback. A callback error stops the listing and is returned unwrapped. `cdc.S3ListClient` is the one-method surface it takes; `S3InitClient` embeds it. `ErrIncompleteObjectListing` and `ListObjectKeys` move here from `init_wiring.go`, the latter as a thin wrapper.
- **`internal/reconcile/deps.go`** — `ListObjects` collects `ObjectInfo{Key, Size, LastModified}` through the shared paginator; the fail-open branch is gone. `s3ObjectAPI` embeds `cdc.S3ListClient`.
- **production e2e harness** — `listS3Keys`, `dumpS3Listing`, and `snapshotS3Inventory` route through `cdc.ListObjectKeys` / `cdc.ForEachObject`.
- **federated e2e harness** (`internal/e2e_harness/federated/s3_operations.go`) — `ListParquetFiles` and `deleteS3Prefix` delegate to package-level `listParquetKeys` / `deleteAllUnderPrefix`, which take the narrow listing surface and go through the shared paginator. File counts now cover every page and cleanup deletes every page; delete failures stay best-effort as before.

`reconcile.go` needs no change: both consumers of the listing already propagate a lister error out of the run.

## Tests

- `TestS3ObjectStore_ListObjectsUnfollowableTruncationFailsClosed` (reconcile) mirrors `TestListObjectKeys_UnfollowableTruncationFailsClosed`: truncated without token, truncated with empty token, repeated token → `errors.Is(err, cdc.ErrIncompleteObjectListing)`, nil result, exact call count. Before the fix the first case returned `nil` error and the other two forwarded the bad token.
- `TestForEachObject_*` (cdc): metadata pass-through across pages with token forwarding, callback error stops the listing, fail-closed rule without delivering the malformed page.
- `TestListParquetKeys_*` and `TestDeleteAllUnderPrefix_*` (federated, untagged unit tests with a scripted two-page client): every page visited with the `.parquet` filter applied, every listed key deleted, token forwarding, and fail-closed on an unfollowable page with nothing counted or deleted.
- Existing `TestListObjectKeys_UnfollowableTruncationFailsClosed`, `TestPreflightDeltaTier_IncompleteListingStopsBeforeAnySwapOrPurge`, and `TestS3ObjectStore_ListObjectsPaginates` pass unchanged.

## Verification

- `make fmt-check`, `make lint` (root and infra) — clean
- `go vet -tags=e2e ./internal/e2e_harness/production/` and `./internal/e2e_harness/federated/` — clean
- `go test ./internal/cdc ./internal/reconcile ./internal/e2e_harness/federated` — ok
- `scripts/test_with_container_runtime.sh` (full `make test`, rootless Podman) — all packages ok (first two commits); CI's Test job covers the third

Implementation plan: https://github.com/Lychee-Technology/forma/issues/521#issuecomment-5563574747
