### PR TITLE
fix(sqlgen): reject bigint predicate operands outside int64 on both routes (#502)

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -848,7 +848,17 @@ applied on both sides:
   shortest round-trip form (`strconv.FormatFloat(v, 'g', -1, 64)`), so the
   DuckDB side recovers the identical float64 the PG side binds — `%.15g`
   dropped the 16th-17th significant digits. `bigint` stays `BIGINT` with
-  exact int64/decimal-string binds (#281/#357).
+  exact int64/decimal-string binds (#281/#357), so it cannot take the DOUBLE
+  widening: an integral `bigint` operand outside int64 range (`gt:1e30`,
+  `equals:9223372036854775808`, and the `Inf`/`NaN` spellings) is instead
+  rejected as user-facing invalid input by every predicate binder
+  (`sqlgen.checkBigIntOperandRange`, #502) — the same bound the write funnel
+  enforces, so no legal data sits on either side of such a comparison and
+  every rejected literal has an exact in-range equivalent
+  (`gt:9223372036854775807`). Before #502 the Postgres route answered against
+  `NUMERIC` while the DuckDB route raised a Conversion Error on
+  `CAST('1e+30' AS BIGINT)`. Fractional `bigint` operands in range are
+  unaffected.
 * **Bool**: both engines compare the `value_numeric <> 0` truthiness — the PG
   EAV EXISTS predicate renders `(x.value_numeric <> 0) =/!= <bool>` — and
   parse operands under one shared rule (`ParseBool` spellings, else any

--- a/internal/e2e_harness/production/bigint_operand_range_e2e_test.go
+++ b/internal/e2e_harness/production/bigint_operand_range_e2e_test.go
@@ -1,0 +1,104 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+)
+
+// This file is the #502 acceptance suite: a bigint predicate operand that
+// does not fit int64 must get the same answer on the hot Postgres route and on
+// every DuckDB tier. The answer is a rejection — shared normalization refuses
+// the operand as invalid input on both routes — because BIGINT columns must
+// keep exact comparison above 2^53 (#281/#357) and so cannot widen to DOUBLE
+// the way #384 widened the narrow classes. Pre-#502 the Postgres route
+// compared the operand against NUMERIC and answered, while the DuckDB route
+// rendered CAST('1e+30' AS BIGINT) and raised a Conversion Error.
+
+// rejectionProbe is one filter that must fail with forma.ErrInvalidInput on
+// every route.
+type rejectionProbe struct {
+	name   string
+	filter Filter
+}
+
+// runRejectionProbes asserts every probe fails with a user-facing invalid
+// input error on the given route. A nil error is the pre-#502 Postgres
+// behaviour (answering); a non-sentinel error is the pre-#502 DuckDB
+// behaviour (Conversion Error surfacing as an opaque failure).
+func runRejectionProbes(ctx context.Context, t *testing.T, env *Env, label string,
+	base Query, probes []rejectionProbe) {
+	t.Helper()
+	for _, p := range probes {
+		q := base
+		q.Filters = []Filter{p.filter}
+		_, err := env.Query(ctx, q)
+		if err == nil {
+			t.Errorf("%s/%s: out-of-int64 bigint operand must be rejected, got an answer", label, p.name)
+			continue
+		}
+		if !errors.Is(err, forma.ErrInvalidInput) {
+			t.Errorf("%s/%s: rejection must be user-facing invalid input, got %v", label, p.name, err)
+		}
+	}
+}
+
+// TestBigIntOperandRangeParityBothDialects seeds a bound bigint (`amount`,
+// bigint_01) at MaxInt64 and an EAV-only bigint (`total`, attr 15), then
+// drives the same probes through hot Postgres, warm delta (real flush) and
+// cold base (real compaction): the out-of-int64 operands are rejected
+// identically everywhere, and the boundary literals keep answering the same
+// row set — the rejection must not clip MaxInt64 itself.
+func TestBigIntOperandRangeParityBothDialects(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	rowMax := CreateEvent(wide, map[string]any{"title": "r-max", "amount": int64(math.MaxInt64), "total": int64(7)})
+	rowSmall := CreateEvent(wide, map[string]any{"title": "r-small", "amount": int64(5), "total": int64(9)})
+	mustApplyEvents(ctx, t, env, "bigint operand range creates", rowMax, rowSmall)
+
+	rejected := []rejectionProbe{
+		// The issue's headline: an EAV-only bigint compared against 1e30.
+		{"total_gt_1e30", Filter{Attr: "total", Op: "gt", Value: "1e30"}},
+		// The bound bigint takes the pg-main binder on Postgres and the same
+		// DuckDB cast on the other route.
+		{"amount_gt_1e30", Filter{Attr: "amount", Op: "gt", Value: "1e30"}},
+		{"amount_lt_negative_1e19", Filter{Attr: "amount", Op: "lt", Value: "-1e19"}},
+		// The first integer past MaxInt64, in bare digits.
+		{"total_equals_2p63", Filter{Attr: "total", Op: "equals", Value: "9223372036854775808"}},
+	}
+	controls := []widthProbe{
+		// MaxInt64 stays addressable in bare and exponent spelling (#357).
+		{"amount_gte_maxint64", Filter{Attr: "amount", Op: "gte", Value: "9223372036854775807"}, []*Event{rowMax}},
+		{"amount_gte_maxint64_exponent", Filter{Attr: "amount", Op: "gte", Value: "9.223372036854775807e18"}, []*Event{rowMax}},
+		// MinInt64 as a bound answers (everything is above it).
+		{"amount_gt_minint64", Filter{Attr: "amount", Op: "gt", Value: "-9223372036854775808"}, []*Event{rowMax, rowSmall}},
+		// The exact in-range equivalent of the rejected gt:1e30 answers empty.
+		{"total_gt_maxint64_empty", Filter{Attr: "total", Op: "gt", Value: "9223372036854775807"}, nil},
+		{"total_lte_maxint64", Filter{Attr: "total", Op: "lte", Value: "9223372036854775807"}, []*Event{rowMax, rowSmall}},
+	}
+
+	hotBase := Query{Schema: wide, PreferHot: true, Limit: 100}
+	runRejectionProbes(ctx, t, env, "hot-pg", hotBase, rejected)
+	runWidthProbes(ctx, t, env, "hot-pg", hotBase, false, controls)
+
+	if _, err := env.RunFlush(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	duckBase := Query{Schema: wide, Limit: 100}
+	runRejectionProbes(ctx, t, env, "warm-duck", duckBase, rejected)
+	runWidthProbes(ctx, t, env, "warm-duck", duckBase, true, controls)
+
+	if _, err := env.RunCompaction(ctx, wide); err != nil {
+		t.Fatalf("compaction: %v", err)
+	}
+	runRejectionProbes(ctx, t, env, "cold-duck", duckBase, rejected)
+	runWidthProbes(ctx, t, env, "cold-duck", duckBase, true, controls)
+}

--- a/internal/sqlgen/bigint_operand_range_test.go
+++ b/internal/sqlgen/bigint_operand_range_test.go
@@ -35,6 +35,11 @@ func TestBigIntOperandRangeAllBinders(t *testing.T) {
 		{"2p63_bare", "9223372036854775808", nil},
 		{"negative_1e19", "-1e19", nil},
 		{"hex_float_2p70", "0x1p70", nil},
+		// The bound is on magnitude, not integrality: a fractional literal
+		// past int64 is rejected too, exactly as the write funnel rejects a
+		// non-integral out-of-range value. Contrast fractional_in_range.
+		{"fractional_out_of_range", "1.5e30", nil},
+		{"negative_fractional_out_of_range", "-9.5e18", nil},
 		{"inf", "Inf", nil},
 		{"negative_inf", "-Inf", nil},
 		{"nan", "NaN", nil},

--- a/internal/sqlgen/bigint_operand_range_test.go
+++ b/internal/sqlgen/bigint_operand_range_test.go
@@ -1,0 +1,135 @@
+package sqlgen
+
+import (
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBigIntOperandRangeAllBinders pins the #502 contract on the three
+// predicate binders — ConvertPgMainValue (PG main + hybrid), parsePgEavValue
+// (PG EAV EXISTS) and parseDuckDBRawParam (DuckDB): an integral bigint operand
+// outside int64 range is invalid input on every binder, so both routes answer
+// the same 400 instead of Postgres comparing NUMERIC while DuckDB raises a
+// Conversion Error on CAST('1e+30' AS BIGINT). The bound is the same one the
+// #384 write funnel enforces, so no legal data can sit on either side of the
+// rejected comparison, and every rejected literal has an exact in-range
+// equivalent (gt:1e30 ≡ gt:9223372036854775807).
+func TestBigIntOperandRangeAllBinders(t *testing.T) {
+	cases := []struct {
+		name    string
+		literal string
+		want    any // nil means rejected with ErrInvalidInput
+	}{
+		// Boundary literals bind exactly (#357): the check must not clip them.
+		{"max_int64_bare", "9223372036854775807", int64(9223372036854775807)},
+		{"min_int64_bare", "-9223372036854775808", int64(-9223372036854775808)},
+		{"max_int64_exponent_spelling", "9.223372036854775807e18", int64(9223372036854775807)},
+		{"in_range_exponent", "1e18", int64(1000000000000000000)},
+		// A fractional literal in range stays float64 — pre-existing contract,
+		// pinned by the characterization matrix; not this issue's corner.
+		{"fractional_in_range", "9007199254740993.5", 9007199254740994.0},
+		// Integral literals past int64 in every spelling ParseFloat accepts.
+		{"1e30", "1e30", nil},
+		{"2p63_bare", "9223372036854775808", nil},
+		{"negative_1e19", "-1e19", nil},
+		{"hex_float_2p70", "0x1p70", nil},
+		{"inf", "Inf", nil},
+		{"negative_inf", "-Inf", nil},
+		{"nan", "NaN", nil},
+	}
+
+	meta := forma.AttributeMetadata{ValueType: forma.ValueTypeBigInt}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pgMain, pgMainErr := ConvertPgMainValue(tc.literal, "probe", meta)
+			_, pgEav, pgEavErr := parsePgEavValue("probe", meta, tc.literal)
+			duck, duckErr := parseDuckDBRawParam(tc.literal, "probe", forma.ValueTypeBigInt)
+
+			if tc.want == nil {
+				for name, err := range map[string]error{"ConvertPgMainValue": pgMainErr, "parsePgEavValue": pgEavErr, "parseDuckDBRawParam": duckErr} {
+					require.ErrorIs(t, err, forma.ErrInvalidInput, name)
+					require.Contains(t, err.Error(), "out of range for bigint attribute 'probe'", name)
+					require.Contains(t, err.Error(), tc.literal, "%s must name the literal as given", name)
+				}
+				return
+			}
+			require.NoError(t, pgMainErr)
+			require.NoError(t, pgEavErr)
+			require.NoError(t, duckErr)
+			require.Equal(t, tc.want, pgMain, "ConvertPgMainValue")
+			require.Equal(t, tc.want, pgEav, "parsePgEavValue")
+			require.Equal(t, tc.want, duck, "parseDuckDBRawParam")
+		})
+	}
+}
+
+// TestBigIntOperandRangeIsBigIntOnly guards the fence: the DOUBLE-width
+// classes (integer/smallint/numeric, #384) compare an operand of any magnitude
+// at DOUBLE on both engines, so 1e30 must keep parsing as float64 there.
+func TestBigIntOperandRangeIsBigIntOnly(t *testing.T) {
+	for _, vt := range []forma.ValueType{forma.ValueTypeInteger, forma.ValueTypeSmallInt, forma.ValueTypeNumeric} {
+		t.Run(string(vt), func(t *testing.T) {
+			meta := forma.AttributeMetadata{ValueType: vt}
+			pgMain, err := ConvertPgMainValue("1e30", "probe", meta)
+			require.NoError(t, err)
+			require.Equal(t, 1e30, pgMain)
+			_, pgEav, err := parsePgEavValue("probe", meta, "1e30")
+			require.NoError(t, err)
+			require.Equal(t, 1e30, pgEav)
+			duck, err := parseDuckDBRawParam("1e30", "probe", vt)
+			require.NoError(t, err)
+			require.Equal(t, 1e30, duck)
+		})
+	}
+}
+
+// TestBigIntOperandRange_Entrypoints proves the rejection reaches the caller
+// from every generator entrypoint, on both the bound (amount) and EAV-only
+// (total) bigint attributes: ToDualClauses (the federated route), the PG-only
+// EAV generator (hot route) and the DuckDB-only clause builder. The DuckDB
+// entrypoint is asserted on its own so the DuckDB route can never fall back
+// to a runtime Conversion Error if the PG binders change.
+func TestBigIntOperandRange_Entrypoints(t *testing.T) {
+	cache := characterizationCache()
+	cases := []struct {
+		name        string
+		cond        forma.Condition
+		wantDualErr string
+		wantErrTail string
+	}{
+		{
+			name:        "bound bigint gt 1e30 rejected in pg-main first",
+			cond:        charKv("amount", "gt:1e30"),
+			wantDualErr: "pg main generation: ",
+			wantErrTail: "value 1e30 out of range for bigint attribute 'amount' (operand must fit [-9223372036854775808, 9223372036854775807])",
+		},
+		{
+			name:        "eav-only bigint equals 2^63 rejected in EAV",
+			cond:        charKv("total", "equals:9223372036854775808"),
+			wantDualErr: "pg sql generation: ",
+			wantErrTail: "value 9223372036854775808 out of range for bigint attribute 'total' (operand must fit [-9223372036854775808, 9223372036854775807])",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			paramIndex := 0
+			_, err := ToDualClauses(tc.cond, "eav_table", 7, cache, &paramIndex)
+			require.Error(t, err)
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			require.Contains(t, err.Error(), tc.wantDualErr+tc.wantErrTail)
+
+			paramIndex = 0
+			_, _, err = NewSQLGenerator().ToSQLClauses(tc.cond, "eav_table", 7, cache, &paramIndex)
+			require.Error(t, err, "PG-only EAV entrypoint")
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			require.Contains(t, err.Error(), tc.wantErrTail)
+
+			_, _, err = BuildDuckClause(tc.cond, cache)
+			require.Error(t, err, "DuckDB-only entrypoint")
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			require.Contains(t, err.Error(), tc.wantErrTail)
+		})
+	}
+}

--- a/internal/sqlgen/dualpath_sql_helpers.go
+++ b/internal/sqlgen/dualpath_sql_helpers.go
@@ -2,6 +2,7 @@ package sqlgen
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +31,9 @@ func ConvertPgMainValue(valStr string, attr string, meta forma.AttributeMetadata
 		case int64:
 			return v, nil
 		case float64:
+			if err := checkBigIntOperandRange(attr, valStr, meta.ValueType, v); err != nil {
+				return nil, err
+			}
 			return v, nil
 		default:
 			return nil, forma.InvalidInputf("invalid numeric value for '%s': %s", attr, valStr)
@@ -155,6 +159,9 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 		case int64:
 			return v, nil
 		case float64:
+			if err := checkBigIntOperandRange(attr, valStr, valueType, v); err != nil {
+				return nil, err
+			}
 			return v, nil
 		default:
 			return nil, forma.InvalidInputf("invalid numeric literal for %s: %s", attr, valStr)
@@ -172,6 +179,33 @@ func parseDuckDBRawParam(valStr string, attr string, valueType forma.ValueType) 
 	default:
 		return valStr, nil
 	}
+}
+
+// checkBigIntOperandRange rejects a bigint predicate operand that does not fit
+// int64 (#502). TryParseNumber already binds every integral literal within
+// int64 range as an exact int64, so a float64 here is either a genuinely
+// fractional literal (kept: lt:1.5 is a meaningful range bound) or an integral
+// one beyond int64 — or an Inf/NaN spelling ParseFloat accepts. Those cannot
+// be compared on the DuckDB route (CAST(? AS BIGINT) raises a Conversion
+// Error) while Postgres would answer against NUMERIC, so the shared
+// normalization refuses them on every binder instead. The bound mirrors the
+// #384 write funnel (checkDeclaredIntegerFit): float64(MaxInt64) is exactly
+// 2^63, so `< 2^63` rejects the first float64 that no longer fits, and NaN
+// fails both halves. A literal one below MinInt64 rounds to the float64 image
+// -2^63 and is accepted as that image, exactly as the write side would.
+// Widening the operand instead (HUGEINT) is not an option: no legal data can
+// sit beyond int64 on either side, and every rejected literal has an exact
+// in-range equivalent (gt:1e30 ≡ gt:9223372036854775807).
+func checkBigIntOperandRange(attr, valStr string, valueType forma.ValueType, v float64) error {
+	if valueType != forma.ValueTypeBigInt {
+		return nil
+	}
+	if v >= math.MinInt64 && v < math.MaxInt64 {
+		return nil
+	}
+	return forma.InvalidInputf(
+		"value %s out of range for bigint attribute '%s' (operand must fit [%d, %d])",
+		valStr, attr, int64(math.MinInt64), int64(math.MaxInt64))
 }
 
 // resolveMainTableColumn returns the column name prefixed with "m." for main table queries.

--- a/internal/sqlgen/duckdb_type_mapper.go
+++ b/internal/sqlgen/duckdb_type_mapper.go
@@ -31,6 +31,11 @@ func MapValueTypeToDuckDBType(v forma.ValueType) string {
 		// answered normally; at DOUBLE any magnitude simply compares.
 		return "DOUBLE"
 	case forma.ValueTypeBigInt:
+		// Stays BIGINT: bigint columns are physically int64 on every tier
+		// and must compare exactly above 2^53 (#281/#357). The cast is
+		// strict, so an operand outside int64 is refused by every predicate
+		// binder before it reaches here (checkBigIntOperandRange, #502)
+		// rather than raising a Conversion Error on this route alone.
 		return "BIGINT"
 	case forma.ValueTypeNumeric:
 		// #384: every numeric column on every tier is DOUBLE (EAV pivot,

--- a/internal/sqlgen/predicate_normalizer.go
+++ b/internal/sqlgen/predicate_normalizer.go
@@ -296,6 +296,9 @@ func parsePgEavValue(attr string, meta forma.AttributeMetadata, valStr string) (
 			// 2^53 (#384) — see NarrowEAVNumericOperand.
 			return "value_numeric", NarrowEAVNumericOperand(meta.ValueType, v), nil
 		case float64:
+			if err := checkBigIntOperandRange(attr, valStr, meta.ValueType, v); err != nil {
+				return "", nil, err
+			}
 			return "value_numeric", v, nil
 		default:
 			return "", nil, forma.InvalidInputf("invalid numeric value for '%s': %s", attr, valStr)


### PR DESCRIPTION
Closes #502

## Problem

A bigint predicate operand that does not fit int64 (e.g. `total gt:1e30`) diverged by route. The Postgres binders compared it against `NUMERIC` and answered; the DuckDB route rendered `CAST('1e+30' AS BIGINT)` and raised a Conversion Error. `BIGINT` cannot widen to `DOUBLE` the way #384 widened integer/smallint/numeric, because bigint columns must compare exactly above 2^53 (#281/#357).

## Fix (option 1 from the issue: consistent rejection at shared normalization)

- New `sqlgen.checkBigIntOperandRange`, called from all three predicate binders (`ConvertPgMainValue`, `parsePgEavValue`, `parseDuckDBRawParam`). A float64 parse result for a bigint attribute outside `[-2^63, 2^63)`, including `Inf`/`NaN` spellings, is refused with `forma.InvalidInputf`, so every route returns the same 400.
- The bound mirrors the write funnel's `checkDeclaredIntegerFit` (#384), so read and write agree on what "fits bigint". The bound is on magnitude, not integrality: a fractional literal past int64 (`1.5e30`) is rejected too, as the write side rejects a non-integral out-of-range value.
- Unaffected: every integral literal within int64 (already bound as exact int64 by `TryParseNumber`, #357) and fractional in-range operands such as `lt:1.5`.
- Every rejected literal has an exact in-range equivalent (`gt:1e30` ≡ `gt:9223372036854775807`), so no query becomes inexpressible.

## Out of scope (unchanged)

- Batch attr-value anchor (`buildAttrValuesAnchor`): a single-route, Postgres-only anchor with no DuckDB twin. It binds caller-supplied values through `TryParseNumber` (relation-enrichment lookup), so an out-of-range float64 simply compares against `value_numeric`; there is no cross-route divergence to fix.
- `BuildListPredicate`: no production caller; it still strict-casts and bypasses the shared binders. Tracked as a follow-up (see the review thread below).
- Historical over-range `NUMERIC` rows (#205).

## Tests

- `internal/sqlgen/bigint_operand_range_test.go`: all three binders reject the same literal set (`1e30`, `9223372036854775808`, `-1e19`, `0x1p70`, `1.5e30`, `-9.5e18`, `Inf`, `-Inf`, `NaN`) with `ErrInvalidInput`, accept the boundary literals (`9223372036854775807`, `-9223372036854775808`, `9.223372036854775807e18`, fractional in-range), and the check is bigint-only. Entrypoint coverage through `ToDualClauses`, `ToSQLClauses` and `BuildDuckClause`.
- `internal/e2e_harness/production/bigint_operand_range_e2e_test.go` (`-tags=e2e`): seeds a bound bigint at `MaxInt64` plus an EAV-only bigint, then drives the same rejection probes and boundary controls through hot Postgres, warm delta (real flush) and cold base (real compaction).

## Docs

`docs/federated-query/design.md` §6.4 records the read-side contract next to the existing bigint `BIGINT`-cast note.

Verification notes follow as a PR comment.
