### PR TITLE
fix(federated): validate quote-bearing parquet paths up front (#529)

### DIFF
--- a/internal/federated/parquet_schema_validation.go
+++ b/internal/federated/parquet_schema_validation.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/parquetcheck"
 	"github.com/lychee-technology/forma/internal/sqlutil"
 	"go.uber.org/zap"
@@ -131,6 +132,12 @@ func (v *parquetSchemaValidator) log() *zap.Logger {
 //
 // When a probe DOES run on a stamped path, the two are cross-checked and any
 // divergence is logged — see warnStampDivergence.
+//
+// Quote-bearing paths used to be skipped (and marked the union incomplete)
+// back when the probes interpolated the path raw; since #456 both
+// globParquetPaths and describeParquetColumns escape it via
+// sqlutil.EscapeLiteral, so a quote, double quote, or semicolon in an object
+// key is validated like any other path (#529, the #479 precedent).
 func (v *parquetSchemaValidator) Validate(
 	ctx context.Context, duck DuckDBQueryExecutor, paths []string,
 	stamps map[string]map[string]string,
@@ -140,13 +147,7 @@ func (v *parquetSchemaValidator) Validate(
 	}
 	union, complete := newColumnUnion(), true
 	for _, path := range paths {
-		if strings.ContainsAny(path, `'";`) {
-			// Cannot embed in a DuckDB literal; the main read fails on it
-			// with its own classification either way.
-			complete = false
-			continue
-		}
-		if strings.ContainsAny(path, "*?[") {
+		if strings.ContainsAny(path, forma.ParquetGlobMetacharacters) {
 			expanded, err := globParquetPaths(ctx, duck, path)
 			if err != nil {
 				complete = false // inconclusive: defer to the execution-path classifier
@@ -178,10 +179,6 @@ func (v *parquetSchemaValidator) validateConcrete(
 ) (bool, error) {
 	complete := true
 	for _, path := range paths {
-		if strings.ContainsAny(path, `'";`) {
-			complete = false
-			continue
-		}
 		stamp := currentStamp(stamps, path)
 		if cols, ok := v.lookupValidatedCols(path, stamp); ok {
 			union.merge(cols)

--- a/internal/federated/parquet_schema_validation_test.go
+++ b/internal/federated/parquet_schema_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/sqlutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -325,6 +326,47 @@ func TestValidateUnionIncompleteOnProbeFailure(t *testing.T) {
 	require.NoError(t, err, "unreadable footer stays inconclusive, not an error")
 	require.False(t, complete)
 	require.Contains(t, union.types, "row_id", "probed files still contribute")
+}
+
+// TestValidateProbesQuoteBearingPath pins #529: describeParquetColumns
+// escapes the path (#456), so a manifest key that legitimately carries a
+// quote, a semicolon, or a double quote is validated up front like any other
+// and contributes to a COMPLETE union, instead of being deferred to the
+// execution-path classifier with #255/#371 switched off for the whole query.
+func TestValidateProbesQuoteBearingPath(t *testing.T) {
+	const quoted = "s3://b/it's;\"odd\".parquet"
+	escaped := sqlutil.EscapeLiteral(quoted)
+	exec := &scriptedDescribeExecutor{cols: map[string][][2]string{
+		"plain.parquet": buildValidSystemCols(),
+		escaped:         append(buildValidSystemCols(), [2]string{"score", "INTEGER"}),
+	}}
+	v := newParquetSchemaValidator()
+	union, complete, err := v.Validate(context.Background(), exec,
+		[]string{"s3://b/plain.parquet", quoted}, nil)
+	require.NoError(t, err)
+	require.True(t, complete, "a quote-bearing path renders safely and must not mark the union incomplete")
+	require.Contains(t, union.types, "score", "the quote-bearing path must contribute its columns")
+	require.Len(t, exec.probes, 2, "one DESCRIBE per path")
+	require.Contains(t, exec.probes[1], "read_parquet('"+escaped+"')", "the quote must render doubled")
+	require.NotContains(t, exec.probes[1], "'"+quoted+"'", "the quote must never render raw")
+}
+
+// The glob branch feeds validateConcrete with whatever the listing returns,
+// so a quote-bearing match must be probed there too (#529).
+func TestValidateProbesQuoteBearingGlobMatch(t *testing.T) {
+	const quoted = "s3://b/1/it's.parquet"
+	escaped := sqlutil.EscapeLiteral(quoted)
+	exec := &scriptedDescribeExecutor{
+		cols:  map[string][][2]string{escaped: append(buildValidSystemCols(), [2]string{"score", "INTEGER"})},
+		globs: map[string][]string{"1/*.parquet": {quoted}},
+	}
+	v := newParquetSchemaValidator()
+	union, complete, err := v.Validate(context.Background(), exec, []string{"s3://b/1/*.parquet"}, nil)
+	require.NoError(t, err)
+	require.True(t, complete)
+	require.Contains(t, union.types, "score")
+	require.Len(t, exec.probes, 2, "the glob listing plus one DESCRIBE")
+	require.Contains(t, exec.probes[1], "read_parquet('"+escaped+"')")
 }
 
 // A cache hit must contribute its stored columns without a second probe.


### PR DESCRIPTION
Closes #529.

## Problem

`Validate` and `validateConcrete` in `internal/federated/parquet_schema_validation.go` skipped any path containing `' " ;` and marked the column union incomplete. That was correct before #456, when the probes interpolated the path raw. Since #456 both probes the validator issues — `globParquetPaths` (`glob('…')`) and `describeParquetColumns` (`DESCRIBE SELECT * FROM read_parquet('…')`) — escape the path via `sqlutil.EscapeLiteral`, so the skip no longer protected anything. It only withheld up-front #256 validation from manifest entries whose object key legitimately carries one of those characters, and because it forced `complete == false`, it also switched off #255 NULL augmentation and the #371 type pin for the whole query.

## Change

- `Validate` no longer has the `' " ;` branch; the glob branch stays and now uses `forma.ParquetGlobMetacharacters`, the same constant `unverifiablePath` adopted in #528.
- `validateConcrete` no longer has the `' " ;` branch.
- The `Validate` doc comment records why quote-bearing paths are validated (#456 escaping, #479 precedent).

Not touched: the #456 caller-template gate (`parquet_hint_scope.go`), which still rejects `' " ; \n \r` in caller-supplied paths, and the compaction writer's own quote check in `internal/compaction/merge_sql.go`. Both are separate render paths.

## Tests

- `TestValidateProbesQuoteBearingPath`: a concrete path carrying `'`, `;`, and `"` is probed alongside a plain one, its DESCRIBE renders the quote doubled and never raw, its columns land in the union, and `complete` is true.
- `TestValidateProbesQuoteBearingGlobMatch`: a glob whose listing yields a quote-bearing match goes through `validateConcrete` the same way.

Both tests were written first and failed against the old predicates (`complete` was false in each).

## Verification

`make fmt-check` ✅ · `make lint` ✅ (root and infra modules, 0 issues) · unit suite over `.`, `./cdc`, `./cmd/...`, `./factory`, and `./internal/...` excluding the Docker-gated `e2e_harness` ✅.
