### PR TITLE
fix(sqlgen): reject case-variant parquet system columns (#532)

### DIFF
--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -185,6 +185,20 @@ resolved lower-case column beside it. This is what makes the premise stated
 under the filter rule below — "registered names never reach it" — hold for
 case variants and not merely for exact-case ones.
 
+That case-insensitivity is **ASCII-only**, because DuckDB's is: the engine
+folds `A`–`Z` and nothing else, so `Á` and `á`, `Ж` and `ж`, and `cafÉ` and
+`café` are distinct identifiers to it, and U+212A KELVIN SIGN does not
+resolve onto `k`. The guard therefore keys on `duckdbFoldIdentifier`, not on
+`strings.ToLower`: Go's Unicode case mappings would merge every one of those
+pairs and reject a schema DuckDB serves correctly, and because they also map
+U+0130 (`İ`) onto `i`, they would read the legitimate attribute `row_İd` as
+the reserved `row_id`. Since a registration failure fails the whole registry,
+a false rejection here is a boot failure, so the boundary is pinned against
+the engine itself rather than its documentation
+(`TestDuckDBIdentifierFoldIsASCIIOnly`). The two runtime guards below still
+fold with `strings.ToLower` and are narrower than DuckDB in the same way;
+that is tracked in #550.
+
 Keyset cursor columns obey the same contract as every other column reference,
 and it is one contract, not a per-seam one (#381). A single validator,
 `federated.validateKeysetCursor`, binds every entry point onto the keyset

--- a/docs/federated-query/design.md
+++ b/docs/federated-query/design.md
@@ -174,7 +174,16 @@ generator (read side) and cannot diverge: the logical WHERE clause is applied
 both against raw `read_parquet` output (physical columns) and against the
 `visible` CTE (unified columns), so both must expose the same names (#260).
 The fold is lossy, so both sides fail fast if two attributes of one schema
-collide on the same folded column.
+collide on the same folded column. `sqlgen.ValidateParquetAttrColumns`, the
+registration guard behind that, compares **case-insensitively** for the same
+reason the keyset and filter guards below do: DuckDB resolves an unquoted
+identifier without regard to case, so `Created_At` reaches the `created_at`
+system column and `Contact_Name` reaches the same column as `contact_name`
+(#532). The emitted names stay byte-stable either way — `ParquetAttrColumn`
+preserves the caller's spelling, and so do the diagnostics, which name the
+resolved lower-case column beside it. This is what makes the premise stated
+under the filter rule below — "registered names never reach it" — hold for
+case variants and not merely for exact-case ones.
 
 Keyset cursor columns obey the same contract as every other column reference,
 and it is one contract, not a per-seam one (#381). A single validator,

--- a/internal/schemameta/lookup_test.go
+++ b/internal/schemameta/lookup_test.go
@@ -161,6 +161,24 @@ func TestFileSchemaRegistryRejectsReservedFoldedColumnAtLoad(t *testing.T) {
 	assert.Contains(t, err.Error(), "reserved")
 }
 
+// TestFileSchemaRegistryRejectsCaseVariantReservedColumnAtLoad pins #532 at
+// the registration seam: Created_At resolves to the created_at system column
+// in DuckDB and must not be accepted into a schema cache.
+func TestFileSchemaRegistryRejectsCaseVariantReservedColumnAtLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONFile(t, fmt.Sprintf("%s/created.json", dir), map[string]any{
+		"type": "object",
+	})
+	writeJSONFile(t, fmt.Sprintf("%s/created_attributes.json", dir), map[string]any{
+		"Created_At": map[string]any{"attributeID": float64(1), "valueType": "text"},
+	})
+
+	_, err := NewFileSchemaRegistryFromDirectory(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Created_At")
+	assert.Contains(t, err.Error(), "reserved")
+}
+
 // TestFileSchemaRegistryRejectsFoldedAttrCollisionAtLoad: two attributes
 // whose folded parquet columns collide are likewise rejected at load.
 func TestFileSchemaRegistryRejectsFoldedAttrCollisionAtLoad(t *testing.T) {
@@ -177,4 +195,22 @@ func TestFileSchemaRegistryRejectsFoldedAttrCollisionAtLoad(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "contact.name")
 	assert.Contains(t, err.Error(), "contact_name")
+}
+
+// TestFileSchemaRegistryRejectsCaseVariantFoldedAttrCollisionAtLoad pins
+// #532: DuckDB treats these two physical parquet aliases as one column.
+func TestFileSchemaRegistryRejectsCaseVariantFoldedAttrCollisionAtLoad(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONFile(t, fmt.Sprintf("%s/fold.json", dir), map[string]any{
+		"type": "object",
+	})
+	writeJSONFile(t, fmt.Sprintf("%s/fold_attributes.json", dir), map[string]any{
+		"contact_name": map[string]any{"attributeID": float64(1), "valueType": "text"},
+		"Contact_Name": map[string]any{"attributeID": float64(2), "valueType": "text"},
+	})
+
+	_, err := NewFileSchemaRegistryFromDirectory(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contact_name")
+	assert.Contains(t, err.Error(), "Contact_Name")
 }

--- a/internal/sqlgen/parquet_attr_column.go
+++ b/internal/sqlgen/parquet_attr_column.go
@@ -93,6 +93,13 @@ var federatedDedupColumns = map[string]struct{}{
 // "Created_At") is admitted and left to fail at the binder or, on the
 // federated route, at the PG EAV payload. Caller fault, so the error is a
 // forma.InvalidInputf carrier that keeps the caller's spelling.
+//
+// The case folding below is still strings.ToLower, so this guard is narrower
+// than DuckDB for non-ASCII names — it can refuse a filter the engine would
+// have bound. That over-rejects a query rather than answering one wrongly,
+// and unlike ValidateParquetAttrColumns it cannot fail registration, so it
+// is tracked separately in #550 rather than changed here; see
+// duckdbFoldIdentifier.
 func ValidateUnregisteredParquetAttrColumn(attr, folded string) error {
 	if strings.EqualFold(folded, parquetAttrPlaceholder) && !strings.EqualFold(attr, parquetAttrPlaceholder) {
 		return forma.InvalidInputf(
@@ -113,13 +120,45 @@ func ValidateUnregisteredParquetAttrColumn(attr, folded string) error {
 	return nil
 }
 
+// duckdbFoldIdentifier lower-cases a folded column name the way DuckDB
+// resolves an unquoted identifier: ASCII only. strings.ToLower is the wrong
+// primitive here — it applies Unicode case mappings DuckDB does not, so it
+// merges identifiers DuckDB keeps distinct and would reject valid schemas
+// (#532). Verified against the pinned DuckDB (see
+// TestDuckDBIdentifierFoldIsASCIIOnly, which asserts this function against
+// the engine rather than against the documentation): "Á"/"á", "Ж"/"ж",
+// "ẞ"/"ß" and "cafÉ"/"café" are distinct columns, and U+212A KELVIN SIGN
+// does not resolve onto "k". The reserved half matters too: Go maps U+0130
+// LATIN CAPITAL LETTER I WITH DOT ABOVE onto "i", so a Unicode fold would
+// collapse the legitimate attribute "row_İd" onto the reserved "row_id" and
+// fail registry construction for every schema in the directory.
+func duckdbFoldIdentifier(col string) string {
+	var folded []byte
+	for i := 0; i < len(col); i++ {
+		c := col[i]
+		if c < 'A' || c > 'Z' {
+			continue
+		}
+		if folded == nil {
+			folded = []byte(col)
+		}
+		folded[i] = c + ('a' - 'A')
+	}
+	if folded == nil {
+		return col
+	}
+	return string(folded)
+}
+
 // ValidateParquetAttrColumns rejects attribute sets whose folded parquet
 // column names land on a reserved system column or collide with each other
 // (the fold is lossy: "contact.name" and "contact_name" both become
 // contact_name). DuckDB resolves unquoted identifiers case-insensitively, so
-// comparisons use lower-cased folded names while errors preserve the caller's
-// spelling and name the resolved column beside it, so a case-variant
-// rejection stays legible against the reserved set an operator can grep.
+// comparisons run on duckdbFoldIdentifier keys — ASCII-only, matching the
+// engine, so non-ASCII names DuckDB keeps distinct are not merged here —
+// while errors preserve the caller's spelling and name the resolved column
+// beside it, so a case-variant rejection stays legible against the reserved
+// set an operator can grep.
 // Schema registration calls it so an unusable schema is
 // rejected before it accepts hot-tier writes; the CDC writer and the
 // federated reader call it again as defense in depth. Plain operator
@@ -139,7 +178,7 @@ func ValidateParquetAttrColumns(cache forma.SchemaAttributeCache) error {
 	colToAttr := make(map[string]foldedAttr, len(names))
 	for _, name := range names {
 		col := ParquetAttrColumn(name)
-		key := strings.ToLower(col)
+		key := duckdbFoldIdentifier(col)
 		if _, ok := reservedParquetColumns[key]; ok {
 			return reservedParquetColumnError(name, col, key)
 		}

--- a/internal/sqlgen/parquet_attr_column.go
+++ b/internal/sqlgen/parquet_attr_column.go
@@ -118,7 +118,9 @@ func ValidateUnregisteredParquetAttrColumn(attr, folded string) error {
 // (the fold is lossy: "contact.name" and "contact_name" both become
 // contact_name). DuckDB resolves unquoted identifiers case-insensitively, so
 // comparisons use lower-cased folded names while errors preserve the caller's
-// spelling. Schema registration calls it so an unusable schema is
+// spelling and name the resolved column beside it, so a case-variant
+// rejection stays legible against the reserved set an operator can grep.
+// Schema registration calls it so an unusable schema is
 // rejected before it accepts hot-tier writes; the CDC writer and the
 // federated reader call it again as defense in depth. Plain operator
 // error, never forma.ErrInvalidInput. Attributes are checked in sorted
@@ -130,21 +132,55 @@ func ValidateParquetAttrColumns(cache forma.SchemaAttributeCache) error {
 	}
 	sort.Strings(names)
 
-	colToAttr := make(map[string]string, len(names))
+	type foldedAttr struct {
+		name string
+		col  string
+	}
+	colToAttr := make(map[string]foldedAttr, len(names))
 	for _, name := range names {
 		col := ParquetAttrColumn(name)
 		key := strings.ToLower(col)
 		if _, ok := reservedParquetColumns[key]; ok {
-			return fmt.Errorf(
-				"attribute %q folds to parquet column %q, which is reserved for system columns; rename the attribute",
-				name, col)
+			return reservedParquetColumnError(name, col, key)
 		}
 		if prev, ok := colToAttr[key]; ok {
-			return fmt.Errorf(
-				"attributes %q and %q both map to parquet column %q; attribute names must remain distinct after identifier folding",
-				prev, name, col)
+			return foldedColumnCollisionError(prev.name, prev.col, name, col, key)
 		}
-		colToAttr[key] = name
+		colToAttr[key] = foldedAttr{name: name, col: col}
 	}
 	return nil
+}
+
+// reservedParquetColumnError explains a reserved-column rejection. When the
+// folded name is already lower case it is itself the reserved entry and the
+// message says so plainly; when the caller's case differs, the message must
+// also name the reserved column the identifier resolves onto, because that
+// lower-cased name — not the caller's spelling — is what an operator finds in
+// reservedParquetColumns (#532).
+func reservedParquetColumnError(name, col, key string) error {
+	if col == key {
+		return fmt.Errorf(
+			"attribute %q folds to parquet column %q, which is reserved for system columns; rename the attribute",
+			name, col)
+	}
+	return fmt.Errorf(
+		"attribute %q folds to parquet column %q, which DuckDB resolves case-insensitively onto the reserved system column %q; rename the attribute",
+		name, col, key)
+}
+
+// foldedColumnCollisionError explains an intra-schema collision. Two
+// attributes that fold to the same string share one parquet column and the
+// message says exactly that; two that differ only in case keep distinct
+// parquet columns — ParquetAttrColumn is byte-stable — and are merged only by
+// DuckDB's case-insensitive identifier matching, so the message names both
+// columns rather than claiming a single one that no parquet footer holds.
+func foldedColumnCollisionError(prevName, prevCol, name, col, key string) error {
+	if prevCol == col {
+		return fmt.Errorf(
+			"attributes %q and %q both map to parquet column %q; attribute names must remain distinct after identifier folding",
+			prevName, name, col)
+	}
+	return fmt.Errorf(
+		"attributes %q and %q map to parquet columns %q and %q, which DuckDB resolves case-insensitively onto the same column %q; attribute names must remain distinct after identifier folding",
+		prevName, name, prevCol, col, key)
 }

--- a/internal/sqlgen/parquet_attr_column.go
+++ b/internal/sqlgen/parquet_attr_column.go
@@ -116,7 +116,9 @@ func ValidateUnregisteredParquetAttrColumn(attr, folded string) error {
 // ValidateParquetAttrColumns rejects attribute sets whose folded parquet
 // column names land on a reserved system column or collide with each other
 // (the fold is lossy: "contact.name" and "contact_name" both become
-// contact_name). Schema registration calls it so an unusable schema is
+// contact_name). DuckDB resolves unquoted identifiers case-insensitively, so
+// comparisons use lower-cased folded names while errors preserve the caller's
+// spelling. Schema registration calls it so an unusable schema is
 // rejected before it accepts hot-tier writes; the CDC writer and the
 // federated reader call it again as defense in depth. Plain operator
 // error, never forma.ErrInvalidInput. Attributes are checked in sorted
@@ -131,17 +133,18 @@ func ValidateParquetAttrColumns(cache forma.SchemaAttributeCache) error {
 	colToAttr := make(map[string]string, len(names))
 	for _, name := range names {
 		col := ParquetAttrColumn(name)
-		if _, ok := reservedParquetColumns[col]; ok {
+		key := strings.ToLower(col)
+		if _, ok := reservedParquetColumns[key]; ok {
 			return fmt.Errorf(
 				"attribute %q folds to parquet column %q, which is reserved for system columns; rename the attribute",
 				name, col)
 		}
-		if prev, ok := colToAttr[col]; ok {
+		if prev, ok := colToAttr[key]; ok {
 			return fmt.Errorf(
 				"attributes %q and %q both map to parquet column %q; attribute names must remain distinct after identifier folding",
 				prev, name, col)
 		}
-		colToAttr[col] = name
+		colToAttr[key] = name
 	}
 	return nil
 }

--- a/internal/sqlgen/parquet_attr_column_test.go
+++ b/internal/sqlgen/parquet_attr_column_test.go
@@ -1,6 +1,7 @@
 package sqlgen
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/lychee-technology/forma"
@@ -54,20 +55,30 @@ func TestValidateParquetAttrColumns_ReservedSystemColumn(t *testing.T) {
 // TestValidateParquetAttrColumns_CaseVariantReservedSystemColumn pins #532:
 // DuckDB resolves unquoted identifiers case-insensitively, so case variants
 // of system columns must be refused at registration before they can bind to a
-// system value on the federated read path.
+// system value on the federated read path. The last two inputs make the fold
+// and the case act together — "Row.ID" folds to "Row_ID" and only then
+// resolves onto row_id — so the parquet-column assertion carries weight
+// independently of the caller-spelling one.
 func TestValidateParquetAttrColumns_CaseVariantReservedSystemColumn(t *testing.T) {
 	for _, attr := range []string{
 		"Created_At",
 		"Row_ID",
 		"RN",
 		"Source_Tier_Priority",
+		"Row.ID",     // → Row_ID → row_id
+		"Created At", // → Created_At → created_at
 	} {
 		err := ValidateParquetAttrColumns(forma.SchemaAttributeCache{
 			attr: {AttributeID: 1, ValueType: forma.ValueTypeText},
 		})
 		require.Error(t, err, "attribute %q must be rejected", attr)
 		require.Contains(t, err.Error(), attr, "error must preserve the caller spelling")
-		require.Contains(t, err.Error(), ParquetAttrColumn(attr))
+		require.Contains(t, err.Error(), ParquetAttrColumn(attr), "error must name the parquet column")
+		// The resolved system column is what the operator greps for in
+		// reservedParquetColumns; without it a Created_At rejection is
+		// unexplainable (review F1 on PR #548).
+		require.Contains(t, err.Error(), strings.ToLower(ParquetAttrColumn(attr)),
+			"error must name the reserved column the fold resolves onto")
 		require.Contains(t, err.Error(), "reserved")
 	}
 }
@@ -86,7 +97,10 @@ func TestValidateParquetAttrColumns_AttrCollision(t *testing.T) {
 
 // TestValidateParquetAttrColumns_CaseVariantAttrCollision pins #532:
 // contact_name and Contact_Name resolve to the same DuckDB column even though
-// ParquetAttrColumn preserves their spelling.
+// ParquetAttrColumn preserves their spelling. The message must therefore name
+// both physical columns and the single column they resolve onto — claiming
+// one shared parquet column would contradict the naming contract this file
+// documents (review F1 on PR #548).
 func TestValidateParquetAttrColumns_CaseVariantAttrCollision(t *testing.T) {
 	err := ValidateParquetAttrColumns(forma.SchemaAttributeCache{
 		"contact_name": {AttributeID: 1, ValueType: forma.ValueTypeText},
@@ -95,6 +109,22 @@ func TestValidateParquetAttrColumns_CaseVariantAttrCollision(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "contact_name")
 	require.Contains(t, err.Error(), "Contact_Name")
+	require.Contains(t, err.Error(), "case-insensitively")
+}
+
+// TestValidateParquetAttrColumns_CaseVariantFoldedAttrCollision exercises the
+// fold and the case together on the collision half: "Contact.Name" folds to
+// "Contact_Name", a column distinct from "contact_name" in the parquet
+// footer, and only DuckDB's identifier matching merges the two.
+func TestValidateParquetAttrColumns_CaseVariantFoldedAttrCollision(t *testing.T) {
+	err := ValidateParquetAttrColumns(forma.SchemaAttributeCache{
+		"contact_name": {AttributeID: 1, ValueType: forma.ValueTypeText},
+		"Contact.Name": {AttributeID: 2, ValueType: forma.ValueTypeText},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Contact.Name", "error must preserve the caller spelling")
+	require.Contains(t, err.Error(), "Contact_Name", "error must name the parquet column of the folded attribute")
+	require.Contains(t, err.Error(), "contact_name")
 }
 
 func TestValidateParquetAttrColumns_ValidCachePasses(t *testing.T) {
@@ -104,5 +134,10 @@ func TestValidateParquetAttrColumns_ValidCachePasses(t *testing.T) {
 		"flag":                 {AttributeID: 3, ValueType: forma.ValueTypeText},
 		// camelCase does not fold onto snake_case system columns.
 		"createdAt": {AttributeID: 4, ValueType: forma.ValueTypeDateTime},
+		// Case normalization narrows nothing: a mixed-case name that neither
+		// hits the reserved set nor has a case-variant sibling still passes
+		// (review O5 on PR #548).
+		"Contact_Phone": {AttributeID: 5, ValueType: forma.ValueTypeText},
+		"Attr":          {AttributeID: 6, ValueType: forma.ValueTypeText},
 	}))
 }

--- a/internal/sqlgen/parquet_attr_column_test.go
+++ b/internal/sqlgen/parquet_attr_column_test.go
@@ -1,8 +1,12 @@
 package sqlgen
 
 import (
+	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
 
 	"github.com/lychee-technology/forma"
 	"github.com/stretchr/testify/require"
@@ -140,4 +144,76 @@ func TestValidateParquetAttrColumns_ValidCachePasses(t *testing.T) {
 		"Contact_Phone": {AttributeID: 5, ValueType: forma.ValueTypeText},
 		"Attr":          {AttributeID: 6, ValueType: forma.ValueTypeText},
 	}))
+}
+
+// TestValidateParquetAttrColumns_NonASCIICaseVariantsPass is the counterpart
+// to the ASCII rejection tests above: the case-insensitive comparison must
+// stop where DuckDB's does. Every pair here is two distinct DuckDB
+// identifiers, so merging them would report a collision that the engine
+// would not, and one such legacy schema fails registry construction for the
+// whole directory. "row_İd" is the reserved half of the same defect: Go maps
+// U+0130 onto "i", so a Unicode fold reads it as the reserved "row_id"
+// (review F1 on PR #548).
+func TestValidateParquetAttrColumns_NonASCIICaseVariantsPass(t *testing.T) {
+	require.NoError(t, ValidateParquetAttrColumns(forma.SchemaAttributeCache{
+		"Á":      {AttributeID: 1, ValueType: forma.ValueTypeText},
+		"á":      {AttributeID: 2, ValueType: forma.ValueTypeText},
+		"Ж":      {AttributeID: 3, ValueType: forma.ValueTypeText},
+		"ж":      {AttributeID: 4, ValueType: forma.ValueTypeText},
+		"cafÉ":   {AttributeID: 5, ValueType: forma.ValueTypeText},
+		"café":   {AttributeID: 6, ValueType: forma.ValueTypeText},
+		"row_İd": {AttributeID: 7, ValueType: forma.ValueTypeText},
+	}))
+
+	// The ASCII half still bites in the same cache: adding a case variant of
+	// an existing ASCII name is refused, so the pass above is the boundary
+	// being respected, not the guard being switched off.
+	require.Error(t, ValidateParquetAttrColumns(forma.SchemaAttributeCache{
+		"Á":            {AttributeID: 1, ValueType: forma.ValueTypeText},
+		"á":            {AttributeID: 2, ValueType: forma.ValueTypeText},
+		"contact_name": {AttributeID: 3, ValueType: forma.ValueTypeText},
+		"Contact_Name": {AttributeID: 4, ValueType: forma.ValueTypeText},
+	}))
+}
+
+// TestDuckDBIdentifierFoldIsASCIIOnly pins duckdbFoldIdentifier against the
+// engine instead of against DuckDB's documentation. Two attribute names
+// share a parquet column exactly when DuckDB refuses to create a table
+// holding both as quoted columns, so that refusal is the oracle: the guard
+// must merge a pair if and only if DuckDB does. Every non-ASCII pair here is
+// one Go's strings.ToLower merges, which is what makes it the wrong
+// primitive (#532, review F1 on PR #548).
+func TestDuckDBIdentifierFoldIsASCIIOnly(t *testing.T) {
+	db, err := sql.Open("duckdb", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	pairs := []struct {
+		a, b string
+		same bool // DuckDB resolves both onto one identifier
+	}{
+		{a: "col_A", b: "col_a", same: true},
+		{a: "Contact_Name", b: "contact_name", same: true},
+		{a: "Row_ID", b: "row_id", same: true},
+		{a: "Á", b: "á", same: false},
+		{a: "Ж", b: "ж", same: false},
+		{a: "ẞ", b: "ß", same: false},
+		{a: "cafÉ", b: "café", same: false},
+		{a: "K", b: "k", same: false}, // U+212A KELVIN SIGN
+		{a: "row_İd", b: "row_id", same: false},
+	}
+
+	for i, p := range pairs {
+		_, err := db.Exec(fmt.Sprintf(`CREATE TABLE t%d ("%s" INT, "%s" INT)`, i, p.a, p.b))
+		duckDBMerges := err != nil
+		if duckDBMerges {
+			require.Contains(t, err.Error(), "already exists",
+				"unexpected DDL failure for %q / %q", p.a, p.b)
+		}
+		require.Equal(t, p.same, duckDBMerges,
+			"DuckDB identifier folding changed for %q / %q; the guard's premise must be rechecked", p.a, p.b)
+		require.Equal(t, duckDBMerges,
+			duckdbFoldIdentifier(p.a) == duckdbFoldIdentifier(p.b),
+			"duckdbFoldIdentifier disagrees with DuckDB on %q / %q", p.a, p.b)
+	}
 }

--- a/internal/sqlgen/parquet_attr_column_test.go
+++ b/internal/sqlgen/parquet_attr_column_test.go
@@ -51,6 +51,27 @@ func TestValidateParquetAttrColumns_ReservedSystemColumn(t *testing.T) {
 	}
 }
 
+// TestValidateParquetAttrColumns_CaseVariantReservedSystemColumn pins #532:
+// DuckDB resolves unquoted identifiers case-insensitively, so case variants
+// of system columns must be refused at registration before they can bind to a
+// system value on the federated read path.
+func TestValidateParquetAttrColumns_CaseVariantReservedSystemColumn(t *testing.T) {
+	for _, attr := range []string{
+		"Created_At",
+		"Row_ID",
+		"RN",
+		"Source_Tier_Priority",
+	} {
+		err := ValidateParquetAttrColumns(forma.SchemaAttributeCache{
+			attr: {AttributeID: 1, ValueType: forma.ValueTypeText},
+		})
+		require.Error(t, err, "attribute %q must be rejected", attr)
+		require.Contains(t, err.Error(), attr, "error must preserve the caller spelling")
+		require.Contains(t, err.Error(), ParquetAttrColumn(attr))
+		require.Contains(t, err.Error(), "reserved")
+	}
+}
+
 // TestValidateParquetAttrColumns_AttrCollision keeps the attr-vs-attr half
 // of the guard on the shared validator.
 func TestValidateParquetAttrColumns_AttrCollision(t *testing.T) {
@@ -61,6 +82,19 @@ func TestValidateParquetAttrColumns_AttrCollision(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "contact.name")
 	require.Contains(t, err.Error(), "contact_name")
+}
+
+// TestValidateParquetAttrColumns_CaseVariantAttrCollision pins #532:
+// contact_name and Contact_Name resolve to the same DuckDB column even though
+// ParquetAttrColumn preserves their spelling.
+func TestValidateParquetAttrColumns_CaseVariantAttrCollision(t *testing.T) {
+	err := ValidateParquetAttrColumns(forma.SchemaAttributeCache{
+		"contact_name": {AttributeID: 1, ValueType: forma.ValueTypeText},
+		"Contact_Name": {AttributeID: 2, ValueType: forma.ValueTypeText},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "contact_name")
+	require.Contains(t, err.Error(), "Contact_Name")
 }
 
 func TestValidateParquetAttrColumns_ValidCachePasses(t *testing.T) {


### PR DESCRIPTION
Closes #532.

## Summary

- Normalize folded parquet column names before reserved-system-column and intra-schema collision checks, using `duckdbFoldIdentifier` — an ASCII-only fold matching what DuckDB actually does, pinned against the engine by `TestDuckDBIdentifierFoldIsASCIIOnly`. Go's `strings.ToLower` is the wrong primitive: it merges `Á`/`á`, `Ж`/`ж`, `cafÉ`/`café` and U+212A/`k`, which DuckDB keeps distinct, and maps U+0130 onto `i`, reading the legitimate `row_İd` as the reserved `row_id`.
- Preserve caller spelling in every diagnostic and retain the byte-stable `ParquetAttrColumn` naming contract.
- Cover case-variant system names and aliases at both the validator and file-schema registration seams.
- Name the resolved lower-case column in both diagnostics, so a case-variant rejection is greppable against `reservedParquetColumns` and the collision message never claims a shared parquet column that the byte-stable fold does not produce.
- Record the registration guard's case-insensitivity, and its ASCII boundary, in `docs/federated-query/design.md` §4.4, which already states a premise ("registered names never reach it") that only this change makes true for case variants.

## Compatibility / release note

A schema using a case-variant reserved name, such as `Created_At`, is already broken: DuckDB resolves its unquoted identifier as the `created_at` system column. This change fails closed during registration, CDC export, and federated projection rather than allowing a silent wrong answer. No parquet column naming or persisted data changes.

Two properties of that fail-closed behavior are worth stating for operators, both pre-existing for exact-case names and only widened here:

- **A single offending schema fails the whole registry.** `validateSchemaAttributeCache` runs inside the per-schema load loop and every caller returns on first error, so one legacy schema carrying `Created_At` fails registry construction for the entire directory or registry table at startup, not just its own entity.
- **Retired ledger entries are in scope.** The validator deliberately runs over the full cache before retired entries are stripped (#342). A *retired* case-variant name produces no wrong answers today — no consumer ever sees it — yet it will now block boot, and "rename the attribute" is not an actionable remedy for a ledger record that exists to preserve a historical name. Tracked in #549.

## Scope

The same case-insensitivity premise backs two guards this PR does not change, both still folding with `strings.ToLower`: `ValidateUnregisteredParquetAttrColumn` (#512/#530) and `federated.validateKeysetCursor` (#381/#509). Both are runtime guards over caller-supplied strings, where being narrower than DuckDB refuses a query rather than failing registration, and both predate this PR. Tracked in #550.

## Verification

- `GOCACHE=$PWD/.gocache GOFLAGS=-buildvcs=false GOTOOLCHAIN=go1.26.0+auto go test ./internal/sqlgen ./internal/schemameta`
- `make fmt-check`
- `git diff --check`
- `make lint`
- `./scripts/test_with_container_runtime.sh` (complete `make test` suite using rootless Podman) — re-run green after the ASCII-fold commit

The red-to-green regression evidence and full verification record are posted on #532.

