### PR TITLE
fix(compaction): stop rejecting quote-bearing parquet URIs that render escaped (#546)

### DIFF
--- a/internal/compaction/merge.go
+++ b/internal/compaction/merge.go
@@ -131,9 +131,10 @@ var _ Merger = (*DuckMerger)(nil)
 
 // validateMergeSourceSchemas checks every merge source against the
 // parquetcheck system-column invariant. Compaction sources are
-// manifest-listed and URI-validated by buildMergeSQL's quoting rules, but a
-// rogue registration (the #187 fabrication class) must abort the merge
-// before it can misfold rows.
+// manifest-listed and rendered through sqlutil.EscapeLiteral at every
+// site (#478, #546), so their spelling cannot break the SQL, but a rogue
+// registration (the #187 fabrication class) must abort the merge before
+// it can misfold rows.
 func validateMergeSourceSchemas(ctx context.Context, db *sql.DB, sourceURIs []string) error {
 	for _, uri := range sourceURIs {
 		if err := validateMergeURI(uri); err != nil {

--- a/internal/compaction/merge_sql.go
+++ b/internal/compaction/merge_sql.go
@@ -28,18 +28,20 @@ const mergeLWWOrderBy = "changed_at DESC, deleted_at DESC NULLS LAST, row_id ASC
 // (internal/cdc/export_sql_builder.go buildParquetCopyOptions defaults).
 const defaultMergeCopyOptions = "FORMAT PARQUET, PARQUET_VERSION V2, COMPRESSION 'ZSTD', COMPRESSION_LEVEL 3"
 
-// validateMergeURI rejects URIs that cannot be embedded in a single-quoted
-// DuckDB literal. Production keys are prefix/schemaID/uuid-ish and never
-// carry quotes; this guards against SQL breakage, not hostile input. The
-// render sites additionally wrap every URI in sqlutil.EscapeLiteral (#478)
-// as defense-in-depth, so escaping is an identity transform on anything
-// this validator admits; the validator stays as the operator-facing error.
+// validateMergeURI refuses the one URI the writer cannot render: the empty
+// string, which is a manifest or path-contract bug rather than an object
+// key. Quote-bearing keys are NOT refused here (#546): every compaction
+// render site wraps the URI in sqlutil.EscapeLiteral (#478), and in a
+// single-quoted DuckDB literal only a single quote can alter SQL structure
+// once doubled — a double quote or semicolon is inert inside the literal.
+// The escaping is the safety boundary; a character gate on top of it
+// would only refuse manifest entries the federated read path already
+// serves (#529), leaving them impossible to compact or reconcile. The
+// caller-supplied template gate in internal/federated/parquet_hint_scope.go
+// (#456) is a different trust domain and keeps its own rejection on purpose.
 func validateMergeURI(uri string) error {
 	if uri == "" {
 		return fmt.Errorf("empty parquet URI")
-	}
-	if strings.ContainsAny(uri, `'";`) {
-		return fmt.Errorf("parquet URI %q contains a quote or semicolon; cannot embed in DuckDB SQL", uri)
 	}
 	return nil
 }

--- a/internal/compaction/merge_sql_test.go
+++ b/internal/compaction/merge_sql_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lychee-technology/forma/internal/sqlutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,14 +36,45 @@ func TestBuildMergeSQL_Validation(t *testing.T) {
 	_, err := buildMergeSQL(nil, "s3://b/t.parquet", "")
 	require.ErrorContains(t, err, "at least one source")
 
-	_, err = buildMergeSQL([]string{"s3://b/a'.parquet"}, "s3://b/t.parquet", "")
-	require.ErrorContains(t, err, "quote or semicolon")
-
-	_, err = buildMergeSQL([]string{"s3://b/a.parquet"}, "s3://b/t';drop.parquet", "")
+	_, err = buildMergeSQL([]string{"s3://b/a.parquet"}, "", "")
 	require.ErrorContains(t, err, "tmp target")
+	require.ErrorContains(t, err, "empty parquet URI")
 
 	_, err = buildMergeSQL([]string{""}, "s3://b/t.parquet", "")
+	require.ErrorContains(t, err, "merge source")
 	require.ErrorContains(t, err, "empty parquet URI")
+}
+
+// TestMergeSQL_QuoteBearingURIsRenderEscaped pins #546, the writer-side
+// twin of internal/federated's TestValidateProbesQuoteBearingPath (#529):
+// every compaction render site wraps the URI in sqlutil.EscapeLiteral
+// (#478), so an object key that legitimately carries a quote, a double
+// quote, or a semicolon is accepted and rendered with the quote doubled,
+// never raw. Before #546 validateMergeURI refused such keys outright, so a
+// manifest entry the read path served could be neither compacted nor
+// reconciled.
+func TestMergeSQL_QuoteBearingURIsRenderEscaped(t *testing.T) {
+	const quoted = "s3://b/p/1/it's;\"odd\".parquet"
+	const quotedTmp = "s3://b/p/1/_tmp/it's;\"odd\".parquet"
+	escaped := sqlutil.EscapeLiteral(quoted)
+	escapedTmp := sqlutil.EscapeLiteral(quotedTmp)
+	require.NotEqual(t, quoted, escaped, "the fixture must actually need escaping")
+
+	merge, err := buildMergeSQL([]string{"s3://b/p/1/plain.parquet", quoted}, quotedTmp, "")
+	require.NoError(t, err, "a quote-bearing source and target render safely and must be accepted")
+	require.Contains(t, merge, "read_parquet(['s3://b/p/1/plain.parquet', '"+escaped+"'], union_by_name=true)")
+	require.NotContains(t, merge, "'"+quoted+"'", "the source quote must never render raw")
+	require.Contains(t, merge, "TO '"+escapedTmp+"'")
+	require.NotContains(t, merge, "'"+quotedTmp+"'", "the target quote must never render raw")
+
+	rowsIn, err := buildMergeRowsInSQL([]string{quoted})
+	require.NoError(t, err)
+	require.Equal(t, "SELECT COUNT(*) FROM read_parquet(['"+escaped+"'], union_by_name=true)", rowsIn)
+
+	stats, err := buildMergeStatsSQL(quotedTmp)
+	require.NoError(t, err)
+	require.Contains(t, stats, "FROM read_parquet('"+escapedTmp+"')")
+	require.NotContains(t, stats, "'"+quotedTmp+"'")
 }
 
 func TestBuildMergeStatsSQL_CoalescesZeroRowMerge(t *testing.T) {
@@ -53,8 +85,9 @@ func TestBuildMergeStatsSQL_CoalescesZeroRowMerge(t *testing.T) {
 	require.Contains(t, sql, `COALESCE(MIN(CAST(row_id AS VARCHAR)), '')`)
 	require.Contains(t, sql, "COALESCE(MIN(changed_at), 0)")
 
-	_, err = buildMergeStatsSQL("bad'uri")
-	require.Error(t, err)
+	_, err = buildMergeStatsSQL("")
+	require.ErrorContains(t, err, "stats target")
+	require.ErrorContains(t, err, "empty parquet URI")
 }
 
 func TestBuildMergeRowsInSQL(t *testing.T) {

--- a/internal/compaction/merge_test.go
+++ b/internal/compaction/merge_test.go
@@ -10,6 +10,7 @@ import (
 
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/lychee-technology/forma/internal/parquetcheck"
+	"github.com/lychee-technology/forma/internal/sqlutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,7 +38,7 @@ func writeParquetFixture(t *testing.T, db *sql.DB, path string, rows []mergeFixt
 			"SELECT CAST('%s' AS UUID) AS row_id, CAST(%d AS BIGINT) AS changed_at, CAST(%s AS BIGINT) AS deleted_at, CAST(50 AS BIGINT) AS ltbase_created_at, %s AS title",
 			r.rowID, r.changedAt, r.deletedAt, title))
 	}
-	q := fmt.Sprintf("COPY (%s) TO '%s' (FORMAT PARQUET)", joinSQL(selects), path)
+	q := fmt.Sprintf("COPY (%s) TO '%s' (FORMAT PARQUET)", joinSQL(selects), sqlutil.EscapeLiteral(path))
 	_, err := db.Exec(q)
 	require.NoError(t, err)
 }
@@ -241,4 +242,44 @@ func TestDuckMerger_RejectsWrongSchemaSource(t *testing.T) {
 	// Positive control: the good source alone merges cleanly.
 	_, err = merger.MergeToTmp(context.Background(), []string{goodPath}, tmpPath)
 	require.NoError(t, err)
+}
+
+// TestDuckMerger_QuoteBearingSourceAndTarget pins #546 end to end: a source
+// file and a tmp target whose keys carry a quote, a double quote, and a
+// semicolon pass validateMergeSourceSchemas, buildMergeSQL,
+// buildMergeRowsInSQL, and buildMergeStatsSQL, because every render site
+// escapes the path (#478). The merge itself must produce the same fold a
+// plain-named source does.
+func TestDuckMerger_QuoteBearingSourceAndTarget(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.parquet")
+	deltaPath := filepath.Join(dir, `it's;"delta".parquet`)
+	tmpPath := filepath.Join(dir, `it's;"merged".parquet`)
+
+	writeParquetFixture(t, db, basePath, []mergeFixtureRow{
+		{rowA, 100, "0", "a-v1"},
+		{rowB, 100, "0", "b-v1"},
+	})
+	writeParquetFixture(t, db, deltaPath, []mergeFixtureRow{
+		{rowA, 200, "0", "a-v2"},
+		{rowB, 300, "300", "NULL"},
+	})
+
+	merger := &DuckMerger{DB: db}
+	stats, err := merger.MergeToTmp(context.Background(), []string{basePath, deltaPath}, tmpPath)
+	require.NoError(t, err, "a quote-bearing source and target render escaped and must merge")
+	require.Equal(t, int64(4), stats.RowsIn)
+	require.Equal(t, int64(1), stats.RowsOut)
+	require.Equal(t, rowA, stats.RowIDMin)
+	require.Equal(t, rowA, stats.RowIDMax)
+
+	var title string
+	err = db.QueryRow(fmt.Sprintf(
+		"SELECT title FROM read_parquet('%s')", sqlutil.EscapeLiteral(tmpPath))).Scan(&title)
+	require.NoError(t, err)
+	require.Equal(t, "a-v2", title)
 }

--- a/internal/compaction/uncovered_rows_test.go
+++ b/internal/compaction/uncovered_rows_test.go
@@ -92,11 +92,37 @@ func TestUncoveredRows_NoListedFilesEverythingUncovered(t *testing.T) {
 	}, uncovered)
 }
 
-func TestUncoveredRows_RejectsInvalidURI(t *testing.T) {
+func TestUncoveredRows_RejectsEmptyURI(t *testing.T) {
 	db, _ := uncoveredDB(t)
 
-	_, err := UncoveredRows(context.Background(), db, "bad'uri.parquet", nil)
-	require.Error(t, err)
-	_, err = UncoveredRows(context.Background(), db, "ok.parquet", []string{"bad'listed.parquet"})
-	require.Error(t, err)
+	_, err := UncoveredRows(context.Background(), db, "", nil)
+	require.ErrorContains(t, err, "uncovered-rows orphan")
+	require.ErrorContains(t, err, "empty parquet URI")
+	_, err = UncoveredRows(context.Background(), db, "ok.parquet", []string{""})
+	require.ErrorContains(t, err, "uncovered-rows listed file")
+	require.ErrorContains(t, err, "empty parquet URI")
+}
+
+// TestUncoveredRows_QuoteBearingPaths pins #546: an orphan or listed file
+// whose key carries a quote, a double quote, or a semicolon is rendered
+// through sqlutil.EscapeLiteral (#478) and therefore accepted, so
+// manifest-reconcile (#203) can build a repair verdict for the same entry
+// the federated read path already serves (#529). The verdict must match
+// what plain names produce.
+func TestUncoveredRows_QuoteBearingPaths(t *testing.T) {
+	db, dir := uncoveredDB(t)
+
+	orphan := filepath.Join(dir, `it's;"orphan".parquet`)
+	writeParquetFixture(t, db, orphan, []mergeFixtureRow{
+		{rowID: rowA, changedAt: 500, deletedAt: "NULL", title: "a-newer"},
+		{rowID: rowB, changedAt: 200, deletedAt: "NULL", title: "b-old"},
+	})
+	listed := filepath.Join(dir, `it's;"base".parquet`)
+	writeParquetFixture(t, db, listed, []mergeFixtureRow{
+		{rowID: rowB, changedAt: 400, deletedAt: "0", title: "b-new"},
+	})
+
+	uncovered, err := UncoveredRows(context.Background(), db, orphan, []string{listed})
+	require.NoError(t, err, "quote-bearing orphan and listed paths render escaped and must be accepted")
+	require.Equal(t, []UncoveredRow{{RowID: rowA, Tombstone: false}}, uncovered)
 }


### PR DESCRIPTION
Closes #546. Follow-up from the PR #545 review (observation O1).

## Problem

`validateMergeURI` in `internal/compaction/merge_sql.go` still refused any URI carrying `'`, `"`, or `;`, with a doc comment claiming such a URI "cannot embed in DuckDB SQL". That rationale has been moot since #478: every compaction render site (`buildMergeSQL` sources and `COPY ... TO` target, `buildMergeRowsInSQL`, `buildMergeStatsSQL`, `UncoveredRows` orphan and listed files) wraps the URI in `sqlutil.EscapeLiteral`, and `parquetcheck.DescribeColumns` escapes too. In a single-quoted DuckDB literal only a single quote can alter SQL structure once doubled; a double quote or semicolon is inert.

After #529 (PR #545) the federated read path validates and serves a quote-bearing manifest entry, but the write side still aborted the whole merge in `validateMergeSourceSchemas` and refused the entry in `UncoveredRows`, so `manifest-reconcile` could not build a repair verdict for it either. One manifest, two rules.

## Change

- `validateMergeURI` keeps only the empty-URI check. The doc comment names `sqlutil.EscapeLiteral` as the safety boundary and points at the #456 caller-template gate in `internal/federated/parquet_hint_scope.go` as a deliberately separate trust domain that keeps its own rejection.
- The `validateMergeSourceSchemas` comment no longer claims sources are "URI-validated by buildMergeSQL's quoting rules".

## Tests

- `TestMergeSQL_QuoteBearingURIsRenderEscaped` (new): a source and a tmp target carrying `' " ;` render through `buildMergeSQL`, `buildMergeRowsInSQL`, and `buildMergeStatsSQL` with the quote doubled and never raw, mirroring `TestValidateProbesQuoteBearingPath` in `internal/federated`.
- `TestDuckMerger_QuoteBearingSourceAndTarget` (new): `MergeToTmp` over a real quote-bearing source file into a quote-bearing tmp path on in-memory DuckDB, which exercises `validateMergeSourceSchemas` end to end.
- `TestUncoveredRows_QuoteBearingPaths` (new): real quote-bearing orphan and listed files produce the same verdict plain names do.
- `TestBuildMergeSQL_Validation`, `TestBuildMergeStatsSQL_CoalescesZeroRowMerge`, and `TestUncoveredRows_RejectsEmptyURI` (renamed) now assert the empty-URI refusal instead of the removed character gate.
- `writeParquetFixture` escapes its path so quote-bearing fixtures can be written.
- The root guard `TestParquetPathRendersAreEscaped` is unchanged and still passes over every compaction render site.

## Verification

- `make fmt-check`, `make lint`: green.
- `./scripts/test_with_container_runtime.sh` (`make test`): green, 34 packages ok.
- The three new tests were written first and failed on the old validator with "contains a quote or semicolon" before the change.

## Out of scope

The #456 caller-template gate (different trust domain) and glob-metacharacter handling in compaction.
