### PR TITLE
fix(cdc): --replace-delta retires the tiers of a schema with zero live rows (#519)

### DIFF
--- a/docs/manifest-reconcile.md
+++ b/docs/manifest-reconcile.md
@@ -521,8 +521,20 @@ delta 真正退役的是 cdc-init 本身：
   对象。删除失败会记录 key 并让该 schema 返回带 key 列表的错误，但已发布的 manifest
   不回滚：读者此时只会看到新 base，残留对象成为未列孤儿，可由下文规则处理。
   `--dry-run` 只打印 `would delete N delta objects`。
-- **无 live 行的 schema 不换 base，也不动 delta。** 这类 schema 没有可发布的 swap，
-  带 `--replace-delta` 时只记一条 warning。
+- **无 live 行的 schema 用一个 0 行 base 完成 swap（#519）。** 所有行都已删除的 schema 没有
+  行可导出，但 manifest 可能仍列着旧类型的 base 与 delta。带 `--replace-delta` 时，这类
+  schema 先导出**一个 0 行的 base 对象**（`{prefix}/{schemaID}/base-<uuid>.parquet`，
+  与 compaction 全墓碑合并写出的形态相同，manifest 条目 `row_count: 0`、无 row-id 范围），
+  再走同一条 CAS 路径发布 swap：base 层替换为仅此一条、delta 层清空，保存成功后再删除
+  清理集中的 delta 对象；`--dry-run` 同样只报告（计 1 个文件、0 行）。manifest **绝不会
+  变成空集**：零条目的 manifest 会让读路径退回按 schema 前缀的 glob 扫描，把未列出的旧
+  base 连同其已被墓碑删除的行一起“复活”。旧 base 对象**只下架、不删除**（与任何重跑一致，
+  #416 起 init 从不删 base），由 `manifest-reconcile --gc` 作为普通未列孤儿回收——manifest
+  仍有一条本前缀内的 base 条目，#463 的空 manifest 防护不会触发，无需 `--allow-empty-manifest-schema`；
+  `--repair` 的晋升守卫（#292）对没有存活行的 schema 一律拒绝晋升，所以这些对象不会被
+  重新列回 manifest。manifest 本身不存在（或没有任何条目）、也没有任何 delta 对象的 schema
+  没有东西可下架，不会为此导出 0 行 base、也不会生成 manifest。不带 `--replace-delta`
+  时行为不变：delta 盘点非空即拒绝，否则不做任何事。
 - **清理集只认命名空间，不认 `tier` 标签。** 可删除的 key 必须是本 schema delta 命名
   空间里的 delta 形态对象：`{delta-prefix}/{schemaID}/<uuid>.parquet`（`--delta-prefix ""`
   时前缀部分不限，但 `/{schemaID}/<uuid>.parquet` 尾部仍然必须匹配）。manifest 里标为

--- a/internal/cdc/duckdb_exporter.go
+++ b/internal/cdc/duckdb_exporter.go
@@ -3,6 +3,7 @@ package cdc
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -123,20 +124,25 @@ func (e *DuckExporter) executeExportSQL(ctx context.Context, cfg CDCConfig, logM
 }
 
 func buildExportSQLPlan(spec exportModeSpec, pgConnStr string, s3TmpPath string, cfg CDCConfig, schemaID int16, snapshotTS int64, rowIDs []uuid.UUID, attrCache forma.SchemaAttributeCache) (exportSQLPlan, error) {
-	if len(rowIDs) == 0 {
-		modeName := "base"
-		if spec.useChangeLog {
-			modeName = "snapshot"
-		}
-		return exportSQLPlan{}, fmt.Errorf("export %s: no row ids provided", modeName)
+	if len(rowIDs) == 0 && spec.useChangeLog {
+		return exportSQLPlan{}, errors.New("export snapshot: no row ids provided")
 	}
 
 	pgEsc := sqlutil.EscapeLiteral(pgConnStr)
 	s3Esc := sqlutil.EscapeLiteral(s3TmpPath)
 	entityMain, eavData := resolveMainAndEAVTableNames(cfg)
-	rowList := quoteUUIDList(rowIDs)
-	mFilter := fmt.Sprintf("ltbase_row_id IN (%s)", rowList)
-	eFilter := fmt.Sprintf("row_id IN (%s)", rowList)
+	// A base export with no row ids is a legitimate request (#519): a schema
+	// with zero live rows still needs one zero-row base object carrying the
+	// full projected column set, so its manifest never lists nothing (an
+	// empty manifest sends readers to the legacy glob fallback, see
+	// manifest.QuerySource.Paths). The FALSE filters keep the projection
+	// intact while selecting no rows.
+	mFilter, eFilter := "FALSE", "FALSE"
+	if len(rowIDs) > 0 {
+		rowList := quoteUUIDList(rowIDs)
+		mFilter = fmt.Sprintf("ltbase_row_id IN (%s)", rowList)
+		eFilter = fmt.Sprintf("row_id IN (%s)", rowList)
+	}
 
 	plan := exportSQLPlan{}
 	if spec.useChangeLog {
@@ -144,7 +150,7 @@ func buildExportSQLPlan(spec exportModeSpec, pgConnStr string, s3TmpPath string,
 		if changeLog == "" {
 			changeLog = "change_log"
 		}
-		clFilter := fmt.Sprintf("row_id IN (%s)", rowList)
+		clFilter := fmt.Sprintf("row_id IN (%s)", quoteUUIDList(rowIDs))
 		plan.changeLogQuery = fmt.Sprintf(
 			"SELECT schema_id, row_id, changed_at, deleted_at FROM %s WHERE schema_id = %d AND flushed_at = 0 AND changed_at <= %d AND %s",
 			changeLog, schemaID, snapshotTS, clFilter,

--- a/internal/cdc/duckdb_exporter_sql_test.go
+++ b/internal/cdc/duckdb_exporter_sql_test.go
@@ -214,8 +214,10 @@ func TestBuildExportSQL_UsesCustomTableNames(t *testing.T) {
 // TestExportToTmpWrapsPlanErrors pins the caller-side context on both export
 // entry points: a plan failure must name the operation the caller was
 // performing, not arrive as a bare pass-through (#276, coding-standard.md).
-// Empty rowIDs is the cheapest plan failure — it returns before any DB or S3
-// use, so a zero-value DuckExporter is enough.
+// The cheapest plan failures return before any DB or S3 use, so a zero-value
+// DuckExporter is enough: empty rowIDs for the snapshot (a base export with
+// no row ids is a legitimate zero-row export since #519) and a missing
+// attribute cache for the base.
 func TestExportToTmpWrapsPlanErrors(t *testing.T) {
 	exporter := &DuckExporter{}
 	cfg := CDCConfig{}
@@ -230,9 +232,9 @@ func TestExportToTmpWrapsPlanErrors(t *testing.T) {
 
 	t.Run("base export", func(t *testing.T) {
 		err := exporter.ExportBaseFileToTmp(context.Background(), cfg,
-			"postgres://user@host/db", "s3://bucket/base/7/_tmp/f.parquet", 7, nil, testAttrCache())
+			"postgres://user@host/db", "s3://bucket/base/7/_tmp/f.parquet", 7, nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "export base file to tmp for schema 7")
-		require.Contains(t, err.Error(), "no row ids provided")
+		require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
 	})
 }

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -275,7 +275,8 @@ func getSchemaIDsToInit(ctx context.Context, db *sql.DB, schemaRegistryTable str
 // initSchema exports all existing data for a single schema to S3 base files.
 // The delta tier is inventoried first (#371): a non-empty delta tier refuses
 // the schema unless the run may replace it, and with that permission the
-// inventory is purged only after the manifest swap has committed.
+// inventory is purged only after the manifest swap has committed — for a
+// schema with zero live rows that swap is an empty one (#519).
 func initSchema(ctx context.Context, runCtx *initRunContext, schemaID int16) (int64, int, error) {
 	inventory, err := preflightDeltaTier(ctx, runCtx, schemaID)
 	if err != nil {
@@ -287,14 +288,11 @@ func initSchema(ctx context.Context, runCtx *initRunContext, schemaID int16) (in
 		return 0, 0, err
 	}
 	if state == nil {
-		if !inventory.empty() {
-			// No live rows means no base swap, and the purge is ordered
-			// strictly after the swap, so the delta tier stays in place.
-			runCtx.logger.Warn("schema has no live rows; delta tier left in place because there is no base swap to publish",
-				zap.Int16("schema_id", schemaID),
-				zap.Int("delta_objects", len(inventory.purgeKeys())))
+		state, err = finishEmptySchema(ctx, runCtx, schemaID, inventory)
+		if err != nil || state == nil {
+			return 0, 0, err
 		}
-		return 0, 0, nil
+		return state.rowsExported, state.filesCreated, nil
 	}
 	state.deltaPurge = inventory.purgeKeys()
 
@@ -436,8 +434,14 @@ func exportBaseFileForBatch(ctx context.Context, runCtx *initRunContext, state *
 }
 
 func exportSchemaBatch(ctx context.Context, runCtx *initRunContext, state *schemaInitState, rowIDs []uuid.UUID) error {
-	batch := buildSchemaBatchExport(runCtx, state, rowIDs)
+	return exportBatch(ctx, runCtx, state, buildSchemaBatchExport(runCtx, state, rowIDs))
+}
 
+// exportBatch runs one prepared batch end to end: the tmp export, the
+// tmp->final copy, the size stat, and the manifest entry record. Dry-run
+// counts the batch and writes nothing. The zero-row base of an emptied
+// schema (finishEmptySchema, #519) goes through the same steps.
+func exportBatch(ctx context.Context, runCtx *initRunContext, state *schemaInitState, batch schemaBatchExport) error {
 	runCtx.logger.Info("exporting batch",
 		zap.Int16("schema_id", state.schemaID),
 		zap.Int("batch_size", len(batch.rowIDs)),

--- a/internal/cdc/init.go
+++ b/internal/cdc/init.go
@@ -276,7 +276,9 @@ func getSchemaIDsToInit(ctx context.Context, db *sql.DB, schemaRegistryTable str
 // The delta tier is inventoried first (#371): a non-empty delta tier refuses
 // the schema unless the run may replace it, and with that permission the
 // inventory is purged only after the manifest swap has committed — for a
-// schema with zero live rows that swap is an empty one (#519).
+// schema with zero live rows that swap publishes one zero-row base object
+// as the whole base tier, never an empty entry set (finishEmptySchema,
+// #519).
 func initSchema(ctx context.Context, runCtx *initRunContext, schemaID int16) (int64, int, error) {
 	inventory, err := preflightDeltaTier(ctx, runCtx, schemaID)
 	if err != nil {

--- a/internal/cdc/init_delta.go
+++ b/internal/cdc/init_delta.go
@@ -198,7 +198,7 @@ func loadManifestDeltaEntries(ctx context.Context, runCtx *initRunContext, schem
 	}
 	m, _, err := loadInitManifest(ctx, runCtx, schemaID, manifestPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load manifest delta entries: %w", err)
 	}
 	return manifest.FilterByTier(m, "delta"), nil
 }
@@ -304,10 +304,19 @@ func purgeDeltaTier(ctx context.Context, runCtx *initRunContext, state *schemaIn
 // unlisted old base objects are left for --gc, as after any re-init.
 //
 // A schema that lists nothing and has no delta objects has nothing to
-// retire; no base is exported and no manifest is minted for it. The
-// returned state carries the run's counts (nil when nothing was done).
+// retire; no base is exported and no manifest is minted for it. The same
+// holds for a run without a manifest template: there is no store to load a
+// manifest from and no swap to publish (updateSchemaManifest no-ops on the
+// populated path for the same reason), and the pre-flight only reaches this
+// branch storeless with an empty inventory. The returned state carries the
+// run's counts (nil when nothing was done).
 func finishEmptySchema(ctx context.Context, runCtx *initRunContext, schemaID int16, inventory deltaInventory) (*schemaInitState, error) {
 	if !runCtx.replaceDelta {
+		return nil, nil
+	}
+	if runCtx.manifestStore == nil {
+		runCtx.logger.Info("schema has no live rows and the run has no manifest template; no manifest to swap, nothing to retire",
+			zap.Int16("schema_id", schemaID))
 		return nil, nil
 	}
 	listed, err := countListedManifestEntries(ctx, runCtx, schemaID)
@@ -345,7 +354,7 @@ func countListedManifestEntries(ctx context.Context, runCtx *initRunContext, sch
 	}
 	m, _, err := loadInitManifest(ctx, runCtx, schemaID, manifestPath)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("count listed manifest entries: %w", err)
 	}
 	return len(m.Files), nil
 }

--- a/internal/cdc/init_delta.go
+++ b/internal/cdc/init_delta.go
@@ -282,3 +282,84 @@ func purgeDeltaTier(ctx context.Context, runCtx *initRunContext, state *schemaIn
 	}
 	return nil
 }
+
+// finishEmptySchema is the zero-live-rows tail of initSchema (#519). A
+// schema whose every row is dead has no rows to export, yet its manifest
+// may still list an old-typed base and delta tier. Without ReplaceDelta
+// nothing changes (the pre-flight already refused a non-empty inventory).
+// With it the run exports ONE zero-row base object and publishes it as the
+// schema's whole base tier under the same CAS path as a populated schema —
+// old base unlisted, delta tier emptied — and only then purges the
+// inventoried delta objects, so the flag retires the stale tiers and the
+// next init once rows exist no longer refuses.
+//
+// The zero-row object is not optional: a manifest that lists nothing sends
+// every read to the legacy per-schema glob (manifest.QuerySource.Paths),
+// which scans the unlisted old base and resurrects the rows its tombstones
+// had deleted. Compaction keeps the same invariant when a merge yields no
+// rows (a RowCount 0 base entry so the manifest never empties), and the
+// object takes compaction's UUID-only key shape (BuildMergedBasePath): an
+// init-shaped `{min}_{max}_{uuid}` name needs a row-id range, and a range-
+// less stem is unclassifiable garbage for manifest-reconcile --gc. The
+// unlisted old base objects are left for --gc, as after any re-init.
+//
+// A schema that lists nothing and has no delta objects has nothing to
+// retire; no base is exported and no manifest is minted for it. The
+// returned state carries the run's counts (nil when nothing was done).
+func finishEmptySchema(ctx context.Context, runCtx *initRunContext, schemaID int16, inventory deltaInventory) (*schemaInitState, error) {
+	if !runCtx.replaceDelta {
+		return nil, nil
+	}
+	listed, err := countListedManifestEntries(ctx, runCtx, schemaID)
+	if err != nil {
+		return nil, fmt.Errorf("retire tiers of schema %d with no live rows: %w", schemaID, err)
+	}
+	state := &schemaInitState{schemaID: schemaID, deltaPurge: inventory.purgeKeys()}
+	if listed == 0 && len(state.deltaPurge) == 0 {
+		runCtx.logger.Info("schema has no live rows, lists nothing and has no delta objects; nothing to retire",
+			zap.Int16("schema_id", schemaID))
+		return nil, nil
+	}
+	// Cache was resolved and validated by the processInitSchemas pre-flight (#193).
+	state.attrCache = runCtx.attrCaches[schemaID]
+	runCtx.logger.Info("schema has no live rows; exporting a zero-row base to retire its listed tiers before the delta purge",
+		zap.Int16("schema_id", schemaID),
+		zap.Int("listed_entries", listed),
+		zap.Int("delta_objects", len(state.deltaPurge)),
+		zap.Bool("dry_run", runCtx.dryRun))
+	if err := exportBatch(ctx, runCtx, state, buildEmptyBaseExport(runCtx, schemaID)); err != nil {
+		return nil, fmt.Errorf("export zero-row base of schema %d with no live rows: %w", schemaID, err)
+	}
+	if err := publishAndPurge(ctx, runCtx, state); err != nil {
+		return nil, fmt.Errorf("retire tiers of schema %d with no live rows: %w", schemaID, err)
+	}
+	return state, nil
+}
+
+// countListedManifestEntries returns how many entries the schema's manifest
+// lists, zero for an absent manifest.
+func countListedManifestEntries(ctx context.Context, runCtx *initRunContext, schemaID int16) (int, error) {
+	manifestPath, err := runCtx.manifestResolver.Resolve(schemaID)
+	if err != nil {
+		return 0, fmt.Errorf("resolve manifest path: %w", err)
+	}
+	m, _, err := loadInitManifest(ctx, runCtx, schemaID, manifestPath)
+	if err != nil {
+		return 0, err
+	}
+	return len(m.Files), nil
+}
+
+// buildEmptyBaseExport is the batch for the zero-row base object of an
+// emptied schema (#519): no row ids, no row-id range, a fresh write-once key
+// in compaction's merged-base shape (see finishEmptySchema), with tmp and
+// final sharing the UUID as every init batch does.
+func buildEmptyBaseExport(runCtx *initRunContext, schemaID int16) schemaBatchExport {
+	fileUUID := uuid.Must(uuid.NewV7()).String()
+	tmpKey := BuildBaseTempPath(runCtx.cfg.S3Prefix, schemaID, fileUUID)
+	return schemaBatchExport{
+		tmpKey:    tmpKey,
+		finalKey:  BuildMergedBasePath(runCtx.cfg.S3Prefix, schemaID, fileUUID),
+		s3TmpPath: fmt.Sprintf("s3://%s/%s", runCtx.cfg.S3Bucket, tmpKey),
+	}
+}

--- a/internal/cdc/init_empty_schema_test.go
+++ b/internal/cdc/init_empty_schema_test.go
@@ -224,3 +224,24 @@ func TestFinishEmptySchema_NothingListedButUnlistedDeltaStillRetires(t *testing.
 	require.Len(t, m.Files, 1)
 	require.Equal(t, int64(0), m.Files[0].RowCount)
 }
+
+// Without a manifest template there is no manifest store (applyInitS3Wiring)
+// and so no manifest to swap: the flag over an emptied schema is a no-op, as
+// updateSchemaManifest is on the populated path, rather than a nil-store
+// panic in the manifest load. The pre-flight only reaches this branch with
+// an empty inventory (a non-empty one is refused without a store).
+func TestFinishEmptySchema_NoManifestStoreIsNoOp(t *testing.T) {
+	var events []string
+	runCtx := emptySchemaRunContext(t, nil, []string{}, &events)
+	runCtx.manifestStore = nil
+	runCtx.manifestResolver = manifest.PathResolver{}
+	runCtx.replaceDelta = true
+
+	inv, err := preflightDeltaTier(context.Background(), runCtx, 1)
+	require.NoError(t, err)
+	require.True(t, inv.empty())
+	state, err := finishEmptySchema(context.Background(), runCtx, 1, inv)
+	require.NoError(t, err)
+	require.Nil(t, state)
+	require.Empty(t, events, "no store: nothing exported, saved or deleted")
+}

--- a/internal/cdc/init_empty_schema_test.go
+++ b/internal/cdc/init_empty_schema_test.go
@@ -1,0 +1,226 @@
+package cdc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/manifest"
+	"github.com/stretchr/testify/require"
+)
+
+// An empty entry set is never published, with or without the flag (#519): a
+// manifest listing nothing would send reads to the glob fallback, so the
+// stale base stays listed and nothing is saved. The zero-row schema case is
+// handled by finishEmptySchema, which always publishes one base entry.
+func TestUpdateSchemaManifest_EmptyEntriesNeverPublished(t *testing.T) {
+	for _, flag := range []bool{false, true} {
+		var events []string
+		st := &recordingStore{events: &events}
+		seedDeltaManifest(t, &st.memManifestStore, "delta/1/0b2f1b6e-1111-4c1d-8e57-000000000001.parquet")
+		runCtx := deltaRunContext(st, nil)
+		runCtx.replaceDelta = flag
+		state := &schemaInitState{schemaID: 1}
+
+		require.NoError(t, updateSchemaManifest(context.Background(), runCtx, state))
+		require.Empty(t, events, "replaceDelta=%v: an empty entry set must not be saved", flag)
+		require.Empty(t, state.deltaPurge, "replaceDelta=%v: no swap, so no delta entry joins the purge set", flag)
+
+		m, _, err := manifest.Load(context.Background(), st, "manifest/1.json")
+		require.NoError(t, err)
+		require.Len(t, m.Files, 2, "replaceDelta=%v: both tiers stay listed", flag)
+		require.Equal(t, "base/1/old_range.parquet", m.Files[0].Path)
+	}
+}
+
+// emptySchemaRunContext is the finishEmptySchema fixture: a manifest store
+// and delete seam that record their events, an export seam that records the
+// batch it was handed, a mock S3 client for the tmp->final copy, and the
+// attribute cache the pre-flight would have resolved.
+func emptySchemaRunContext(t *testing.T, st manifest.Store, listed []string, events *[]string) *initRunContext {
+	t.Helper()
+	runCtx := deltaRunContext(st, listed)
+	runCtx.cfg.S3Prefix = "base"
+	runCtx.s3Client = &objectOnlyS3Client{}
+	runCtx.attrCaches = map[int16]forma.SchemaAttributeCache{1: testAttrCache()}
+	runCtx.deleteObject = recordingDelete(events)
+	runCtx.exportBaseFile = func(_ context.Context, state *schemaInitState, batch schemaBatchExport) error {
+		require.Empty(t, batch.rowIDs, "the zero-row base exports no row ids")
+		require.NotEmpty(t, state.attrCache, "the export needs the schema's attribute cache")
+		require.Equal(t, "s3://bkt/"+batch.tmpKey, batch.s3TmpPath)
+		*events = append(*events, "export "+batch.finalKey)
+		return nil
+	}
+	return runCtx
+}
+
+// exportedKey returns the final key the export seam recorded.
+func exportedKey(t *testing.T, events []string) string {
+	t.Helper()
+	require.NotEmpty(t, events)
+	require.True(t, strings.HasPrefix(events[0], "export "), "first event %q, want the export", events[0])
+	return strings.TrimPrefix(events[0], "export ")
+}
+
+// #519: a schema with zero live rows under --replace-delta exports one
+// zero-row base object, publishes it as the sole base entry with the delta
+// tier emptied, and deletes the inventoried delta objects only after the
+// swap — the same export, save, delete order as a populated schema. The old
+// base is unlisted (left for manifest-reconcile --gc), never deleted.
+func TestFinishEmptySchema_ReplaceDeltaExportsZeroRowBaseThenSwapsThenPurges(t *testing.T) {
+	listedKey := "delta/1/0b2f1b6e-1111-4c1d-8e57-000000000001.parquet"
+	unlistedKey := "delta/1/0b2f1b6e-0000-4c1d-8e57-000000000000.parquet"
+	var events []string
+	st := &recordingStore{events: &events}
+	seedDeltaManifest(t, &st.memManifestStore, listedKey)
+	runCtx := emptySchemaRunContext(t, st, []string{listedKey, unlistedKey}, &events)
+	runCtx.replaceDelta = true
+
+	inv, err := preflightDeltaTier(context.Background(), runCtx, 1)
+	require.NoError(t, err)
+	state, err := finishEmptySchema(context.Background(), runCtx, 1, inv)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, int64(0), state.rowsExported)
+	require.Equal(t, 1, state.filesCreated)
+
+	key := exportedKey(t, events)
+	require.True(t, strings.HasPrefix(key, "base/1/base-"), "zero-row base key %q must take the merged-base shape", key)
+	require.True(t, strings.HasSuffix(key, ".parquet"), key)
+	require.Equal(t, []string{"export " + key, "save", "delete " + unlistedKey, "delete " + listedKey}, events)
+
+	m, _, err := manifest.Load(context.Background(), st, "manifest/1.json")
+	require.NoError(t, err)
+	require.Len(t, m.Files, 1, "exactly the zero-row base is listed: %+v", m.Files)
+	entry := m.Files[0]
+	require.Equal(t, "base", entry.Tier)
+	require.Equal(t, key, entry.Path)
+	require.Equal(t, int64(0), entry.RowCount)
+	require.Empty(t, entry.RowIDMin)
+	require.Empty(t, entry.RowIDMax)
+	require.Empty(t, manifest.FilterByTier(m, "delta"))
+	require.Equal(t, int16(1), m.SchemaID)
+}
+
+// Without the flag the branch is the historical no-op: nothing exported,
+// nothing saved, nothing deleted, the stale base still listed.
+func TestFinishEmptySchema_WithoutFlagChangesNothing(t *testing.T) {
+	var events []string
+	st := &recordingStore{events: &events}
+	seedDeltaManifest(t, &st.memManifestStore)
+	runCtx := emptySchemaRunContext(t, st, []string{}, &events)
+
+	state, err := finishEmptySchema(context.Background(), runCtx, 1, deltaInventory{})
+	require.NoError(t, err)
+	require.Nil(t, state)
+	require.Empty(t, events)
+	m, _, err := manifest.Load(context.Background(), st, "manifest/1.json")
+	require.NoError(t, err)
+	require.Len(t, m.Files, 1)
+}
+
+// Dry-run reports the zero-row base and the purge set like any purge and
+// touches nothing: no export, no save, no delete.
+func TestFinishEmptySchema_DryRunWritesAndDeletesNothing(t *testing.T) {
+	listedKey := "delta/1/0b2f1b6e-1111-4c1d-8e57-000000000001.parquet"
+	var events []string
+	st := &recordingStore{events: &events}
+	seedDeltaManifest(t, &st.memManifestStore, listedKey)
+	runCtx := emptySchemaRunContext(t, st, []string{listedKey}, &events)
+	runCtx.replaceDelta, runCtx.dryRun = true, true
+
+	inv, err := preflightDeltaTier(context.Background(), runCtx, 1)
+	require.NoError(t, err)
+	state, err := finishEmptySchema(context.Background(), runCtx, 1, inv)
+	require.NoError(t, err)
+	require.Empty(t, events, "dry-run neither exports, saves nor deletes")
+	require.NotNil(t, state)
+	require.Equal(t, 1, state.filesCreated, "dry-run reports the zero-row base it would write")
+	require.Equal(t, int64(0), state.rowsExported)
+	require.Equal(t, []string{listedKey}, state.deltaPurge)
+}
+
+// A failed save deletes nothing: the delete-after-swap ordering holds for
+// the zero-row swap exactly as for a populated one.
+func TestFinishEmptySchema_FailedSwapDeletesNothing(t *testing.T) {
+	listedKey := "delta/1/0b2f1b6e-1111-4c1d-8e57-000000000001.parquet"
+	var events []string
+	st := &recordingStore{events: &events, saveErr: errors.New("s3 write denied")}
+	seedDeltaManifest(t, &st.memManifestStore, listedKey)
+	runCtx := emptySchemaRunContext(t, st, []string{listedKey}, &events)
+	runCtx.replaceDelta = true
+
+	inv, err := preflightDeltaTier(context.Background(), runCtx, 1)
+	require.NoError(t, err)
+	_, err = finishEmptySchema(context.Background(), runCtx, 1, inv)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "schema 1")
+	require.Equal(t, []string{"export " + exportedKey(t, events), "save"}, events)
+}
+
+// A failed export publishes nothing and deletes nothing: the old manifest
+// still lists every tier.
+func TestFinishEmptySchema_FailedExportPublishesNothing(t *testing.T) {
+	listedKey := "delta/1/0b2f1b6e-1111-4c1d-8e57-000000000001.parquet"
+	var events []string
+	st := &recordingStore{events: &events}
+	seedDeltaManifest(t, &st.memManifestStore, listedKey)
+	runCtx := emptySchemaRunContext(t, st, []string{listedKey}, &events)
+	runCtx.replaceDelta = true
+	runCtx.exportBaseFile = func(context.Context, *schemaInitState, schemaBatchExport) error {
+		return errors.New("duckdb copy failed")
+	}
+
+	inv, err := preflightDeltaTier(context.Background(), runCtx, 1)
+	require.NoError(t, err)
+	_, err = finishEmptySchema(context.Background(), runCtx, 1, inv)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duckdb copy failed")
+	require.Empty(t, events)
+	m, _, err := manifest.Load(context.Background(), st, "manifest/1.json")
+	require.NoError(t, err)
+	require.Len(t, m.Files, 2)
+}
+
+// A schema that was never initialized (no manifest) and has no delta
+// objects has nothing to retire: no base is exported and no manifest is
+// minted, so the flag over an untouched schema leaves no trace.
+func TestFinishEmptySchema_NothingListedNoDeltaDoesNothing(t *testing.T) {
+	var events []string
+	st := &recordingStore{events: &events}
+	runCtx := emptySchemaRunContext(t, st, []string{}, &events)
+	runCtx.replaceDelta = true
+
+	inv, err := preflightDeltaTier(context.Background(), runCtx, 1)
+	require.NoError(t, err)
+	state, err := finishEmptySchema(context.Background(), runCtx, 1, inv)
+	require.NoError(t, err)
+	require.Nil(t, state)
+	require.Empty(t, events)
+	_, _, err = manifest.Load(context.Background(), st, "manifest/1.json")
+	require.True(t, manifest.IsNotFound(err), "no manifest object minted, got %v", err)
+}
+
+// A never-initialized schema whose delta prefix holds an unlisted delta
+// object still gets the swap: the zero-row base is published and the
+// object purged, so the stale delta cannot be re-adopted by --repair.
+func TestFinishEmptySchema_NothingListedButUnlistedDeltaStillRetires(t *testing.T) {
+	unlistedKey := "delta/1/0b2f1b6e-0000-4c1d-8e57-000000000000.parquet"
+	var events []string
+	st := &recordingStore{events: &events}
+	runCtx := emptySchemaRunContext(t, st, []string{unlistedKey}, &events)
+	runCtx.replaceDelta = true
+
+	inv, err := preflightDeltaTier(context.Background(), runCtx, 1)
+	require.NoError(t, err)
+	state, err := finishEmptySchema(context.Background(), runCtx, 1, inv)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, []string{"export " + exportedKey(t, events), "save", "delete " + unlistedKey}, events)
+	m, _, err := manifest.Load(context.Background(), st, "manifest/1.json")
+	require.NoError(t, err)
+	require.Len(t, m.Files, 1)
+	require.Equal(t, int64(0), m.Files[0].RowCount)
+}

--- a/internal/cdc/init_exporter_sql_test.go
+++ b/internal/cdc/init_exporter_sql_test.go
@@ -47,11 +47,38 @@ func TestBuildBaseExportSQL_ErrorsWithoutAttrCache(t *testing.T) {
 	require.Contains(t, err.Error(), "1")
 }
 
-func TestBuildBaseExportSQL_ErrorsOnEmptyRowIDs(t *testing.T) {
-	_, _, _, err := buildBaseExportSQL("pg", "s3://bucket/base/1/_tmp/tmp.parquet", CDCConfig{}, 1, nil, nil)
-	if err == nil {
-		t.Fatalf("expected error for empty row ids")
-	}
+// #519: a base export with no row ids is a zero-row export, not an error. A
+// schema with zero live rows still gets one base object with the full
+// projected column set (its manifest must never list nothing), so both
+// source queries select no rows via a FALSE filter and the projection is
+// unchanged. The attribute-cache requirement still applies.
+func TestBuildBaseExportSQL_EmptyRowIDsSelectsNoRowsWithFullProjection(t *testing.T) {
+	sql, mQuery, eQuery, err := buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", CDCConfig{}, 1, nil, testAttrCache())
+	require.NoError(t, err)
+	require.Contains(t, mQuery, "ltbase_schema_id = 1 AND ltbase_deleted_at IS NULL AND FALSE")
+	require.Contains(t, eQuery, "schema_id = 1 AND FALSE")
+	require.NotContains(t, mQuery, "ltbase_row_id IN (")
+	require.NotContains(t, eQuery, "row_id IN (")
+	require.Contains(t, sql, "TO 's3://bucket/base/1/_tmp/tmp.parquet'")
+
+	withRows, _, _, err := buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", CDCConfig{}, 1,
+		[]uuid.UUID{uuid.MustParse("019bed54-48eb-7cdc-aed3-8d38ec9c1394")}, testAttrCache())
+	require.NoError(t, err)
+	require.Equal(t, selectClause(t, withRows), selectClause(t, sql), "zero-row export projects the same columns as a populated one")
+
+	_, _, _, err = buildBaseExportSQL("host=pg", "s3://bucket/base/1/_tmp/tmp.parquet", CDCConfig{}, 1, nil, nil)
+	require.ErrorIs(t, err, ErrSchemaAttrCacheUnavailable)
+}
+
+// selectClause returns the export's outer SELECT list, up to its FROM.
+func selectClause(t *testing.T, sql string) string {
+	t.Helper()
+	start := strings.Index(sql, "SELECT ")
+	require.NotEqual(t, -1, start, "no SELECT in %s", sql)
+	rest := sql[start:]
+	end := strings.Index(rest, " FROM ")
+	require.NotEqual(t, -1, end, "no FROM in %s", sql)
+	return rest[:end]
 }
 
 func TestBuildBaseExportSQL_WithSchemaCacheProjectsColumns(t *testing.T) {

--- a/internal/cdc/init_publish.go
+++ b/internal/cdc/init_publish.go
@@ -74,8 +74,17 @@ func loadInitManifest(ctx context.Context, runCtx *initRunContext, schemaID int1
 // confirmAmbiguousSwap instead, because a committed swap whose purge is
 // skipped would leave the old delta objects as unlisted orphans that
 // manifest-reconcile --repair re-adopts as lost deletes.
+//
+// An empty entry set is never published, flag or no flag: splicing nothing
+// into the base tier would leave a manifest that lists nothing, and a
+// manifest with zero entries sends every read to the legacy per-schema glob
+// (manifest.QuerySource.Paths), which scans the unlisted old base and
+// resurrects the rows its tombstones had deleted. A schema with zero live
+// rows therefore exports one zero-row base object and publishes that
+// (finishEmptySchema, #519), the same rule compaction follows for an
+// all-tombstone merge.
 func updateSchemaManifest(ctx context.Context, runCtx *initRunContext, state *schemaInitState) error {
-	if runCtx.manifestStore == nil || len(state.fileEntries) == 0 || runCtx.dryRun {
+	if runCtx.manifestStore == nil || runCtx.dryRun || len(state.fileEntries) == 0 {
 		return nil
 	}
 

--- a/internal/e2e_harness/production/init_empty_schema_e2e_test.go
+++ b/internal/e2e_harness/production/init_empty_schema_e2e_test.go
@@ -1,0 +1,141 @@
+//go:build e2e
+
+package production
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lychee-technology/forma/internal/cdc"
+	"github.com/lychee-technology/forma/internal/manifest"
+)
+
+// TestInitReplaceDeltaRetiresEmptiedSchema (#519): a schema that was
+// initialized, then had every row deleted and the tombstones flushed, has
+// zero live rows but still lists a base and a delta tier. A plain re-init
+// refuses (#371); a dry-run with --replace-delta mutates nothing; a real
+// --replace-delta run exports one zero-row base object and publishes it as
+// the sole base entry with no delta listed (a manifest listing nothing
+// would send reads to the glob fallback and resurrect the deleted rows),
+// deletes the delta objects, leaves the superseded base objects on S3 as
+// unlisted orphans for manifest-reconcile --gc, and the federated result is
+// empty. Once rows exist again a plain init succeeds: the flag is
+// idempotent for emptied schemas.
+func TestInitReplaceDeltaRetiresEmptiedSchema(t *testing.T) {
+	cluster := SharedCluster(t)
+	env := NewEnv(t, cluster)
+	ctx := context.Background()
+	wide := DefaultSchemaFixtures()[1]
+
+	creates := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 6})
+	if err := env.ApplyEvents(ctx, creates...); err != nil {
+		t.Fatalf("apply creates: %v", err)
+	}
+	first, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	if first.RowsExported != 6 {
+		t.Fatalf("first init exported %d rows, want 6", first.RowsExported)
+	}
+	oldBaseKeys := manifestKeys(t, env, manifest.FilterByTier(first.Manifest, "base"))
+	if len(oldBaseKeys) == 0 {
+		t.Fatal("first init listed no base entries")
+	}
+
+	deletes := make([]*Event, 0, len(creates))
+	for _, ev := range creates {
+		deletes = append(deletes, DeleteEvent(wide, ev.RowID))
+	}
+	if err := env.ApplyEvents(ctx, deletes...); err != nil {
+		t.Fatalf("apply deletes: %v", err)
+	}
+	flush, err := env.RunFlush(ctx)
+	if err != nil {
+		t.Fatalf("flush tombstones: %v", err)
+	}
+	if flush.UnflushedAfter != 0 {
+		t.Fatalf("flush left %d unflushed rows", flush.UnflushedAfter)
+	}
+	deltaKeys := manifestKeys(t, env, manifest.FilterByTier(flush.Manifests[wide.ID], "delta"))
+	if len(deltaKeys) == 0 {
+		t.Fatal("flush listed no delta entries for the tombstones")
+	}
+
+	// Zero live rows, delta listed: the plain re-init still refuses.
+	if _, err := env.RunInit(ctx, wide); !errors.Is(err, cdc.ErrDeltaTierPresent) {
+		t.Fatalf("plain init over emptied schema: err = %v, want cdc.ErrDeltaTierPresent", err)
+	}
+
+	before := captureState(t, ctx, env, wide)
+	dry, err := env.RunInitWith(ctx, wide, InitOverrides{DryRun: true, ReplaceDelta: true})
+	if err != nil {
+		t.Fatalf("dry-run init with replace-delta: %v", err)
+	}
+	if dry.RowsExported != 0 || dry.FilesCreated != 1 {
+		t.Errorf("dry-run planned %d rows / %d files, want 0 rows / 1 zero-row base", dry.RowsExported, dry.FilesCreated)
+	}
+	assertStateUnchanged(t, "empty-schema dry-run (replace-delta)", before, captureState(t, ctx, env, wide))
+
+	report, err := env.RunInitWith(ctx, wide, InitOverrides{ReplaceDelta: true})
+	if err != nil {
+		t.Fatalf("init with replace-delta over emptied schema: %v", err)
+	}
+	if report.RowsExported != 0 || report.FilesCreated != 1 {
+		t.Errorf("empty swap exported %d rows / %d files, want 0 rows / 1 zero-row base", report.RowsExported, report.FilesCreated)
+	}
+	if report.Manifest == nil {
+		t.Fatal("manifest missing after the empty swap")
+	}
+	bases := manifest.FilterByTier(report.Manifest, "base")
+	if len(bases) != 1 {
+		t.Fatalf("manifest lists %d base entries after the empty swap, want exactly the zero-row base: %+v", len(bases), report.Manifest.Files)
+	}
+	if bases[0].RowCount != 0 || bases[0].RowIDMin != "" || bases[0].RowIDMax != "" {
+		t.Errorf("zero-row base entry = %+v, want RowCount 0 and no row-id range", bases[0])
+	}
+	if n := countTier(report.Manifest, "delta"); n != 0 {
+		t.Errorf("manifest still lists %d delta entries after the empty swap: %+v", n, report.Manifest.Files)
+	}
+	assertBaseRows(ctx, t, env, report.Manifest, 0)
+	assertS3KeysPresence(ctx, t, env, "after empty swap", deltaKeys, false)
+	// Init never deletes base objects (#416/#203): the superseded set is
+	// unlisted and left for manifest-reconcile --gc.
+	assertS3KeysPresence(ctx, t, env, "after empty swap", oldBaseKeys, true)
+
+	if result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100}); result != nil && len(result.Records) != 0 {
+		t.Errorf("federated result has %d rows over an emptied schema, want 0", len(result.Records))
+	}
+
+	// Rows arrive again: the plain init no longer refuses.
+	more := env.GenerateScript(ScriptSpec{Schema: wide, Creates: 3})
+	if err := env.ApplyEvents(ctx, more...); err != nil {
+		t.Fatalf("apply later creates: %v", err)
+	}
+	third, err := env.RunInit(ctx, wide)
+	if err != nil {
+		t.Fatalf("plain init after the empty swap: %v", err)
+	}
+	if third.RowsExported != 3 {
+		t.Errorf("init after the empty swap exported %d rows, want 3", third.RowsExported)
+	}
+	assertBaseRows(ctx, t, env, third.Manifest, 3)
+	if result := env.AssertQueryMatches(ctx, Query{Schema: wide, Limit: 100}); result != nil && len(result.Records) != 3 {
+		t.Errorf("federated result has %d rows after re-population, want 3", len(result.Records))
+	}
+}
+
+// manifestKeys resolves manifest entries to bucket-relative keys.
+func manifestKeys(t *testing.T, env *Env, entries []manifest.FileEntry) []string {
+	t.Helper()
+	keys := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		key, ok := cdc.NormalizeObjectKey(env.Cluster.Bucket, entry.Path)
+		if !ok {
+			t.Fatalf("manifest entry %q is not addressable in bucket %s", entry.Path, env.Cluster.Bucket)
+		}
+		keys = append(keys, key)
+	}
+	return keys
+}


### PR DESCRIPTION
Closes #519 (follow-up of the #518 review finding F1, #371).

## What changed

`initSchema` returned early when a schema had zero live rows, so `cdc-init --replace-delta` over a schema whose every row was deleted and flushed left its stale base and delta tiers listed and the delta objects in place. The next plain init kept refusing with `ErrDeltaTierPresent`.

With `--replace-delta` that branch now goes through `finishEmptySchema` (`internal/cdc/init_delta.go`):

1. Export **one zero-row base object** through the shared `exportBatch` path. The base export SQL accepts an empty row-id list (`FALSE` row filters, full projected column set); snapshot exports still refuse it.
2. Publish it as the **sole base entry** (`RowCount 0`, no row-id range) with the delta tier emptied, under the same CAS publish as a populated schema (412 re-splice, ambiguous-save confirmation).
3. Purge the inventoried delta objects only after the save commits.

Dry-run reports 1 file / 0 rows and touches nothing. A schema that lists nothing and has no delta objects gets nothing exported and no manifest minted. Without the flag nothing changes. Old base objects are unlisted, never deleted (#416 / #203), and are ordinary orphans for `manifest-reconcile --gc`.

## Why a zero-row base instead of an empty swap

The plan posted on #519 proposed publishing an empty entry set. The production e2e caught that this **resurrects deleted rows**: `manifest.QuerySource.Paths` treats a manifest with zero entries like an absent one and falls back to the per-schema glob, which scans the unlisted old base without the purged tombstones (all 6 deleted rows came back). Compaction already keeps the invariant for an all-tombstone merge (a `RowCount 0` base entry so the manifest never empties), so init now follows the same rule. `updateSchemaManifest` never publishes an empty entry set, flag or no flag.

The object takes compaction's `base-{uuid}.parquet` key shape: an init-shaped `{min}_{max}_{uuid}` name needs a row-id range, and a range-less stem is unclassifiable for `--gc`. Because the manifest keeps one in-prefix base entry, the #463 empty-manifest guard does not trip and `--gc` needs no `--allow-empty-manifest-schema`.

Rulings 2 and 3 of the plan comment are superseded accordingly; a comment on #519 records the deviation.

## Verification

```
go test ./internal/cdc/ ./internal/compaction/ ./internal/manifest/ -count=1   # ok
go test . ./cdc ./cmd/... ./factory ./internal/... -count=1                     # ok (e2e_harness with DOCKER_HOST set)
go test -v ./internal/e2e_harness/production/ -tags=e2e \
  -run 'TestInitReplaceDeltaRetiresEmptiedSchema|TestCDCFlushAndInit' -count=1  # PASS under rootless Podman
make fmt-check && make lint                                                     # clean
```

New unit tests: `internal/cdc/init_empty_schema_test.go` (export → save → delete ordering, dry-run, failed save, failed export, nothing-to-retire, unlisted-delta-only), zero-row base SQL plan in `init_exporter_sql_test.go`.
