### PR TITLE
fix: enforce value/column fidelity on the write path and refuse non-round-trippable bindings (#459)

### DIFF
--- a/cmd/server/schemas/log_attributes.json
+++ b/cmd/server/schemas/log_attributes.json
@@ -21,7 +21,7 @@
   "leadId": {
     "attributeID": 4,
     "valueType": "text",
-    "column_binding": {"col_name":"uuid_02"}
+    "column_binding": {"col_name":"text_02"}
   },
   "noteId": {
     "attributeID": 5,
@@ -56,6 +56,6 @@
   "visitId": {
     "attributeID": 10,
     "valueType": "text",
-    "column_binding": {"col_name":"uuid_01"}
+    "column_binding": {"col_name":"text_03"}
   }
 }

--- a/cmd/tools/README.md
+++ b/cmd/tools/README.md
@@ -10,6 +10,12 @@ Forma Tools CLI
 - `manifest-reconcile`：比对 S3 parquet 对象与 manifest 条目，报告孤儿/dangling，
   `--repair` 补录 #197 flush 孤儿，`--gc` 清理 #188 compaction 遗留。
   详见 `docs/manifest-reconcile.md`。退出码：0 一致 / 2 有差异 / 1 失败。
+- `validate-schema-consistency`：升级前校验 schema 元数据与 EAV 存储的一致性，
+  使用与服务端相同的元数据加载路径。检查项包括：
+  - 重复的 `attributeID` / `column_binding.col_name`；
+  - `valueType`↔column-encoding 绑定无法 round-trip 的情况（#459）；
+  - `eav_data` 中未知的 `attr_id`、存储列错位、list 属性下残留的标量行。
+  详见 `docs/schema-consistency-migration.md`。
 
 generate-attributes
 -------------------

--- a/cmd/tools/validate_schema_consistency.go
+++ b/cmd/tools/validate_schema_consistency.go
@@ -113,7 +113,9 @@ func runValidateSchemaConsistencyOut(ctx context.Context, args []string, out io.
 }
 
 func (v schemaConsistencyValidator) run(ctx context.Context) error {
-	loader := schemameta.NewMetadataLoader(v.pool, v.schemaTable, v.schemaDir)
+	// Deferred so checkColumnBindings can list every mismatch across the
+	// deployed set instead of the loader stopping at the first (#459).
+	loader := schemameta.NewMetadataLoader(v.pool, v.schemaTable, v.schemaDir).DeferColumnBindingCheck()
 	cache, err := loader.LoadMetadata(ctx)
 	if err != nil {
 		return fmt.Errorf("load schema metadata: %w", err)
@@ -171,6 +173,8 @@ func (v schemaConsistencyValidator) report(failures, notices []validationIssue, 
 
 func (v schemaConsistencyValidator) collectIssues(ctx context.Context, cache *schemameta.MetadataCache) ([]validationIssue, error) {
 	var issues []validationIssue
+
+	issues = append(issues, v.checkColumnBindings(cache)...)
 
 	unknownIssues, err := v.checkUnknownAttributeIDs(ctx, cache)
 	if err != nil {

--- a/cmd/tools/validate_schema_consistency_bindings.go
+++ b/cmd/tools/validate_schema_consistency_bindings.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/lychee-technology/forma/internal/schemameta"
+)
+
+// checkColumnBindings reports every active binding whose valueType cannot
+// round-trip through its main column (#459). Registration refuses such a
+// binding for new schemas, but a schema deployed before that guard still
+// carries it — and with it a write path that answers a redacted 500 (text→
+// uuid column) or silently drops the value (text→numeric column). The tool
+// loads through DeferColumnBindingCheck so the whole set is listed at once.
+func (v schemaConsistencyValidator) checkColumnBindings(cache *schemameta.MetadataCache) []validationIssue {
+	var issues []validationIssue
+	for _, schemaName := range cache.ListSchemas() {
+		schemaCache, ok := cache.GetSchemaCache(schemaName)
+		if !ok {
+			continue
+		}
+		for attrName, meta := range schemaCache {
+			if err := schemameta.ValidateColumnBinding(attrName, meta); err != nil {
+				issues = append(issues, validationIssue{
+					category: "valueType/column-encoding binding mismatches",
+					details:  fmt.Sprintf("schema=%s %v", schemaName, err),
+				})
+			}
+		}
+	}
+	return issues
+}

--- a/cmd/tools/validate_schema_consistency_bindings_test.go
+++ b/cmd/tools/validate_schema_consistency_bindings_test.go
@@ -38,8 +38,11 @@ func TestValidateSchemaConsistencyReportsBindingMismatches(t *testing.T) {
 			t.Fatalf("missing %q in output:\n%s", want, got)
 		}
 	}
-	if strings.Contains(got, "name") {
+	if strings.Contains(got, "attribute name (") {
 		t.Fatalf("compatible binding must not be reported:\n%s", got)
+	}
+	if n := strings.Count(got, "- valueType/column-encoding binding mismatches:"); n != 2 {
+		t.Fatalf("expected exactly two binding mismatch lines, got %d:\n%s", n, got)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("EAV checks must still run: %v", err)

--- a/cmd/tools/validate_schema_consistency_bindings_test.go
+++ b/cmd/tools/validate_schema_consistency_bindings_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/pashagolub/pgxmock/v4"
+)
+
+// #459: registration guards only future schemas; a deployment already
+// carrying text→uuid_02 has the live 500/silent-drop shape today. The tool
+// lists every such binding across the deployed set as a failure, and still
+// runs the EAV checks (it loads through the deferred-binding loader).
+func TestValidateSchemaConsistencyReportsBindingMismatches(t *testing.T) {
+	schemaDir := t.TempDir()
+	writeSchemaConsistencyArtifacts(t, schemaDir, "contact",
+		`{"type":"object","properties":{"leadId":{"type":"string"},"rank":{"type":"integer"}}}`,
+		`{"leadId":{"attributeID":1,"valueType":"text","column_binding":{"col_name":"uuid_02"}},
+		  "rank":{"attributeID":2,"valueType":"bool","column_binding":{"col_name":"smallint_01"}},
+		  "name":{"attributeID":3,"valueType":"text","column_binding":{"col_name":"text_01"}}}`)
+	mock := newSchemaConsistencyMock(t, pgxmock.NewRows([]string{"schema_id", "attr_id", "record_count"}))
+
+	var out strings.Builder
+	validator := schemaConsistencyValidator{
+		pool: mock, schemaDir: schemaDir, schemaTable: "schema_registry_dev", eavTable: "eav_data_dev", out: &out,
+	}
+	err := validator.run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "failed with 2 issue(s)") {
+		t.Fatalf("expected two binding failures, got err=%v out=%q", err, out.String())
+	}
+	got := out.String()
+	for _, want := range []string{
+		"- valueType/column-encoding binding mismatches: schema=contact attribute leadId (valueType text) cannot round-trip through main column uuid_02",
+		"- valueType/column-encoding binding mismatches: schema=contact attribute rank (valueType bool) cannot round-trip through main column smallint_01",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in output:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "name") {
+		t.Fatalf("compatible binding must not be reported:\n%s", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("EAV checks must still run: %v", err)
+	}
+}

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -590,10 +590,16 @@ One rule, one funnel (`transform.populateTypedValue` → `checkStorageFit`):
 - EAV-only attribute: the destination is the declared `valueType`.
   `smallint`/`integer`/`bigint` must be integral and inside the type's
   range; `numeric` is unconstrained (#205 owns its float64 ceiling).
-- Column-bound attribute: the declared type **and** the column's own width.
+- Column-bound attribute: the declared type **and** the column's own width
+  (`double_*` is unconstrained; #205 owns the float64 ceiling, so
+  `bigint`→`double_01` rounds above 2^53 rather than refusing).
   `numeric`→`integer_01` refuses `1.5` and `3e9`; `integer`→`smallint_01`
   refuses `40000`. Before #459 these wrapped (`int16(40000) = -25536`) into
-  `entity_main`.
+  `entity_main`. The width check judges the slot the store actually writes:
+  a declared `bigint` carries an exact int64 sidecar and admits the full
+  int64 range, while a `numeric` value is stored from its float64 image, so
+  `numeric`→`bigint_01` refuses `9223372036854775807` (its image is 2^63,
+  which does not fit).
 - `text`→`uuid_*`: the value must parse as a UUID (published 4xx, not the
   redacted 500 `uuid.Parse` used to raise in `storeInMainColumn`).
 - A value whose typed slot does not match the column family is refused, never

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -582,6 +582,34 @@ already flushed does not re-enter the federated dirty set on a hand-delete, and
 DuckDB keeps serving the stale copy from `/delta/` or `/base/` while
 PostgreSQL-only reads see the value gone.
 
+## Value/column fidelity on the write path (#384, #459)
+
+One rule, one funnel (`transform.populateTypedValue` → `checkStorageFit`):
+**a value must fit its physical destination, else `forma.InvalidInputf`.**
+
+- EAV-only attribute: the destination is the declared `valueType`.
+  `smallint`/`integer`/`bigint` must be integral and inside the type's
+  range; `numeric` is unconstrained (#205 owns its float64 ceiling).
+- Column-bound attribute: the declared type **and** the column's own width.
+  `numeric`→`integer_01` refuses `1.5` and `3e9`; `integer`→`smallint_01`
+  refuses `40000`. Before #459 these wrapped (`int16(40000) = -25536`) into
+  `entity_main`.
+- `text`→`uuid_*`: the value must parse as a UUID (published 4xx, not the
+  redacted 500 `uuid.Parse` used to raise in `storeInMainColumn`).
+- A value whose typed slot does not match the column family is refused, never
+  dropped.
+
+The published message names the attribute, the value, the destination and
+the allowed range, e.g. `invalid value for attribute 'rank' (attrID=3): value
+40000 out of range for bound column smallint_01 (smallint) (allowed [-32768,
+32767])`.
+
+Registration (`schemameta.ValidateColumnBinding`) refuses a
+`valueType`↔column-encoding pair that cannot round-trip at all, so the runtime
+rule only ever sees width and UUID-shape questions on a well-formed schema;
+`validate-schema-consistency` lists such pairs across an already-deployed set
+(see `docs/schema-consistency-migration.md`).
+
 ## Read-path consistency errors
 
 Read operations return plain errors when persisted data and metadata disagree.

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -485,6 +485,17 @@ width is refused at write time as invalid input); `date`/`datetime`→bigint
 (`unix_ms` or default) or text (`iso8601`); `bool`→smallint (`bool_smallint`)
 or text (`bool_text`); `list` never binds.
 
+Some refused pairs do store and read back losslessly on the Postgres path:
+`uuid`→text, `bool`→smallint/integer/bigint/double with the default encoding,
+and `date`/`datetime`→double with the default encoding. They are refused as a
+matter of policy, not because stored data is at risk: the filter rendering
+and the DuckDB projection key on the declared type and the encoding, so a
+`bool` with the default encoding is compared as text `'1'`/`'0'` and a `uuid`
+attribute is projected from a UUID-typed column. If a deployment carries one
+of these shapes, no row is corrupted; rebind with the explicit encoding
+(`bool_smallint`, `bool_text`, `unix_ms`) or to the column family the
+valueType names, and migrate the existing column values with SQL as above.
+
 ### Scalar rows under list attributes (`#372`)
 
 Example validator output:

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -459,7 +459,25 @@ before deploying:
   and admissible value already has that shape.
 
 Existing rows in the old column are not moved by either change; migrate them
-with SQL first if they must survive.
+with SQL first if they must survive. For the shipped `log` schema, which #459
+rebound `leadId` from `uuid_02` to `text_02` and `visitId` from `uuid_01` to
+`text_03`:
+
+```sql
+-- shipped `log` schema: leadId uuid_02 -> text_02, visitId uuid_01 -> text_03
+UPDATE entity_main
+   SET text_02 = uuid_02::text
+ WHERE ltbase_schema_id = <log schema id> AND uuid_02 IS NOT NULL;
+UPDATE entity_main
+   SET text_03 = uuid_01::text
+ WHERE ltbase_schema_id = <log schema id> AND uuid_01 IS NOT NULL;
+-- NULL the old columns once the new binding is live
+```
+
+Parquet tiers (delta/base) are keyed by attribute name, not by main column, so
+they need no rewrite. The shipped `cmd/server/schemas/log_attributes.json`
+itself was rebound in #459; a deployment still carrying the old copy must apply
+this migration before upgrading, or the server refuses to load the schema.
 
 Admitted pairs: `text`→text; `uuid`→uuid; `smallint`/`integer`/`bigint`/`numeric`
 → smallint/integer/bigint/double (a value that does not fit the column's

--- a/docs/schema-consistency-migration.md
+++ b/docs/schema-consistency-migration.md
@@ -119,6 +119,10 @@ It validates:
 - every referenced `<schema>_attributes.json` parses successfully
 - each schema’s metadata has unique `attributeID` values
 - each schema’s metadata has unique `column_binding.col_name` values
+- every active `column_binding` can round-trip its `valueType` through the
+  bound column and encoding (`#459`) — e.g. `text`→`uuid_02` or `bool` with
+  the default encoding are refused; the server refuses to start on the same
+  shapes, so run this before deploying a build carrying the guard
 - `eav_data.attr_id` values all map to known metadata IDs for the same
   `schema_id` — ids belonging to a `retired` ledger entry (`#342`) are reported
   as informational rather than as failures, because those rows are the `#294`
@@ -435,6 +439,33 @@ Example validator output:
 This means the row uses the wrong physical value column for the declared `valueType`.
 
 Fix by rewriting the bad rows into the correct column and clearing the wrong one.
+
+### valueType/column-encoding binding mismatches (`#459`)
+
+Example validator output:
+
+```text
+- valueType/column-encoding binding mismatches: schema=log attribute leadId (valueType text) cannot round-trip through main column uuid_02 (uuid column, encoding default): text binds only to text columns (default encoding)
+```
+
+The attribute's `valueType` and its `column_binding` disagree about the
+physical encoding. Before the guard, such a write answered a redacted 500
+(text into a uuid column) or silently dropped the value (text into a numeric
+column). The server now refuses to load the schema; fix the attributes file
+before deploying:
+
+- rebind the attribute to a column of the right family (e.g. `text_02`), or
+- change `valueType` to what the column stores (e.g. `uuid`) if every stored
+  and admissible value already has that shape.
+
+Existing rows in the old column are not moved by either change; migrate them
+with SQL first if they must survive.
+
+Admitted pairs: `text`→text; `uuid`→uuid; `smallint`/`integer`/`bigint`/`numeric`
+→ smallint/integer/bigint/double (a value that does not fit the column's
+width is refused at write time as invalid input); `date`/`datetime`→bigint
+(`unix_ms` or default) or text (`iso8601`); `bool`→smallint (`bool_smallint`)
+or text (`bool_text`); `list` never binds.
 
 ### Scalar rows under list attributes (`#372`)
 

--- a/internal/entity_write_fidelity_test.go
+++ b/internal/entity_write_fidelity_test.go
@@ -1,0 +1,136 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/schemavalidate"
+	"github.com/lychee-technology/forma/internal/transform"
+	"github.com/stretchr/testify/require"
+)
+
+// fidelityRegistry mirrors numericValidationRegistry but binds attributes to
+// main columns so the #459 storage-fit rule has something to check. count and
+// rank are declared one width wider than their column (bigint->integer_01,
+// integer->smallint_01): a registrable narrowing where the declared-type check
+// passes and only the bound-column check stands between the value and a
+// wrapped row. The leadId text->uuid_02 binding deliberately bypasses
+// schemameta registration (which now refuses it): this is the already-deployed
+// shape the runtime rule must still refuse with a published 4xx, not a 500.
+type fidelityRegistry struct{}
+
+const fidelitySchemaJSON = `{
+  "type": "object",
+  "properties": {
+    "name":   {"type": "string"},
+    "count":  {"type": "integer"},
+    "rank":   {"type": "integer"},
+    "leadId": {"type": "string", "pattern": "^[a-zA-Z0-9_-]+$"}
+  },
+  "required": ["name"]
+}`
+
+func (fidelityRegistry) GetSchemaAttributeCacheByName(name string) (int16, forma.SchemaAttributeCache, error) {
+	if name != "test" {
+		return 0, nil, fmt.Errorf("schema %s not found", name)
+	}
+	return 100, forma.SchemaAttributeCache{
+		"name": {AttributeID: 1, ValueType: forma.ValueTypeText},
+		"count": {AttributeID: 2, ValueType: forma.ValueTypeBigInt,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnInteger01}},
+		"rank": {AttributeID: 3, ValueType: forma.ValueTypeInteger,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnSmallint01}},
+		"leadId": {AttributeID: 4, ValueType: forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnUUID02}},
+	}, nil
+}
+
+func (r fidelityRegistry) GetSchemaAttributeCacheByID(int16) (string, forma.SchemaAttributeCache, error) {
+	_, cache, err := r.GetSchemaAttributeCacheByName("test")
+	return "test", cache, err
+}
+
+func (fidelityRegistry) ListSchemas() []string { return []string{"test"} }
+
+func (fidelityRegistry) GetSchemaByName(string) (int16, forma.JSONSchema, error) {
+	return 100, forma.JSONSchema{ID: 100, Name: "test", Schema: fidelitySchemaJSON}, nil
+}
+
+func (fidelityRegistry) GetSchemaByID(int16) (string, forma.JSONSchema, error) {
+	return "test", forma.JSONSchema{ID: 100, Name: "test", Schema: fidelitySchemaJSON}, nil
+}
+
+// newFidelityManager builds a report-only (strict=false) manager so the update
+// cases prove the storage-fit rule, not JSON Schema validation, is what refuses.
+func newFidelityManager(t *testing.T) (forma.EntityManager, *mockPersistentRecordRepository) {
+	t.Helper()
+	registry := fidelityRegistry{}
+
+	validator, err := schemavalidate.New(registry, t.TempDir())
+	require.NoError(t, err)
+
+	config := createTestConfig()
+	config.Entity.ValidateUpdatesStrict = false
+
+	transformer := transform.NewPersistentRecordTransformer(registry)
+	repo := newMockPersistentRecordRepository()
+	manager := mustNewEntityManager(t, transformer, repo, nil, registry, config, validator)
+	return manager, repo
+}
+
+// requirePublishedInvalidInput asserts the error is a published (not
+// redacted) invalid-input carrier whose public message names the cause.
+func requirePublishedInvalidInput(t *testing.T, err error, want string) {
+	t.Helper()
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	msg, ok := forma.ResolvePublicMessage(err)
+	require.True(t, ok, "must publish, not redact: %v", err)
+	require.Contains(t, msg, want)
+}
+
+// TestEntityManager_WriteFidelity is #459 at the manager seam: the three
+// corruption shapes (integer wrap, smallint wrap, text into a uuid column) are
+// published invalid input on create AND update. Update validation is
+// report-only by default, so the storage-fit rule in transform, not JSON
+// Schema, is what refuses them there.
+func TestEntityManager_WriteFidelity(t *testing.T) {
+	ctx := context.Background()
+	em, repo := newFidelityManager(t)
+	created, err := em.Create(ctx, createOp(map[string]any{"name": "a", "count": 1, "rank": 1}))
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		data map[string]any
+		want string
+	}{
+		{"integer main column wraps no more",
+			map[string]any{"name": "a", "count": float64(3e9)},
+			"bound column integer_01 (integer)"},
+		{"smallint main column wraps no more",
+			map[string]any{"name": "a", "rank": 40000},
+			"bound column smallint_01 (smallint)"},
+		{"text to uuid column is 4xx not 500",
+			map[string]any{"name": "a", "leadId": "abc"},
+			`text value "abc" is not a UUID`},
+	}
+	for _, tc := range cases {
+		t.Run("create/"+tc.name, func(t *testing.T) {
+			_, err := em.Create(ctx, createOp(tc.data))
+			requirePublishedInvalidInput(t, err, tc.want)
+		})
+		t.Run("update/"+tc.name, func(t *testing.T) {
+			_, err := em.Update(ctx, updateOp(created.RowID, tc.data))
+			requirePublishedInvalidInput(t, err, tc.want)
+		})
+	}
+
+	// Nothing wrapped or mismatched reached storage.
+	stored := repo.records[100][created.RowID]
+	require.NotNil(t, stored)
+	require.Equal(t, int32(1), stored.Int32Items["integer_01"])
+	require.Equal(t, int16(1), stored.Int16Items["smallint_01"])
+	require.NotContains(t, stored.UUIDItems, "uuid_02")
+}

--- a/internal/postgres_persistent_repository_test.go
+++ b/internal/postgres_persistent_repository_test.go
@@ -131,6 +131,7 @@ func TestBuildHybridConditionsBoundAuditColumn(t *testing.T) {
 	require.NoError(t, cache.RegisterSchema("log", 1, forma.SchemaAttributeCache{
 		"createdBy": {
 			AttributeName: "createdBy",
+			ValueType:     forma.ValueTypeText,
 			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnCreatedBy},
 		},
 	}))

--- a/internal/schemameta/binding_compat.go
+++ b/internal/schemameta/binding_compat.go
@@ -1,0 +1,103 @@
+package schemameta
+
+import (
+	"fmt"
+
+	"github.com/lychee-technology/forma"
+)
+
+// ValidateColumnBinding reports whether an attribute's valueType can
+// round-trip through its main-column binding (#459). A binding outside the
+// matrix below used to surface only at write time — as a redacted 500
+// (text→uuid column: uuid.Parse failure) or a silent drop (text→smallint:
+// empty numeric slot) — so registration refuses it up front, and
+// validate-schema-consistency reports it across an already-deployed set.
+//
+//	valueType                        column type                         encoding
+//	text                             text                                default
+//	uuid                             uuid                                default
+//	smallint/integer/bigint/numeric  smallint, integer, bigint, double   default (width enforced at write)
+//	date/datetime                    bigint                              default or unix_ms
+//	date/datetime                    text                                iso8601
+//	bool                             smallint                            bool_smallint
+//	bool                             text                                bool_text
+//	list                             —                                   never bindable
+//
+// Width narrowing inside the numeric family is deliberately admitted:
+// numeric→smallint is a shipped shape, and transform.checkStorageFit rejects
+// any value that does not fit the column. System columns (ltbase_*) go through
+// the same matrix via ColumnType(). A nil binding is always valid.
+func ValidateColumnBinding(attrName string, meta forma.AttributeMetadata) error {
+	binding := meta.ColumnBinding
+	if binding == nil {
+		return nil
+	}
+	encoding := binding.Encoding
+	if encoding == "" {
+		encoding = forma.MainColumnEncodingDefault
+	}
+	colType := binding.ColumnType()
+	if bindingRoundTrips(meta.ValueType, colType, encoding) {
+		return nil
+	}
+	return fmt.Errorf(
+		"attribute %s (valueType %s) cannot round-trip through main column %s (%s column, encoding %s): %s",
+		attrName, meta.ValueType, binding.ColumnName, colType, encoding, bindableColumnsFor(meta.ValueType, encoding))
+}
+
+func bindingRoundTrips(vt forma.ValueType, colType forma.MainColumnType, enc forma.MainColumnEncoding) bool {
+	isTime := vt == forma.ValueTypeDate || vt == forma.ValueTypeDateTime
+	switch enc {
+	case forma.MainColumnEncodingDefault:
+		switch vt {
+		case forma.ValueTypeText:
+			return colType == forma.MainColumnTypeText
+		case forma.ValueTypeUUID:
+			return colType == forma.MainColumnTypeUUID
+		case forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeNumeric:
+			switch colType {
+			case forma.MainColumnTypeSmallint, forma.MainColumnTypeInteger, forma.MainColumnTypeBigint, forma.MainColumnTypeDouble:
+				return true
+			}
+			return false
+		case forma.ValueTypeDate, forma.ValueTypeDateTime:
+			return colType == forma.MainColumnTypeBigint
+		}
+		return false
+	case forma.MainColumnEncodingUnixMs:
+		return isTime && colType == forma.MainColumnTypeBigint
+	case forma.MainColumnEncodingISO8601:
+		return isTime && colType == forma.MainColumnTypeText
+	case forma.MainColumnEncodingBoolInt:
+		return vt == forma.ValueTypeBool && colType == forma.MainColumnTypeSmallint
+	case forma.MainColumnEncodingBoolText:
+		return vt == forma.ValueTypeBool && colType == forma.MainColumnTypeText
+	}
+	return false
+}
+
+// bindableColumnsFor names the expected state for the error: what this
+// valueType may bind to, or why it binds to nothing.
+func bindableColumnsFor(vt forma.ValueType, enc forma.MainColumnEncoding) string {
+	switch enc {
+	case forma.MainColumnEncodingDefault, forma.MainColumnEncodingUnixMs, forma.MainColumnEncodingISO8601,
+		forma.MainColumnEncodingBoolInt, forma.MainColumnEncodingBoolText:
+	default:
+		return fmt.Sprintf("unknown encoding %q; use default, unix_ms, iso8601, bool_smallint or bool_text", enc)
+	}
+	switch vt {
+	case forma.ValueTypeText:
+		return "text binds only to text columns (default encoding)"
+	case forma.ValueTypeUUID:
+		return "uuid binds only to uuid columns (default encoding)"
+	case forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeNumeric:
+		return string(vt) + " binds only to smallint, integer, bigint or double columns (default encoding; values must fit the column width)"
+	case forma.ValueTypeDate, forma.ValueTypeDateTime:
+		return string(vt) + " binds only to bigint columns (default or unix_ms encoding) or text columns (iso8601 encoding)"
+	case forma.ValueTypeBool:
+		return "bool binds only to smallint columns (bool_smallint encoding) or text columns (bool_text encoding)"
+	case forma.ValueTypeList:
+		return "list attributes store one element per eav_data row and have no scalar column form"
+	}
+	return fmt.Sprintf("unknown valueType %q has no main column form", vt)
+}

--- a/internal/schemameta/binding_compat.go
+++ b/internal/schemameta/binding_compat.go
@@ -27,6 +27,10 @@ import (
 // numeric→smallint is a shipped shape, and transform.checkStorageFit rejects
 // any value that does not fit the column. System columns (ltbase_*) go through
 // the same matrix via ColumnType(). A nil binding is always valid.
+//
+// The write path, the Postgres read path and the CDC export round-trip every
+// admitted pair. For date/datetime → text (iso8601) the DuckDB hot-leg
+// projection is unverified; see #555.
 func ValidateColumnBinding(attrName string, meta forma.AttributeMetadata) error {
 	binding := meta.ColumnBinding
 	if binding == nil {

--- a/internal/schemameta/binding_compat_test.go
+++ b/internal/schemameta/binding_compat_test.go
@@ -1,0 +1,112 @@
+package schemameta
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma"
+)
+
+func bindingMeta(vt forma.ValueType, col forma.MainColumn, enc forma.MainColumnEncoding) forma.AttributeMetadata {
+	return forma.AttributeMetadata{AttributeID: 1, ValueType: vt,
+		ColumnBinding: &forma.MainColumnBinding{ColumnName: col, Encoding: enc}}
+}
+
+// #459: the registration matrix admits exactly the (valueType, column type,
+// encoding) triples every storage surface round-trips.
+func TestValidateColumnBinding_Matrix(t *testing.T) {
+	d, u, i, b, bt := forma.MainColumnEncodingDefault, forma.MainColumnEncodingUnixMs,
+		forma.MainColumnEncodingISO8601, forma.MainColumnEncodingBoolInt, forma.MainColumnEncodingBoolText
+	ok := []forma.AttributeMetadata{
+		bindingMeta(forma.ValueTypeText, forma.MainColumnText01, d),
+		bindingMeta(forma.ValueTypeText, forma.MainColumnText01, ""), // empty encoding == default
+		bindingMeta(forma.ValueTypeUUID, forma.MainColumnUUID01, d),
+		bindingMeta(forma.ValueTypeSmallInt, forma.MainColumnSmallint01, d),
+		bindingMeta(forma.ValueTypeInteger, forma.MainColumnInteger01, d),
+		bindingMeta(forma.ValueTypeBigInt, forma.MainColumnBigint01, d),
+		bindingMeta(forma.ValueTypeNumeric, forma.MainColumnDouble01, d),
+		bindingMeta(forma.ValueTypeNumeric, forma.MainColumnSmallint01, d), // width enforced at write
+		bindingMeta(forma.ValueTypeBigInt, forma.MainColumnInteger01, d),   // width enforced at write
+		bindingMeta(forma.ValueTypeDate, forma.MainColumnBigint01, u),
+		bindingMeta(forma.ValueTypeDate, forma.MainColumnBigint01, d),
+		bindingMeta(forma.ValueTypeDateTime, forma.MainColumnText01, i),
+		bindingMeta(forma.ValueTypeBool, forma.MainColumnSmallint01, b),
+		bindingMeta(forma.ValueTypeBool, forma.MainColumnText01, bt),
+		bindingMeta(forma.ValueTypeDate, forma.MainColumnCreatedAt, u),
+		bindingMeta(forma.ValueTypeUUID, forma.MainColumnRowID, d),
+		{AttributeID: 1, ValueType: forma.ValueTypeText}, // unbound
+	}
+	for _, m := range ok {
+		assert.NoError(t, ValidateColumnBinding("a", m), "%+v", *bindingOrZero(m))
+	}
+	bad := []struct {
+		meta forma.AttributeMetadata
+		want string
+	}{
+		{bindingMeta(forma.ValueTypeText, forma.MainColumnUUID02, d), "cannot round-trip through main column uuid_02"},
+		{bindingMeta(forma.ValueTypeText, forma.MainColumnSmallint01, d), "cannot round-trip through main column smallint_01"},
+		{bindingMeta(forma.ValueTypeUUID, forma.MainColumnText01, d), "uuid columns"},
+		{bindingMeta(forma.ValueTypeNumeric, forma.MainColumnText01, d), "smallint, integer, bigint or double columns"},
+		{bindingMeta(forma.ValueTypeDate, forma.MainColumnText01, d), "iso8601"},
+		{bindingMeta(forma.ValueTypeDate, forma.MainColumnBigint01, i), "bigint columns"},
+		{bindingMeta(forma.ValueTypeBool, forma.MainColumnSmallint01, d), "bool_smallint"},
+		{bindingMeta(forma.ValueTypeBool, forma.MainColumnText01, b), "bool_text"},
+		{bindingMeta(forma.ValueTypeList, forma.MainColumnText01, d), "list"},
+		{bindingMeta(forma.ValueTypeText, forma.MainColumnText01, "base64"), "unknown encoding"},
+		{bindingMeta(forma.ValueType("money"), forma.MainColumnDouble01, d), "unknown valueType"},
+		{bindingMeta(forma.ValueTypeText, forma.MainColumnRowID, d), "cannot round-trip through main column ltbase_row_id"},
+	}
+	for _, tc := range bad {
+		err := ValidateColumnBinding("leadId", tc.meta)
+		require.Error(t, err, "%+v", *tc.meta.ColumnBinding)
+		assert.Contains(t, err.Error(), "attribute leadId (valueType "+string(tc.meta.ValueType)+")")
+		assert.Contains(t, err.Error(), tc.want)
+	}
+}
+
+func bindingOrZero(m forma.AttributeMetadata) *forma.MainColumnBinding {
+	if m.ColumnBinding == nil {
+		return &forma.MainColumnBinding{}
+	}
+	return m.ColumnBinding
+}
+
+func TestValidateSchemaAttributeCache_RejectsIncompatibleBinding(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"leadId": {AttributeName: "leadId", AttributeID: 4, ValueType: forma.ValueTypeText,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnUUID02}},
+	}
+	err := validateSchemaAttributeCache("log", cache)
+	require.Error(t, err)
+	for _, want := range []string{"schema log", "leadId", "text", "uuid_02"} {
+		assert.Contains(t, err.Error(), want)
+	}
+}
+
+// Retired entries are an attributeID/column ledger, never a write
+// destination, so their binding is not judged (#342).
+func TestValidateSchemaAttributeCache_RetiredBindingNotJudged(t *testing.T) {
+	cache := forma.SchemaAttributeCache{
+		"old": {AttributeName: "old", AttributeID: 4, ValueType: forma.ValueTypeText, Retired: true,
+			ColumnBinding: &forma.MainColumnBinding{ColumnName: forma.MainColumnUUID02}},
+	}
+	require.NoError(t, validateSchemaAttributeCache("log", cache))
+}
+
+func TestDirectoryRegistry_RejectsIncompatibleBinding(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONFile(t, filepath.Join(dir, "log.json"), map[string]any{
+		"type": "object", "properties": map[string]any{"leadId": map[string]any{"type": "string"}},
+	})
+	writeJSONFile(t, filepath.Join(dir, "log_attributes.json"), map[string]any{
+		"leadId": map[string]any{"attributeID": float64(4), "valueType": "text",
+			"column_binding": map[string]any{"col_name": "uuid_02"}},
+	})
+	_, err := NewFileSchemaRegistryFromDirectory(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "log_attributes.json")
+	assert.Contains(t, err.Error(), "uuid_02")
+}

--- a/internal/schemameta/binding_compat_test.go
+++ b/internal/schemameta/binding_compat_test.go
@@ -16,7 +16,9 @@ func bindingMeta(vt forma.ValueType, col forma.MainColumn, enc forma.MainColumnE
 }
 
 // #459: the registration matrix admits exactly the (valueType, column type,
-// encoding) triples every storage surface round-trips.
+// encoding) triples the write path, the Postgres read path and the CDC export
+// round-trip. The DuckDB hot-leg projection of date/datetime → text (iso8601)
+// is unverified; see #555.
 func TestValidateColumnBinding_Matrix(t *testing.T) {
 	d, u, i, b, bt := forma.MainColumnEncodingDefault, forma.MainColumnEncodingUnixMs,
 		forma.MainColumnEncodingISO8601, forma.MainColumnEncodingBoolInt, forma.MainColumnEncodingBoolText

--- a/internal/schemameta/loader.go
+++ b/internal/schemameta/loader.go
@@ -238,6 +238,10 @@ type MetadataLoader struct {
 	pool            DBPool
 	schemaTableName string
 	schemaDirectory string
+	// deferBindingCheck skips ValidateColumnBinding during load so a caller
+	// that reports mismatches itself (validate-schema-consistency) can see
+	// every one instead of the first. Runtime loads never set it.
+	deferBindingCheck bool
 }
 
 // NewMetadataLoader creates a new metadata loader
@@ -247,6 +251,14 @@ func NewMetadataLoader(pool DBPool, schemaTableName, schemaDirectory string) *Me
 		schemaTableName: schemaTableName,
 		schemaDirectory: schemaDirectory,
 	}
+}
+
+// DeferColumnBindingCheck makes LoadMetadata admit bindings that cannot
+// round-trip (#459) so the caller can report all of them; it returns the
+// receiver for chaining. Only validate-schema-consistency should use it.
+func (ml *MetadataLoader) DeferColumnBindingCheck() *MetadataLoader {
+	ml.deferBindingCheck = true
+	return ml
 }
 
 // LoadMetadata loads all metadata and returns a cache
@@ -357,7 +369,7 @@ func (ml *MetadataLoader) loadAttributeMetadataFromFiles(cache *MetadataCache) e
 			schemaCache[attrName] = meta
 		}
 		// Validate the FULL cache before stripping — see activeAttributeCache (#342).
-		if err := validateSchemaAttributeCache(schemaName, schemaCache); err != nil {
+		if err := validateSchemaAttributeCacheOpts(schemaName, schemaCache, !ml.deferBindingCheck); err != nil {
 			return fmt.Errorf("attributes file %s: %w", attributesFile, err)
 		}
 		active := activeAttributeCache(schemaCache)

--- a/internal/schemameta/loader_test.go
+++ b/internal/schemameta/loader_test.go
@@ -465,3 +465,34 @@ func TestSchemaFingerprintTracksContent(t *testing.T) {
 	_, ok = mcA.SchemaFingerprint(42)
 	require.False(t, ok)
 }
+
+// #459: the runtime loader refuses a binding that cannot round-trip; the
+// validation tool defers that check so it can list every mismatch itself.
+func TestLoadMetadata_IncompatibleBindingRejectedUnlessDeferred(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	writeJSONFile(t, filepath.Join(dir, "log_attributes.json"), map[string]any{
+		"leadId": map[string]any{"attributeID": float64(4), "valueType": "text",
+			"column_binding": map[string]any{"col_name": "uuid_02"}},
+	})
+
+	strict, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer strict.Close()
+	strict.ExpectQuery(regexp.QuoteMeta(`SELECT schema_name, schema_id FROM ` + sanitizeIdentifier("reg"))).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_name", "schema_id"}).AddRow("log", int16(7)))
+	_, err = NewMetadataLoader(strict, "reg", dir).LoadMetadata(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uuid_02")
+
+	lenient, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer lenient.Close()
+	lenient.ExpectQuery(regexp.QuoteMeta(`SELECT schema_name, schema_id FROM ` + sanitizeIdentifier("reg"))).
+		WillReturnRows(pgxmock.NewRows([]string{"schema_name", "schema_id"}).AddRow("log", int16(7)))
+	cache, err := NewMetadataLoader(lenient, "reg", dir).DeferColumnBindingCheck().LoadMetadata(ctx)
+	require.NoError(t, err)
+	schemaCache, ok := cache.GetSchemaCache("log")
+	require.True(t, ok)
+	assert.Contains(t, schemaCache, "leadId")
+}

--- a/internal/schemameta/validation.go
+++ b/internal/schemameta/validation.go
@@ -23,11 +23,20 @@ func parseAttributeID(raw any, attrName, source string) (int16, error) {
 }
 
 // validateSchemaAttributeCache rejects attributeID, main-column, and folded
-// parquet-column collisions across the FULL cache, retired entries included.
-// Every error it returns begins with "schema <name>", so callers wrap it with
-// what it cannot know — the attributes file the metadata came from, or the
-// numeric schema id — never with the name again.
+// parquet-column collisions across the FULL cache, retired entries included,
+// and (#459) any active binding whose valueType cannot round-trip through its
+// column. Every error it returns begins with "schema <name>", so callers wrap
+// it with what it cannot know — the attributes file the metadata came from,
+// or the numeric schema id — never with the name again.
 func validateSchemaAttributeCache(schemaName string, cache forma.SchemaAttributeCache) error {
+	return validateSchemaAttributeCacheOpts(schemaName, cache, true)
+}
+
+// validateSchemaAttributeCacheOpts is the form validate-schema-consistency
+// loads through with checkBindings=false: it reports every binding mismatch
+// itself (via ValidateColumnBinding) instead of stopping at the first. Every
+// runtime load path passes true.
+func validateSchemaAttributeCacheOpts(schemaName string, cache forma.SchemaAttributeCache, checkBindings bool) error {
 	seenAttrIDs := make(map[int16]string, len(cache))
 	seenBindings := make(map[forma.MainColumn]string)
 	for attrName, meta := range cache {
@@ -43,6 +52,14 @@ func validateSchemaAttributeCache(schemaName string, cache forma.SchemaAttribute
 			return bindingCollisionError(schemaName, cache, meta.ColumnBinding.ColumnName, existingAttr, attrName)
 		}
 		seenBindings[meta.ColumnBinding.ColumnName] = attrName
+
+		// Retired entries are a ledger, never a write destination (#342).
+		if !checkBindings || meta.Retired {
+			continue
+		}
+		if err := ValidateColumnBinding(attrName, meta); err != nil {
+			return fmt.Errorf("schema %s: %w", schemaName, err)
+		}
 	}
 
 	// Reject attribute names whose folded parquet columns land on a CDC/read

--- a/internal/transform/persistent_record.go
+++ b/internal/transform/persistent_record.go
@@ -171,90 +171,119 @@ func (t *persistentRecordTransformer) storeInMainColumn(record *model.Persistent
 		return nil
 	}
 
-	columnName := string(binding.ColumnName)
+	// checkStorageFit enforces the funnel rule: the value must fit where it is
+	// physically going (#459); an empty slot here means a caller bypassed the
+	// funnel, and dropping the value silently would confirm to the client
+	// something that was never written.
+	stored, err := t.storeWithEncoding(record, attr, binding)
+	if err != nil {
+		return err
+	}
+	if !stored {
+		return fmt.Errorf("no value to store in main column %s: attr id %d of schema %d (row %s) has an empty %s slot",
+			binding.ColumnName, attr.AttrID, attr.SchemaID, attr.RowID, binding.ColumnType())
+	}
+	return nil
+}
 
+// storeWithEncoding dispatches on the binding's encoding, then on the column
+// type for the default encoding. It reports whether a value was written so
+// the caller can refuse an empty slot instead of dropping it (#459).
+func (t *persistentRecordTransformer) storeWithEncoding(record *model.PersistentRecord, attr model.EAVRecord, binding *forma.MainColumnBinding) (bool, error) {
+	columnName := string(binding.ColumnName)
 	switch binding.Encoding {
 	case forma.MainColumnEncodingUnixMs:
 		// Date stored as Unix milliseconds in bigint column
 		if attr.ValueInt64 != nil {
 			record.Int64Items[columnName] = *attr.ValueInt64
-		} else if attr.ValueNumeric != nil {
-			record.Int64Items[columnName] = int64(*attr.ValueNumeric)
+			return true, nil
 		}
-
+		if attr.ValueNumeric != nil {
+			record.Int64Items[columnName] = int64(*attr.ValueNumeric)
+			return true, nil
+		}
+		return false, nil
 	case forma.MainColumnEncodingBoolInt:
 		// Bool stored as smallint (1/0)
-		if attr.ValueNumeric != nil {
-			if float64ToBool(*attr.ValueNumeric) {
-				record.Int16Items[columnName] = 1
-			} else {
-				record.Int16Items[columnName] = 0
-			}
+		if attr.ValueNumeric == nil {
+			return false, nil
 		}
-
+		record.Int16Items[columnName] = 0
+		if float64ToBool(*attr.ValueNumeric) {
+			record.Int16Items[columnName] = 1
+		}
+		return true, nil
 	case forma.MainColumnEncodingBoolText:
 		// Bool stored as text ("1"/"0")
-		if attr.ValueNumeric != nil {
-			if float64ToBool(*attr.ValueNumeric) {
-				record.TextItems[columnName] = "1"
-			} else {
-				record.TextItems[columnName] = "0"
-			}
+		if attr.ValueNumeric == nil {
+			return false, nil
 		}
-
+		record.TextItems[columnName] = "0"
+		if float64ToBool(*attr.ValueNumeric) {
+			record.TextItems[columnName] = "1"
+		}
+		return true, nil
 	case forma.MainColumnEncodingISO8601:
 		// Date stored as ISO 8601 string in text column
-		if attr.ValueNumeric != nil {
-			record.TextItems[columnName] = unixMillisFloat64ToTimeUTC(*attr.ValueNumeric).Format(time.RFC3339)
+		if attr.ValueNumeric == nil {
+			return false, nil
 		}
-
-	case forma.MainColumnEncodingDefault:
-		fallthrough
+		record.TextItems[columnName] = unixMillisFloat64ToTimeUTC(*attr.ValueNumeric).Format(time.RFC3339)
+		return true, nil
 	default:
-		// Default encoding based on column type
-		switch binding.ColumnType() {
-		case forma.MainColumnTypeText:
-			if attr.ValueText != nil {
-				record.TextItems[columnName] = *attr.ValueText
-			}
-
-		case forma.MainColumnTypeSmallint:
-			if attr.ValueNumeric != nil {
-				record.Int16Items[columnName] = int16(*attr.ValueNumeric)
-			}
-
-		case forma.MainColumnTypeInteger:
-			if attr.ValueNumeric != nil {
-				record.Int32Items[columnName] = int32(*attr.ValueNumeric)
-			}
-
-		case forma.MainColumnTypeBigint:
-			if attr.ValueInt64 != nil {
-				record.Int64Items[columnName] = *attr.ValueInt64
-			} else if attr.ValueNumeric != nil {
-				record.Int64Items[columnName] = int64(*attr.ValueNumeric)
-			}
-
-		case forma.MainColumnTypeDouble:
-			if attr.ValueNumeric != nil {
-				record.Float64Items[columnName] = *attr.ValueNumeric
-			}
-		case forma.MainColumnTypeUUID:
-			if attr.ValueText != nil {
-				uuidValue, err := uuid.Parse(*attr.ValueText)
-				if err != nil {
-					return fmt.Errorf("failed to parse uuid: %w. schema id: %d, row id: %s, attr id: %d, array indices: %s, value: %s",
-						err, attr.SchemaID, attr.RowID, attr.AttrID, attr.ArrayIndices, *attr.ValueText)
-				}
-				record.UUIDItems[columnName] = uuidValue
-			}
-
-		default:
-			return fmt.Errorf("unsupported column type: %s", binding.ColumnType())
-		}
+		return t.storeWithDefaultEncoding(record, attr, binding)
 	}
+}
 
-	return nil
+// storeWithDefaultEncoding writes the slot the column type consumes. The
+// uuid branch cannot fail for a value that passed checkStorageFit; the
+// parse stays as an invariant check.
+func (t *persistentRecordTransformer) storeWithDefaultEncoding(record *model.PersistentRecord, attr model.EAVRecord, binding *forma.MainColumnBinding) (bool, error) {
+	columnName := string(binding.ColumnName)
+	switch binding.ColumnType() {
+	case forma.MainColumnTypeText:
+		if attr.ValueText == nil {
+			return false, nil
+		}
+		record.TextItems[columnName] = *attr.ValueText
+	case forma.MainColumnTypeSmallint:
+		if attr.ValueNumeric == nil {
+			return false, nil
+		}
+		record.Int16Items[columnName] = int16(*attr.ValueNumeric)
+	case forma.MainColumnTypeInteger:
+		if attr.ValueNumeric == nil {
+			return false, nil
+		}
+		record.Int32Items[columnName] = int32(*attr.ValueNumeric)
+	case forma.MainColumnTypeBigint:
+		if attr.ValueInt64 != nil {
+			record.Int64Items[columnName] = *attr.ValueInt64
+			return true, nil
+		}
+		if attr.ValueNumeric == nil {
+			return false, nil
+		}
+		record.Int64Items[columnName] = int64(*attr.ValueNumeric)
+	case forma.MainColumnTypeDouble:
+		if attr.ValueNumeric == nil {
+			return false, nil
+		}
+		record.Float64Items[columnName] = *attr.ValueNumeric
+	case forma.MainColumnTypeUUID:
+		if attr.ValueText == nil {
+			return false, nil
+		}
+		uuidValue, err := uuid.Parse(*attr.ValueText)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse uuid: %w. schema id: %d, row id: %s, attr id: %d, array indices: %s, value: %s",
+				err, attr.SchemaID, attr.RowID, attr.AttrID, attr.ArrayIndices, *attr.ValueText)
+		}
+		record.UUIDItems[columnName] = uuidValue
+	default:
+		return false, fmt.Errorf("unsupported column type: %s", binding.ColumnType())
+	}
+	return true, nil
 }
 
 // readFromMainColumn reads an attribute value from the main table columns.

--- a/internal/transform/persistent_record.go
+++ b/internal/transform/persistent_record.go
@@ -165,10 +165,9 @@ func (t *persistentRecordTransformer) FromPersistentRecord(ctx context.Context, 
 }
 
 func (t *persistentRecordTransformer) storeInMainColumn(record *model.PersistentRecord, attr model.EAVRecord, binding *forma.MainColumnBinding) error {
-	// Ignore system column bindings - system columns can only be set internally by code
-	switch binding.ColumnName {
-	case forma.MainColumnRowID, forma.MainColumnSchemaID,
-		forma.MainColumnCreatedAt, forma.MainColumnUpdatedAt, forma.MainColumnDeletedAt:
+	// System column bindings are read-only views: the record's own fields are
+	// the source of truth and are set internally by code.
+	if isSystemManagedColumn(binding.ColumnName) {
 		return nil
 	}
 
@@ -444,4 +443,17 @@ func (t *persistentRecordTransformer) readWithDefaultEncoding(record *model.Pers
 	}
 
 	return nil, false, nil
+}
+
+// isSystemManagedColumn reports the main columns the record owns itself
+// (row id, schema id, lifecycle timestamps). A binding to one of them is a
+// read-only alias — storeInMainColumn skips it, and so does checkStorageFit,
+// because the caller's value is never what gets written there.
+func isSystemManagedColumn(col forma.MainColumn) bool {
+	switch col {
+	case forma.MainColumnRowID, forma.MainColumnSchemaID,
+		forma.MainColumnCreatedAt, forma.MainColumnUpdatedAt, forma.MainColumnDeletedAt:
+		return true
+	}
+	return false
 }

--- a/internal/transform/persistent_record_test.go
+++ b/internal/transform/persistent_record_test.go
@@ -333,3 +333,24 @@ func TestPersistentRecordTransformer_InjectsBaseTimestamps(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, updated, updatedAt.UnixMilli())
 }
+
+// #459 shape 1 end to end: an out-of-range value for a narrow bound column
+// is refused by ToPersistentRecord as published invalid input and never
+// reaches Int32Items wrapped.
+func TestPersistentRecordTransformer_RejectsOutOfRangeBoundColumn(t *testing.T) {
+	ctx := context.Background()
+	registry := newPersistentTransformerRegistry()
+	transformer := NewPersistentRecordTransformer(registry)
+	schemaID, _, err := registry.GetSchemaAttributeCacheByName("persistent_test")
+	require.NoError(t, err)
+
+	_, err = transformer.ToPersistentRecord(ctx, schemaID, uuid.Must(uuid.NewV7()), map[string]any{
+		"name": "Tester",
+		"age":  float64(3e9),
+	})
+	require.ErrorIs(t, err, forma.ErrInvalidInput)
+	msg, ok := forma.ResolvePublicMessage(err)
+	require.True(t, ok)
+	assert.Contains(t, msg, "attribute 'age'")
+	assert.Contains(t, msg, "bound column integer_01 (integer)")
+}

--- a/internal/transform/storage_fit.go
+++ b/internal/transform/storage_fit.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"fmt"
 	"math"
+	"strconv"
 
 	"github.com/google/uuid"
 
@@ -21,9 +22,9 @@ import (
 // The declared-type check runs first even for bound attributes: the column
 // may be wider than the declared type (smallint declared, integer column),
 // and the declared type is what every DuckDB tier projects by (#384).
-func checkStorageFit(attr *model.EAVRecord, raw any, meta forma.AttributeMetadata) error {
+func checkStorageFit(attr *model.EAVRecord, meta forma.AttributeMetadata) error {
 	if isNumericFamily(meta.ValueType) && attr.ValueNumeric != nil {
-		if err := checkIntegerFit(raw, *attr.ValueNumeric, meta.ValueType, "declared type "+string(meta.ValueType)); err != nil {
+		if err := checkIntegerFit(attr, meta.ValueType, "declared type "+string(meta.ValueType)); err != nil {
 			return err
 		}
 	}
@@ -31,7 +32,7 @@ func checkStorageFit(attr *model.EAVRecord, raw any, meta forma.AttributeMetadat
 	if binding == nil || isSystemManagedColumn(binding.ColumnName) {
 		return nil
 	}
-	return checkBoundColumnFit(attr, raw, meta.ValueType, binding)
+	return checkBoundColumnFit(attr, meta.ValueType, binding)
 }
 
 // checkBoundColumnFit mirrors storeInMainColumn's dispatch: the same
@@ -44,7 +45,7 @@ func checkStorageFit(attr *model.EAVRecord, raw any, meta forma.AttributeMetadat
 // storeWithDefaultEncoding's int16()/int32() narrowing wraps (#459). The
 // registration matrix refuses date→integer, but the funnel must not depend on
 // registration: a deployed or programmatic registry can supply the binding.
-func checkBoundColumnFit(attr *model.EAVRecord, raw any, vt forma.ValueType, binding *forma.MainColumnBinding) error {
+func checkBoundColumnFit(attr *model.EAVRecord, vt forma.ValueType, binding *forma.MainColumnBinding) error {
 	col := binding.ColumnName
 	colType := binding.ColumnType()
 	switch binding.Encoding {
@@ -65,7 +66,7 @@ func checkBoundColumnFit(attr *model.EAVRecord, raw any, vt forma.ValueType, bin
 		}
 	}
 	if fitType, ok := columnFitType(colType); ok {
-		return checkIntegerFit(raw, *attr.ValueNumeric, fitType, fmt.Sprintf("bound column %s (%s)", col, colType))
+		return checkIntegerFit(attr, fitType, fmt.Sprintf("bound column %s (%s)", col, colType))
 	}
 	return nil
 }
@@ -127,13 +128,24 @@ func columnFitType(colType forma.MainColumnType) (forma.ValueType, bool) {
 	return "", false
 }
 
-// checkIntegerFit rejects a numeric-family value that cannot fit the integer
-// width vt names. dest labels the destination in the message ("declared type
-// integer", "bound column smallint_01 (smallint)"). eav_data.value_numeric is
-// an unconstrained NUMERIC and Go's int16()/int32() conversions wrap, so this
-// funnel is the only place the width can be enforced (#384, #459). numeric
-// stays unconstrained (#205 owns its float64 ceiling).
-func checkIntegerFit(raw any, numVal float64, vt forma.ValueType, dest string) error {
+// checkIntegerFit rejects a value in the numeric slot that cannot fit the
+// integer width vt names. dest labels the destination in the message
+// ("declared type integer", "bound column smallint_01 (smallint)").
+// eav_data.value_numeric is an unconstrained NUMERIC and Go's int16()/int32()
+// conversions wrap, so this funnel is the only place the width can be
+// enforced (#384, #459). numeric stays unconstrained (#205 owns its float64
+// ceiling). The caller guarantees attr.ValueNumeric is non-nil.
+//
+// The check judges the slot the store consumes, not the caller's raw value:
+// storeWithDefaultEncoding's bigint arm and the unix_ms arm write the exact
+// ValueInt64 sidecar when it is populated and int64(*ValueNumeric) otherwise,
+// and populateTypedValue fills the sidecar for declared bigint and
+// date/datetime only. A numeric-declared 9223372036854775807 is therefore
+// stored from its float64 image (2^63, which int64() wraps), so the image is
+// what must fit; deriving an exact int64 from the raw value here would admit
+// it (#459 review F1).
+func checkIntegerFit(attr *model.EAVRecord, vt forma.ValueType, dest string) error {
+	numVal := *attr.ValueNumeric
 	var lo, hi float64
 	switch vt {
 	case forma.ValueTypeSmallInt:
@@ -141,10 +153,11 @@ func checkIntegerFit(raw any, numVal float64, vt forma.ValueType, dest string) e
 	case forma.ValueTypeInteger:
 		lo, hi = math.MinInt32, math.MaxInt32
 	case forma.ValueTypeBigInt:
-		// An exactly-representable int64 fits by construction; this also
-		// admits boundary literals like "9223372036854775807" whose float64
-		// image rounds up to 2^63 and would fail the bound check below.
-		if _, ok := toInt64ExactForEAV(raw); ok {
+		// The exact sidecar is an int64 and fits by construction; it is also
+		// how a declared bigint admits boundary literals like
+		// "9223372036854775807", whose float64 image rounds up to 2^63 and
+		// would fail the bound check below.
+		if attr.ValueInt64 != nil {
 			return nil
 		}
 		// Constant conversion: math.MinInt64 converts to exactly -2^63
@@ -154,7 +167,7 @@ func checkIntegerFit(raw any, numVal float64, vt forma.ValueType, dest string) e
 			return errNonIntegralFor(numVal, dest)
 		}
 		if numVal < math.MinInt64 || numVal >= math.MaxInt64 {
-			return fmt.Errorf("value %v out of range for %s (allowed [-9223372036854775808, 9223372036854775807])", numVal, dest)
+			return fmt.Errorf("value %s out of range for %s (allowed [-9223372036854775808, 9223372036854775807])", formatFitValue(numVal), dest)
 		}
 		return nil
 	default:
@@ -164,11 +177,27 @@ func checkIntegerFit(raw any, numVal float64, vt forma.ValueType, dest string) e
 		return errNonIntegralFor(numVal, dest)
 	}
 	if numVal < lo || numVal > hi {
-		return fmt.Errorf("value %v out of range for %s (allowed [%.0f, %.0f])", numVal, dest, lo, hi)
+		return fmt.Errorf("value %s out of range for %s (allowed [%.0f, %.0f])", formatFitValue(numVal), dest, lo, hi)
 	}
 	return nil
 }
 
 func errNonIntegralFor(numVal float64, dest string) error {
-	return fmt.Errorf("non-integral value %v does not fit %s (whole number required)", numVal, dest)
+	return fmt.Errorf("non-integral value %s does not fit %s (whole number required)", formatFitValue(numVal), dest)
+}
+
+// formatFitValue renders the rejected value in plain digits for the
+// magnitudes an integer column can be asked to hold (epoch millis print as
+// 1704067200000, not 1.7040672e+12). An integral value prints exactly, so a
+// caller who sent 9223372036854775807 sees the 9223372036854775808 its
+// float64 image became. Beyond 1e21 the shortest round-trip form keeps 1e300
+// from becoming 301 digits.
+func formatFitValue(numVal float64) string {
+	if math.Abs(numVal) >= 1e21 {
+		return strconv.FormatFloat(numVal, 'g', -1, 64)
+	}
+	if numVal == math.Trunc(numVal) {
+		return strconv.FormatFloat(numVal, 'f', 0, 64)
+	}
+	return strconv.FormatFloat(numVal, 'f', -1, 64)
 }

--- a/internal/transform/storage_fit.go
+++ b/internal/transform/storage_fit.go
@@ -1,0 +1,160 @@
+package transform
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/google/uuid"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+// checkStorageFit is the single write-side fidelity rule shared by #384 and
+// #459: a value must fit its physical destination — the bound main column
+// when the attribute has one, its declared type otherwise. populateTypedValue
+// has already typed the value for the declared valueType; this decides
+// whether that typed value can be stored losslessly where it is going.
+// Every error returned here is wrapped into forma.InvalidInputf by the
+// caller: it describes the caller's value, so it is published.
+//
+// The declared-type check runs first even for bound attributes: the column
+// may be wider than the declared type (smallint declared, integer column),
+// and the declared type is what every DuckDB tier projects by (#384).
+func checkStorageFit(attr *model.EAVRecord, raw any, meta forma.AttributeMetadata) error {
+	if isNumericFamily(meta.ValueType) && attr.ValueNumeric != nil {
+		if err := checkIntegerFit(raw, *attr.ValueNumeric, meta.ValueType, "declared type "+string(meta.ValueType)); err != nil {
+			return err
+		}
+	}
+	binding := meta.ColumnBinding
+	if binding == nil || isSystemManagedColumn(binding.ColumnName) {
+		return nil
+	}
+	return checkBoundColumnFit(attr, raw, meta.ValueType, binding)
+}
+
+// checkBoundColumnFit mirrors storeInMainColumn's dispatch: the same
+// (encoding, column type) decides which EAVRecord slot is serialized, so the
+// slot must be populated, and a narrow integer column caps the value at the
+// column's width no matter how wide the declared type is (#459).
+func checkBoundColumnFit(attr *model.EAVRecord, raw any, vt forma.ValueType, binding *forma.MainColumnBinding) error {
+	col := binding.ColumnName
+	switch binding.Encoding {
+	case forma.MainColumnEncodingUnixMs, forma.MainColumnEncodingBoolInt,
+		forma.MainColumnEncodingBoolText, forma.MainColumnEncodingISO8601:
+		// These encodings serialize the numeric slot (epoch millis or 0/1).
+		if attr.ValueNumeric == nil {
+			return errSlotMismatch(vt, col, "a date, datetime or bool value")
+		}
+		return nil
+	}
+
+	colType := binding.ColumnType()
+	switch colType {
+	case forma.MainColumnTypeText:
+		if attr.ValueText == nil {
+			return errSlotMismatch(vt, col, "a text value")
+		}
+	case forma.MainColumnTypeUUID:
+		if attr.ValueText == nil {
+			return errSlotMismatch(vt, col, "a UUID value")
+		}
+		if _, err := uuid.Parse(*attr.ValueText); err != nil {
+			return fmt.Errorf("%s value %q is not a UUID: bound column %s requires one", vt, *attr.ValueText, col)
+		}
+	case forma.MainColumnTypeSmallint, forma.MainColumnTypeInteger, forma.MainColumnTypeBigint:
+		if attr.ValueNumeric == nil {
+			return errSlotMismatch(vt, col, "a numeric value")
+		}
+		// Epoch millis (date/datetime) and 0/1 (bool) always fit; only the
+		// numeric family carries caller-chosen magnitude.
+		if !isNumericFamily(vt) {
+			return nil
+		}
+		fitType, _ := columnFitType(colType)
+		return checkIntegerFit(raw, *attr.ValueNumeric, fitType, fmt.Sprintf("bound column %s (%s)", col, colType))
+	case forma.MainColumnTypeDouble:
+		if attr.ValueNumeric == nil {
+			return errSlotMismatch(vt, col, "a numeric value")
+		}
+	default:
+		return fmt.Errorf("attribute bound to column %s of unsupported type %s", col, colType)
+	}
+	return nil
+}
+
+func errSlotMismatch(vt forma.ValueType, col forma.MainColumn, expects string) error {
+	return fmt.Errorf("%s value cannot be stored in main column %s, which stores %s: the attribute's valueType and column binding disagree", vt, col, expects)
+}
+
+// isNumericFamily reports the valueTypes whose magnitude is caller-chosen and
+// therefore subject to width checks. date/datetime and bool also occupy the
+// numeric slot, but their images (epoch millis, 0/1) fit every integer column.
+func isNumericFamily(vt forma.ValueType) bool {
+	switch vt {
+	case forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeNumeric:
+		return true
+	}
+	return false
+}
+
+// columnFitType maps a narrow integer main column to the declared type whose
+// range equals the column's storage width.
+func columnFitType(colType forma.MainColumnType) (forma.ValueType, bool) {
+	switch colType {
+	case forma.MainColumnTypeSmallint:
+		return forma.ValueTypeSmallInt, true
+	case forma.MainColumnTypeInteger:
+		return forma.ValueTypeInteger, true
+	case forma.MainColumnTypeBigint:
+		return forma.ValueTypeBigInt, true
+	}
+	return "", false
+}
+
+// checkIntegerFit rejects a numeric-family value that cannot fit the integer
+// width vt names. dest labels the destination in the message ("declared type
+// integer", "bound column smallint_01 (smallint)"). eav_data.value_numeric is
+// an unconstrained NUMERIC and Go's int16()/int32() conversions wrap, so this
+// funnel is the only place the width can be enforced (#384, #459). numeric
+// stays unconstrained (#205 owns its float64 ceiling).
+func checkIntegerFit(raw any, numVal float64, vt forma.ValueType, dest string) error {
+	var lo, hi float64
+	switch vt {
+	case forma.ValueTypeSmallInt:
+		lo, hi = math.MinInt16, math.MaxInt16
+	case forma.ValueTypeInteger:
+		lo, hi = math.MinInt32, math.MaxInt32
+	case forma.ValueTypeBigInt:
+		// An exactly-representable int64 fits by construction; this also
+		// admits boundary literals like "9223372036854775807" whose float64
+		// image rounds up to 2^63 and would fail the bound check below.
+		if _, ok := toInt64ExactForEAV(raw); ok {
+			return nil
+		}
+		// Constant conversion: math.MinInt64 converts to exactly -2^63
+		// (a valid value); math.MaxInt64 rounds up to exactly 2^63, so >=
+		// rejects the first float64 that no longer fits.
+		if numVal != math.Trunc(numVal) {
+			return errNonIntegralFor(numVal, dest)
+		}
+		if numVal < math.MinInt64 || numVal >= math.MaxInt64 {
+			return fmt.Errorf("value %v out of range for %s (allowed [-9223372036854775808, 9223372036854775807])", numVal, dest)
+		}
+		return nil
+	default:
+		return nil
+	}
+	if numVal != math.Trunc(numVal) {
+		return errNonIntegralFor(numVal, dest)
+	}
+	if numVal < lo || numVal > hi {
+		return fmt.Errorf("value %v out of range for %s (allowed [%.0f, %.0f])", numVal, dest, lo, hi)
+	}
+	return nil
+}
+
+func errNonIntegralFor(numVal float64, dest string) error {
+	return fmt.Errorf("non-integral value %v does not fit %s (whole number required)", numVal, dest)
+}

--- a/internal/transform/storage_fit.go
+++ b/internal/transform/storage_fit.go
@@ -36,21 +36,44 @@ func checkStorageFit(attr *model.EAVRecord, raw any, meta forma.AttributeMetadat
 
 // checkBoundColumnFit mirrors storeInMainColumn's dispatch: the same
 // (encoding, column type) decides which EAVRecord slot is serialized, so the
-// slot must be populated, and a narrow integer column caps the value at the
-// column's width no matter how wide the declared type is (#459).
+// slot must be populated. Every value serialized from the numeric slot into a
+// smallint, integer or bigint column — a numeric-family value, epoch millis
+// (date/datetime, default or unix_ms) or 0/1 (bool_smallint) — is then
+// width-checked against the COLUMN's width, whatever the declared type or
+// encoding: epoch millis (~1.7e12) overflow integer and smallint, and
+// storeWithDefaultEncoding's int16()/int32() narrowing wraps (#459). The
+// registration matrix refuses date→integer, but the funnel must not depend on
+// registration: a deployed or programmatic registry can supply the binding.
 func checkBoundColumnFit(attr *model.EAVRecord, raw any, vt forma.ValueType, binding *forma.MainColumnBinding) error {
 	col := binding.ColumnName
+	colType := binding.ColumnType()
 	switch binding.Encoding {
-	case forma.MainColumnEncodingUnixMs, forma.MainColumnEncodingBoolInt,
-		forma.MainColumnEncodingBoolText, forma.MainColumnEncodingISO8601:
-		// These encodings serialize the numeric slot (epoch millis or 0/1).
+	case forma.MainColumnEncodingBoolText, forma.MainColumnEncodingISO8601:
+		// Text renderings of the numeric slot: nothing to width-check.
 		if attr.ValueNumeric == nil {
 			return errSlotMismatch(vt, col, "a date, datetime or bool value")
 		}
 		return nil
+	case forma.MainColumnEncodingUnixMs, forma.MainColumnEncodingBoolInt:
+		// Integer renderings of the numeric slot; width-checked below.
+		if attr.ValueNumeric == nil {
+			return errSlotMismatch(vt, col, "a date, datetime or bool value")
+		}
+	default:
+		if err := checkDefaultEncodingSlot(attr, vt, col, colType); err != nil {
+			return err
+		}
 	}
+	if fitType, ok := columnFitType(colType); ok {
+		return checkIntegerFit(raw, *attr.ValueNumeric, fitType, fmt.Sprintf("bound column %s (%s)", col, colType))
+	}
+	return nil
+}
 
-	colType := binding.ColumnType()
+// checkDefaultEncodingSlot verifies that the slot storeWithDefaultEncoding
+// serializes for colType is populated (and, for uuid columns, parseable).
+// On success an integer or double column is guaranteed a non-nil numeric slot.
+func checkDefaultEncodingSlot(attr *model.EAVRecord, vt forma.ValueType, col forma.MainColumn, colType forma.MainColumnType) error {
 	switch colType {
 	case forma.MainColumnTypeText:
 		if attr.ValueText == nil {
@@ -63,18 +86,7 @@ func checkBoundColumnFit(attr *model.EAVRecord, raw any, vt forma.ValueType, bin
 		if _, err := uuid.Parse(*attr.ValueText); err != nil {
 			return fmt.Errorf("%s value %q is not a UUID: bound column %s requires one", vt, *attr.ValueText, col)
 		}
-	case forma.MainColumnTypeSmallint, forma.MainColumnTypeInteger, forma.MainColumnTypeBigint:
-		if attr.ValueNumeric == nil {
-			return errSlotMismatch(vt, col, "a numeric value")
-		}
-		// Epoch millis (date/datetime) and 0/1 (bool) always fit; only the
-		// numeric family carries caller-chosen magnitude.
-		if !isNumericFamily(vt) {
-			return nil
-		}
-		fitType, _ := columnFitType(colType)
-		return checkIntegerFit(raw, *attr.ValueNumeric, fitType, fmt.Sprintf("bound column %s (%s)", col, colType))
-	case forma.MainColumnTypeDouble:
+	case forma.MainColumnTypeSmallint, forma.MainColumnTypeInteger, forma.MainColumnTypeBigint, forma.MainColumnTypeDouble:
 		if attr.ValueNumeric == nil {
 			return errSlotMismatch(vt, col, "a numeric value")
 		}
@@ -88,9 +100,11 @@ func errSlotMismatch(vt forma.ValueType, col forma.MainColumn, expects string) e
 	return fmt.Errorf("%s value cannot be stored in main column %s, which stores %s: the attribute's valueType and column binding disagree", vt, col, expects)
 }
 
-// isNumericFamily reports the valueTypes whose magnitude is caller-chosen and
-// therefore subject to width checks. date/datetime and bool also occupy the
-// numeric slot, but their images (epoch millis, 0/1) fit every integer column.
+// isNumericFamily reports the valueTypes whose magnitude is caller-chosen, so
+// checkStorageFit runs the declared-type width check on them (numeric itself
+// passes that check unconstrained, #205). date/datetime and bool also occupy
+// the numeric slot (epoch millis, 0/1); their declared type carries no width,
+// and only the bound column's width (checkBoundColumnFit) constrains them.
 func isNumericFamily(vt forma.ValueType) bool {
 	switch vt {
 	case forma.ValueTypeSmallInt, forma.ValueTypeInteger, forma.ValueTypeBigInt, forma.ValueTypeNumeric:

--- a/internal/transform/storage_fit_test.go
+++ b/internal/transform/storage_fit_test.go
@@ -1,0 +1,79 @@
+package transform
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lychee-technology/forma"
+	"github.com/lychee-technology/forma/internal/model"
+)
+
+func boundMeta(vt forma.ValueType, col forma.MainColumn, enc forma.MainColumnEncoding) forma.AttributeMetadata {
+	return forma.AttributeMetadata{
+		AttributeID:   9,
+		ValueType:     vt,
+		ColumnBinding: &forma.MainColumnBinding{ColumnName: col, Encoding: enc},
+	}
+}
+
+// #459: the write funnel's fidelity rule is "fit the physical destination".
+// A bound narrow column caps the value at the column's width no matter how
+// wide the declared valueType is, so storeInMainColumn's int16()/int32()
+// narrowing can never wrap.
+func TestCheckStorageFit_BoundColumnWidth(t *testing.T) {
+	cases := []struct {
+		name    string
+		meta    forma.AttributeMetadata
+		value   any
+		wantErr string // substring of the published message; "" means accepted
+	}{
+		{"integer declared, smallint column, 40000 rejected",
+			boundMeta(forma.ValueTypeInteger, forma.MainColumnSmallint01, forma.MainColumnEncodingDefault), float64(40000),
+			"bound column smallint_01 (smallint)"},
+		{"numeric declared, integer column, 3e9 rejected",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), float64(3e9),
+			"bound column integer_01 (integer)"},
+		{"numeric declared, integer column, 1.5 rejected",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), 1.5,
+			"whole number required"},
+		{"bigint declared, integer column, 2^31 rejected",
+			boundMeta(forma.ValueTypeBigInt, forma.MainColumnInteger02, forma.MainColumnEncodingDefault), float64(math.MaxInt32) + 1,
+			"bound column integer_02"},
+		{"numeric declared, smallint column, 4 ok",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnSmallint02, forma.MainColumnEncodingDefault), 4, ""},
+		{"integer declared, integer column, max ok",
+			boundMeta(forma.ValueTypeInteger, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), float64(math.MaxInt32), ""},
+		{"bigint declared, bigint column, max exact string ok",
+			boundMeta(forma.ValueTypeBigInt, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), "9223372036854775807", ""},
+		{"numeric declared, double column, 1e300 ok",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnDouble01, forma.MainColumnEncodingDefault), 1e300, ""},
+		{"smallint declared, integer column, still capped by declared type",
+			boundMeta(forma.ValueTypeSmallInt, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), float64(40000),
+			"declared type smallint"},
+		{"date to bigint unix_ms ok",
+			boundMeta(forma.ValueTypeDate, forma.MainColumnBigint02, forma.MainColumnEncodingUnixMs), "2024-03-14T09:26:00Z", ""},
+		{"bool to smallint bool_smallint ok",
+			boundMeta(forma.ValueTypeBool, forma.MainColumnSmallint01, forma.MainColumnEncodingBoolInt), true, ""},
+		{"system column binding is not a write destination",
+			boundMeta(forma.ValueTypeDate, forma.MainColumnCreatedAt, forma.MainColumnEncodingUnixMs), "2024-03-14T09:26:00Z", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec model.EAVRecord
+			set, err := populateTypedValue(&rec, "qty", tc.value, tc.meta)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				require.True(t, set)
+				return
+			}
+			require.Error(t, err)
+			require.ErrorIs(t, err, forma.ErrInvalidInput, "fit rejection must be user-facing invalid input")
+			msg, ok := forma.ResolvePublicMessage(err)
+			require.True(t, ok, "fit rejection must publish its message")
+			require.Contains(t, msg, tc.wantErr)
+			require.Contains(t, msg, "attribute 'qty'")
+		})
+	}
+}

--- a/internal/transform/storage_fit_test.go
+++ b/internal/transform/storage_fit_test.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -109,6 +110,22 @@ func TestCheckStorageFit_FamilyMismatch(t *testing.T) {
 		{"numeric declared, bound to bigint_01 default encoding, value 1e19 rejected",
 			boundMeta(forma.ValueTypeNumeric, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), 1e19,
 			"bound column bigint_01 (bigint)"},
+		// #459 review F1: a numeric-declared value carries no exact int64
+		// sidecar, so the bigint column is written from the float64 image
+		// (2^63 for MaxInt64), which int64() wraps to MinInt64. The exact
+		// shortcut must not admit it on the strength of the raw literal.
+		{"numeric declared, bigint column, MaxInt64 string rejected",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), "9223372036854775807",
+			"value 9223372036854775808 out of range for bound column bigint_01 (bigint)"},
+		{"numeric declared, bigint column, MaxInt64 int64 rejected",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), int64(math.MaxInt64),
+			"value 9223372036854775808 out of range for bound column bigint_01 (bigint)"},
+		{"numeric declared, bigint column, MinInt64 int64 accepted (float image is exact)",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), int64(math.MinInt64), ""},
+		{"numeric declared, bigint column, 2^62 accepted",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), int64(1) << 62, ""},
+		{"bigint declared, bigint column, MaxInt64 int64 accepted via exact sidecar",
+			boundMeta(forma.ValueTypeBigInt, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), int64(math.MaxInt64), ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -122,6 +139,84 @@ func TestCheckStorageFit_FamilyMismatch(t *testing.T) {
 			msg, ok := forma.ResolvePublicMessage(err)
 			require.True(t, ok)
 			require.Contains(t, msg, tc.wantErr)
+		})
+	}
+}
+
+// #459 review F1: whatever checkStorageFit admits into a bigint column,
+// storeInMainColumn must write without wrapping. For a numeric-declared
+// attribute the store consumes the float64 image, so the admitted set is
+// exactly the float64s that convert to int64 exactly; a declared bigint
+// carries the exact sidecar and admits the full int64 range.
+func TestCheckStorageFit_BigintColumnStoreParity(t *testing.T) {
+	tr := &persistentRecordTransformer{}
+	values := []any{
+		int64(math.MaxInt64), "9223372036854775807", float64(math.MaxInt64),
+		int64(math.MinInt64), "-9223372036854775808", float64(math.MinInt64),
+		int64(1) << 62, int64(-1) << 62, "9223372036854775000", 1e18, 0, -1,
+	}
+	for _, vt := range []forma.ValueType{forma.ValueTypeNumeric, forma.ValueTypeBigInt} {
+		meta := boundMeta(vt, forma.MainColumnBigint01, forma.MainColumnEncodingDefault)
+		for _, value := range values {
+			name := fmt.Sprintf("%s/%v(%T)", vt, value, value)
+			t.Run(name, func(t *testing.T) {
+				var rec model.EAVRecord
+				_, err := populateTypedValue(&rec, "n", value, meta)
+				if err != nil {
+					require.ErrorIs(t, err, forma.ErrInvalidInput)
+					return
+				}
+				record := &model.PersistentRecord{Int64Items: map[string]int64{}}
+				require.NoError(t, tr.storeInMainColumn(record, rec, meta.ColumnBinding))
+				stored, ok := record.Int64Items[string(forma.MainColumnBigint01)]
+				require.True(t, ok)
+				if rec.ValueInt64 != nil {
+					require.Equal(t, *rec.ValueInt64, stored, "exact sidecar must be stored verbatim")
+					return
+				}
+				require.Equal(t, *rec.ValueNumeric, float64(stored), "float image must convert to int64 without wrapping")
+			})
+		}
+	}
+	// The declared-bigint sidecar admits the boundary the float image cannot.
+	var rec model.EAVRecord
+	_, err := populateTypedValue(&rec, "n", int64(math.MaxInt64), boundMeta(forma.ValueTypeBigInt, forma.MainColumnBigint01, forma.MainColumnEncodingDefault))
+	require.NoError(t, err)
+	require.NotNil(t, rec.ValueInt64)
+	require.Equal(t, int64(math.MaxInt64), *rec.ValueInt64)
+}
+
+// #459 review O4: a rejected value prints as the caller wrote it (plain
+// digits), not in exponent form — epoch millis and 3e9 were rendering as
+// 1.7040672e+12 and 3e+09.
+func TestCheckStorageFit_MessageRendersPlainDigits(t *testing.T) {
+	cases := []struct {
+		name  string
+		meta  forma.AttributeMetadata
+		value any
+		want  string
+	}{
+		{"3e9 into integer",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), 3e9,
+			"value 3000000000 out of range"},
+		{"epoch millis into integer",
+			boundMeta(forma.ValueTypeDate, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), "2024-01-01T00:00:00Z",
+			"value 1704067200000 out of range"},
+		{"fractional into integer",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), 1.5,
+			"non-integral value 1.5 does not fit"},
+		{"huge magnitude keeps the short form",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), 1e300,
+			"value 1e+300 out of range"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec model.EAVRecord
+			_, err := populateTypedValue(&rec, "n", tc.value, tc.meta)
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			msg, ok := forma.ResolvePublicMessage(err)
+			require.True(t, ok)
+			require.Contains(t, msg, tc.want)
 		})
 	}
 }

--- a/internal/transform/storage_fit_test.go
+++ b/internal/transform/storage_fit_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/lychee-technology/forma"
@@ -76,4 +77,78 @@ func TestCheckStorageFit_BoundColumnWidth(t *testing.T) {
 			require.Contains(t, msg, "attribute 'qty'")
 		})
 	}
+}
+
+// #459 shapes 2 and 3: a valueType whose typed slot does not match the bound
+// column's family used to 500 (text→uuid: uuid.Parse in storeInMainColumn)
+// or silently drop (text→smallint: nil ValueNumeric, no else branch). Both
+// are now refused in the funnel as published invalid input.
+func TestCheckStorageFit_FamilyMismatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		meta    forma.AttributeMetadata
+		value   any
+		wantErr string
+	}{
+		{"text to uuid column, non-uuid rejected",
+			boundMeta(forma.ValueTypeText, forma.MainColumnUUID02, forma.MainColumnEncodingDefault), "abc",
+			`text value "abc" is not a UUID: bound column uuid_02 requires one`},
+		{"text to uuid column, uuid accepted",
+			boundMeta(forma.ValueTypeText, forma.MainColumnUUID02, forma.MainColumnEncodingDefault), "0190f3a4-2f1e-7c3b-9a2d-1b2c3d4e5f60", ""},
+		{"text to smallint column rejected, not dropped",
+			boundMeta(forma.ValueTypeText, forma.MainColumnSmallint01, forma.MainColumnEncodingDefault), "7",
+			"text value cannot be stored in main column smallint_01, which stores a numeric value"},
+		{"numeric to text column rejected",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnText01, forma.MainColumnEncodingDefault), 7,
+			"numeric value cannot be stored in main column text_01, which stores a text value"},
+		{"text to bigint unix_ms rejected",
+			boundMeta(forma.ValueTypeText, forma.MainColumnBigint01, forma.MainColumnEncodingUnixMs), "2024-01-01",
+			"text value cannot be stored in main column bigint_01, which stores a date, datetime or bool value"},
+		{"uuid to uuid column accepted",
+			boundMeta(forma.ValueTypeUUID, forma.MainColumnUUID01, forma.MainColumnEncodingDefault), "0190f3a4-2f1e-7c3b-9a2d-1b2c3d4e5f60", ""},
+		{"numeric declared, bound to bigint_01 default encoding, value 1e19 rejected",
+			boundMeta(forma.ValueTypeNumeric, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), 1e19,
+			"bound column bigint_01 (bigint)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec model.EAVRecord
+			_, err := populateTypedValue(&rec, "leadId", tc.value, tc.meta)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, forma.ErrInvalidInput)
+			msg, ok := forma.ResolvePublicMessage(err)
+			require.True(t, ok)
+			require.Contains(t, msg, tc.wantErr)
+		})
+	}
+}
+
+// storeInMainColumn is the last line of defense: if a record ever reaches it
+// with no value in the slot its column serializes, that is an error, not a
+// silent drop (#459 shape 3).
+func TestStoreInMainColumn_EmptySlotIsAnError(t *testing.T) {
+	tr := &persistentRecordTransformer{}
+	record := &model.PersistentRecord{
+		TextItems: map[string]string{}, Int16Items: map[string]int16{}, Int32Items: map[string]int32{},
+		Int64Items: map[string]int64{}, UUIDItems: map[string]uuid.UUID{}, Float64Items: map[string]float64{},
+	}
+	attr := model.EAVRecord{AttrID: 4} // no slot populated
+	for _, binding := range []forma.MainColumnBinding{
+		{ColumnName: forma.MainColumnSmallint01, Encoding: forma.MainColumnEncodingDefault},
+		{ColumnName: forma.MainColumnText01, Encoding: forma.MainColumnEncodingDefault},
+		{ColumnName: forma.MainColumnUUID01, Encoding: forma.MainColumnEncodingDefault},
+		{ColumnName: forma.MainColumnBigint01, Encoding: forma.MainColumnEncodingUnixMs},
+		{ColumnName: forma.MainColumnText02, Encoding: forma.MainColumnEncodingBoolText},
+	} {
+		b := binding
+		err := tr.storeInMainColumn(record, attr, &b)
+		require.Error(t, err, "binding %+v", b)
+		require.Contains(t, err.Error(), string(b.ColumnName))
+		require.Contains(t, err.Error(), "attr id 4")
+	}
+	require.Empty(t, record.TextItems)
+	require.Empty(t, record.Int16Items)
 }

--- a/internal/transform/storage_fit_test.go
+++ b/internal/transform/storage_fit_test.go
@@ -152,3 +152,56 @@ func TestStoreInMainColumn_EmptySlotIsAnError(t *testing.T) {
 	require.Empty(t, record.TextItems)
 	require.Empty(t, record.Int16Items)
 }
+
+// #459 review: the width cap applies to every value serialized from the
+// numeric slot into a smallint/integer/bigint column, not only to the
+// numeric family. Epoch millis (~1.7e12) do not fit integer or smallint, and
+// storeWithDefaultEncoding's int32()/int16() narrowing would wrap them; the
+// registration matrix refuses those pairs, but the funnel must not depend on
+// registration (a deployed or programmatic registry can supply the binding).
+func TestCheckStorageFit_NonNumericFamilyColumnWidth(t *testing.T) {
+	cases := []struct {
+		name    string
+		meta    forma.AttributeMetadata
+		value   any
+		wantErr []string // substrings of the published message; empty means accepted
+	}{
+		{"date to integer default encoding rejected",
+			boundMeta(forma.ValueTypeDate, forma.MainColumnInteger01, forma.MainColumnEncodingDefault), "2024-01-01",
+			[]string{"bound column integer_01 (integer)", "out of range"}},
+		{"datetime to smallint unix_ms rejected",
+			boundMeta(forma.ValueTypeDateTime, forma.MainColumnSmallint01, forma.MainColumnEncodingUnixMs), "2024-01-01T00:00:00Z",
+			[]string{"bound column smallint_01 (smallint)", "out of range"}},
+		{"datetime to integer unix_ms rejected",
+			boundMeta(forma.ValueTypeDateTime, forma.MainColumnInteger02, forma.MainColumnEncodingUnixMs), "2024-01-01T00:00:00Z",
+			[]string{"bound column integer_02 (integer)", "out of range"}},
+		{"datetime to bigint unix_ms accepted",
+			boundMeta(forma.ValueTypeDateTime, forma.MainColumnBigint01, forma.MainColumnEncodingUnixMs), "2024-01-01T00:00:00Z", nil},
+		{"date to bigint default encoding accepted",
+			boundMeta(forma.ValueTypeDate, forma.MainColumnBigint01, forma.MainColumnEncodingDefault), "2024-01-01", nil},
+		{"bool to smallint bool_smallint accepted",
+			boundMeta(forma.ValueTypeBool, forma.MainColumnSmallint01, forma.MainColumnEncodingBoolInt), true, nil},
+		{"datetime to text iso8601 accepted",
+			boundMeta(forma.ValueTypeDateTime, forma.MainColumnText01, forma.MainColumnEncodingISO8601), "2024-01-01T00:00:00Z", nil},
+		{"bool to text bool_text accepted",
+			boundMeta(forma.ValueTypeBool, forma.MainColumnText01, forma.MainColumnEncodingBoolText), false, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec model.EAVRecord
+			set, err := populateTypedValue(&rec, "when", tc.value, tc.meta)
+			if len(tc.wantErr) == 0 {
+				require.NoError(t, err)
+				require.True(t, set)
+				return
+			}
+			require.ErrorIs(t, err, forma.ErrInvalidInput, "fit rejection must be user-facing invalid input")
+			msg, ok := forma.ResolvePublicMessage(err)
+			require.True(t, ok, "fit rejection must publish its message")
+			for _, want := range tc.wantErr {
+				require.Contains(t, msg, want)
+			}
+			require.Contains(t, msg, "attribute 'when'")
+		})
+	}
+}

--- a/internal/transform/typed_value.go
+++ b/internal/transform/typed_value.go
@@ -2,7 +2,6 @@ package transform
 
 import (
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/lychee-technology/forma"
@@ -39,9 +38,6 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 			return handleConversionError(err)
 		}
 		if numVal, err = finiteForEAV(numVal); err != nil {
-			return handleConversionError(err)
-		}
-		if err := checkDeclaredIntegerFit(value, numVal, meta.ValueType); err != nil {
 			return handleConversionError(err)
 		}
 		attr.ValueNumeric = &numVal
@@ -87,53 +83,12 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 		return handleConversionError(fmt.Errorf("unsupported value type '%s'", meta.ValueType))
 	}
 
+	// One fidelity rule for every destination (#384 declared type, #459
+	// bound column): the value must fit where it is physically going.
+	if err := checkStorageFit(attr, value, meta); err != nil {
+		return handleConversionError(err)
+	}
 	return true, nil
-}
-
-// checkDeclaredIntegerFit rejects a numeric-family value that cannot fit its
-// declared integer type (#384): eav_data.value_numeric is an unconstrained
-// NUMERIC, so Postgres would happily store and match a value the DuckDB tiers
-// project by width — the write funnel is the only place the declared type can
-// still be enforced. numeric stays unconstrained (#205 owns its float64
-// ceiling).
-func checkDeclaredIntegerFit(raw any, numVal float64, vt forma.ValueType) error {
-	var lo, hi float64
-	switch vt {
-	case forma.ValueTypeSmallInt:
-		lo, hi = math.MinInt16, math.MaxInt16
-	case forma.ValueTypeInteger:
-		lo, hi = math.MinInt32, math.MaxInt32
-	case forma.ValueTypeBigInt:
-		// An exactly-representable int64 fits by construction; this also
-		// admits boundary literals like "9223372036854775807" whose float64
-		// image rounds up to 2^63 and would fail the bound check below.
-		if _, ok := toInt64ExactForEAV(raw); ok {
-			return nil
-		}
-		// Constant conversion: math.MinInt64 converts to exactly -2^63
-		// (a valid value); math.MaxInt64 rounds up to exactly 2^63, so >=
-		// rejects the first float64 that no longer fits.
-		if numVal != math.Trunc(numVal) {
-			return errNonIntegralForType(numVal, vt)
-		}
-		if numVal < math.MinInt64 || numVal >= math.MaxInt64 {
-			return fmt.Errorf("value %v out of range for declared type %s (allowed [-9223372036854775808, 9223372036854775807])", numVal, vt)
-		}
-		return nil
-	default:
-		return nil
-	}
-	if numVal != math.Trunc(numVal) {
-		return errNonIntegralForType(numVal, vt)
-	}
-	if numVal < lo || numVal > hi {
-		return fmt.Errorf("value %v out of range for declared type %s (allowed [%.0f, %.0f])", numVal, vt, lo, hi)
-	}
-	return nil
-}
-
-func errNonIntegralForType(numVal float64, vt forma.ValueType) error {
-	return fmt.Errorf("non-integral value %v does not fit declared type %s (whole number required)", numVal, vt)
 }
 
 func toString(value any) (string, error) {

--- a/internal/transform/typed_value.go
+++ b/internal/transform/typed_value.go
@@ -85,7 +85,7 @@ func populateTypedValue(attr *model.EAVRecord, attrName string, value any, meta 
 
 	// One fidelity rule for every destination (#384 declared type, #459
 	// bound column): the value must fit where it is physically going.
-	if err := checkStorageFit(attr, value, meta); err != nil {
+	if err := checkStorageFit(attr, meta); err != nil {
 		return handleConversionError(err)
 	}
 	return true, nil


### PR DESCRIPTION
Closes #459

## Problem

The write path checked a value against its *declared* `valueType` (#384) but never against where the value was physically going. Four shapes fell through:

1. A numeric value out of range for a **bound narrow column** silently wrapped: `integer`→`smallint_01` with `40000` stored `-25536`; `numeric`→`integer_01` with `3e9` wrapped in `int32()`.
2. A `text` attribute bound to a **`uuid_*` column** (the shipped `log` schema's `leadId`/`visitId`) answered a redacted **500** on `uuid.Parse` failure.
3. A `text` attribute bound to a **numeric column** left the typed slot empty and the value was **silently dropped** from the main table.
4. Nothing refused such bindings at registration or metadata load, and `validate-schema-consistency` did not report them across a deployed set.

## Contract

**Write-side fidelity rule (shared with #384; one funnel, `transform.populateTypedValue` → `checkStorageFit`).** A value must fit its physical destination, else `forma.InvalidInputf` (published 4xx):

1. EAV-only (no binding): fit the declared type — `smallint`/`integer`/`bigint` must be integral and inside `[-2^15,2^15)`, `[-2^31,2^31)`, `[-2^63,2^63)`; `numeric` unconstrained (#205). *(Already enforced by #384; unchanged.)*
2. Bound to a main column: rule 1 **and** the column's own width — any value serialized from the numeric slot into `smallint_*`/`integer_*`/`bigint_*` must be integral and inside that column's range regardless of declared type or encoding (so `numeric`→`integer_01` rejects `1.5` and `3e9`; `integer`→`smallint_01` rejects `40000`; a `date` bound to `integer_01` rejects its epoch millis). `double_*` is unconstrained (#205 owns the float64 ceiling).
3. Bound to `uuid_*`: the text value must parse as a UUID (a `uuid` valueType already guarantees this; a `text` valueType is checked here).
4. The typed slot must match the column family (text-slot value → text/uuid column; numeric-slot value → numeric/encoded column). A mismatch is refused, never dropped.

Messages name the value, the destination and the allowed range, e.g. `value 40000 out of range for bound column smallint_01 (smallint) (allowed [-32768, 32767])`, `text value "abc" is not a UUID: bound column uuid_02 requires one`.

**Registration matrix (`schemameta.ValidateColumnBinding`).** A binding must be one of:

| valueType | column type | encoding |
| --- | --- | --- |
| `text` | text | default |
| `uuid` | uuid | default |
| `smallint`/`integer`/`bigint`/`numeric` | smallint, integer, bigint, double | default (width enforced at write) |
| `date`/`datetime` | bigint | default or `unix_ms` |
| `date`/`datetime` | text | `iso8601` |
| `bool` | smallint | `bool_smallint` |
| `bool` | text | `bool_text` |
| `list` | — | never bindable |

Unknown encodings and unknown valueTypes are rejected. Retired entries are skipped (ledger only). System columns (`ltbase_*`) go through the same matrix via `ColumnType()`. The matrix is enforced at `RegisterSchema` and at every runtime metadata load; only the `validate-schema-consistency` tool loads leniently (`MetadataLoader.DeferColumnBindingCheck()`) so it can report every mismatch in one pass.

## Changes

- **`internal/transform`** — new `storage_fit.go`: `checkStorageFit` (declared-type fit from #384 + bound-column width + uuid parse + slot/family match) called once at the end of `populateTypedValue`; `checkDeclaredIntegerFit` folded into it. `storeInMainColumn` split into `storeWithEncoding`/`storeWithDefaultEncoding` returning `(bool, error)` so an empty slot is an error, never a silent drop. Tests: `storage_fit_test.go` (width, family mismatch, non-numeric-family values into narrow columns), `TestPersistentRecordTransformer_RejectsOutOfRangeBoundColumn`, `TestStoreInMainColumn_EmptySlotIsAnError`.
- **`internal/schemameta`** — new `binding_compat.go` (`ValidateColumnBinding`), hooked into `validateSchemaAttributeCacheOpts(name, cache, checkBindings)` for registration and load; `MetadataLoader.DeferColumnBindingCheck()` for the tool.
- **`internal`** — `entity_write_fidelity_test.go` pins the published 4xx (`errors.Is(err, forma.ErrInvalidInput)`, `forma.ResolvePublicMessage`) through the manager seam for create and update, and that no row is written.
- **`cmd/tools`** — `validate-schema-consistency` gains the `valueType/column-encoding binding mismatches` category (`schema=<name> <error>` per line); README entry added.
- **`cmd/server/schemas/log_attributes.json`** — `leadId` `uuid_02`→`text_02`, `visitId` `uuid_01`→`text_03`. Both are `text` attributes; the uuid binding was the shape that 500'd on write (and, incidentally, rendered a `COALESCE(VARCHAR, UUID)` the DuckDB hot leg refuses). Rebinding to text columns keeps the declared type, which is what callers send. Deployments carrying the old copy: run the tool, then the migration SQL in `docs/schema-consistency-migration.md` before upgrading — the server now refuses to load the old binding.
- **docs** — `docs/error-handling.md` gains "Value/column fidelity on the write path (#384, #459)"; `docs/schema-consistency-migration.md` describes the new check, the admitted pairs and the concrete migration SQL.

The AC "Update response reflects stored state" was already delivered by #457 (PR #553): `Update` returns `FromPersistentRecord(stored)` from `MergePersistentRecord`, pinned by `TestEntityManager_Update_ResponseIsStorageRoundTrip`. No change here.

## Deliberate exclusions / follow-ups

- `bigint`→`double_*` precision loss above 2^53 is not checked; #205 owns the float64 ceiling.
- `uuid`→text columns are refused at registration although the transform would round-trip them, because the DuckDB projection assumes a UUID-typed main column for a `uuid` attribute.
- `date`/`datetime`→text `iso8601` is admitted (write path, Postgres read and CDC export round-trip it) but the DuckDB hot-leg projection does not normalise it — pre-existing, tracked in #555; the matrix comment says so.
- `storeWithEncoding` still writes `unix_ms`/`bool_smallint` into `Int64Items`/`Int16Items` without consulting `ColumnType()`. The matrix refuses the mismatched pairs at registration and the main-table writer rejects an unknown key loudly (`unsupported column`), so it is a slot-placement inconsistency rather than a fidelity hole; worth aligning with `checkBoundColumnFit` in a follow-up.

## Verification

- `make fmt-check` clean; `make lint` (golangci-lint v1.64.8, root + infra) clean.
- `./scripts/test_with_container_runtime.sh` (rootless Podman): all 34 packages `ok`, exit 0, on the final HEAD.
- `go test ./internal/e2e_harness/... -timeout=5m -count=1`:
  ```
  ok  	github.com/lychee-technology/forma/internal/e2e_harness	7.660s
  ok  	github.com/lychee-technology/forma/internal/e2e_harness/federated	0.059s
  ok  	github.com/lychee-technology/forma/internal/e2e_harness/federated/benchmark	0.082s
  ok  	github.com/lychee-technology/forma/internal/e2e_harness/production	0.061s
  ```
