### PR TITLE
refactor(sqlgen): single-source the dedup columns and attr placeholder (#531)

### DIFF
--- a/internal/federated/keyset.go
+++ b/internal/federated/keyset.go
@@ -73,10 +73,15 @@ var keysetSystemColumns = map[string]struct{}{
 // caught by mistake: schema registration rejects an attribute whose fold
 // collides with a reserved parquet column, and rn and source_tier_priority are
 // both in that reserved set (sqlgen.ValidateParquetAttrColumns).
-var keysetRejectedColumns = map[string]struct{}{
-	"rn":                   {},
-	"source_tier_priority": {},
-}
+//
+// The set is DERIVED from sqlgen, not redeclared here (#531). The same columns
+// are refused on the filter path by
+// sqlgen.ValidateUnregisteredParquetAttrColumn, and layering forbids the
+// reverse import, so sqlgen owns the definition and a column added there
+// reaches this guard too. The map below is this package's own copy:
+// FederatedDedupColumns hands out a fresh one per call, so neither package can
+// edit the other's guard.
+var keysetRejectedColumns = sqlgen.FederatedDedupColumns()
 
 // safeSQLIdentifier matches a bare, unquoted DuckDB identifier. Cursor
 // attributes are interpolated into SQL as identifiers, not bound as
@@ -86,15 +91,6 @@ var keysetRejectedColumns = map[string]struct{}{
 // attribute like "contact.annualIncome" passes, while a quote, semicolon,
 // parenthesis or leading digit does not.
 var safeSQLIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
-
-// parquetAttrFallbackColumn is the placeholder column name ParquetAttrColumn
-// substitutes when the fold empties an attribute name. It is a legitimate
-// attribute name in its own right, so the cursor rule can only reject a name
-// that FOLDS ONTO it — a folded "attr" whose raw attribute was something else,
-// whether the fold emptied the name (the empty string, "[]", a bare pair of
-// backticks) or merely stripped it down to the literal placeholder, as
-// "[attr]" and a backtick-wrapped attr do.
-const parquetAttrFallbackColumn = "attr"
 
 // validateKeysetCursor is THE keyset cursor contract, and the only validation
 // entry point. Both seams call it — the engine gate (engine.go) and the
@@ -151,14 +147,18 @@ func validateKeysetCursor(cursor *model.KeysetCursor, orders []model.AttributeOr
 		// name the code generator emits, so a rule applied to the raw name
 		// guards a string that never reaches SQL.
 		folded := sqlgen.ParquetAttrColumn(col.Attribute)
-		if strings.EqualFold(folded, parquetAttrFallbackColumn) && !strings.EqualFold(col.Attribute, parquetAttrFallbackColumn) {
-			// The literal "attr" is ParquetAttrColumn's placeholder: it
-			// substitutes it whenever the fold empties the name — "", "[]",
+		if strings.EqualFold(folded, sqlgen.ParquetAttrPlaceholder) &&
+			!strings.EqualFold(col.Attribute, sqlgen.ParquetAttrPlaceholder) {
+			// sqlgen.ParquetAttrPlaceholder is the column ParquetAttrColumn
+			// substitutes whenever the fold empties the name — "", "[]",
 			// "``" — and a name like "[attr]" or "`attr`" strips down onto it
-			// directly. That placeholder exists for the export writer, which
-			// needs some column name for every attribute; here either route
-			// would silently retarget the cursor at a real attribute called
-			// "attr".
+			// directly. It is read from sqlgen rather than restated here so
+			// the guard cannot outlive the literal it guards (#531); it is
+			// also a legitimate attribute name in its own right, which is why
+			// the rule can only reject a name that FOLDS ONTO it. That
+			// placeholder exists for the export writer, which needs some
+			// column name for every attribute; here either route would
+			// silently retarget the cursor at a real attribute called "attr".
 			//
 			// Both comparisons are case-insensitive, for the same reason the
 			// two map lookups below are: DuckDB resolves unquoted identifiers

--- a/internal/federated/keyset_test.go
+++ b/internal/federated/keyset_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lychee-technology/forma"
 	"github.com/lychee-technology/forma/internal/model"
+	"github.com/lychee-technology/forma/internal/sqlgen"
 	"github.com/stretchr/testify/require"
 )
 
@@ -306,4 +307,56 @@ func TestPaginatedQueryTakesKeysetPathOnCursorAlone(t *testing.T) {
 	require.Contains(t, err.Error(), `expected "row_id"`)
 	require.Zero(t, pg.runOptimizedCalls,
 		"the keyset path runs, not the in-memory merge path which calls RunOptimizedQuery")
+}
+
+// TestKeysetCursorRejectsEverySqlgenDedupColumn is the cross-package drift
+// guard from #531. The dedup-machinery set is defined once, in sqlgen, and
+// enforced twice: on the filter path by
+// sqlgen.ValidateUnregisteredParquetAttrColumn and on the cursor path by
+// validateKeysetCursor. This test drives the cursor path from the sqlgen set
+// itself rather than from a literal list, so a column added there that this
+// guard does not refuse — or a local set reintroduced here and left behind —
+// fails CI instead of reopening the #354 silent-wrong-answer class on
+// whichever path was missed.
+//
+// Every column is exercised under the spellings the fold and DuckDB's
+// case-insensitive resolution reach it by, so the guard is pinned as a rule
+// about the folded, lower-cased name rather than about a bare literal.
+func TestKeysetCursorRejectsEverySqlgenDedupColumn(t *testing.T) {
+	dedup := sqlgen.FederatedDedupColumns()
+	require.NotEmpty(t, dedup, "sqlgen must define the dedup column set this guard enforces")
+
+	for col := range dedup {
+		spellings := []string{col, strings.ToUpper(col), "[" + col + "]", "[" + strings.ToUpper(col) + "]"}
+		if i := strings.Index(col, "_"); i >= 0 {
+			spellings = append(spellings, col[:i]+"."+col[i+1:], col[:i]+" "+col[i+1:])
+		}
+		for _, spelling := range spellings {
+			err := validateKeysetCursor(keysetCursorOn(spelling, "row_id"), nil)
+			require.Error(t, err, "cursor column %q folds onto dedup column %q and must be refused", spelling, col)
+			require.Contains(t, err.Error(), "dedup machinery",
+				"cursor column %q must be refused as dedup machinery, not by some other rule", spelling)
+			require.Contains(t, err.Error(), spelling, "the error must keep the caller's spelling")
+		}
+	}
+}
+
+// TestKeysetCursorPlaceholderTracksSqlgen pins the other half of #531: the
+// placeholder rule reads sqlgen.ParquetAttrPlaceholder instead of restating
+// "attr", so changing the placeholder in ParquetAttrColumn cannot leave this
+// guard enforcing the old string. Driven from the const, not from a literal.
+func TestKeysetCursorPlaceholderTracksSqlgen(t *testing.T) {
+	placeholder := sqlgen.ParquetAttrPlaceholder
+	require.Equal(t, placeholder, sqlgen.ParquetAttrColumn(""),
+		"the placeholder must be what the fold actually substitutes")
+
+	// A name the fold TRANSFORMS onto the placeholder is refused; the
+	// placeholder under its own name is a legitimate attribute and is not.
+	err := validateKeysetCursor(keysetCursorOn("["+placeholder+"]", "row_id"), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "folds onto the placeholder")
+	require.Contains(t, err.Error(), placeholder)
+
+	require.NoError(t, validateKeysetCursor(keysetCursorOn(placeholder, "row_id"), nil))
+	require.NoError(t, validateKeysetCursor(keysetCursorOn(strings.ToUpper(placeholder), "row_id"), nil))
 }

--- a/internal/sqlgen/parquet_attr_column.go
+++ b/internal/sqlgen/parquet_attr_column.go
@@ -26,7 +26,7 @@ var parquetAttrReplacer = strings.NewReplacer("`", "", ".", "_", " ", "_", "[", 
 func ParquetAttrColumn(attr string) string {
 	col := parquetAttrReplacer.Replace(attr)
 	if col == "" {
-		return "attr"
+		return ParquetAttrPlaceholder
 	}
 	return col
 }
@@ -61,19 +61,38 @@ var reservedParquetColumns = map[string]struct{}{
 	"ltbase_deleted_at":    {},
 }
 
-// parquetAttrPlaceholder is the column ParquetAttrColumn substitutes when the
+// ParquetAttrPlaceholder is the column ParquetAttrColumn substitutes when the
 // fold empties a name ("", "[]", a lone backtick); a name like "[attr]"
-// strips down onto it directly.
-const parquetAttrPlaceholder = "attr"
+// strips down onto it directly. ParquetAttrColumn itself returns it rather
+// than a bare literal, and it is exported because internal/federated's cursor
+// guard enforces the same placeholder rule: one definition of the string, not
+// one per package (#531). A const, so a consumer cannot reassign it.
+const ParquetAttrPlaceholder = "attr"
 
 // federatedDedupColumns are the visible-CTE columns that are dedup machinery,
 // not data: a filter on either binds successfully and compares against the
 // dedup rank, so it fails silently-wrong rather than loudly. Refused under
-// any spelling, identity fold included (the keyset counterpart is
-// federated.keysetRejectedColumns).
+// any spelling, identity fold included.
+//
+// This is the single definition of the set. internal/federated applies the
+// same rule to keyset cursors and derives its own set from
+// FederatedDedupColumns rather than redeclaring one, so a column added here
+// reaches both guards (#531).
 var federatedDedupColumns = map[string]struct{}{
 	"rn":                   {},
 	"source_tier_priority": {},
+}
+
+// FederatedDedupColumns returns the dedup-machinery column set, lower-cased
+// the way both guards look it up. The map is a fresh copy on every call: the
+// set is package state that decides whether a query is refused, so handing out
+// the live map would let any importer edit the guard rather than read it.
+func FederatedDedupColumns() map[string]struct{} {
+	cols := make(map[string]struct{}, len(federatedDedupColumns))
+	for col := range federatedDedupColumns {
+		cols[col] = struct{}{}
+	}
+	return cols
 }
 
 // ValidateUnregisteredParquetAttrColumn guards a filter attribute the schema
@@ -101,7 +120,7 @@ var federatedDedupColumns = map[string]struct{}{
 // is tracked separately in #550 rather than changed here; see
 // duckdbFoldIdentifier.
 func ValidateUnregisteredParquetAttrColumn(attr, folded string) error {
-	if strings.EqualFold(folded, parquetAttrPlaceholder) && !strings.EqualFold(attr, parquetAttrPlaceholder) {
+	if strings.EqualFold(folded, ParquetAttrPlaceholder) && !strings.EqualFold(attr, ParquetAttrPlaceholder) {
 		return forma.InvalidInputf(
 			"filter attribute %q is not registered and folds onto the placeholder column %q, which would silently filter on a real attribute of that name: filter on a registered schema attribute",
 			attr, folded)

--- a/internal/sqlgen/parquet_attr_column.go
+++ b/internal/sqlgen/parquet_attr_column.go
@@ -83,10 +83,14 @@ var federatedDedupColumns = map[string]struct{}{
 	"source_tier_priority": {},
 }
 
-// FederatedDedupColumns returns the dedup-machinery column set, lower-cased
-// the way both guards look it up. The map is a fresh copy on every call: the
-// set is package state that decides whether a query is refused, so handing out
-// the live map would let any importer edit the guard rather than read it.
+// FederatedDedupColumns returns the dedup-machinery column set. Its entries
+// are stored lower-cased, matching the keys both guards look up: each folds
+// the caller's name and lower-cases the result before the map lookup, because
+// DuckDB resolves unquoted identifiers case-insensitively.
+//
+// The map is a fresh copy on every call: the set is package state that decides
+// whether a query is refused, so handing out the live map would let any
+// importer edit the guard rather than read it.
 func FederatedDedupColumns() map[string]struct{} {
 	cols := make(map[string]struct{}, len(federatedDedupColumns))
 	for col := range federatedDedupColumns {

--- a/internal/sqlgen/parquet_attr_column_test.go
+++ b/internal/sqlgen/parquet_attr_column_test.go
@@ -217,3 +217,36 @@ func TestDuckDBIdentifierFoldIsASCIIOnly(t *testing.T) {
 			"duckdbFoldIdentifier disagrees with DuckDB on %q / %q", p.a, p.b)
 	}
 }
+
+// TestParquetAttrColumnUsesPlaceholderConst pins that the empty-name fallback
+// and the exported placeholder are the same string by construction (#531).
+// ParquetAttrColumn used to return a bare "attr" literal beside a const of the
+// same value, so a change to one silently left the other behind. The literal
+// assertion stays: the value is a byte-stable contract with parquet files
+// already flushed to S3, so it is pinned as a value, not only as an identity.
+func TestParquetAttrColumnUsesPlaceholderConst(t *testing.T) {
+	require.Equal(t, "attr", ParquetAttrPlaceholder)
+	for _, empty := range []string{"", "[]", "`", "``", "[`]"} {
+		require.Equal(t, ParquetAttrPlaceholder, ParquetAttrColumn(empty),
+			"ParquetAttrColumn(%q) must fall back to the placeholder", empty)
+	}
+}
+
+// TestFederatedDedupColumnsIsACopy pins the accessor internal/federated derives
+// its keyset reject set from (#531). The set decides whether a query is
+// refused, so the accessor must hand out a copy: a caller that edits what it
+// gets back must not be able to edit the guard, in either direction.
+func TestFederatedDedupColumnsIsACopy(t *testing.T) {
+	want := map[string]struct{}{"rn": {}, "source_tier_priority": {}}
+	require.Equal(t, want, FederatedDedupColumns())
+
+	tampered := FederatedDedupColumns()
+	delete(tampered, "rn")
+	tampered["contact_name"] = struct{}{}
+
+	require.Equal(t, want, FederatedDedupColumns(), "the accessor must not return the live map")
+	require.Error(t, ValidateUnregisteredParquetAttrColumn("rn", ParquetAttrColumn("rn")),
+		"deleting from a returned copy must not unblock a dedup column")
+	require.NoError(t, ValidateUnregisteredParquetAttrColumn("contact_name", ParquetAttrColumn("contact_name")),
+		"adding to a returned copy must not block an ordinary attribute")
+}


### PR DESCRIPTION
Closes #531.

## Problem

Two definitions existed twice, once per package, with nothing keeping them equal:

| `internal/sqlgen/parquet_attr_column.go` | `internal/federated/keyset.go` |
| --- | --- |
| `federatedDedupColumns` (`rn`, `source_tier_priority`) | `keysetRejectedColumns` (same two) |
| `parquetAttrPlaceholder = "attr"` | `parquetAttrFallbackColumn = "attr"` |

`sqlgen.ValidateUnregisteredParquetAttrColumn` (filters, #512) and
`federated.validateKeysetCursor` (cursors, #509) apply the same fold rule to
them. Both sites commented their counterpart, but a column added to the dedup
machinery could be taught to one guard and silently left out of the other,
reopening the #354 silent-wrong-answer class on whichever path was missed.

## Change

`sqlgen` owns both definitions — the only direction layering allows, since
`federated` imports `sqlgen` and not the reverse.

- `parquetAttrPlaceholder` becomes the exported const `ParquetAttrPlaceholder`,
  and `ParquetAttrColumn` returns it instead of the bare `"attr"` literal (the
  issue's "also worth considering" item).
- `federatedDedupColumns` stays unexported behind
  `FederatedDedupColumns() map[string]struct{}`, which returns a fresh copy per
  call. This is the one deviation from the issue's sketch: an exported map
  *variable* would trade the drift hazard for an aliasing one, since any
  importer could edit a set that decides whether a query is refused.
- `federated` derives `keysetRejectedColumns` from that accessor and compares
  against `sqlgen.ParquetAttrPlaceholder`, deleting both local declarations.

No behaviour change. The two sets are identical today, and the lookup rules are
preserved exactly on both paths: fold, then `strings.ToLower` for the map
lookups; case-insensitive comparison for the placeholder. The
`strings.ToLower`-vs-DuckDB narrowness in both guards is untouched and stays
tracked in #550.

## Tests

- `internal/sqlgen`: `FederatedDedupColumns()` returns a copy — mutating what it
  hands back changes neither a later call nor what the filter guard refuses; and
  `ParquetAttrColumn`'s empty-name fallback is the placeholder const. The literal
  `"attr"` is still asserted separately, because that value is a byte-stable
  contract with parquet already flushed to S3.
- `internal/federated`: `TestKeysetCursorRejectsEverySqlgenDedupColumn` drives
  the cursor guard from `sqlgen.FederatedDedupColumns()` rather than from a
  literal list, under every spelling the fold and DuckDB's case-insensitive
  resolution reach a column by. `TestKeysetCursorPlaceholderTracksSqlgen` does
  the same for the placeholder rule.

The drift guard was verified to bite rather than merely pass: with a third
column added to the sqlgen set **and** `federated` regressed to a hardcoded
local set (the pre-PR shape), the new test fails with

```
cursor column "tier_rank" folds onto dedup column "tier_rank" and must be refused
```

Both changes were then reverted; the committed tree is the wired version.

All pre-existing cursor and filter tests pass unchanged, which is the
no-behaviour-change evidence.

## Gates

`make fmt-check`, `make lint`, and the full unit suite via
`./scripts/test_with_container_runtime.sh` — all green. Both touched source
files stay well under the 500-line limit (244 and 274).
