### PR TITLE
refactor(transform): extract attribute_converter.go below the line cap (#375)

### DIFF
--- a/internal/transform/attribute_converter.go
+++ b/internal/transform/attribute_converter.go
@@ -1,20 +1,13 @@
 package transform
 
 import (
-	"encoding/json"
 	"fmt"
 	"slices"
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/lychee-technology/forma/internal/model"
 
 	"github.com/google/uuid"
 	"github.com/lychee-technology/forma"
-	"github.com/lychee-technology/forma/internal/numutil"
+	"github.com/lychee-technology/forma/internal/model"
 	"github.com/lychee-technology/forma/internal/schemameta"
-	"go.uber.org/zap"
 )
 
 // AttributeConverter provides conversion between model.EntityAttribute and model.EAVRecord
@@ -35,19 +28,6 @@ func NewAttributeConverter(registry forma.SchemaRegistry) *AttributeConverter {
 // empty set, leaves enforcement exactly as it was.
 func (c *AttributeConverter) SetRelationRoots(lookup RelationRootsLookup) {
 	c.relationRoots = lookup
-}
-
-// relationRootsFor resolves the relation roots of schemaID, translating the ID
-// to the schema name the lookup is keyed by.
-func (c *AttributeConverter) relationRootsFor(schemaID int16) (RelationRoots, error) {
-	if c.relationRoots == nil {
-		return nil, nil
-	}
-	schemaName, _, err := c.registry.GetSchemaByID(schemaID)
-	if err != nil {
-		return nil, fmt.Errorf("resolve schema name for id %d: %w", schemaID, err)
-	}
-	return c.relationRoots(schemaName), nil
 }
 
 // ToEAVRecord converts an model.EntityAttribute to an model.EAVRecord.
@@ -169,7 +149,7 @@ func (c *AttributeConverter) FromEAVRecords(records []model.EAVRecord) ([]model.
 	schemaID := records[0].SchemaID
 	cache, idToName, err := schemameta.GetSchemaMetadata(c.registry, schemaID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load schema metadata for schema %d: %w", schemaID, err)
 	}
 
 	presentAttrIndices := make(map[string]map[string]struct{}, len(records))
@@ -219,272 +199,8 @@ func (c *AttributeConverter) FromEAVRecords(records []model.EAVRecord) ([]model.
 	}
 
 	if err := c.checkRequiredAttributes(schemaID, cache, presentAttrIndices); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("required-policy check for schema %d: %w", schemaID, err)
 	}
 
 	return attributes, nil
-}
-
-// checkRequiredAttributes enforces each attribute's required policy against the
-// attribute names the records actually carried, per array-index context.
-func (c *AttributeConverter) checkRequiredAttributes(
-	schemaID int16,
-	cache forma.SchemaAttributeCache,
-	presentAttrIndices map[string]map[string]struct{},
-) error {
-	relationRoots, err := c.relationRootsFor(schemaID)
-	if err != nil {
-		return fmt.Errorf("resolve relation roots for required-policy check: %w", err)
-	}
-
-	missingRequired := make(map[int16]string)
-	for attrName, metadata := range cache {
-		// #314/#315: relation-root data is derived on read and never
-		// schema-validated on write — since #318 the whole subtree is stripped
-		// from the payload before validation — so required policies beneath a
-		// root must follow the same rule, otherwise expanding a root's
-		// attributes (#315 resolved contactSnapshot's $ref) turns payloads #314
-		// ruled acceptable into 400s.
-		//
-		// The carve-out belongs to this check, not to the read path: ToAttributes
-		// reaches FromEAVRecords on every create and update (transformer.go). The
-		// write path's own required check (validateRequiredAttributesFromInput,
-		// transformer.go) has none, so a required_always beneath a root still
-		// rejects the stripped payload there. Documented in docs/error-handling.md.
-		if relationRoots.Covers(attrName) {
-			continue
-		}
-		switch metadata.EffectiveRequiredPolicy() {
-		case forma.RequiredPolicyAlways:
-			if isRequiredAttributeMissing(attrName, presentAttrIndices, true) {
-				missingRequired[metadata.AttributeID] = attrName
-			}
-		case forma.RequiredPolicyIfParentPresent:
-			if isRequiredAttributeMissing(attrName, presentAttrIndices, false) {
-				missingRequired[metadata.AttributeID] = attrName
-			}
-		}
-	}
-	if len(missingRequired) == 0 {
-		return nil
-	}
-
-	zap.S().Infow("missing EAV records for attrIDs.", "idToName", missingRequired)
-	names := make([]string, 0, len(missingRequired))
-	idsByName := make(map[string]int16, len(missingRequired))
-	for id, name := range missingRequired {
-		names = append(names, name)
-		idsByName[name] = id
-	}
-	// Name the alphabetically first missing attribute, not whichever the map
-	// yields first, so the same drift produces the same error on every run.
-	missingAttrName := slices.Min(names)
-
-	// Plain error, deliberately. FromEAVRecords is not write-only: the read
-	// path rebuilds already-stored records through it
-	// (persistent_record.go's FromPersistentRecord), so a persisted row
-	// missing a required EAV row reaches here too. Wrapping
-	// forma.ErrInvalidInput here — as an earlier #301 sweep did — made the
-	// HTTP boundary answer that persisted-drift case with a verbatim 400,
-	// inverting the split AGENTS.md and this repo's error-handling doc
-	// draw: write validation carries the sentinel, read-path consistency
-	// failures stay plain and operator-visible.
-	//
-	// The write path's 400 does not depend on this wrap. It has its own
-	// write-only validator, validateRequiredAttributesFromInput
-	// (transformer.go), which ToAttributes runs against the caller's input
-	// before flattening and which does carry the sentinel.
-	return fmt.Errorf("missing required attribute '%s' (attrID=%d) in EAV records",
-		missingAttrName, idsByName[missingAttrName])
-}
-
-// Helper functions for conversion
-//
-// The numeric coercion helpers (toFloat64ForEAV, parseTrimmedFloat64) live in
-// numeric_conversion.go alongside the finiteForEAV guard they feed.
-
-func toTimeForEAV(value any) (time.Time, error) {
-	switch v := value.(type) {
-	case time.Time:
-		return v, nil
-	case *time.Time:
-		timeValue, err := derefPointer(v, "time")
-		if err != nil {
-			return time.Time{}, err
-		}
-		return timeValue, nil
-	default:
-		return time.Time{}, fmt.Errorf("cannot convert %T to time.Time", value)
-	}
-}
-
-func toBoolForEAV(value any) (bool, error) {
-	switch v := value.(type) {
-	case string:
-		return isTrueStringForEAV(v), nil
-	case *string:
-		str, err := derefPointer(v, "string")
-		if err != nil {
-			return false, err
-		}
-		return isTrueStringForEAV(str), nil
-	case bool:
-		return v, nil
-	case *bool:
-		booleanValue, err := derefPointer(v, "bool")
-		if err != nil {
-			return false, err
-		}
-		return booleanValue, nil
-	case int:
-		return boolFromPositive(v), nil
-	case *int:
-		num, err := derefPointer(v, "int")
-		if err != nil {
-			return false, err
-		}
-		return boolFromPositive(num), nil
-	case int16:
-		return boolFromPositive(v), nil
-	case *int16:
-		num, err := derefPointer(v, "int16")
-		if err != nil {
-			return false, err
-		}
-		return boolFromPositive(num), nil
-	case int32:
-		return boolFromNonZero(v), nil
-	case *int32:
-		num, err := derefPointer(v, "int32")
-		if err != nil {
-			return false, err
-		}
-		return boolFromPositive(num), nil
-	case int64:
-		return boolFromNonZero(v), nil
-	case *int64:
-		num, err := derefPointer(v, "int64")
-		if err != nil {
-			return false, err
-		}
-		return boolFromPositive(num), nil
-	case float32:
-		return finiteFloat64ToBool(float64(v))
-	case *float32:
-		num, err := derefPointer(v, "float32")
-		if err != nil {
-			return false, err
-		}
-		return finiteFloat64ToBool(float64(num))
-	case float64:
-		return finiteFloat64ToBool(v)
-	case *float64:
-		num, err := derefPointer(v, "float64")
-		if err != nil {
-			return false, err
-		}
-		return finiteFloat64ToBool(num)
-	case json.Number:
-		f, err := v.Float64()
-		if err != nil {
-			return false, fmt.Errorf("cannot convert json.Number %q to bool: %w", v.String(), err)
-		}
-		if err := finiteBoolInput(f); err != nil {
-			return false, err
-		}
-		return f != 0, nil
-	default:
-		return false, fmt.Errorf("cannot convert %T to bool", value)
-	}
-}
-
-// finiteFloat64ToBool is toBoolForEAV's float path: reject non-finite, then
-// apply the existing threshold coercion unchanged.
-func finiteFloat64ToBool(value float64) (bool, error) {
-	if err := finiteBoolInput(value); err != nil {
-		return false, err
-	}
-	return float64ToBool(value), nil
-}
-
-func derefPointer[T any](value *T, typeName string) (T, error) {
-	if value == nil {
-		var zero T
-		return zero, fmt.Errorf("nil %s pointer", typeName)
-	}
-	return *value, nil
-}
-
-func boolFromPositive[T ~int | ~int16 | ~int32 | ~int64](value T) bool {
-	return value > 0
-}
-
-func boolFromNonZero[T ~int32 | ~int64](value T) bool {
-	return value != 0
-}
-
-func isTrueStringForEAV(value string) bool {
-	return strings.ToLower(value) == "true" || value == "1"
-}
-
-func toTime(value any) (time.Time, error) {
-	switch v := value.(type) {
-	case time.Time:
-		return v, nil
-	case string:
-		epoch, err := strconv.ParseInt(v, 10, 64)
-		if err == nil {
-			return time.UnixMilli(epoch), nil
-		}
-
-		formats := []string{
-			time.RFC3339Nano,
-			time.RFC3339,
-			"2006-01-02",
-			"2006-01",
-		}
-		for _, format := range formats {
-			if parsed, err := time.Parse(format, v); err == nil {
-				return parsed, nil
-			}
-		}
-		return time.Time{}, fmt.Errorf("unsupported time format: %s", v)
-	default:
-		return time.Time{}, fmt.Errorf("cannot convert %T to time.Time", value)
-	}
-}
-
-func toBool(value any) (bool, error) {
-	switch v := value.(type) {
-	case bool:
-		return v, nil
-	case string:
-		return strconv.ParseBool(v)
-	case int:
-		return v != 0, nil
-	case int64:
-		return v != 0, nil
-	case float64:
-		if err := finiteBoolInput(v); err != nil {
-			return false, err
-		}
-		return v != 0, nil
-	case json.Number:
-		f, err := v.Float64()
-		if err != nil {
-			return false, fmt.Errorf("cannot convert json.Number %q to bool: %w", v.String(), err)
-		}
-		if err := finiteBoolInput(f); err != nil {
-			return false, err
-		}
-		return f != 0, nil
-	default:
-		return false, fmt.Errorf("cannot convert %T to bool", value)
-	}
-}
-
-// ToFloat64Ok is an exported helper that behaves like the legacy optimizer helper:
-// it returns (float64, bool) where bool indicates success.
-func ToFloat64(v any) (float64, bool) {
-	return numutil.ToFloat64(v)
 }

--- a/internal/transform/attribute_required.go
+++ b/internal/transform/attribute_required.go
@@ -1,8 +1,99 @@
 package transform
 
 import (
+	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/lychee-technology/forma"
+	"go.uber.org/zap"
 )
+
+// relationRootsFor resolves the relation roots of schemaID, translating the ID
+// to the schema name the lookup is keyed by.
+func (c *AttributeConverter) relationRootsFor(schemaID int16) (RelationRoots, error) {
+	if c.relationRoots == nil {
+		return nil, nil
+	}
+	schemaName, _, err := c.registry.GetSchemaByID(schemaID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema name for id %d: %w", schemaID, err)
+	}
+	return c.relationRoots(schemaName), nil
+}
+
+// checkRequiredAttributes enforces each attribute's required policy against the
+// attribute names the records actually carried, per array-index context.
+func (c *AttributeConverter) checkRequiredAttributes(
+	schemaID int16,
+	cache forma.SchemaAttributeCache,
+	presentAttrIndices map[string]map[string]struct{},
+) error {
+	relationRoots, err := c.relationRootsFor(schemaID)
+	if err != nil {
+		return fmt.Errorf("resolve relation roots for required-policy check: %w", err)
+	}
+
+	missingRequired := make(map[int16]string)
+	for attrName, metadata := range cache {
+		// #314/#315: relation-root data is derived on read and never
+		// schema-validated on write — since #318 the whole subtree is stripped
+		// from the payload before validation — so required policies beneath a
+		// root must follow the same rule, otherwise expanding a root's
+		// attributes (#315 resolved contactSnapshot's $ref) turns payloads #314
+		// ruled acceptable into 400s.
+		//
+		// The carve-out belongs to this check, not to the read path: ToAttributes
+		// reaches FromEAVRecords on every create and update (transformer.go). The
+		// write path's own required check (validateRequiredAttributesFromInput,
+		// transformer.go) has none, so a required_always beneath a root still
+		// rejects the stripped payload there. Documented in docs/error-handling.md.
+		if relationRoots.Covers(attrName) {
+			continue
+		}
+		switch metadata.EffectiveRequiredPolicy() {
+		case forma.RequiredPolicyAlways:
+			if isRequiredAttributeMissing(attrName, presentAttrIndices, true) {
+				missingRequired[metadata.AttributeID] = attrName
+			}
+		case forma.RequiredPolicyIfParentPresent:
+			if isRequiredAttributeMissing(attrName, presentAttrIndices, false) {
+				missingRequired[metadata.AttributeID] = attrName
+			}
+		}
+	}
+	if len(missingRequired) == 0 {
+		return nil
+	}
+
+	zap.S().Infow("missing EAV records for attrIDs.", "idToName", missingRequired)
+	names := make([]string, 0, len(missingRequired))
+	idsByName := make(map[string]int16, len(missingRequired))
+	for id, name := range missingRequired {
+		names = append(names, name)
+		idsByName[name] = id
+	}
+	// Name the alphabetically first missing attribute, not whichever the map
+	// yields first, so the same drift produces the same error on every run.
+	missingAttrName := slices.Min(names)
+
+	// Plain error, deliberately. FromEAVRecords is not write-only: the read
+	// path rebuilds already-stored records through it
+	// (persistent_record.go's FromPersistentRecord), so a persisted row
+	// missing a required EAV row reaches here too. Wrapping
+	// forma.ErrInvalidInput here — as an earlier #301 sweep did — made the
+	// HTTP boundary answer that persisted-drift case with a verbatim 400,
+	// inverting the split AGENTS.md and this repo's error-handling doc
+	// draw: write validation carries the sentinel, read-path consistency
+	// failures stay plain and operator-visible.
+	//
+	// The write path's 400 does not depend on this wrap. It has its own
+	// write-only validator, validateRequiredAttributesFromInput
+	// (transformer.go), which ToAttributes runs against the caller's input
+	// before flattening and which does carry the sentinel.
+	return fmt.Errorf("missing required attribute '%s' (attrID=%d) in EAV records",
+		missingAttrName, idsByName[missingAttrName])
+}
 
 // shouldEnforceRequiredAttribute applies RequiredPolicyIfParentPresent semantics
 // to an attribute using the observed EAV array-index context.

--- a/internal/transform/scalar_conversion.go
+++ b/internal/transform/scalar_conversion.go
@@ -1,0 +1,203 @@
+package transform
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lychee-technology/forma/internal/numutil"
+)
+
+// Scalar coercion helpers behind AttributeConverter.ToEAVRecord and
+// populateTypedValue (typed_value.go).
+//
+// The numeric coercion helpers (toFloat64ForEAV, parseTrimmedFloat64) live in
+// numeric_conversion.go alongside the finiteForEAV guard they feed.
+
+func toTimeForEAV(value any) (time.Time, error) {
+	switch v := value.(type) {
+	case time.Time:
+		return v, nil
+	case *time.Time:
+		timeValue, err := derefPointer(v, "time")
+		if err != nil {
+			return time.Time{}, err
+		}
+		return timeValue, nil
+	default:
+		return time.Time{}, fmt.Errorf("cannot convert %T to time.Time", value)
+	}
+}
+
+func toBoolForEAV(value any) (bool, error) {
+	switch v := value.(type) {
+	case string:
+		return isTrueStringForEAV(v), nil
+	case *string:
+		str, err := derefPointer(v, "string")
+		if err != nil {
+			return false, err
+		}
+		return isTrueStringForEAV(str), nil
+	case bool:
+		return v, nil
+	case *bool:
+		booleanValue, err := derefPointer(v, "bool")
+		if err != nil {
+			return false, err
+		}
+		return booleanValue, nil
+	case int:
+		return boolFromPositive(v), nil
+	case *int:
+		num, err := derefPointer(v, "int")
+		if err != nil {
+			return false, err
+		}
+		return boolFromPositive(num), nil
+	case int16:
+		return boolFromPositive(v), nil
+	case *int16:
+		num, err := derefPointer(v, "int16")
+		if err != nil {
+			return false, err
+		}
+		return boolFromPositive(num), nil
+	case int32:
+		return boolFromNonZero(v), nil
+	case *int32:
+		num, err := derefPointer(v, "int32")
+		if err != nil {
+			return false, err
+		}
+		return boolFromPositive(num), nil
+	case int64:
+		return boolFromNonZero(v), nil
+	case *int64:
+		num, err := derefPointer(v, "int64")
+		if err != nil {
+			return false, err
+		}
+		return boolFromPositive(num), nil
+	case float32:
+		return finiteFloat64ToBool(float64(v))
+	case *float32:
+		num, err := derefPointer(v, "float32")
+		if err != nil {
+			return false, err
+		}
+		return finiteFloat64ToBool(float64(num))
+	case float64:
+		return finiteFloat64ToBool(v)
+	case *float64:
+		num, err := derefPointer(v, "float64")
+		if err != nil {
+			return false, err
+		}
+		return finiteFloat64ToBool(num)
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return false, fmt.Errorf("cannot convert json.Number %q to bool: %w", v.String(), err)
+		}
+		if err := finiteBoolInput(f); err != nil {
+			return false, err
+		}
+		return f != 0, nil
+	default:
+		return false, fmt.Errorf("cannot convert %T to bool", value)
+	}
+}
+
+// finiteFloat64ToBool is toBoolForEAV's float path: reject non-finite, then
+// apply the existing threshold coercion unchanged.
+func finiteFloat64ToBool(value float64) (bool, error) {
+	if err := finiteBoolInput(value); err != nil {
+		return false, err
+	}
+	return float64ToBool(value), nil
+}
+
+func derefPointer[T any](value *T, typeName string) (T, error) {
+	if value == nil {
+		var zero T
+		return zero, fmt.Errorf("nil %s pointer", typeName)
+	}
+	return *value, nil
+}
+
+func boolFromPositive[T ~int | ~int16 | ~int32 | ~int64](value T) bool {
+	return value > 0
+}
+
+func boolFromNonZero[T ~int32 | ~int64](value T) bool {
+	return value != 0
+}
+
+func isTrueStringForEAV(value string) bool {
+	return strings.ToLower(value) == "true" || value == "1"
+}
+
+func toTime(value any) (time.Time, error) {
+	switch v := value.(type) {
+	case time.Time:
+		return v, nil
+	case string:
+		epoch, err := strconv.ParseInt(v, 10, 64)
+		if err == nil {
+			return time.UnixMilli(epoch), nil
+		}
+
+		formats := []string{
+			time.RFC3339Nano,
+			time.RFC3339,
+			"2006-01-02",
+			"2006-01",
+		}
+		for _, format := range formats {
+			if parsed, err := time.Parse(format, v); err == nil {
+				return parsed, nil
+			}
+		}
+		return time.Time{}, fmt.Errorf("unsupported time format: %s", v)
+	default:
+		return time.Time{}, fmt.Errorf("cannot convert %T to time.Time", value)
+	}
+}
+
+func toBool(value any) (bool, error) {
+	switch v := value.(type) {
+	case bool:
+		return v, nil
+	case string:
+		return strconv.ParseBool(v)
+	case int:
+		return v != 0, nil
+	case int64:
+		return v != 0, nil
+	case float64:
+		if err := finiteBoolInput(v); err != nil {
+			return false, err
+		}
+		return v != 0, nil
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return false, fmt.Errorf("cannot convert json.Number %q to bool: %w", v.String(), err)
+		}
+		if err := finiteBoolInput(f); err != nil {
+			return false, err
+		}
+		return f != 0, nil
+	default:
+		return false, fmt.Errorf("cannot convert %T to bool", value)
+	}
+}
+
+// ToFloat64Ok is an exported helper that behaves like the legacy optimizer helper:
+// it returns (float64, bool) where bool indicates success.
+func ToFloat64(v any) (float64, bool) {
+	return numutil.ToFloat64(v)
+}

--- a/internal/transform/scalar_conversion.go
+++ b/internal/transform/scalar_conversion.go
@@ -10,8 +10,10 @@ import (
 	"github.com/lychee-technology/forma/internal/numutil"
 )
 
-// Scalar coercion helpers behind AttributeConverter.ToEAVRecord and
-// populateTypedValue (typed_value.go).
+// Scalar coercion helpers shared by the EAV write funnels
+// (AttributeConverter.ToEAVRecord, populateTypedValue in typed_value.go) and
+// the read path (extractValueFromEAVRecord sends a stored ValueNumeric back
+// through toBoolForEAV). derefPointer is also reused by numeric_conversion.go.
 //
 // The numeric coercion helpers (toFloat64ForEAV, parseTrimmedFloat64) live in
 // numeric_conversion.go alongside the finiteForEAV guard they feed.
@@ -196,7 +198,7 @@ func toBool(value any) (bool, error) {
 	}
 }
 
-// ToFloat64Ok is an exported helper that behaves like the legacy optimizer helper:
+// ToFloat64 is an exported helper that behaves like the legacy optimizer helper:
 // it returns (float64, bool) where bool indicates success.
 func ToFloat64(v any) (float64, bool) {
 	return numutil.ToFloat64(v)


### PR DESCRIPTION
Closes #375.

`internal/transform/attribute_converter.go` sat at 490/500 lines. This splits it along two seams (plan and rationale on the issue: https://github.com/Lychee-Technology/forma/issues/375#issuecomment-5650075090):

- **`relationRootsFor` + `checkRequiredAttributes` → `attribute_required.go`.** That file already held the `isRequiredAttributeMissing` helpers these two are the only caller of, so the whole required policy now lives in one 178-line file. `SetRelationRoots` stays with the struct as the `RelationRootsAware` method.
- **Receiver-free scalar coercion helpers → new `scalar_conversion.go`** (`toTimeForEAV`, `toBoolForEAV`, `derefPointer`, `toTime`, `toBool`, `ToFloat64`, …), mirroring the existing `numeric_conversion.go` seam.

`attribute_converter.go` now holds only the converter type and its four conversion methods: **206 lines**.

### Deferred judgement calls from the #373 review

Both bare `return nil, err` sites in `FromEAVRecords` are now wrapped:

- `GetSchemaMetadata` → `load schema metadata for schema %d: %w`
- `checkRequiredAttributes` → `required-policy check for schema %d: %w`

AGENTS.md's rule is unconditional; the wrap adds the operation and schema ID rather than restating the callee's facts. Both remain plain errors (no sentinel, no HTTP status change). Every existing assertion on these messages is a `strings.Contains`, so no test changed.

### Commits

1. `3037a86` — the move plus the two wraps. Pure move: `git diff` on `attribute_converter.go` adds only the import line and the two wraps; the extracted tails are byte-identical.
2. `62d10fc` — comment-only fixes from the review (stale `ToFloat64Ok` name, incomplete caller map in the `scalar_conversion.go` header). Kept separate so commit 1 stays verifiable as an extraction.

### Follow-ups filed from the review

- #562 — `toBoolForEAV` integer→bool coercion differs by width and pointer-ness (pre-existing, preserved byte-for-byte here).
- #563 — `transform.ToFloat64` has no callers.

### Verification

- `make fmt-check`, `make lint` — green
- `make test` — all packages green except `internal/e2e_harness`, which needs a container runtime on this machine (pre-existing, unrelated)
- After commit 2: `go test ./internal/transform/ -count=1` ok, `go vet ./internal/transform/` clean, `gofmt -l` clean.
